### PR TITLE
feat: add plan lock/unlock functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.12.3",
       "license": "MIT",
       "dependencies": {
-        "@nasa-jpl/stellar": "^1.0.5",
+        "@nasa-jpl/stellar": "^1.0.6",
         "@sveltejs/adapter-node": "1.0.0-next.86",
         "@sveltejs/kit": "1.0.0-next.405",
         "ag-grid-community": "^28.1.0",
@@ -305,9 +305,9 @@
       }
     },
     "node_modules/@nasa-jpl/stellar": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@nasa-jpl/stellar/-/stellar-1.0.5.tgz",
-      "integrity": "sha512-/5TE/QtzBYGxsDLIF1N4FKzlJAqPdZ4BcYASn1OrSD93a4He3g7moNNYmn1E+jaZiqQd+3Z1I0HaPMYokEAbDw=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/stellar/-/stellar-1.0.6.tgz",
+      "integrity": "sha512-1y6kNYnOCXgSqMdzP3s1qhUE4bEvQjyNbU1QxPnbzjzwo8y9vgPkEJn6R16/6LlCLI+rXDh4KncKiXAQR5X25g=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5614,9 +5614,9 @@
       }
     },
     "@nasa-jpl/stellar": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@nasa-jpl/stellar/-/stellar-1.0.5.tgz",
