### PR TITLE
fix: use correct Monaco Editor TypeScript lib string

### DIFF
--- a/src/components/constraints/ConstraintEditor.svelte
+++ b/src/components/constraints/ConstraintEditor.svelte
@@ -22,7 +22,7 @@
     const { typescriptDefaults } = typescript;
     const options = typescriptDefaults.getCompilerOptions();
 
-    typescriptDefaults.setCompilerOptions({ ...options, lib: ['ESNext'], strictNullChecks: true });
+    typescriptDefaults.setCompilerOptions({ ...options, lib: ['esnext'], strictNullChecks: true });
     typescriptDefaults.setExtraLibs(constraintsTsFiles);
   }
 </script>

--- a/src/components/expansion/ExpansionLogicEditor.svelte
+++ b/src/components/expansion/ExpansionLogicEditor.svelte
@@ -26,7 +26,7 @@
     const { typescriptDefaults } = typescript;
     const options = typescriptDefaults.getCompilerOptions();
 
-    typescriptDefaults.setCompilerOptions({ ...options, lib: ['ESNext'], strictNullChecks: true });
+    typescriptDefaults.setCompilerOptions({ ...options, lib: ['esnext'], strictNullChecks: true });
     typescriptDefaults.setExtraLibs([...commandDictionaryTsFiles, ...activityTypeTsFiles]);
   }
 </script>

--- a/src/components/scheduling/SchedulingGoalEditor.svelte
+++ b/src/components/scheduling/SchedulingGoalEditor.svelte
@@ -22,7 +22,7 @@
     const { typescriptDefaults } = typescript;
     const options = typescriptDefaults.getCompilerOptions();
 
-    typescriptDefaults.setCompilerOptions({ ...options, lib: ['ESNext'], strictNullChecks: true });
+    typescriptDefaults.setCompilerOptions({ ...options, lib: ['esnext'], strictNullChecks: true });
     typescriptDefaults.setExtraLibs(schedulingTsFiles);
   }
 </script>


### PR DESCRIPTION
- 'ESNext' is not recognized by the editor and fails silently
- This is contrary to the TypeScript documentation
- Use 'esnext' which is the [correct format for Monaco](https://github.com/microsoft/monaco-editor/blob/main/src/language/typescript/lib/lib.index.ts)