### PR TITLE
[AERIE-1505] feat: move placeholder time format display to label so as to be visible at all times

### DIFF
--- a/src/components/activity/ActivityForm.svelte
+++ b/src/components/activity/ActivityForm.svelte
@@ -184,7 +184,7 @@
       </fieldset>
 
       <Field field={startTimeField} on:valid={onUpdateStartTime}>
-        <label for="start-time" slot="label">Start Time</label>
+        <label for="start-time" slot="label">Start Time - YYYY-DDDThh:mm:ss</label>
         <input autocomplete="off" class="st-input w-100" disabled={isChild} name="start-time" />
       </Field>
 

--- a/src/routes/plans/index.svelte
+++ b/src/routes/plans/index.svelte
@@ -138,13 +138,13 @@
           </Field>
 
           <Field field={startTimeField}>
-            <label for="start-time" slot="label">Start Time</label>
-            <input autocomplete="off" class="st-input w-100" name="start-time" placeholder="YYYY-DDDThh:mm:ss" />
+            <label for="start-time" slot="label">Start Time - YYYY-DDDThh:mm:ss</label>
+            <input autocomplete="off" class="st-input w-100" name="start-time" />
           </Field>
 
           <Field field={endTimeField}>
-            <label for="end-time" slot="label">End Time</label>
-            <input autocomplete="off" class="st-input w-100" name="end-time" placeholder="YYYY-DDDThh:mm:ss" />
+            <label for="end-time" slot="label">End Time - YYYY-DDDThh:mm:ss</label>
+            <input autocomplete="off" class="st-input w-100" name="end-time" />
           </Field>
 
           <Field field={simTemplateField}>


### PR DESCRIPTION
This addresses [AERIE-1505](https://jira.jpl.nasa.gov/browse/AERIE-1505) by moving the time format display from the input's placeholder to the label

To verify:
1. Verify that the start and end times have the correct label on the plan creation form
2. Verify that the start time has the correct label on any activity instance in a plan