### PR TITLE
fix: listen to correct events for activity start time field

### DIFF
--- a/src/components/activity/ActivityFormPanel.svelte
+++ b/src/components/activity/ActivityFormPanel.svelte
@@ -196,7 +196,7 @@
         />
       </fieldset>
 
-      <Field field={startTimeField} on:valid={onUpdateStartTime}>
+      <Field field={startTimeField} on:blur={onUpdateStartTime} on:keydown={onUpdateStartTime}>
         <label for="start-time" slot="label">Start Time - YYYY-DDDThh:mm:ss</label>
         <input autocomplete="off" class="st-input w-100" disabled={isChild} name="start-time" />
       </Field>


### PR DESCRIPTION
Use `on:keydown` and `on:blur` instead of the old `on:valid` event for the activity start time input.

Closes https://jira.jpl.nasa.gov/browse/AERIE-1969