### PR TITLE
feat: update editor save button style to reflect presence of unsaved edits

### DIFF
--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -23,6 +23,7 @@
   export let mode: 'create' | 'edit' = 'create';
 
   let constraintDefinition: string = initialConstraintDefinition;
+  let savedConstraintDefinition: string = mode === 'create' ? '' : initialConstraintDefinition;
   let constraintDescription: string = initialConstraintDescription;
   let constraintId: number | null = initialConstraintId;
   let constraintName: string = initialConstraintName;
@@ -35,6 +36,9 @@
 
   $: saveButtonEnabled =
     constraintDefinition !== '' && constraintName !== '' && (constraintModelId !== null || constraintPlanId !== null);
+  $: constraintModified = constraintDefinition !== savedConstraintDefinition;
+  $: saveButtonText = mode === 'edit' && !constraintModified ? 'Saved' : 'Save';
+  $: saveButtonClass = saveButtonEnabled && constraintModified ? 'primary' : 'secondary';
 
   $: if (constraintPlanId !== null) {
     const plan = initialPlans.find(plan => plan.id === constraintPlanId);
@@ -73,6 +77,8 @@
         constraintPlanId,
         constraintSummary,
       );
+
+      savedConstraintDefinition = constraintDefinition;
     }
   }
 </script>
@@ -86,8 +92,8 @@
         <button class="st-button secondary ellipsis" on:click={() => goto(`${base}/constraints`)}>
           {mode === 'create' ? 'Cancel' : 'Close'}
         </button>
-        <button class="st-button secondary ellipsis" disabled={!saveButtonEnabled} on:click={saveConstraint}>
-          Save
+        <button class="st-button {saveButtonClass} ellipsis" disabled={!saveButtonEnabled} on:click={saveConstraint}>
+          {saveButtonText}
         </button>
       </div>
     </svelte:fragment>

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -28,12 +28,16 @@
   let ruleDictionaryId: number | null = initialRuleDictionaryId;
   let ruleId: number | null = initialRuleId;
   let ruleLogic: string = initialRuleLogic;
+  let savedRuleLogic: string = mode === 'create' ? '' : initialRuleLogic;
   let ruleModelId: number | null = initialRuleModelId;
   let ruleUpdatedAt: string | null = initialRuleUpdatedAt;
   let saveButtonEnabled: boolean = false;
 
   $: activityTypeNames.setVariables({ modelId: ruleModelId ?? -1 });
   $: saveButtonEnabled = ruleActivityType !== null && ruleLogic !== '';
+  $: ruleModified = ruleLogic !== savedRuleLogic;
+  $: saveButtonText = mode === 'edit' && !ruleModified ? 'Saved' : 'Save';
+  $: saveButtonClass = ruleModified && saveButtonEnabled ? 'primary' : 'secondary';
 
   function onDidChangeModelContent(event: CustomEvent<{ value: string }>) {
     const { detail } = event;
@@ -64,6 +68,7 @@
       const updated_at = await effects.updateExpansionRule(ruleId, updatedRule);
       if (updated_at !== null) {
         ruleUpdatedAt = updated_at;
+        savedRuleLogic = ruleLogic;
       }
     }
   }
@@ -78,8 +83,8 @@
         <button class="st-button secondary ellipsis" on:click={() => goto(`${base}/expansion/rules`)}>
           {mode === 'create' ? 'Cancel' : 'Close'}
         </button>
-        <button class="st-button secondary ellipsis" disabled={!saveButtonEnabled} on:click={saveRule}>
-          {$savingExpansionRule ? 'Saving...' : 'Save'}
+        <button class="st-button {saveButtonClass} ellipsis" disabled={!saveButtonEnabled} on:click={saveRule}>
+          {$savingExpansionRule ? 'Saving...' : saveButtonText}
         </button>
       </div>
     </svelte:fragment>

--- a/src/components/scheduling/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/SchedulingGoalForm.svelte
@@ -27,6 +27,7 @@
   let goalAuthor: string | null = initialGoalAuthor;
   let goalCreatedDate: string | null = initialGoalCreatedDate;
   let goalDefinition: string = initialGoalDefinition;
