### PR TITLE
ci: move docker secrets to enviornment variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    environment: test-workflow
     steps:
       - name: Checkout Repo (UI)
         uses: actions/checkout@v3
@@ -36,6 +37,12 @@ jobs:
           docker compose -f docker-compose-test.yml up -d
           docker images
           docker ps -a
+        env:
+          AERIE_USERNAME: '${{secrets.AERIE_USERNAME}}'
+          AERIE_PASSWORD: '${{secrets.AERIE_PASSWORD}}'
+          POSTGRES_DB: '${{secrets.POSTGRES_DB}}'
+          POSTGRES_USER: '${{secrets.POSTGRES_USER}}'
+          POSTGRES_PASSWORD: '${{secrets.POSTGRES_PASSWORD}}'
       - name: Setup Node (UI)
         uses: actions/setup-node@v2
         with:

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -9,10 +9,10 @@ services:
     depends_on: ['postgres']
     environment:
       COMMANDING_DB: aerie_commanding
-      COMMANDING_DB_PASSWORD: aerie
+      COMMANDING_DB_PASSWORD: '${AERIE_PASSWORD}'
       COMMANDING_DB_PORT: 5432
-      COMMANDING_DB_SERVER: postgres
-      COMMANDING_DB_USER: aerie
+      COMMANDING_DB_SERVER: '${POSTGRES_DB}'
+      COMMANDING_DB_USER: '${AERIE_USERNAME}'
       COMMANDING_LOCAL_STORE: /usr/src/app/commanding_file_store
       COMMANDING_SERVER_PORT: 27184
       LOG_FILE: console
@@ -35,10 +35,10 @@ services:
       PORT: 9000
       POSTGRES_AERIE_MERLIN_DB: aerie_merlin
       POSTGRES_AERIE_SCHEDULER_DB: aerie_scheduler
-      POSTGRES_HOST: postgres
-      POSTGRES_PASSWORD: aerie
+      POSTGRES_HOST: '${POSTGRES_DB}'
+      POSTGRES_PASSWORD: '${AERIE_PASSWORD}'
       POSTGRES_PORT: 5432
-      POSTGRES_USER: aerie
+      POSTGRES_USER: '${AERIE_USERNAME}'
     image: 'ghcr.io/nasa-ammos/aerie-gateway:develop'
     ports: ['9000:9000']
     restart: always
@@ -49,10 +49,10 @@ services:
     depends_on: ['postgres']
     environment:
       MERLIN_DB: 'aerie_merlin'
-      MERLIN_DB_PASSWORD: 'aerie'
+      MERLIN_DB_PASSWORD: '${AERIE_PASSWORD}'
       MERLIN_DB_PORT: 5432
-      MERLIN_DB_SERVER: 'postgres'
-      MERLIN_DB_USER: 'aerie'
+      MERLIN_DB_SERVER: '${POSTGRES_DB}'
+      MERLIN_DB_USER: '${AERIE_USERNAME}'
       MERLIN_LOCAL_STORE: /usr/src/app/merlin_file_store
       MERLIN_PORT: 27183
       MERLIN_USE_NEW_CONSTRAINT_PIPELINE: 'true'
@@ -70,10 +70,10 @@ services:
     depends_on: ['postgres']
     environment:
       MERLIN_WORKER_DB: 'aerie_merlin'
-      MERLIN_WORKER_DB_PASSWORD: 'aerie'
+      MERLIN_WORKER_DB_PASSWORD: '${AERIE_PASSWORD}'
       MERLIN_WORKER_DB_PORT: 5432
-      MERLIN_WORKER_DB_SERVER: 'postgres'
-      MERLIN_WORKER_DB_USER: 'aerie'
+      MERLIN_WORKER_DB_SERVER: '${POSTGRES_DB}'
+      MERLIN_WORKER_DB_USER: '${AERIE_USERNAME}'
       MERLIN_WORKER_LOCAL_STORE: /usr/src/app/merlin_file_store
       JAVA_OPTS: >
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
@@ -89,10 +89,10 @@ services:
     depends_on: ['postgres']
     environment:
       MERLIN_WORKER_DB: 'aerie_merlin'
