### PR TITLE
fix: include activity in layer based on label text

### DIFF
--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -225,7 +225,7 @@
 
       for (const point of $activityPoints) {
         const r = new RegExp(filter?.type);
-        const includeActivity = r.test(point.type);
+        const includeActivity = r.test(point?.label?.text);
         const isParentActivity = !point.parent;
 
         if (


### PR DESCRIPTION
- Including based on point type is incorrect since point type is always 'activity'
- See: https://jira.jpl.nasa.gov/browse/AERIE-1781