### PR TITLE
feat: async scheduling request

### DIFF
--- a/src/components/app/Grid.svelte
+++ b/src/components/app/Grid.svelte
@@ -144,5 +144,6 @@
 
   .split-grid {
     display: grid;
+    overflow: scroll;
   }
 </style>

--- a/src/components/scheduling/SchedulingEditor.svelte
+++ b/src/components/scheduling/SchedulingEditor.svelte
@@ -68,7 +68,11 @@
         <i class="bi bi-save" style="font-size: 0.8rem" />
         Save Goal
       </button>
-      <button class="st-button secondary ellipsis" on:click={() => schedulingActions.selectGoal()}>
+      <button
+        class="st-button secondary ellipsis"
+        disabled={!$selectedSpecGoal}
+        on:click={() => schedulingActions.selectGoal()}
+      >
         <i class="bi bi-plus-square" style="font-size: 0.8rem" />
         New Goal
       </button>
@@ -76,6 +80,18 @@
   </svelte:fragment>
 
   <svelte:fragment slot="body">
+    {#if $selectedSpecGoal}
+      <fieldset>
+        <label for="id">Id</label>
+        <input
+          class="st-input w-100"
+          disabled
+          name="id"
+          value="{$selectedSpecGoal.specification_id}-{$selectedSpecGoal.goal.id}"
+        />
+      </fieldset>
+    {/if}
+
     <Field field={nameField}>
       <label for="name" slot="label">Goal Name</label>
       <input autocomplete="off" class="st-input w-100" name="name" placeholder="Enter Goal Name (required)" required />

--- a/src/components/ui/Panel.svelte
+++ b/src/components/ui/Panel.svelte
@@ -37,6 +37,11 @@
     font-size: 1rem;
   }
 
+  .body {
+    display: flex;
+    flex-direction: column;
+  }
+
   .padBody,
   .padHeader {
     padding: 0.5rem;

--- a/src/types/scheduling.d.ts
+++ b/src/types/scheduling.d.ts
@@ -56,6 +56,5 @@ type SchedulingSpecGoal = {
 
 type SchedulingSpecGoalInsertInput = {
   goal_id: number;
-  priority: number;
   specification_id: number;
 };

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -272,14 +272,6 @@ const gql = {
     }
   `,
 
-  GET_SCHEDULING_SPEC_GOAL_PRIORITIES: `#graphql
-    query GetSchedulingSpecGoalPriorities($specification_id: Int!) {
-      specGoals: scheduling_specification_goals(where: { specification_id: { _eq: $specification_id } }) {
-        priority
-      }
-    }
-  `,
-
   RESOURCE_TYPES: `#graphql
     query ResourceTypes($modelId: ID!) {
       resourceTypes(missionModelId: $modelId) {

--- a/src/utilities/grid.ts
+++ b/src/utilities/grid.ts
@@ -58,22 +58,29 @@ export const constraintsGrid: Grid = {
 };
 
 export const schedulingGrid: Grid = {
-  columnSizes: '1fr 3px 2fr 3px 1fr',
+  columnSizes: '1fr 3px 3fr',
   columns: [
-    { componentName: 'SchedulingEditor', id: 1, type: 'component' },
-    { id: 2, track: 1, type: 'gutter' },
     {
-      id: 3,
-      rowSizes: '70% 3px 1fr',
+      id: 1,
+      rowSizes: '1fr 3px 1fr',
       rows: [
-        { componentName: 'Timeline', id: 4, timelineId: 0, type: 'component' },
-        { id: 5, track: 1, type: 'gutter' },
-        { activityTableId: 0, componentName: 'ActivityTable', id: 6, type: 'component' },
+        { componentName: 'Scheduling', id: 2, type: 'component' },
+        { id: 3, track: 1, type: 'gutter' },
+        { componentName: 'SchedulingEditor', id: 4, type: 'component' },
       ],
       type: 'rows',
     },
-    { id: 7, track: 3, type: 'gutter' },
-    { componentName: 'Scheduling', id: 8, type: 'component' },
+    { id: 5, track: 1, type: 'gutter' },
+    {
+      id: 6,
+      rowSizes: '70% 3px 1fr',
+      rows: [
+        { componentName: 'Timeline', id: 7, timelineId: 0, type: 'component' },
+        { id: 8, track: 1, type: 'gutter' },
+        { activityTableId: 0, componentName: 'ActivityTable', id: 9, type: 'component' },
+      ],
+      type: 'rows',
+    },
   ],
   gridName: 'Scheduling',
   id: 0,

--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -465,18 +465,6 @@ const req = {
     }
   },
 
-  async getSchedulingSpecGoalPriorities(specification_id: number): Promise<number[]> {
-    try {
-      const data = await reqHasura<SchedulingSpecGoal[]>(gql.GET_SCHEDULING_SPEC_GOAL_PRIORITIES, {
-        specification_id,
-      });
-      const { specGoals } = data;
-      return specGoals.map(({ priority }) => priority).sort();
-    } catch (e) {
-      console.log(e);
-    }
-  },
-
   async getView(query: URLSearchParams): Promise<View | null> {
     let response: Response;
     let json: GetViewResponse;


### PR DESCRIPTION
- Make scheduling request fully async and poll 10 times if incomplete
- Remove obsolete scheduling spec goal priority queries and requests
- Add id field to scheduling editor to show an existing goal is selected
- Update scheduling grid to two columns, split editor and goal list
- Update Panel and Grid CSS for flex and overflow behavior