-      MERLIN_WORKER_DB_PASSWORD: 'aerie'
+      MERLIN_WORKER_DB_PASSWORD: '${AERIE_PASSWORD}'
       MERLIN_WORKER_DB_PORT: 5432
-      MERLIN_WORKER_DB_SERVER: 'postgres'
-      MERLIN_WORKER_DB_USER: 'aerie'
+      MERLIN_WORKER_DB_SERVER: '${POSTGRES_DB}'
+      MERLIN_WORKER_DB_USER: '${AERIE_USERNAME}'
       MERLIN_WORKER_LOCAL_STORE: /usr/src/app/merlin_file_store
       JAVA_OPTS: >
         -Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG
@@ -110,10 +110,10 @@ services:
       MERLIN_GRAPHQL_URL: http://hasura:8080/v1/graphql
       MERLIN_LOCAL_STORE: /usr/src/app/merlin_file_store
       SCHEDULER_DB: 'aerie_scheduler'
-      SCHEDULER_DB_PASSWORD: 'aerie'
+      SCHEDULER_DB_PASSWORD: '${AERIE_PASSWORD}'
       SCHEDULER_DB_PORT: 5432
-      SCHEDULER_DB_SERVER: 'postgres'
-      SCHEDULER_DB_USER: 'aerie'
+      SCHEDULER_DB_SERVER: '${POSTGRES_DB}'
+      SCHEDULER_DB_USER: '${AERIE_USERNAME}'
       SCHEDULER_LOCAL_STORE: /usr/src/app/scheduler_file_store
       SCHEDULER_LOGGING: 'true'
       SCHEDULER_OUTPUT_MODE: UpdateInputPlanWithNewActivities
@@ -132,15 +132,15 @@ services:
     container_name: hasura
     depends_on: ['postgres']
     environment:
-      AERIE_COMMANDING_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_commanding
-      AERIE_MERLIN_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_merlin
-      AERIE_SCHEDULER_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_scheduler
-      AERIE_UI_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_ui
+      AERIE_COMMANDING_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@${POSTGRES_DB}:5432/aerie_commanding'
+      AERIE_MERLIN_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@${POSTGRES_DB}:5432/aerie_merlin'
+      AERIE_SCHEDULER_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@${POSTGRES_DB}:5432/aerie_scheduler'
+      AERIE_UI_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@${POSTGRES_DB}:5432/aerie_ui'
       HASURA_GRAPHQL_DEV_MODE: 'true'
       HASURA_GRAPHQL_ENABLE_CONSOLE: 'true'
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
       HASURA_GRAPHQL_LOG_LEVEL: info
-      HASURA_GRAPHQL_METADATA_DATABASE_URL: postgres://aerie:aerie@postgres:5432/aerie_hasura
+      HASURA_GRAPHQL_METADATA_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@${POSTGRES_DB}:5432/aerie_hasura'
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
     image: 'hasura/graphql-engine:v2.8.4.cli-migrations-v3'
     ports: ['8080:8080']
@@ -150,9 +150,11 @@ services:
   postgres:
     container_name: postgres
     environment:
-      POSTGRES_DB: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_USER: postgres
+      AERIE_PASSWORD: '${AERIE_PASSWORD}'
+      AERIE_USERNAME: '${AERIE_USERNAME}'
+      POSTGRES_DB: '${POSTGRES_DB}'
+      POSTGRES_PASSWORD: '${POSTGRES_PASSWORD}'
+      POSTGRES_USER: '${POSTGRES_USER}'
     image: postgres:14.1
     ports: ['5432:5432']
     restart: always


### PR DESCRIPTION
- Replaces secrets in docker-compose-test.yml with environment variables.
- Modifies test.yml to use the Github environment e2e-test to provide these secrets 
- Closes [AERIE-1696](https://jira.jpl.nasa.gov/browse/AERIE-1696)

Merge after https://github.com/NASA-AMMOS/aerie/pull/279 is merged and finished deploying