### PR TITLE
feat: add scheduling DSL types to goal editor

### DIFF
--- a/src/components/form/Field.svelte
+++ b/src/components/form/Field.svelte
@@ -80,7 +80,7 @@
 
   async function onBlur(event: FocusEvent) {
     const { value } = getTarget(event);
-    const valid = await field.validate(value);
+    const valid = await field.validateAndSet(value);
     if (valid) dispatch('valid');
   }
 
@@ -95,7 +95,7 @@
     if (key === 'Enter') {
       event.preventDefault();
       const { value } = getTarget(event);
-      const valid = await field.validate(value);
+      const valid = await field.validateAndSet(value);
       if (valid) dispatch('valid');
     }
   }

--- a/src/components/ui/MonacoEditor.svelte
+++ b/src/components/ui/MonacoEditor.svelte
@@ -14,6 +14,7 @@
   export let lineNumbers: Editor.LineNumbersType | undefined = undefined;
   export let minimap: Editor.IEditorMinimapOptions | undefined = undefined;
   export let model: Editor.ITextModel | null | undefined = undefined;
+  export let monaco: Monaco | undefined = undefined;
   export let override: Editor.IEditorOverrideServices | undefined = undefined;
   export let scrollBeyondLastLine: boolean | undefined = undefined;
   export let theme: string | undefined = undefined;
@@ -58,7 +59,7 @@
       theme,
       value,
     };
