### PR TITLE
fix: only call `isRowSelectable` when defined

### DIFF
--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -34,7 +34,7 @@
   function onCellContextMenu(event: CustomEvent) {
     const { detail } = event;
     const { data: clickedRow } = detail;
-    if (selectedItemIds.length <= 1 && isRowSelectable(detail)) {
+    if (selectedItemIds.length <= 1 && (!isRowSelectable || isRowSelectable(detail))) {
       selectedItemId = clickedRow.id;
     }
 


### PR DESCRIPTION
To test:

1. Verify that opening the context menu for the Views table and Activity table does not result in error in console