### PR TITLE
feat: query resource profiles directly

### DIFF
--- a/src/components/timeline/LayerLine.svelte
+++ b/src/components/timeline/LayerLine.svelte
@@ -5,7 +5,6 @@
   import type { ScaleTime } from 'd3-scale';
   import { curveLinear, line as d3Line } from 'd3-shape';
   import { createEventDispatcher, onMount, tick } from 'svelte';
-  import { planStartTimeMs } from '../../stores/plan';
   import { getYScale, searchQuadtreePoint } from '../../utilities/timeline';
 
   export let drawHeight: number = 0;
@@ -156,7 +155,7 @@
               radius,
               selected: false,
               type: 'line',
-              x: $planStartTimeMs + x / 1000,
+              x,
               y,
             });
           }
@@ -175,7 +174,7 @@
               radius,
               selected: false,
               type: 'line',
-              x: $planStartTimeMs + x / 1000,
+              x,
               y,
             });
           }

--- a/src/components/timeline/LayerXRange.svelte
+++ b/src/components/timeline/LayerXRange.svelte
@@ -16,7 +16,6 @@
     schemeTableau10,
   } from 'd3-scale-chromatic';
   import { createEventDispatcher, onMount, tick } from 'svelte';
-  import { planStartTimeMs } from '../../stores/plan';
   import { clamp } from '../../utilities/generic';
   import { searchQuadtreeRect } from '../../utilities/timeline';
 
@@ -224,7 +223,7 @@
               name,
               selected: false,
               type: 'x-range',
-              x: $planStartTimeMs + x / 1000,
+              x,
             });
           }
         } else if (schema.type === 'string') {
@@ -238,7 +237,7 @@
               name,
               selected: false,
               type: 'x-range',
-              x: $planStartTimeMs + x / 1000,
+              x,
             });
             domainMap[text] = text;
           }
@@ -254,7 +253,7 @@
               name,
               selected: false,
               type: 'x-range',
-              x: $planStartTimeMs + x / 1000,
+              x,
             });
           }
         }

--- a/src/routes/plans/[id].svelte
+++ b/src/routes/plans/[id].svelte
@@ -37,7 +37,7 @@
     resetPlanStores,
     viewTimeRange,
   } from '../../stores/plan';
