### PR TITLE
fix: Prevent deletion of system views

### DIFF
--- a/src/components/activity/ActivityTable.svelte
+++ b/src/components/activity/ActivityTable.svelte
@@ -12,7 +12,7 @@
   type CellRendererParams = {
     deleteActivityDirective: (activity: Activity) => void;
   };
-  type ActivityCellRendererParams = ICellRendererParams & CellRendererParams;
+  type ActivityCellRendererParams = ICellRendererParams<Activity> & CellRendererParams;
 
   const activityActionColumnDef: DataGridColumnDef = {
     cellClass: 'action-cell-container',

--- a/src/components/constraints/Constraints.svelte
+++ b/src/components/constraints/Constraints.svelte
@@ -18,7 +18,7 @@
     deleteConstraint: (constraint: Constraint) => void;
     editConstraint: (constraint: Constraint) => void;
   };
-  type ConstraintsCellRendererParams = ICellRendererParams & CellRendererParams;
+  type ConstraintsCellRendererParams = ICellRendererParams<Constraint> & CellRendererParams;
 
   export let initialPlans: PlanList[] = [];
 

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -21,7 +21,7 @@
   type CellRendererParams = {
     deleteExpansionSequence: (sequence: ExpansionSequence) => void;
   };
-  type ExpansionSequenceCellRendererParams = ICellRendererParams & CellRendererParams;
+  type ExpansionSequenceCellRendererParams = ICellRendererParams<ExpansionSequence> & CellRendererParams;
 
   const columnDefs: DataGridColumnDef[] = [
     {

--- a/src/components/expansion/ExpansionRules.svelte
+++ b/src/components/expansion/ExpansionRules.svelte
@@ -19,7 +19,7 @@
     deleteRule: (rule: ExpansionRule) => void;
     editRule: (rule: ExpansionRule) => void;
   };
-  type ExpansionRuleCellRendererParams = ICellRendererParams & CellRendererParams;
+  type ExpansionRuleCellRendererParams = ICellRendererParams<ExpansionRule> & CellRendererParams;
 
   const columnDefs: DataGridColumnDef[] = [
     {

--- a/src/components/expansion/ExpansionSets.svelte
+++ b/src/components/expansion/ExpansionSets.svelte
@@ -17,7 +17,7 @@
   type CellRendererParams = {
     deleteSet: (sequence: ExpansionSet) => void;
   };
-  type ExpansionSetCellRendererParams = ICellRendererParams & CellRendererParams;
+  type ExpansionSetCellRendererParams = ICellRendererParams<ExpansionSet> & CellRendererParams;
 
   const columnDefs: DataGridColumnDef[] = [
     {

--- a/src/components/scheduling/SchedulingGoals.svelte
+++ b/src/components/scheduling/SchedulingGoals.svelte
@@ -19,7 +19,7 @@
     deleteGoal: (goal: SchedulingGoal) => void;
     editGoal: (goal: SchedulingGoal) => void;
   };
-  type SchedulingGoalsCellRendererParams = ICellRendererParams & CellRendererParams;
+  type SchedulingGoalsCellRendererParams = ICellRendererParams<SchedulingGoal> & CellRendererParams;
 
   const columnDefs: DataGridColumnDef[] = [
     {

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import type { ColDef } from 'ag-grid-community';
+  import type { ColDef, RowNode } from 'ag-grid-community';
   import { createEventDispatcher } from 'svelte';
   import ContextMenu from '../../context-menu/ContextMenu.svelte';
   import ContextMenuHeader from '../../context-menu/ContextMenuHeader.svelte';
@@ -13,6 +13,8 @@
   export let pluralItemDisplayText: string;
   export let selectedItemId: number | null = null;
   export let singleItemDisplayText: string;
+
+  export let isRowSelectable: (node: RowNode<TRowData>) => boolean = undefined;
 
   const dispatch = createEventDispatcher();
 
@@ -54,6 +56,7 @@
   bind:this={dataGrid}
   {columnDefs}
   bind:currentSelectedRowId={selectedItemId}
+  {isRowSelectable}
   rowSelection="multiple"
   rowData={items}
   bind:selectedRowIds={selectedItemIds}

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -23,7 +23,7 @@
   let isFiltered: boolean = false;
   let selectedItemIds: number[] = [];
 
-  $: if (!selectedItemIds.includes(selectedItemId) && selectedItemId !== null) {
+  $: if (!selectedItemIds.includes(selectedItemId) && selectedItemId != null) {
     selectedItemIds = [selectedItemId];
   }
 
@@ -34,7 +34,7 @@
   function onCellContextMenu(event: CustomEvent) {
     const { detail } = event;
     const { data: clickedRow } = detail;
-    if (selectedItemIds.length <= 1) {
+    if (selectedItemIds.length <= 1 && isRowSelectable(detail)) {
       selectedItemId = clickedRow.id;
     }
 
@@ -74,8 +74,10 @@
   <ContextMenuItem on:click={selectAllItems}>
     Select All {isFiltered ? 'Visible ' : ''}{pluralItemDisplayText}
   </ContextMenuItem>
-  <ContextMenuItem on:click={bulkDeleteItems}>
-    Delete {selectedItemIds.length}
-    {selectedItemIds.length > 1 ? pluralItemDisplayText : singleItemDisplayText}
-  </ContextMenuItem>
+  {#if selectedItemIds.length}
+    <ContextMenuItem on:click={bulkDeleteItems}>
+      Delete {selectedItemIds.length}
+      {selectedItemIds.length > 1 ? pluralItemDisplayText : singleItemDisplayText}
+    </ContextMenuItem>
+  {/if}
 </ContextMenu>

--- a/src/components/ui/DataGrid/DataGrid.test.ts
+++ b/src/components/ui/DataGrid/DataGrid.test.ts
@@ -1,0 +1,95 @@
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import DataGrid from './DataGrid.svelte';
+
+const numOfRows = 10;
+const testRowData = [...new Array(numOfRows)].map((_, i) => ({ id: i, name: `test ${i}` }));
+
+describe('DataGrid Component', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('Should render all the rows', async () => {
+    const { container } = render(DataGrid, {
+      columnDefs: [
+        {
+          field: 'name',
+          headerName: 'Name',
+        },
+      ],
+      rowData: testRowData,
+    });
+
+    expect(container.querySelectorAll('.ag-center-cols-clipper .ag-row')).toHaveLength(numOfRows);
+  });
+
+  it('Should highlight the correctly selected rows on initialization', async () => {
+    const { container } = render(DataGrid, {
+      columnDefs: [
+        {
+          field: 'name',
+          headerName: 'Name',
+        },
+      ],
+      rowData: testRowData,
+      rowSelection: 'multiple',
+      selectedRowIds: [1, 2, 3],
+    });
+
+    expect(container.querySelectorAll('.ag-center-cols-clipper .ag-row.ag-row-selected')).toHaveLength(3);
+  });
+
+  it('Should highlight the correctly selected rows through user interaction', async () => {
+    const { container } = render(DataGrid, {
+      columnDefs: [
+        {
+          field: 'name',
+          headerName: 'Name',
+        },
+      ],
+      rowData: testRowData,
+      rowSelection: 'multiple',
+    });
+
+    expect(container.querySelectorAll('.ag-center-cols-clipper .ag-row.ag-row-selected')).toHaveLength(0);
+
+    await fireEvent.click(container.querySelectorAll('.ag-center-cols-clipper .ag-row')[0]);
+
+    expect(container.querySelectorAll('.ag-center-cols-clipper .ag-row.ag-row-selected')).toHaveLength(1);
+
+    await fireEvent.click(container.querySelectorAll('.ag-center-cols-clipper .ag-row')[2], { shiftKey: true });
+
+    expect(container.querySelectorAll('.ag-center-cols-clipper .ag-row.ag-row-selected')).toHaveLength(3);
+  });
+
+  it('Should indicate that the row that was selected last is indicated as the current selected row', async () => {
+    const { container } = render(DataGrid, {
+      columnDefs: [
+        {
+          field: 'name',
+          headerName: 'Name',
+        },
+      ],
+      rowData: testRowData,
+      rowSelection: 'multiple',
+    });
+
+    expect(container.querySelectorAll('.ag-center-cols-clipper .ag-row.ag-row-selected')).toHaveLength(0);
+
+    await fireEvent.click(container.querySelectorAll('.ag-center-cols-clipper .ag-row')[2]);
+    await fireEvent.click(container.querySelectorAll('.ag-center-cols-clipper .ag-row')[0], {
+      bubbles: true,
+      shiftKey: true,
+    });
+
+    expect(container.querySelectorAll('.ag-center-cols-clipper .ag-row.ag-row-selected')).toHaveLength(3);
+
+    // need to wait for the component to fully update
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(
+      container.querySelector('.ag-center-cols-clipper .ag-row.ag-row-selected.ag-current-row-selected'),
+    ).not.toBeNull();
+  });
+});

--- a/src/components/view/ViewsPanel.svelte
+++ b/src/components/view/ViewsPanel.svelte
@@ -16,7 +16,7 @@
     deleteView: (view: View) => void;
     openView: (view: View) => void;
   };
-  type ViewCellRendererParams = ICellRendererParams & CellRendererParams;
+  type ViewCellRendererParams = ICellRendererParams<View> & CellRendererParams;
 
   const columnDefs: DataGridColumnDef[] = [
     {
@@ -34,15 +34,20 @@
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: ViewCellRendererParams) => {
+        const isEditable = params.data.owner !== 'system';
         const actionsDiv = document.createElement('div');
         actionsDiv.className = 'actions-cell';
         new DataGridActions({
           props: {
-            deleteCallback: params.deleteView,
-            deleteTooltip: {
-              content: 'Delete View',
-              placement: 'bottom',
-            },
+            ...(isEditable
+              ? {
+                  deleteCallback: params.deleteView,
+                  deleteTooltip: {
+                    content: 'Delete View',
+                    placement: 'bottom',
+                  },
+                }
+              : {}),
             rowData: params.data,
             viewCallback: params.openView,
             viewTooltip: {
@@ -109,6 +114,7 @@
     {#if $views.length}
       <BulkActionDataGrid
         {columnDefs}
+        isRowSelectable={rowData => rowData.data.owner !== 'system'}
         items={$views}
         pluralItemDisplayText="Views"
         singleItemDisplayText="View"

--- a/src/css/ag-grid-stellar.css
+++ b/src/css/ag-grid-stellar.css
@@ -444,7 +444,7 @@
   font-size: 1rem;
 }
 
-.ag-theme-stellar.ag-selectable-rows .ag-row {
+.ag-theme-stellar .ag-row.ag-selectable-row {
   cursor: pointer;
 }
 
@@ -460,15 +460,15 @@
   background: var(--ag-selected-row-hover-background-color);
 }
 
-.ag-theme-stellar .ag-row.ag-row-selected.ag-first-row-selected::before {
+.ag-theme-stellar .ag-row.ag-row-selected.ag-current-row-selected::before {
   background: var(--ag-selected-row-first-background-color);
 }
 
-.ag-theme-stellar .ag-row.ag-row-selected.ag-first-row-selected.ag-row-hover::before {
+.ag-theme-stellar .ag-row.ag-row-selected.ag-current-row-selected.ag-row-hover::before {
   background: var(--ag-selected-row-first-hover-background-color);
 }
 
-.ag-theme-stellar .ag-row.ag-row-selected.ag-first-row-selected .actions-cell .st-button.icon:hover {
+.ag-theme-stellar .ag-row.ag-row-selected.ag-current-row-selected .actions-cell .st-button.icon:hover {
   background: var(--ag-selected-row-background-color);
 }
 

--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -14,7 +14,7 @@
   type CellRendererParams = {
     deleteCommandDictionary: (dictionary: CommandDictionary) => void;
   };
-  type CommandDictionaryCellRendererParams = ICellRendererParams & CellRendererParams;
+  type CommandDictionaryCellRendererParams = ICellRendererParams<CommandDictionary> & CellRendererParams;
 
   const columnDefs: DataGridColumnDef[] = [
     {

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -20,7 +20,7 @@
   type CellRendererParams = {
     deleteModel: (model: ModelList) => void;
   };
-  type ModelCellRendererParams = ICellRendererParams & CellRendererParams;
+  type ModelCellRendererParams = ICellRendererParams<ModelList> & CellRendererParams;
 
   const columnDefs: DataGridColumnDef[] = [
     { field: 'name', headerName: 'Name', resizable: true, sortable: true },

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -29,7 +29,7 @@
   type CellRendererParams = {
     deletePlan: (plan: Plan) => void;
   };
-  type PlanCellRendererParams = ICellRendererParams & CellRendererParams;
+  type PlanCellRendererParams = ICellRendererParams<Plan> & CellRendererParams;
 
   const columnDefs: DataGridColumnDef[] = [
     { field: 'name', headerName: 'Name', resizable: true, sortable: true },

--- a/src/types/dataGrid.d.ts
+++ b/src/types/dataGrid.d.ts
@@ -7,8 +7,8 @@ interface DataGridRowSelection<TRowData> {
 
 type DataGridRowsSelection<TRowData> = TRowData[];
 
-interface ICellRendererParams {
-  data: TRowData;
+interface ICellRendererParams<T> {
+  data: T;
 }
 
 interface TRowData {


### PR DESCRIPTION
To test:

1. Navigate into a plan
2. Open Views panel
3. Verify that no `trash` icon is visible when hovering over "system" owned views
4. Verify that the "system" owned views are not clickable to select and not selected when selecting all in the context menu