### PR TITLE
feat: validate select field on input and dispatch event

### DIFF
--- a/src/components/activity/ActivityFormPanel.svelte
+++ b/src/components/activity/ActivityFormPanel.svelte
@@ -268,7 +268,7 @@
                 <PenIcon />
               </button>
             {:else}
-              <Field field={activityNameField} on:keydown={onUpdateActivityName} on:blur={onUpdateActivityName}>
+              <Field field={activityNameField} on:change={onUpdateActivityName}>
                 <input
                   on:keyup={onActivityNameKeyup}
                   autocomplete="off"

--- a/src/components/form/Field.svelte
+++ b/src/components/form/Field.svelte
@@ -74,14 +74,6 @@
     }
   });
 
-  async function onBlur(event: FocusEvent) {
-    event.preventDefault();
-
-    const { value } = getTarget(event);
-    const valid = await field.validateAndSet(value);
-    dispatch('blur', { valid });
-  }
-
   function onInput(event: InputEvent) {
     const { value } = getTarget(event);
     $field.value = value;
@@ -92,17 +84,6 @@
     $field.value = value;
     const valid = await field.validateAndSet(value);
     dispatch('change', { valid });
-  }
-
-  async function onKeyDown(event: KeyboardEvent) {
-    const { key } = event;
-
-    if (key === 'Enter') {
-      event.preventDefault();
-      const { value } = getTarget(event);
-      const valid = await field.validateAndSet(value);
-      dispatch('keydown', { valid });
-    }
   }
 </script>
 

--- a/src/components/form/Field.svelte
+++ b/src/components/form/Field.svelte
@@ -52,29 +52,25 @@
     select = container.querySelector('select');
 
     if (input && field) {
-      input.addEventListener('blur', onBlur);
       input.addEventListener('input', onInput);
-      input.addEventListener('keydown', onKeyDown);
+      input.addEventListener('change', onChange);
       input.value = $field.value;
     }
 
     if (select && field) {
-      select.addEventListener('blur', onBlur);
-      select.addEventListener('input', onInput);
+      select.addEventListener('change', onChange);
       select.value = $field.value;
     }
   });
 
   onDestroy(() => {
     if (input) {
-      input.removeEventListener('blur', onBlur);
       input.removeEventListener('input', onInput);
-      input.removeEventListener('keydown', onKeyDown);
+      input.removeEventListener('change', onChange);
     }
 
     if (select) {
-      select.removeEventListener('blur', onBlur);
-      select.removeEventListener('input', onInput);
+      select.removeEventListener('change', onChange);
     }
   });
 
@@ -86,11 +82,16 @@
     dispatch('blur', { valid });
   }
 
-  async function onInput(event: InputEvent) {
+  function onInput(event: InputEvent) {
+    const { value } = getTarget(event);
+    $field.value = value;
+  }
+
+  async function onChange(event: InputEvent) {
     const { value } = getTarget(event);
     $field.value = value;
     const valid = await field.validateAndSet(value);
-    dispatch('input', { valid });
+    dispatch('change', { valid });
   }
 
   async function onKeyDown(event: KeyboardEvent) {

--- a/src/components/form/Field.svelte
+++ b/src/components/form/Field.svelte
@@ -86,9 +86,11 @@
     dispatch('blur', { valid });
   }
 
-  function onInput(event: InputEvent) {
+  async function onInput(event: InputEvent) {
     const { value } = getTarget(event);
     $field.value = value;
+    const valid = await field.validateAndSet(value);
+    dispatch('input', { valid });
   }
 
   async function onKeyDown(event: KeyboardEvent) {


### PR DESCRIPTION
Add in validation of select inputs on "input" and dispatch the "input" event.
Closes [AERIE-1936](https://jira.jpl.nasa.gov/browse/AERIE-1936) where the model select was not affecting the "create" plan button until the user blurred out of the select.