### PR TITLE
Use `resourceSamples` in place of sim. results

### DIFF
--- a/src/types/simulation.d.ts
+++ b/src/types/simulation.d.ts
@@ -28,6 +28,11 @@ type ResourceType = {
   schema: ValueSchema;
 };
 
+type ResourceSamples = {
+  name: string;
+  schema: ValueSchema;
+};
+
 type ResourceValue = {
   x: number;
   y: number | string;

--- a/src/types/simulation.d.ts
+++ b/src/types/simulation.d.ts
@@ -28,11 +28,6 @@ type ResourceType = {
   schema: ValueSchema;
 };
 
-type ResourceSamples = {
-  name: string;
-  schema: ValueSchema;
-};
-
 type ResourceValue = {
   x: number;
   y: number | string;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -866,6 +866,17 @@ const effects = {
     }
   },
 
+  async resourceSamples(planId: number): Promise<Record<string, ResourceValue[]>> {
+    try {
+      const data = await reqHasura<{resourceSamples: Record<string, ResourceValue[]>}>(gql.RESOURCE_SAMPLES, { planId });
+      const { resourceSamples } = data;
+      return resourceSamples.resourceSamples;
+    } catch (e) {
+      console.log(e);
+      return {};
+    }
+  },
+
   async schedule(): Promise<void> {
     try {
       const { id: planId } = get(plan);
@@ -953,7 +964,8 @@ const effects = {
             map[name] = schema;
             return map;
           }, {});
-          const newResources: Resource[] = Object.entries(results.resources).map(([name, values]) => ({
+          const resourceSamples: Record<string, ResourceValue[]> = await effects.resourceSamples(planId);
+          const newResources: Resource[] = Object.entries(resourceSamples).map(([name, values]) => ({
             name,
             schema: resourceTypesMap[name],
             startTime: results.start,

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -855,6 +855,19 @@ const effects = {
     }
   },
 
+  async resourceSamples(planId: number): Promise<Record<string, ResourceValue[]>> {
+    try {
+      const data = await reqHasura<{ resourceSamples: Record<string, ResourceValue[]> }>(gql.RESOURCE_SAMPLES, {
+        planId,
+      });
+      const { resourceSamples } = data;
+      return resourceSamples.resourceSamples;
+    } catch (e) {
+      console.log(e);
+      return {};
+    }
+  },
+
   async resourceTypes(modelId: number): Promise<ResourceType[]> {
     try {
       const data = await reqHasura<ResourceType[]>(gql.RESOURCE_TYPES, { modelId });
@@ -863,17 +876,6 @@ const effects = {
     } catch (e) {
       console.log(e);
       return [];
-    }
-  },
-
-  async resourceSamples(planId: number): Promise<Record<string, ResourceValue[]>> {
-    try {
-      const data = await reqHasura<{resourceSamples: Record<string, ResourceValue[]>}>(gql.RESOURCE_SAMPLES, { planId });
-      const { resourceSamples } = data;
-      return resourceSamples.resourceSamples;
-    } catch (e) {
-      console.log(e);
-      return {};
     }
   },
 

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -428,6 +428,14 @@ const gql = {
     }
   `,
 
+  RESOURCE_SAMPLES: `#graphql
+    query ResourceSamples($planId: Int!) {
+      resourceSamples(planId: $planId) {
+        resourceSamples
+      }
+    }
+  `,
+
   SCHEDULE: `#graphql
     query Schedule($specificationId: Int!) {
       schedule(specificationId: $specificationId){

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -419,19 +419,19 @@ const gql = {
     }
   `,
 
+  RESOURCE_SAMPLES: `#graphql
+    query ResourceSamples($planId: Int!) {
+      resourceSamples(planId: $planId) {
+        resourceSamples
+      }
+    }
+  `,
+
   RESOURCE_TYPES: `#graphql
     query ResourceTypes($modelId: ID!) {
       resourceTypes(missionModelId: $modelId) {
         name
         schema
-      }
-    }
-  `,
-
-  RESOURCE_SAMPLES: `#graphql
-    query ResourceSamples($planId: Int!) {
-      resourceSamples(planId: $planId) {
-        resourceSamples
       }
     }
   `,


### PR DESCRIPTION
## Description

Depends on https://github.com/NASA-AMMOS/aerie/pull/189 to implement the `resourceSamples`.
This PR removes the reliance upon resource samples returned from the `simulate` endpoint and instead uses the `resourceSamples` endpoint.

Credit and thanks to @mattdailis for singlehandedly making these changes 🥳

## Verification

Tested manually with Banananation. Resource samples continue to be correctly returned and displayed in the UI.