### PR TITLE
[AERIE-1713] Sort parameters by order field

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prebuild": "npm run version",
     "predev": "node ./scripts/check-node.cjs",
     "preview": "svelte-kit preview",
-    "test": "npm run test:unit",
+    "test": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:codegen": "playwright codegen http://localhost:3000",
     "test:e2e:debug": "PWDEBUG=1 playwright test",

--- a/src/components/parameters/ParameterRecSeries.svelte
+++ b/src/components/parameters/ParameterRecSeries.svelte
@@ -31,6 +31,7 @@
         error: null,
         index: i,
         name: `[${i}]`,
+        order: i,
         schema: schema.items,
         value: getArgument(value[i], schema.items),
       };

--- a/src/components/parameters/ParameterRecStruct.svelte
+++ b/src/components/parameters/ParameterRecStruct.svelte
@@ -20,21 +20,22 @@
   $: subFormParameters = getSubFormParameters(formParameter);
 
   function getSubFormParameters(formParameter: FormParameter<ValueSchemaStruct>): FormParameter[] {
-    const subFormParameters = [];
     const { schema, value = [] } = formParameter;
     const { items: keys } = schema;
     const structKeys = Object.keys(keys).sort();
 
-    for (const key of structKeys) {
+    const subFormParameters = structKeys.map((key, index) => {
       const subFormParameter: FormParameter = {
         error: null,
         key,
         name: key,
+        order: index,
         schema: schema.items[key],
         value: value ? value[key] || null : null,
       };
-      subFormParameters.push(subFormParameter);
-    }
+
+      return subFormParameter;
+    });
 
     return subFormParameters;
   }

--- a/src/components/parameters/Parameters.svelte
+++ b/src/components/parameters/Parameters.svelte
@@ -15,7 +15,7 @@
   let level: number = 0;
 
   $: labelColumnWidth = clientWidth * 0.65;
-  $: sortedFormParameters = formParameters.sort((a, b) => compare(a.name, b.name));
+  $: sortedFormParameters = formParameters.sort((a, b) => compare(a.order, b.order));
 </script>
 
 {#each sortedFormParameters as formParameter (formParameter.name)}

--- a/src/components/parameters/Parameters.svelte.test.ts
+++ b/src/components/parameters/Parameters.svelte.test.ts
@@ -1,0 +1,40 @@
+import { cleanup, render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import Parameters from './Parameters.svelte';
+
+describe('Parameters component', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('Should render the list of parameters in the correct order', () => {
+    const formParameters: FormParameter[] = [
+      {
+        error: null,
+        name: 'bar',
+        order: 1,
+        schema: {
+          type: 'string',
+        },
+        value: 'value 2',
+      },
+      {
+        error: null,
+        name: 'foo',
+        order: 0,
+        schema: {
+          type: 'string',
+        },
+        value: 'value 1',
+      },
+    ];
+    const { getAllByRole } = render(Parameters, {
+      formParameters,
+    });
+
+    expect(getAllByRole('textbox').length).toBe(2);
+    expect((getAllByRole('textbox')[0] as HTMLInputElement).value).toEqual('value 1');
+    expect((getAllByRole('textbox')[1] as HTMLInputElement).value).toEqual('value 2');
+  });
+});

--- a/src/components/parameters/Parameters.svelte.test.ts
+++ b/src/components/parameters/Parameters.svelte.test.ts
@@ -29,9 +29,7 @@ describe('Parameters component', () => {
         value: 'value 1',
       },
     ];
-    const { getAllByRole } = render(Parameters, {
-      formParameters,
-    });
+    const { getAllByRole } = render(Parameters, { formParameters });
 
     expect(getAllByRole('textbox').length).toBe(2);
     expect((getAllByRole('textbox')[0] as HTMLInputElement).value).toEqual('value 1');

--- a/src/components/parameters/Parameters.svelte.test.ts
+++ b/src/components/parameters/Parameters.svelte.test.ts
@@ -1,6 +1,5 @@
 import { cleanup, render } from '@testing-library/svelte';
 import { afterEach, describe, expect, it } from 'vitest';
-
 import Parameters from './Parameters.svelte';
 
 describe('Parameters component', () => {

--- a/src/types/parameter.d.ts
+++ b/src/types/parameter.d.ts
@@ -10,6 +10,7 @@ type FormParameter<T = ValueSchema> = {
   index?: number;
   key?: string;
   name: string;
+  order: number;
   schema: T;
   value: Argument;
 };

--- a/src/utilities/parameters.ts
+++ b/src/utilities/parameters.ts
@@ -35,7 +35,7 @@ export function getFormParameters(
   argumentsMap: ArgumentsMap,
   defaultArgumentsMap: ArgumentsMap = {},
 ): FormParameter[] {
-  const formParameters = Object.entries(parametersMap).map(([name, { schema }]) => {
+  const formParameters = Object.entries(parametersMap).map(([name, { order, schema }]) => {
     const arg: Argument = argumentsMap[name];
     const defaultArg: Argument | undefined = defaultArgumentsMap[name];
     const value = getArgument(arg, schema, defaultArg);
@@ -43,6 +43,7 @@ export function getFormParameters(
     const formParameter: FormParameter = {
       error: null,
       name,
+      order,
       schema,
       value,
     };


### PR DESCRIPTION
This resolves https://jira.jpl.nasa.gov/browse/AERIE-1713

To test:

1. Create a plan with an activity that has multiple parameters (e.g. BakeBananaBread)
2. Verify that the order of the parameters listed for that activity is consistent with the order that they appear in the activity's constructor ([example](https://github.com/NASA-AMMOS/aerie/blob/develop/examples/banananation/src/main/java/gov/nasa/jpl/aerie/banananation/activities/BakeBananaBreadActivity.java))