-    const monaco = await import('monaco-editor');
+    monaco = await import('monaco-editor');
     editor = monaco.editor.create(div, options, override);
 
     editor.onDidChangeModelContent((e: Editor.IModelContentChangedEvent) => {

--- a/src/routes/plans/[id].svelte
+++ b/src/routes/plans/[id].svelte
@@ -13,11 +13,15 @@
     const planId = parseFloat(id);
 
     const initialPlan = await req.getPlan(planId);
+    const initialSchedulingDslTypes = await req.getSchedulingDslTypes(
+      initialPlan.model.id,
+    );
     const initialView = await req.getView(url.searchParams);
 
     return {
       props: {
         initialPlan,
+        initialSchedulingDslTypes,
         initialView,
       },
     };
@@ -81,7 +85,11 @@
     viewTimeRange,
   } from '../../stores/plan';
   import { resourceActions } from '../../stores/resources';
-  import { schedulingActions, schedulingStatus } from '../../stores/scheduling';
+  import {
+    schedulingActions,
+    schedulingDslTypes,
+    schedulingStatus,
+  } from '../../stores/scheduling';
   import {
     modelParametersMap,
     simulationActions,
@@ -101,6 +109,7 @@
   import { tooltip } from '../../utilities/tooltip';
 
   export let initialPlan: Plan | null;
+  export let initialSchedulingDslTypes: string;
   export let initialView: View | null;
 
   let constraintMenu: Menu;
@@ -120,6 +129,10 @@
     $viewTimeRange = $maxTimeRange;
 
     simulationTemplates.setVariables({ modelId: initialPlan.model.id });
+  }
+
+  $: if (initialSchedulingDslTypes) {
+    $schedulingDslTypes = initialSchedulingDslTypes;
   }
 
   $: if (initialView) {

--- a/src/routes/plans/index.svelte
+++ b/src/routes/plans/index.svelte
@@ -79,7 +79,7 @@
     const queryModelId = $page.url.searchParams.get('modelId');
     if (queryModelId) {
       $modelIdField.value = parseFloat(queryModelId);
-      modelIdField.validate();
+      modelIdField.validateAndSet();
       removeQueryParam('modelId');
       if (nameInputField) {
         nameInputField.focus();

--- a/src/stores/form.ts
+++ b/src/stores/form.ts
@@ -27,13 +27,16 @@ export function field<T>(
   const { set, subscribe, update } = writable<Field<T>>(field);
 
   return {
+    reset(value: T): void {
+      update(currentField => initialField(value, currentField.validators));
+    },
     set(newField: Field<T>) {
       const dirty = newField.initialValue !== newField.value;
       set({ ...newField, dirty });
     },
     subscribe,
     update,
-    async validate(newValue?: T): Promise<boolean> {
+    async validateAndSet(newValue?: T): Promise<boolean> {
       const currentField: Field<T> = get(this);
       const value = newValue === undefined ? currentField.value : newValue;
       const dirty = initialValue !== value;

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -12,6 +12,8 @@ import { getGqlSubscribable } from './subscribable';
 
 /* Stores. */
 
+export const schedulingDslTypes: Writable<string> = writable('');
+
 export const schedulingSpecGoals = getGqlSubscribable<SchedulingSpecGoal[]>(
   gql.SUB_SCHEDULING_SPEC_GOALS,
   { specification_id: -1 },
@@ -124,6 +126,7 @@ export const schedulingActions = {
   },
 
   reset(): void {
+    schedulingDslTypes.set('');
     schedulingStatus.set(Status.Clean);
     selectedGoalId.set(null);
   },

--- a/src/types/form.d.ts
+++ b/src/types/form.d.ts
@@ -12,7 +12,8 @@ type Field<T> = {
 };
 
 type FieldStore<T> = import('svelte/store').Writable<Field<T>> & {
-  validate(value?: T): Promise<boolean>;
+  reset(value: T): void;
+  validateAndSet(value?: T): Promise<boolean>;
 };
 
 type ValidatorFn<T> = (value: T) => Promise<ValidationResult>;

--- a/src/types/monaco.d.ts
+++ b/src/types/monaco.d.ts
@@ -1,0 +1,5 @@
+type Monaco = typeof import('monaco-editor');
+
+interface Window {
+  MonacoEnvironment: Monaco.Environment;
+}

--- a/src/types/scheduling.d.ts
+++ b/src/types/scheduling.d.ts
@@ -1,3 +1,9 @@
+type SchedulingDslTypesResponse = {
+  reason: string;
+  status: 'failure' | 'success';
+  typescript: string;
+};
+
 type SchedulingGoal = {
   analyses: SchedulingGoalAnalysis[];
   author: string | null;

--- a/src/types/window.d.ts
+++ b/src/types/window.d.ts
@@ -1,3 +1,0 @@
-interface Window {
-  MonacoEnvironment: import('monaco-editor/esm/vs/editor/editor.api').Environment;
-}

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -262,6 +262,16 @@ const gql = {
     }
   `,
 
+  GET_SCHEDULING_DSL_TYPES: `#graphql
+    query GetSchedulingDslTypes($model_id: Int!) {
+      schedulingDslTypes: schedulingDslTypescript(missionModelId: $model_id) {
+        reason
+        status
+        typescript
+      }
+    }
+  `,
+
   GET_SCHEDULING_SPEC_GOAL_PRIORITIES: `#graphql
     query GetSchedulingSpecGoalPriorities($specification_id: Int!) {
       specGoals: scheduling_specification_goals(where: { specification_id: { _eq: $specification_id } }) {

--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -496,6 +496,27 @@ const req = {
     }
   },
 
+  async getSchedulingDslTypes(model_id: number): Promise<string> {
+    try {
+      const data = await reqHasura<SchedulingDslTypesResponse>(
+        gql.GET_SCHEDULING_DSL_TYPES,
+        { model_id },
+      );
+      const { schedulingDslTypes } = data;
+      const { reason, status, typescript } = schedulingDslTypes;
+
+      if (status === 'success') {
+        return typescript;
+      } else {
+        console.log(reason);
+        return '';
+      }
+    } catch (e) {
+      console.log(e);
+      return '';
+    }
+  },
+
   async getSchedulingSpecGoalPriorities(
     specification_id: number,
   ): Promise<number[]> {


### PR DESCRIPTION
- Add query, request, and store for scheduling DSL type string
- Add scheduling DSL typescript types to goal Monaco Editor instance
- Update form store naming and add reset function
- Add global Monaco type
- Depends on https://github.com/NASA-AMMOS/aerie/pull/120