### PR TITLE
refactor: move set app stores to __layout.svelte

### DIFF
--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,22 +1,24 @@
 <script lang="ts" context="module">
   import type { Load } from '@sveltejs/kit';
   import '../css/app.css';
-  import req from '../utilities/requests';
+  import { env as envStore, user as userStore, version as versionStore } from '../stores/app';
 
   export const load: Load = async ({ fetch, session }) => {
-    await req.setAppStores(fetch, session);
+    // Set env store.
+    const envResponse = await fetch('/env');
+    const env = await envResponse.json();
+    envStore.set(env);
+
+    // Set version store.
+    const versionResponse = await fetch('/version.json');
+    const version = await versionResponse.json();
+    versionStore.set(version);
+
+    // Set user store.
+    userStore.set(session.user);
+
     return {};
   };
 </script>
 
-<div>
-  <slot />
-</div>
-
-<style>
-  div {
-    display: grid;
-    height: 100%;
-    width: 100%;
-  }
-</style>
+<slot />

--- a/src/types/kit.d.ts
+++ b/src/types/kit.d.ts
@@ -1,1 +1,0 @@
-type Fetch = (info: RequestInfo, init?: RequestInit) => Promise<Response>;

--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -1,5 +1,5 @@
 import { get } from 'svelte/store';
-import { env as envStore, user as userStore, version as versionStore } from '../stores/app';
+import { user as userStore } from '../stores/app';
 import { plan } from '../stores/plan';
 import { toActivity } from './activities';
 import { gatewayUrl, hasuraUrl } from './app';
@@ -645,25 +645,6 @@ const req = {
         message: 'An unexpected error occurred',
         success: false,
       };
-    }
-  },
-
-  async setAppStores(fetch: Fetch, session: App.Session): Promise<void> {
-    try {
-      // Set env store.
-      const envResponse = await fetch('/env');
-      const env = await envResponse.json();
-      envStore.set(env);
-
-      // Set version store.
-      const versionResponse = await fetch('/version.json');
-      const version = await versionResponse.json();
-      versionStore.set(version);
-
-      // Set user store.
-      userStore.set(session.user);
-    } catch (e) {
-      console.log(e);
     }
   },
 


### PR DESCRIPTION
- Move setAppStores functionality to __layout.svelte since it should only happen in one place
- Remove obsolete wrapper div in __layout.svelte
- Remove obsolete kit.d.ts types (Fetch)