-  import { resetResourceStores, resourceTypes } from '../../stores/resources';
+  import { resetResourceStores } from '../../stores/resources';
   import { resetSchedulingStores, schedulingStatus, schedulingTsFiles } from '../../stores/scheduling';
   import {
     modelParametersMap,
@@ -66,7 +66,6 @@
       const initialPlan = await effects.getPlan(planId);
 
       if (initialPlan) {
-        const initialResourceTypes = await effects.getResourceTypes(initialPlan.model.id);
         const initialTsFilesConstraints = await effects.getTsFilesConstraints(initialPlan.model.id);
         const initialTsFilesScheduling = await effects.getTsFilesScheduling(initialPlan.model.id);
         const initialView = await effects.getView(url.searchParams);
@@ -74,7 +73,6 @@
         return {
           props: {
             initialPlan,
-            initialResourceTypes,
             initialTsFilesConstraints,
             initialTsFilesScheduling,
             initialView,
@@ -92,7 +90,6 @@
 
 <script lang="ts">
   export let initialPlan: Plan | null;
-  export let initialResourceTypes: ResourceType[];
   export let initialTsFilesConstraints: TypeScriptFile[];
   export let initialTsFilesScheduling: TypeScriptFile[];
   export let initialView: View | null;
@@ -121,7 +118,6 @@
     $modelParametersMap = initialPlan.model.parameters.parameters;
     $plan = initialPlan;
     $planConstraints = initialPlan.constraints;
-    $resourceTypes = initialResourceTypes;
     simulation.updateValue(() => initialPlan.simulations[0]);
 
     $planEndTimeMs = getUnixEpochTime(initialPlan.end_time);

--- a/src/stores/resources.ts
+++ b/src/stores/resources.ts
@@ -1,33 +1,11 @@
-import { derived, writable, type Readable, type Writable } from 'svelte/store';
+import { writable, type Writable } from 'svelte/store';
 
 /* Writeable. */
 
-export const resourceSamplesMap: Writable<Record<string, ResourceValue[]>> = writable({});
-
-export const resourceTypes: Writable<ResourceType[]> = writable([]);
-
-/* Derived. */
-
-export const resourceTypesMap: Readable<Record<string, ValueSchema>> = derived(resourceTypes, $resourceTypes =>
-  $resourceTypes.reduce((map: Record<string, ValueSchema>, { name, schema }) => {
-    map[name] = schema;
-    return map;
-  }, {}),
-);
-
-export const resources: Readable<Resource[]> = derived(
-  [resourceSamplesMap, resourceTypesMap],
-  ([$resourceSamplesMap, $resourceTypesMap]) =>
-    Object.entries($resourceSamplesMap).map(([name, values]) => ({
-      name,
-      schema: $resourceTypesMap[name],
-      values,
-    })),
-);
+export const resources: Writable<Resource[]> = writable([]);
 
 /* Helper Functions. */
 
 export function resetResourceStores() {
-  resourceSamplesMap.set({});
-  resourceTypes.set([]);
+  resources.set([]);
 }

--- a/src/types/simulation.d.ts
+++ b/src/types/simulation.d.ts
@@ -1,3 +1,23 @@
+type ProfilesForPlanResponse = {
+  duration: string;
+  simulations: [{ datasets: [{ dataset: { profiles: Profile[] } }] }];
+  start_time: string;
+};
+
+type Profile = {
+  name: string;
+  profile_segments: ProfileSegment[];
+  type: {
+    schema?: ValueSchema;
+    type: 'discrete' | 'real';
+  };
+};
+
+type ProfileSegment = {
+  dynamics: any;
+  start_offset: string;
+};
+
 type Simulation = {
   arguments: ArgumentsMap;
   datasets: SimulationDataset[] | null;

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -433,6 +433,29 @@ const gql = {
     }
   `,
 
+  GET_PROFILES_FOR_PLAN: `#graphql
+    query GetProfilesForPlan($planId: Int!) {
+      plan: plan_by_pk(id: $planId) {
+        duration
+        simulations(limit: 1) {
+          datasets(order_by: { id: desc }, limit: 1) {
+            dataset {
+              profiles {
+                name
+                profile_segments {
+                  dynamics
+                  start_offset
+                }
+                type
+              }
+            }
+          }
+        }
+        start_time
+      }
+    }
+  `,
+
   GET_SEQUENCE_ID: `#graphql
     query GetSequenceId($simulation_dataset_id: Int!, $simulated_activity_id: Int!) {
       sequence: sequence_to_simulated_activity_by_pk(
@@ -525,23 +548,6 @@ const gql = {
         }
       ) {
         seq_id
-      }
-    }
-  `,
-
-  RESOURCE_SAMPLES: `#graphql
-    query ResourceSamples($planId: Int!) {
-      resourceSamples(planId: $planId) {
-        resourceSamples
-      }
-    }
-  `,
-
-  RESOURCE_TYPES: `#graphql
-    query ResourceTypes($modelId: ID!) {
-      resourceTypes(missionModelId: $modelId) {
-        name
-        schema
       }
     }
   `,


### PR DESCRIPTION
- Query for resource profiles based on the latest simulation dataset id
- Transform profiles into samples directly to render
- Remove obsolete resource stores
- Remove obsolete resource samples and resource types queries

References:
- [get() from Merlin's GetProfileSegmentsAction](https://github.com/NASA-AMMOS/aerie/blob/develop/merlin-server/src/main/java/gov/nasa/jpl/aerie/merlin/server/remotes/postgres/GetProfileSegmentsAction.java#L46)
- [takeSamples() from Merlin's SimulationResults](https://github.com/NASA-AMMOS/aerie/blob/develop/merlin-driver/src/main/java/gov/nasa/jpl/aerie/merlin/driver/SimulationResults.java#L48)

See: https://jira.jpl.nasa.gov/browse/AERIE-1677