### PR TITLE
test: more plan page tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,6 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 
 const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
-  fullyParallel: true,
   reporter: [
     [process.env.CI ? 'github' : 'list'],
     ['html', { open: 'never', outputFile: 'index.html', outputFolder: 'test-results' }],

--- a/src/components/app/Grid.svelte
+++ b/src/components/app/Grid.svelte
@@ -85,7 +85,7 @@
     {/each}
   </div>
 {:else if grid?.type === 'component'}
-  <div class="component">
+  <div class="component" data-component-name={grid.componentName}>
     {#if grid.componentName === 'ActivityForm'}
       <ActivityForm gridId={grid.id} />
     {:else if grid.componentName === 'ActivityTable'}

--- a/src/routes/__error.svelte
+++ b/src/routes/__error.svelte
@@ -1,1 +1,1 @@
-<div>An unexpected error occured.</div>
+<div class="app-error">An unexpected error occured.</div>

--- a/src/routes/plans/[id].svelte
+++ b/src/routes/plans/[id].svelte
@@ -110,7 +110,7 @@
 
 <CssGrid rows="42px calc(100vh - 42px)">
   <Nav>
-    <span slot="title">{initialPlan.name}</span>
+    <span class="plan-title" slot="title">{initialPlan.name}</span>
 
     <svelte:fragment slot="right">
       <NavButton icon="si si-activity" title="Activities" />

--- a/tests/e2e/plan-page.test.ts
+++ b/tests/e2e/plan-page.test.ts
@@ -34,7 +34,19 @@ test.describe('Plan Page', () => {
     await modelsPage.deleteModel();
   });
 
-  test('Plan title should be visible in the top navigation bar', async ({ planPage, plansPage }) => {
+  test('Error page should not be visible, and the plan title should be visible in the top navigation bar', async ({
+    planPage,
+    plansPage,
+  }) => {
+    await expect(planPage.appError).not.toBeVisible();
     await expect(planPage.planTitle(plansPage.planName)).toBeVisible();
+  });
+
+  test('Initially the Activities layout should be displayed', async ({ planPage }) => {
+    await expect(planPage.activityFormComponent).toBeVisible();
+    await expect(planPage.activityTableComponent).toBeVisible();
+    await expect(planPage.activityTypesComponent).toBeVisible();
+    await expect(planPage.timelineComponent).toBeVisible();
+    await expect(planPage.activitiesNavButton).toHaveClass(/selected/);
   });
 });

--- a/tests/fixtures/ModelsPage.ts
+++ b/tests/fixtures/ModelsPage.ts
@@ -46,9 +46,6 @@ export class ModelsPage {
     await this.createButton.click();
     await this.tableRow.waitFor({ state: 'attached' });
     await expect(this.tableRow).toBeVisible();
-
-    // Artificial wait for Hasura events to finish seeding the database when a model is created.
-    await this.page.waitForTimeout(3000);
   }
 
   async deleteModel() {

--- a/tests/fixtures/PlanPage.ts
+++ b/tests/fixtures/PlanPage.ts
@@ -3,15 +3,44 @@ import type { Locator, Page } from '@playwright/test';
 export class PlanPage {
   readonly page: Page;
 
+  readonly appError: Locator;
   readonly planTitle: (planName: string) => Locator;
+
+  readonly activityFormComponent: Locator;
+  readonly activityTableComponent: Locator;
+  readonly activityTypesComponent: Locator;
+  readonly timelineComponent: Locator;
+
+  readonly activitiesNavButton: Locator;
+  readonly constraintsNavButton: Locator;
+  readonly schedulingNavButton: Locator;
+  readonly simulationNavButton: Locator;
+  readonly viewsNavButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
 
-    this.planTitle = (planName: string) => page.locator(`.title:has-text("${planName}")`);
+    this.appError = page.locator('.app-error');
+    this.planTitle = (planName: string) => page.locator(`.plan-title:has-text("${planName}")`);
+
+    this.activityFormComponent = page.locator('[data-component-name="ActivityForm"]');
+    this.activityTableComponent = page.locator('[data-component-name="ActivityTable"]');
+    this.activityTypesComponent = page.locator('[data-component-name="ActivityTypes"]');
+    this.timelineComponent = page.locator('[data-component-name="Timeline"]');
+
+    this.activitiesNavButton = page.locator(`.nav-button:has-text("Activities")`);
+    this.constraintsNavButton = page.locator(`.nav-button:has-text("Constraints")`);
+    this.schedulingNavButton = page.locator(`.nav-button:has-text("Scheduling")`);
+    this.simulationNavButton = page.locator(`.nav-button:has-text("Simulation")`);
+    this.viewsNavButton = page.locator(`.nav-button:has-text("Views")`);
   }
 
+  /**
+   * Wait for Hasura events to finish seeding the database after a model is created.
+   * If we do not wait then navigation to the plan will fail because the data is not there yet.
+   */
   async goto(planId: string) {
+    await this.page.waitForTimeout(1000);
     await this.page.goto(`/plans/${planId}`);
   }
 }


### PR DESCRIPTION
- Add test for plan page activities layout
- Remove fully parallel from Playwright config for now
- Add selectors to application for easier test selection
- Move Hasura wait code to PlanPage fixture since it's not needed elsewhere