### PR TITLE
feat: close DatePicker on date selection

### DIFF
--- a/e2e-tests/fixtures/Plans.ts
+++ b/e2e-tests/fixtures/Plans.ts
@@ -67,7 +67,7 @@ export class Plans {
     await this.inputEndTime.focus();
     await this.inputEndTime.fill(this.endTime);
     await this.inputEndTime.evaluate(e => e.dispatchEvent(new Event('change')));
-    await this.inputEndTime.evaluate(() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })));
+    await this.inputEndTime.evaluate(e => e.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' })));
   }
 
   async fillInputName() {
@@ -80,7 +80,7 @@ export class Plans {
     await this.inputStartTime.focus();
     await this.inputStartTime.fill(this.startTime);
     await this.inputStartTime.evaluate(e => e.dispatchEvent(new Event('change')));
-    await this.inputEndTime.evaluate(() => document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' })));
+    await this.inputStartTime.evaluate(e => e.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' })));
   }
 
   async goto() {

--- a/src/components/form/DatePickerField.svelte
+++ b/src/components/form/DatePickerField.svelte
@@ -20,7 +20,7 @@
 </script>
 
 <fieldset>
-  <label class={$field.invalid ? 'error' : ''} for={name}>{label}</label>
+  <label class:error={$field.invalid} for={name}>{label}</label>
   <DatePicker dateString={$field.value} {disabled} hasError={$field.invalid} {name} on:change={onChange} />
   <FieldError {field} />
 </fieldset>

--- a/src/components/ui/DatePicker/DatePicker.svelte
+++ b/src/components/ui/DatePicker/DatePicker.svelte
@@ -137,8 +137,6 @@
   function closeDatePicker() {
     isOpen = false;
     isTouched = true;
-
-    dispatch('change', { value: dateString });
   }
 
   function decrementMonth() {
@@ -195,14 +193,19 @@
 
   function onInputKeydown(event: KeyboardEvent) {
     const { key } = event;
+    openDatePicker();
 
     if (key === 'Enter') {
+      event.preventDefault();
+
       autoCompleteDate(event);
+      closeDatePicker();
     }
   }
 
   function onSelect({ detail }: CustomEvent) {
     setDateString(getDoyTime(detail as Date, false));
+    closeDatePicker();
   }
 
   function openDatePicker() {
@@ -222,6 +225,9 @@
 
   function setToday() {
     setDateString(getDoyTime(currentDate));
+
+    viewMonth = currentDate.getUTCMonth();
+    viewYear = currentYear;
   }
 </script>
 
@@ -260,13 +266,13 @@
       <Month {maxDate} {minDate} month={viewMonth} year={viewYear} {selectedDate} on:select={onSelect} />
       <div class="date-picker-actions">
         <div>
-          <div class="action button" on:click={setToday}>
+          <div class="action button" on:mousedown={setToday}>
             <div class="action-icon"><Calendar /></div>
             <div class="action-label">Today</div>
           </div>
         </div>
         <div>
-          <div class="action button" on:click={clearDate}>
+          <div class="action button" on:mousedown={clearDate}>
             <div class="action-icon"><i class="bi bi-magic" /></div>
             <div class="action-label">Clear</div>
           </div>
@@ -289,6 +295,7 @@
     min-height: 100px;
     z-index: 99999;
     user-select: none;
+    box-shadow: 0px 8px 16px 0px var(--st-gray-20);
   }
 
   .date-picker .date-picker-portal .date-picker-inputs {

--- a/src/components/ui/DatePicker/DatePicker.svelte
+++ b/src/components/ui/DatePicker/DatePicker.svelte
@@ -291,11 +291,11 @@
     background: #ffffff;
     border: 1px solid var(--st-gray-20);
     border-radius: 10px;
+    box-shadow: 0px 8px 16px 0px var(--st-gray-20);
     min-width: 150px;
     min-height: 100px;
     z-index: 99999;
     user-select: none;
-    box-shadow: 0px 8px 16px 0px var(--st-gray-20);
   }
 
   .date-picker .date-picker-portal .date-picker-inputs {

--- a/src/components/ui/DatePicker/DatePicker.svelte.test.ts
+++ b/src/components/ui/DatePicker/DatePicker.svelte.test.ts
@@ -41,6 +41,27 @@ describe('DatePicker DatePicker Component', () => {
     expect(queryByText('April')).toBeNull();
   });
 
+  it('Should close the datepicker when the user confirms their typing changes', async () => {
+    const { getByRole, queryByText } = render(DatePicker);
+
+    await fireEvent.focus(getByRole('textbox'));
+    await fireEvent.change(getByRole('textbox'), { target: { value: '2022-100' } });
+    await fireEvent.keyDown(getByRole('textbox'), { key: 'Enter' });
+
+    expect(queryByText('April')).toBeNull();
+  });
+
+  it('Should close the datepicker when the user confirms their day selection', async () => {
+    const { getByRole, getByText, queryByText } = render(DatePicker, {
+      dateString: '2021-360T00:00:00',
+    });
+
+    await fireEvent.focus(getByRole('textbox'));
+    await fireEvent.click(getByText('359'));
+
+    expect(queryByText('April')).toBeNull();
+  });
+
   it('Should autocomplete the date when partially valid', async () => {
     const { getByDisplayValue, getByRole } = render(DatePicker);
 

--- a/src/components/ui/DatePicker/Day.svelte
+++ b/src/components/ui/DatePicker/Day.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
-  import { classNames } from '../../../utilities/generic';
   import { getDoy } from '../../../utilities/time';
 
   export let date: Date;
@@ -12,12 +11,12 @@
   const dispatch = createEventDispatcher();
 
   let isSelected: boolean = false;
-  let isWithinBounds: boolean = true;
+  let isOutsideBounds: boolean = false;
   let isToday: boolean = false;
 
   $: isToday = isSameDay(date, new Date());
   $: isSelected = isSameDay(date, selectedDate);
-  $: isWithinBounds = minDate.getTime() <= date.getTime() && date.getTime() <= maxDate.getTime();
+  $: isOutsideBounds = minDate.getTime() > date.getTime() || date.getTime() > maxDate.getTime();
   $: isOutsideCurrentMonth = month !== date.getUTCMonth();
 
   function isSameDay(date1: Date, date2: Date) {
@@ -32,19 +31,18 @@
   }
 
   function onSelect() {
-    if (isWithinBounds) {
+    if (!isOutsideBounds) {
       dispatch('select', date);
     }
   }
 </script>
 
 <div
-  class={classNames('date-picker-day', {
-    disabled: !isWithinBounds,
-    outside: isOutsideCurrentMonth,
-    selected: isSelected,
-    today: isToday,
-  })}
+  class="date-picker-day"
+  class:isOutsideBounds
+  class:isOutsideCurrentMonth
+  class:isSelected
+  class:isToday
   on:click|stopPropagation={onSelect}
 >
   <div class="doy">{getDoy(date)}</div>
@@ -74,27 +72,27 @@
     font-weight: 500;
   }
 
-  .date-picker-day.selected {
+  .date-picker-day.isSelected {
     background-color: var(--st-primary-50);
   }
 
-  .date-picker-day.selected .doy {
+  .date-picker-day.isSelected .doy {
     color: var(--st-gray-10);
   }
 
-  .date-picker-day.selected .date {
+  .date-picker-day.isSelected .date {
     color: var(--st-gray-30);
   }
 
-  .today {
+  .isToday {
     background-color: var(--st-gray-20);
   }
 
-  .outside {
+  .isOutsideCurrentMonth {
     opacity: 0.4;
   }
 
-  .disabled {
+  .isOutsideBounds {
     opacity: 0.3;
     cursor: not-allowed;
   }

--- a/src/components/ui/DatePicker/Day.svelte.test.ts
+++ b/src/components/ui/DatePicker/Day.svelte.test.ts
@@ -29,9 +29,10 @@ describe('DatePicker Day Component', () => {
       selectedDate: null,
     });
 
-    expect(container.querySelector('.selected')).toBeNull();
-    expect(container.querySelector('.today')).toBeNull();
-    expect(container.querySelector('.disabled')).toBeNull();
+    expect(container.querySelector('.isSelected')).toBeNull();
+    expect(container.querySelector('.isToday')).toBeNull();
+    expect(container.querySelector('.isOutsideCurrentMonth')).toBeNull();
+    expect(container.querySelector('.isOutsideBounds')).toBeNull();
   });
 
   it('Should indicate that the day is the current selected date', () => {
@@ -43,7 +44,7 @@ describe('DatePicker Day Component', () => {
       selectedDate: new Date(Date.UTC(2020, 2, 15)),
     });
 
-    expect(container.querySelector('.selected')).not.toBeNull();
+    expect(container.querySelector('.isSelected')).not.toBeNull();
   });
 
   it('Should indicate that the day is today', () => {
@@ -54,17 +55,28 @@ describe('DatePicker Day Component', () => {
       month: 2,
     });
 
-    expect(container.querySelector('.today')).not.toBeNull();
+    expect(container.querySelector('.isToday')).not.toBeNull();
+  });
+
+  it('Should indicate that the day is outside the current month', () => {
+    const { container } = render(Day, {
+      date: new Date(Date.UTC(2020, 2, 15)),
+      maxDate: new Date(Date.UTC(2023, 1, 1)),
+      minDate: new Date(Date.UTC(2018, 1, 1)),
+      month: 3,
+    });
+
+    expect(container.querySelector('.isOutsideCurrentMonth')).not.toBeNull();
   });
 
   it('Should be disabled if outside of the min/max range', () => {
     const { container } = render(Day, {
-      date: new Date(),
+      date: new Date(Date.UTC(2020, 2, 15)),
       maxDate: new Date(Date.UTC(2019, 1, 1)),
       minDate: new Date(Date.UTC(2018, 1, 1)),
       month: 2,
     });
 
-    expect(container.querySelector('.disabled')).not.toBeNull();
+    expect(container.querySelector('.isOutsideBounds')).not.toBeNull();
   });
 });


### PR DESCRIPTION
To test:
1. Verify that clicking a day should set the date and close the picker
2. Verify that typing in a date string and pressing Enter should close the picker
3. In the Activity form, verify that typing in a date string and pressing Enter only sends one update request