### PR TITLE
[AERIE-1485] fix: handle ctrl + s on windows machines to run simulation

### DIFF
--- a/src/routes/plans/[id].svelte
+++ b/src/routes/plans/[id].svelte
@@ -171,7 +171,7 @@
 
   function onKeydown(event: KeyboardEvent): void {
     const { key, ctrlKey, metaKey } = event;
-    if ((window.navigator.platform.match('Mac') ? metaKey : ctrlKey) && key === 's') {
+    if ((window.navigator.platform.match(/mac/i) ? metaKey : ctrlKey) && key === 's') {
       event.preventDefault();
       effects.simulate();
     }

--- a/src/routes/plans/[id].svelte
+++ b/src/routes/plans/[id].svelte
@@ -170,9 +170,8 @@
   }
 
   function onKeydown(event: KeyboardEvent): void {
-    const { key, metaKey } = event;
-
-    if (metaKey && key === 's') {
+    const { key, ctrlKey, metaKey } = event;
+    if ((window.navigator.platform.match('Mac') ? metaKey : ctrlKey) && key === 's') {
       event.preventDefault();
       effects.simulate();
     }


### PR DESCRIPTION
This resolves https://jira.jpl.nasa.gov/browse/AERIE-1485

To test:

_Windows_
1. Open/create an activity plan
2. Click on the "Simulation" link
3. Verify that pressing `CTRL` + `s` triggers a simulation

_Mac_
1. On a Mac, open/create an activity plan
2. Click on the "Simulation" link
3. Verify that pressing `CMD` + `s` still correctly triggers a simulation