### PR TITLE
feat: add hover background on datepicker month and year dropdowns

### DIFF
--- a/src/components/ui/DatePicker/DatePicker.svelte
+++ b/src/components/ui/DatePicker/DatePicker.svelte
@@ -299,7 +299,7 @@
   }
 
   .date-picker .date-picker-portal .date-picker-inputs {
-    column-gap: 0.5rem;
+    column-gap: 0.25rem;
     display: grid;
     font-size: 1.01rem;
     font-weight: 300;

--- a/src/components/ui/DatePicker/DatePickerDropdown.svelte
+++ b/src/components/ui/DatePicker/DatePickerDropdown.svelte
@@ -66,9 +66,9 @@
   }
 
   .display-value .value {
+    border-radius: 3px;
     font-weight: bold;
     padding: 0.25rem;
-    border-radius: 3px;
   }
 
   .display-value:hover .value {

--- a/src/components/ui/DatePicker/DatePickerDropdown.svelte
+++ b/src/components/ui/DatePicker/DatePickerDropdown.svelte
@@ -66,7 +66,7 @@
   }
 
   .display-value .value {
-    border-radius: 3px;
+    border-radius: 4px;
     font-weight: bold;
     padding: 0.25rem;
   }

--- a/src/components/ui/DatePicker/DatePickerDropdown.svelte
+++ b/src/components/ui/DatePicker/DatePickerDropdown.svelte
@@ -67,6 +67,12 @@
 
   .display-value .value {
     font-weight: bold;
+    padding: 0.25rem;
+    border-radius: 3px;
+  }
+
+  .display-value:hover .value {
+    background-color: var(--st-gray-15);
   }
 
   .date-picker-dropdown select {


### PR DESCRIPTION
To test:

1. Open a date picker
2. Hover over the displayed month and year
3. Verify that hovering over shows a gray background behind the month or year