+  let savedGoalDefinition: string = mode === 'create' ? '' : initialGoalDefinition;
   let goalDescription: string = initialGoalDescription;
   let goalId: number | null = initialGoalId;
   let goalModelId: number | null = initialGoalModelId;
@@ -37,6 +38,9 @@
   let specId: number | null = initialSpecId;
 
   $: saveButtonEnabled = goalDefinition !== '' && goalModelId !== null && goalName !== '';
+  $: goalModified = goalDefinition !== savedGoalDefinition;
+  $: saveButtonText = mode === 'edit' && !goalModified ? 'Saved' : 'Save';
+  $: saveButtonClass = goalModified && saveButtonEnabled ? 'primary' : 'secondary';
 
   function onDidChangeModelContent(event: CustomEvent<{ value: string }>) {
     const { detail } = event;
@@ -78,6 +82,7 @@
       const updatedGoal = await effects.updateSchedulingGoal(goalId, goal);
       if (updatedGoal) {
         goalModifiedDate = updatedGoal.modified_date;
+        savedGoalDefinition = goalDefinition;
       }
     }
   }
@@ -92,7 +97,9 @@
         <button class="st-button secondary ellipsis" on:click={() => goto(`${base}/scheduling/goals`)}>
           {mode === 'create' ? 'Cancel' : 'Close'}
         </button>
-        <button class="st-button secondary ellipsis" disabled={!saveButtonEnabled} on:click={saveGoal}> Save </button>
+        <button class="st-button {saveButtonClass} ellipsis" disabled={!saveButtonEnabled} on:click={saveGoal}>
+          {saveButtonText}
+        </button>
       </div>
     </svelte:fragment>
 

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -21,6 +21,7 @@
   export let initialSequenceUpdatedAt: string | null = null;
   export let mode: 'create' | 'edit' = 'create';
 
+  let savedSequenceDefinition: string = mode === 'create' ? '' : initialSequenceDefinition;
   let sequenceCreatedAt: string | null = initialSequenceCreatedAt;
   let sequenceDefinition: string = initialSequenceDefinition;
   let sequenceCommandDictionaryId: number | null = initialSequenceCommandDictionaryId;
@@ -32,6 +33,9 @@
   let savingSequence: boolean = false;
 
   $: saveButtonEnabled = sequenceCommandDictionaryId !== null && sequenceDefinition !== '' && sequenceName !== '';
+  $: sequenceModified = sequenceDefinition !== savedSequenceDefinition;
+  $: saveButtonText = mode === 'edit' && !sequenceModified ? 'Saved' : 'Save';
+  $: saveButtonClass = sequenceModified && saveButtonEnabled ? 'primary' : 'secondary';
 
   onMount(() => {
     if (mode === 'edit') {
@@ -84,6 +88,7 @@
           sequenceUpdatedAt = updated_at;
         }
         await getUserSequenceSeqJson();
+        savedSequenceDefinition = sequenceDefinition;
       }
       savingSequence = false;
     }
@@ -101,8 +106,8 @@
         <button class="st-button secondary ellipsis" on:click={() => goto(`${base}/sequencing`)}>
           {mode === 'create' ? 'Cancel' : 'Close'}
         </button>
-        <button class="st-button secondary ellipsis" disabled={!saveButtonEnabled} on:click={saveSequence}>
-          {savingSequence ? 'Saving...' : 'Save'}
+        <button class="st-button {saveButtonClass} ellipsis" disabled={!saveButtonEnabled} on:click={saveSequence}>
+          {savingSequence ? 'Saving...' : saveButtonText}
         </button>
       </div>
     </svelte:fragment>


### PR DESCRIPTION
Updated the constraint, goal, and expansion rule editor pages to notify users when there are unsaved edits. The save button style indicates when there are save-able changes:

![2022-08-31 16 29 36](https://user-images.githubusercontent.com/888818/187802541-ead7d9a0-c757-4d9c-b581-5a7de88ed158.gif)