-      "integrity": "sha512-/5TE/QtzBYGxsDLIF1N4FKzlJAqPdZ4BcYASn1OrSD93a4He3g7moNNYmn1E+jaZiqQd+3Z1I0HaPMYokEAbDw=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/stellar/-/stellar-1.0.6.tgz",
+      "integrity": "sha512-1y6kNYnOCXgSqMdzP3s1qhUE4bEvQjyNbU1QxPnbzjzwo8y9vgPkEJn6R16/6LlCLI+rXDh4KncKiXAQR5X25g=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "version": "node ./scripts/version.js"
   },
   "dependencies": {
-    "@nasa-jpl/stellar": "^1.0.5",
+    "@nasa-jpl/stellar": "^1.0.6",
     "@sveltejs/adapter-node": "1.0.0-next.86",
     "@sveltejs/kit": "1.0.0-next.405",
     "ag-grid-community": "^28.1.0",

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -6,9 +6,10 @@
   import { select } from 'd3-selection';
   import { createEventDispatcher, onMount, tick } from 'svelte';
   import { activityPoints } from '../../stores/activities';
+  import { timelineLockStatus } from '../../stores/views';
   import effects from '../../utilities/effects';
   import { getDoyTime } from '../../utilities/time';
-  import { searchQuadtreeRect } from '../../utilities/timeline';
+  import { searchQuadtreeRect, TimelineLockStatus } from '../../utilities/timeline';
 
   export let activityColor: string = '';
   export let activityHeight: number = 20;
@@ -57,6 +58,8 @@
   $: overlaySvgSelection = select(overlaySvg);
   $: rowHeight = activityHeight + activityRowPadding;
 
+  $: timelineLocked = $timelineLockStatus === TimelineLockStatus.Locked;
+
   $: if (
     $activityPoints !== undefined &&
     activityColor &&
@@ -79,10 +82,10 @@
   });
 
   /**
-   * @note We only allow dragging parent activities.
+   * @note We only allow dragging parent activities. Disable dragging all activities if timeline is "locked"
    */
   function dragActivityStart(points: ActivityPoint[], offsetX: number): void {
-    if (points.length) {
+    if (!timelineLocked && points.length) {
       const [point] = points;
       if (point.parent_id === null) {
         dragOffsetX = offsetX - xScaleView(point.x);

--- a/src/components/timeline/TimelineLockControl.svelte
+++ b/src/components/timeline/TimelineLockControl.svelte
@@ -25,6 +25,8 @@
     }
   };
 
+  $: lockClassName = $timelineLockStatus === TimelineLockStatus.TemporaryUnlock ? 'temporary-unlock' : '';
+
   onMount(() => {
     document.addEventListener('keydown', onKeydown);
     document.addEventListener('keyup', onKeyup);
@@ -36,10 +38,24 @@
   });
 </script>
 
-<button class="st-button icon" on:click={onClick}>
+<button class={`st-button icon ${lockClassName}`} on:click={onClick}>
   {#if $timelineLockStatus !== TimelineLockStatus.Locked}
     <UnlockIcon />
   {:else}
     <LockIcon />
   {/if}
 </button>
+
+<style>
+  .st-button {
+    border: 1px solid rgba(0, 0, 0, 0.16);
+    color: var(--st-gray-70);
+  }
+
+  .temporary-unlock,
+  .temporary-unlock:hover {
+    background-color: var(--st-blue);
+    border-color: transparent;
+    color: #ffffff;
+  }
+</style>

--- a/src/components/timeline/TimelineLockControl.svelte
+++ b/src/components/timeline/TimelineLockControl.svelte
@@ -4,6 +4,7 @@
   import { onMount } from 'svelte';
   import { timelineLockStatus } from '../../stores/views';
   import { TimelineLockStatus } from '../../utilities/timeline';
+  import { tooltip } from '../../utilities/tooltip';
 
   let onKeydown = e => {
     // If user holds shift while not focused on an input then activate the temporary unlock.
@@ -28,6 +29,7 @@
   };
 
   $: lockClassName = $timelineLockStatus === TimelineLockStatus.TemporaryUnlock ? 'temporary-unlock' : '';
+  const lockTooltipContent = 'Click to unlock timeline, or press and hold the Shift key to temporarily unlock';
 
   onMount(() => {
     document.addEventListener('keydown', onKeydown);
@@ -40,13 +42,15 @@
   });
 </script>
 
-<button class={`st-button icon ${lockClassName}`} on:click={onClick}>
-  {#if $timelineLockStatus !== TimelineLockStatus.Locked}
-    <UnlockIcon />
-  {:else}
+{#if $timelineLockStatus === TimelineLockStatus.Locked}
+  <button class="st-button icon" on:click={onClick} use:tooltip={{ content: lockTooltipContent, placement: 'bottom' }}>
     <LockIcon />
-  {/if}
-</button>
+  </button>
+{:else}
+  <button class={`st-button icon ${lockClassName}`} on:click={onClick}>
+    <UnlockIcon />
+  </button>
+{/if}
 
 <style>
   .st-button {

--- a/src/components/timeline/TimelineLockControl.svelte
+++ b/src/components/timeline/TimelineLockControl.svelte
@@ -60,7 +60,7 @@
 
   .temporary-unlock,
   .temporary-unlock:hover {
-    background-color: var(--st-blue);
+    background-color: #2f80ed;
     border-color: transparent;
     color: #ffffff;
   }

--- a/src/components/timeline/TimelineLockControl.svelte
+++ b/src/components/timeline/TimelineLockControl.svelte
@@ -6,27 +6,27 @@
   import { TimelineLockStatus } from '../../utilities/timeline';
   import { tooltip } from '../../utilities/tooltip';
 
-  let onKeydown = e => {
+  function onKeydown(e) {
     // If user holds shift while not focused on an input then activate the temporary unlock.
     // If an input is focused, we assume they're holding shift to capitalize instead.
     if (e.key === 'Shift' && e.target.tagName !== 'INPUT' && $timelineLockStatus !== TimelineLockStatus.Unlocked) {
       $timelineLockStatus = TimelineLockStatus.TemporaryUnlock;
     }
-  };
+  }
 
-  let onKeyup = e => {
+  function onKeyup(e) {
     if (e.key === 'Shift' && $timelineLockStatus === TimelineLockStatus.TemporaryUnlock) {
       $timelineLockStatus = TimelineLockStatus.Locked;
     }
-  };
+  }
 
-  let onClick = () => {
+  function onClick() {
     if ($timelineLockStatus === TimelineLockStatus.Locked) {
       $timelineLockStatus = TimelineLockStatus.Unlocked;
     } else {
       $timelineLockStatus = TimelineLockStatus.Locked;
     }
-  };
+  }
 
   $: lockClassName = $timelineLockStatus === TimelineLockStatus.TemporaryUnlock ? 'temporary-unlock' : '';
   const lockTooltipContent = 'Click to unlock timeline, or press and hold the Shift key to temporarily unlock';

--- a/src/components/timeline/TimelineLockControl.svelte
+++ b/src/components/timeline/TimelineLockControl.svelte
@@ -48,7 +48,7 @@
 
 <style>
   .st-button {
-    border: 1px solid rgba(0, 0, 0, 0.16);
+    border: 1px solid var(--st-gray-30);
     color: var(--st-gray-70);
   }
 

--- a/src/components/timeline/TimelineLockControl.svelte
+++ b/src/components/timeline/TimelineLockControl.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import LockIcon from '@nasa-jpl/stellar/icons/svg/lock.svg?component';
+  import UnlockIcon from '@nasa-jpl/stellar/icons/svg/unlock.svg?component';
+  import { onMount } from 'svelte';
+  import { timelineLockStatus } from '../../stores/views';
+  import { TimelineLockStatus } from '../../utilities/timeline';
+
+  let onKeydown = e => {
+    if (e.key === 'Shift' && $timelineLockStatus !== TimelineLockStatus.Unlocked) {
+      timelineLockStatus.set(TimelineLockStatus.TemporaryUnlock);
+    }
+  };
+
+  let onKeyup = e => {
+    if (e.key === 'Shift' && $timelineLockStatus === TimelineLockStatus.TemporaryUnlock) {
+      timelineLockStatus.set(TimelineLockStatus.Locked);
+    }
+  };
+
+  let onClick = () => {
+    if ($timelineLockStatus === TimelineLockStatus.Locked) {
+      timelineLockStatus.set(TimelineLockStatus.Unlocked);
+    } else {
+      timelineLockStatus.set(TimelineLockStatus.Locked);
+    }
+  };
+
+  onMount(() => {
+    document.addEventListener('keydown', onKeydown);
+    document.addEventListener('keyup', onKeyup);
+
+    return () => {
+      document.removeEventListener('keydown', onKeydown);
+      document.removeEventListener('keyup', onKeyup);
+    };
+  });
+</script>
+
+<button class="st-button icon" on:click={onClick}>
+  {#if $timelineLockStatus !== TimelineLockStatus.Locked}
+    <UnlockIcon />
+  {:else}
+    <LockIcon />
+  {/if}
+</button>

--- a/src/components/timeline/TimelineLockControl.svelte
+++ b/src/components/timeline/TimelineLockControl.svelte
@@ -6,22 +6,24 @@
   import { TimelineLockStatus } from '../../utilities/timeline';
 
   let onKeydown = e => {
-    if (e.key === 'Shift' && $timelineLockStatus !== TimelineLockStatus.Unlocked) {
-      timelineLockStatus.set(TimelineLockStatus.TemporaryUnlock);
+    // If user holds shift while not focused on an input then activate the temporary unlock.
+    // If an input is focused, we assume they're holding shift to capitalize instead.
+    if (e.key === 'Shift' && e.target.tagName !== 'INPUT' && $timelineLockStatus !== TimelineLockStatus.Unlocked) {
+      $timelineLockStatus = TimelineLockStatus.TemporaryUnlock;
     }
   };
 
   let onKeyup = e => {
     if (e.key === 'Shift' && $timelineLockStatus === TimelineLockStatus.TemporaryUnlock) {
-      timelineLockStatus.set(TimelineLockStatus.Locked);
+      $timelineLockStatus = TimelineLockStatus.Locked;
     }
   };
 
   let onClick = () => {
     if ($timelineLockStatus === TimelineLockStatus.Locked) {
-      timelineLockStatus.set(TimelineLockStatus.Unlocked);
+      $timelineLockStatus = TimelineLockStatus.Unlocked;
     } else {
-      timelineLockStatus.set(TimelineLockStatus.Locked);
+      $timelineLockStatus = TimelineLockStatus.Locked;
     }
   };
 

--- a/src/components/timeline/TimelineLockControl.svelte
+++ b/src/components/timeline/TimelineLockControl.svelte
@@ -6,6 +6,20 @@
   import { TimelineLockStatus } from '../../utilities/timeline';
   import { tooltip } from '../../utilities/tooltip';
 
+  const lockTooltipContent = 'Click to unlock timeline, or press and hold the Shift key to temporarily unlock';
+
+  $: lockClassName = $timelineLockStatus === TimelineLockStatus.TemporaryUnlock ? 'temporary-unlock' : '';
+
+  onMount(() => {
+    document.addEventListener('keydown', onKeydown);
+    document.addEventListener('keyup', onKeyup);
+
+    return () => {
+      document.removeEventListener('keydown', onKeydown);
+      document.removeEventListener('keyup', onKeyup);
+    };
+  });
+
   function onKeydown(e) {
     // If user holds shift while not focused on an input then activate the temporary unlock.
     // If an input is focused, we assume they're holding shift to capitalize instead.
@@ -27,19 +41,6 @@
       $timelineLockStatus = TimelineLockStatus.Locked;
     }
   }
-
-  $: lockClassName = $timelineLockStatus === TimelineLockStatus.TemporaryUnlock ? 'temporary-unlock' : '';
-  const lockTooltipContent = 'Click to unlock timeline, or press and hold the Shift key to temporarily unlock';
-
-  onMount(() => {
-    document.addEventListener('keydown', onKeydown);
-    document.addEventListener('keyup', onKeyup);
-
-    return () => {
-      document.removeEventListener('keydown', onKeydown);
-      document.removeEventListener('keyup', onKeyup);
-    };
-  });
 </script>
 
 {#if $timelineLockStatus === TimelineLockStatus.Locked}

--- a/src/components/timeline/TimelinePanel.svelte
+++ b/src/components/timeline/TimelinePanel.svelte
@@ -3,7 +3,9 @@
 <script lang="ts">
   import GridMenu from '../menus/GridMenu.svelte';
   import Panel from '../ui/Panel.svelte';
+  import PanelHeaderActions from '../ui/PanelHeaderActions.svelte';
   import Timeline from './Timeline.svelte';
+  import TimelineLockControl from './TimelineLockControl.svelte';
 
   export let gridId: number;
   export let timelineId: number;
@@ -12,6 +14,9 @@
 <Panel padBody={false}>
   <svelte:fragment slot="header">
     <GridMenu {gridId} title="Timeline" />
+    <PanelHeaderActions>
+      <TimelineLockControl />
+    </PanelHeaderActions>
   </svelte:fragment>
 
   <svelte:fragment slot="body">

--- a/src/stores/views.ts
+++ b/src/stores/views.ts
@@ -1,6 +1,7 @@
 import { derived, get, writable, type Writable } from 'svelte/store';
 import { getTarget } from '../utilities/generic';
 import { activitiesGrid, constraintsGrid, schedulingGrid, simulationGrid, updateGrid } from '../utilities/grid';
+import { TimelineLockStatus } from '../utilities/timeline';
 
 /* Writeable. */
 
@@ -15,6 +16,8 @@ export const selectedRowId: Writable<number | null> = writable(null);
 export const selectedTimelineId: Writable<number | null> = writable(null);
 
 export const selectedYAxisId: Writable<number | null> = writable(null);
+
+export const timelineLockStatus: Writable<TimelineLockStatus> = writable(TimelineLockStatus.Locked);
 
 /* Derived. */
 

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -1,6 +1,12 @@
 import type { Quadtree, QuadtreeLeaf } from 'd3-quadtree';
 import { scaleLinear, scaleTime, type ScaleLinear, type ScaleTime } from 'd3-scale';
 
+export enum TimelineLockStatus {
+  Locked = 'Locked',
+  Unlocked = 'Unlocked',
+  TemporaryUnlock = 'TemporaryUnlock',
+}
+
 export const CANVAS_PADDING_X = 0;
 export const CANVAS_PADDING_Y = 8;
 


### PR DESCRIPTION
To prevent users from accidentally moving activities, timelines are now locked by default. They can be unlocked by clicking the lock icon, or temporarily unlocked by holding Shift. There was some previous discussion about using Control instead of Shift to activate this functionality. But then I remembered that Control + Click by default brings up the context menu in browsers. So I thought it didn't seem wise to overwrite that functionality without a good reason, so we went with Shift for now.

One thing to note is that this lock control will lock/unlock any/all active timelines. i.e. if you are displaying two timelines at once, clicking the lock icon will unlock both. I think ultimately that might be what we want to happen anyway, but not sure if we think we should make each lock icon paired to the specific timeline instance. It would be harder to split the holding shift functionality, so I figured sticking with a global control probably makes sense for now.

![2022-08-22 15 46 55](https://user-images.githubusercontent.com/888818/186032707-64a27b0e-00e0-4fc7-8d2e-b82d62c356f9.gif)
