### PR TITLE
feat: inline forms for activity directive metadata

### DIFF
--- a/src/components/activity/ActivityFormPanel.svelte
+++ b/src/components/activity/ActivityFormPanel.svelte
@@ -20,6 +20,7 @@
   import ActivityMetadataField from '../activityMetadata/ActivityMetadataField.svelte';
   import DatePickerField from '../form/DatePickerField.svelte';
   import Field from '../form/Field.svelte';
+  import Input from '../form/Input.svelte';
   import GridMenu from '../menus/GridMenu.svelte';
   import Parameters from '../parameters/Parameters.svelte';
   import Panel from '../ui/Panel.svelte';
@@ -293,44 +294,59 @@
         <details open style:cursor="pointer">
           <summary>Definition</summary>
           <fieldset>
-            <label for="id">Activity ID</label>
-            <input class="st-input w-100" disabled name="id" value={id} />
+            <Input layout="inline">
+              <label use:tooltip={{ content: 'Activity ID', placement: 'left' }} for="id">Activity ID</label>
+              <input class="st-input w-100" disabled name="id" value={id} />
+            </Input>
           </fieldset>
 
           <fieldset>
-            <label for="activity-type">Activity Type</label>
-            <input class="st-input w-100" disabled name="activity-type" value={type} />
+            <Input layout="inline">
+              <label use:tooltip={{ content: 'Activity Type', placement: 'left' }} for="activity-type"
+                >Activity Type</label
+              >
+              <input class="st-input w-100" disabled name="activity-type" value={type} />
+            </Input>
           </fieldset>
 
           <fieldset>
-            <label for="parent-id">Parent ID</label>
-            <input
-              class="st-input w-100"
-              disabled
-              name="parent-id"
-              value={isChild ? parent_id : 'None (Root Activity)'}
-            />
+            <Input layout="inline">
+              <label use:tooltip={{ content: 'Parent ID', placement: 'left' }} for="parent-id">Parent ID</label>
+              <input
+                class="st-input w-100"
+                disabled
+                name="parent-id"
+                value={isChild ? parent_id : 'None (Root Activity)'}
+              />
+            </Input>
           </fieldset>
 
           <fieldset>
-            <label for="duration">Duration</label>
-            <input class="st-input w-100" disabled name="duration" value={duration ?? 'None'} />
+            <Input layout="inline">
+              <label use:tooltip={{ content: 'Duration', placement: 'left' }} for="duration">Duration</label>
+              <input class="st-input w-100" disabled name="duration" value={duration ?? 'None'} />
+            </Input>
           </fieldset>
 
           <fieldset>
-            <label for="simulationStatus">Simulation Status</label>
-            <input
-              class="st-input w-100"
-              disabled
-              name="simulationStatus"
-              value={unfinished ? 'Unfinished' : duration ? 'Finished' : 'None'}
-            />
+            <Input layout="inline">
+              <label use:tooltip={{ content: 'Simulation Status', placement: 'left' }} for="simulationStatus"
+                >Simulation Status</label
+              >
+              <input
+                class="st-input w-100"
+                disabled
+                name="simulationStatus"
+                value={unfinished ? 'Unfinished' : duration ? 'Finished' : 'None'}
+              />
+            </Input>
           </fieldset>
 
           <DatePickerField
             disabled={isChild}
             field={startTimeField}
             label="Start Time - YYYY-DDDThh:mm:ss"
+            layout="inline"
             name="start-time"
             on:change={onUpdateStartTime}
             on:keydown={onUpdateStartTime}
@@ -338,54 +354,73 @@
 
           {#if duration !== null}
             <fieldset>
-              <label for="endTime">End Time</label>
-              <input class="st-input w-100" disabled name="endTime" value={endTime} />
+              <Input layout="inline">
+                <label use:tooltip={{ content: 'End Time', placement: 'left' }} for="endTime">End Time</label>
+                <input class="st-input w-100" disabled name="endTime" value={endTime} />
+              </Input>
             </fieldset>
           {/if}
 
           <fieldset>
-            <label for="creationTime">Creation Time</label>
-            <input class="st-input w-100" disabled name="creationTime" value={creationTime ?? 'None'} />
+            <Input layout="inline">
+              <label use:tooltip={{ content: 'Creation Time', placement: 'left' }} for="creationTime"
+                >Creation Time</label
+              >
+              <input class="st-input w-100" disabled name="creationTime" value={creationTime ?? 'None'} />
+            </Input>
           </fieldset>
 
           <fieldset>
-            <label for="lastModifiedTime">Last Modified Time</label>
-            <input class="st-input w-100" disabled name="lastModifiedTime" value={lastModifiedTime ?? 'None'} />
+            <Input layout="inline">
+              <label use:tooltip={{ content: 'Last Modified Time', placement: 'left' }} for="lastModifiedTime"
+                >Last Modified Time</label
+              >
+              <input class="st-input w-100" disabled name="lastModifiedTime" value={lastModifiedTime ?? 'None'} />
+            </Input>
           </fieldset>
 
           <fieldset>
-            <label for="sourceSchedulingGoalId">Source Scheduling Goal ID</label>
-            <input
-              class="st-input w-100"
-              disabled
-              name="sourceSchedulingGoalId"
-              value={sourceSchedulingGoalId ?? 'None'}
-            />
+            <Input layout="inline">
+              <label
+                use:tooltip={{ content: 'Source Scheduling Goal ID', placement: 'left' }}
+                for="sourceSchedulingGoalId">Source Scheduling Goal ID</label
+              >
+              <input
+                class="st-input w-100"
+                disabled
+                name="sourceSchedulingGoalId"
+                value={sourceSchedulingGoalId ?? 'None'}
+              />
+            </Input>
           </fieldset>
 
           {#if duration !== null}
             <fieldset>
-              <label for="endTime">End Time</label>
-              <input class="st-input w-100" disabled name="endTime" value={endTime} />
+              <Input layout="inline">
+                <label use:tooltip={{ content: 'End Time', placement: 'left' }} for="endTime">End Time</label>
+                <input class="st-input w-100" disabled name="endTime" value={endTime} />
+              </Input>
             </fieldset>
           {/if}
 
           <fieldset>
-            <label for="activityTags">Tags</label>
-            <!--
+            <Input layout="inline">
+              <label use:tooltip={{ content: 'Tags', placement: 'left' }} for="activityTags">Tags</label>
+              <!--
               Make use of svelte's 'key' here and switch on activity ID in order to clear the
               text input in the tags component which would otherwise remain populated with
               dirty input when a user switches to a new activity.
              -->
-            {#key id}
-              <Tags
-                disabled={isChild}
-                autocompleteValues={planTags}
-                name="activityTags"
-                on:change={onUpdateTags}
-                {tags}
-              />
-            {/key}
+              {#key id}
+                <Tags
+                  disabled={isChild}
+                  autocompleteValues={planTags}
+                  name="activityTags"
+                  on:change={onUpdateTags}
+                  {tags}
+                />
+              {/key}
+            </Input>
           </fieldset>
         </details>
       </div>
@@ -458,31 +493,42 @@
         <details open style:cursor="pointer">
           <summary>Sequencing</summary>
 
-          <div class="mt-2 mb-3">
-            <label for="simulationDatasetId">Simulation Dataset ID</label>
-            <input class="st-input w-100" disabled name="simulationDatasetId" value={$simulationDatasetId ?? 'None'} />
+          <div class="p-2">
+            <Input layout="inline">
+              <label use:tooltip={{ content: 'Simulation Dataset ID', placement: 'left' }} for="simulationDatasetId"
+                >Simulation Dataset ID</label
+              >
+              <input
+                class="st-input w-100"
+                disabled
+                name="simulationDatasetId"
+                value={$simulationDatasetId ?? 'None'}
+              />
+            </Input>
           </div>
 
-          <div class="mt-2">
-            <label for="expansionSet">Sequence ID</label>
-            <select
-              bind:value={seq_id}
-              class="st-select w-100"
-              name="sequences"
-              disabled={!$filteredExpansionSequences.length}
-              on:change={updateExpansionSequenceToActivity}
-            >
-              {#if !$filteredExpansionSequences.length}
-                <option value={null}>No Sequences for Simulation Dataset {$simulationDatasetId ?? ''}</option>
-              {:else}
-                <option value={null} />
-                {#each $filteredExpansionSequences as sequence}
-                  <option value={sequence.seq_id}>
-                    {sequence.seq_id}
-                  </option>
-                {/each}
-              {/if}
-            </select>
+          <div class="p-2">
+            <Input layout="inline">
+              <label use:tooltip={{ content: 'Sequence ID', placement: 'left' }} for="expansionSet">Sequence ID</label>
+              <select
+                bind:value={seq_id}
+                class="st-select w-100"
+                name="sequences"
+                disabled={!$filteredExpansionSequences.length}
+                on:change={updateExpansionSequenceToActivity}
+              >
+                {#if !$filteredExpansionSequences.length}
+                  <option value={null}>No Sequences for Simulation Dataset {$simulationDatasetId ?? ''}</option>
+                {:else}
+                  <option value={null} />
+                  {#each $filteredExpansionSequences as sequence}
+                    <option value={sequence.seq_id}>
+                      {sequence.seq_id}
+                    </option>
+                  {/each}
+                {/if}
+              </select>
+            </Input>
           </div>
         </details>
       </fieldset>

--- a/src/components/activity/ActivityFormPanel.svelte
+++ b/src/components/activity/ActivityFormPanel.svelte
@@ -302,8 +302,12 @@
 
           <fieldset>
             <Input layout="inline">
-              <label use:tooltip={{ content: 'Activity Type', placement: 'left' }} for="activity-type"
-                >Activity Type</label
+              <label
+                use:tooltip={{
+                  content: 'Activity Type',
+                  placement: 'left',
+                }}
+                for="activity-type">Activity Type</label
               >
               <input class="st-input w-100" disabled name="activity-type" value={type} />
             </Input>
@@ -330,8 +334,12 @@
 
           <fieldset>
             <Input layout="inline">
-              <label use:tooltip={{ content: 'Simulation Status', placement: 'left' }} for="simulationStatus"
-                >Simulation Status</label
+              <label
+                use:tooltip={{
+                  content: 'Simulation Status',
+                  placement: 'left',
+                }}
+                for="simulationStatus">Simulation Status</label
               >
               <input
                 class="st-input w-100"
@@ -363,8 +371,12 @@
 
           <fieldset>
             <Input layout="inline">
-              <label use:tooltip={{ content: 'Creation Time', placement: 'left' }} for="creationTime"
-                >Creation Time</label
+              <label
+                use:tooltip={{
+                  content: 'Creation Time',
+                  placement: 'left',
+                }}
+                for="creationTime">Creation Time</label
               >
               <input class="st-input w-100" disabled name="creationTime" value={creationTime ?? 'None'} />
             </Input>
@@ -372,8 +384,12 @@
 
           <fieldset>
             <Input layout="inline">
-              <label use:tooltip={{ content: 'Last Modified Time', placement: 'left' }} for="lastModifiedTime"
-                >Last Modified Time</label
+              <label
+                use:tooltip={{
+                  content: 'Last Modified Time',
+                  placement: 'left',
+                }}
+                for="lastModifiedTime">Last Modified Time</label
               >
               <input class="st-input w-100" disabled name="lastModifiedTime" value={lastModifiedTime ?? 'None'} />
             </Input>
@@ -495,8 +511,12 @@
 
           <div class="p-2">
             <Input layout="inline">
-              <label use:tooltip={{ content: 'Simulation Dataset ID', placement: 'left' }} for="simulationDatasetId"
-                >Simulation Dataset ID</label
+              <label
+                use:tooltip={{
+                  content: 'Simulation Dataset ID',
+                  placement: 'left',
+                }}
+                for="simulationDatasetId">Simulation Dataset ID</label
               >
               <input
                 class="st-input w-100"

--- a/src/components/activity/ActivityFormPanel.svelte
+++ b/src/components/activity/ActivityFormPanel.svelte
@@ -257,11 +257,7 @@
     {#if $selectedActivity}
       <div class="activity-header">
         {#if activityName}
-          <div
-            class={classNames('activity-header-title', {
-              'activity-header-title--editing': editingActivityName,
-            })}
-          >
+          <div class={classNames('activity-header-title', { 'activity-header-title--editing': editingActivityName })}>
             {#if !editingActivityName}
               <button class="icon st-button activity-header-title-edit-button" on:click={editActivityName}>
                 <div class="activity-header-title-value st-typography-medium">
@@ -295,20 +291,16 @@
           <summary>Definition</summary>
           <fieldset>
             <Input layout="inline">
-              <label use:tooltip={{ content: 'Activity ID', placement: 'left' }} for="id">Activity ID</label>
+              <label use:tooltip={{ content: 'Activity ID', placement: 'left' }} for="id"> Activity ID </label>
               <input class="st-input w-100" disabled name="id" value={id} />
             </Input>
           </fieldset>
 
           <fieldset>
             <Input layout="inline">
-              <label
-                use:tooltip={{
-                  content: 'Activity Type',
-                  placement: 'left',
-                }}
-                for="activity-type">Activity Type</label
-              >
+              <label use:tooltip={{ content: 'Activity Type', placement: 'left' }} for="activity-type">
+                Activity Type
+              </label>
               <input class="st-input w-100" disabled name="activity-type" value={type} />
             </Input>
           </fieldset>
@@ -334,13 +326,9 @@
 
           <fieldset>
             <Input layout="inline">
-              <label
-                use:tooltip={{
-                  content: 'Simulation Status',
-                  placement: 'left',
-                }}
-                for="simulationStatus">Simulation Status</label
-              >
+              <label use:tooltip={{ content: 'Simulation Status', placement: 'left' }} for="simulationStatus">
+                Simulation Status
+              </label>
               <input
                 class="st-input w-100"
                 disabled
@@ -371,26 +359,18 @@
 
           <fieldset>
             <Input layout="inline">
-              <label
-                use:tooltip={{
-                  content: 'Creation Time',
-                  placement: 'left',
-                }}
-                for="creationTime">Creation Time</label
-              >
+              <label use:tooltip={{ content: 'Creation Time', placement: 'left' }} for="creationTime">
+                Creation Time
+              </label>
               <input class="st-input w-100" disabled name="creationTime" value={creationTime ?? 'None'} />
             </Input>
           </fieldset>
 
           <fieldset>
             <Input layout="inline">
-              <label
-                use:tooltip={{
-                  content: 'Last Modified Time',
-                  placement: 'left',
-                }}
-                for="lastModifiedTime">Last Modified Time</label
-              >
+              <label use:tooltip={{ content: 'Last Modified Time', placement: 'left' }} for="lastModifiedTime">
+                Last Modified Time
+              </label>
               <input class="st-input w-100" disabled name="lastModifiedTime" value={lastModifiedTime ?? 'None'} />
             </Input>
           </fieldset>
@@ -399,8 +379,10 @@
             <Input layout="inline">
               <label
                 use:tooltip={{ content: 'Source Scheduling Goal ID', placement: 'left' }}
-                for="sourceSchedulingGoalId">Source Scheduling Goal ID</label
+                for="sourceSchedulingGoalId"
               >
+                Source Scheduling Goal ID
+              </label>
               <input
                 class="st-input w-100"
                 disabled
@@ -511,13 +493,9 @@
 
           <div class="p-2">
             <Input layout="inline">
-              <label
-                use:tooltip={{
-                  content: 'Simulation Dataset ID',
-                  placement: 'left',
-                }}
-                for="simulationDatasetId">Simulation Dataset ID</label
-              >
+              <label use:tooltip={{ content: 'Simulation Dataset ID', placement: 'left' }} for="simulationDatasetId">
+                Simulation Dataset ID
+              </label>
               <input
                 class="st-input w-100"
                 disabled

--- a/src/components/form/DatePickerField.svelte
+++ b/src/components/form/DatePickerField.svelte
@@ -2,13 +2,16 @@
 
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import { tooltip } from '../../utilities/tooltip';
   import DatePicker from '../ui/DatePicker/DatePicker.svelte';
   import FieldError from './FieldError.svelte';
+  import Input from './Input.svelte';
 
   export let disabled: boolean = false;
   export let field: FieldStore<any>;
   export let name: string = '';
   export let label: string = '';
+  export let layout: 'inline' | 'stacked' | null = 'stacked';
 
   const dispatch = createEventDispatcher();
 
@@ -19,8 +22,20 @@
   }
 </script>
 
-<fieldset>
-  <label class:error={$field.invalid} for={name}>{label}</label>
-  <DatePicker dateString={$field.value} {disabled} hasError={$field.invalid} {name} on:change={onChange} />
-  <FieldError {field} />
+<fieldset class="date-picker-field">
+  <Input {layout}>
+    {#if layout === 'inline'}
+      <label use:tooltip={{ content: label, placement: 'left' }} class:error={$field.invalid} for={name}>{label}</label>
+    {:else}
+      <label class:error={$field.invalid} for={name}>{label}</label>
+    {/if}
+    <DatePicker dateString={$field.value} {disabled} hasError={$field.invalid} {name} on:change={onChange} />
+    <FieldError {field} />
+  </Input>
 </fieldset>
+
+<style>
+  .date-picker-field :global(.input) {
+    position: inherit;
+  }
+</style>

--- a/src/components/form/Input.svelte
+++ b/src/components/form/Input.svelte
@@ -2,6 +2,9 @@
 
 <script lang="ts">
   import { onDestroy, onMount } from 'svelte';
+  import { classNames } from '../../utilities/generic';
+
+  export let layout: 'inline' | 'stacked' | null = 'stacked';
 
   let container: HTMLDivElement;
   let input: HTMLInputElement | null;
@@ -24,6 +27,11 @@
     input.style.paddingRight = `${padLeft + right.clientWidth + padRight}px`;
     setChildrenStyles([right]);
   }
+
+  $: inputClasses = classNames('input', {
+    'input-inline': layout === 'inline',
+    'input-stacked': layout === 'stacked',
+  });
 
   onMount(() => {
     input = container.querySelector('input');
@@ -73,7 +81,7 @@
   }
 </script>
 
-<div bind:this={container} class="input">
+<div bind:this={container} class={inputClasses}>
   {#if $$slots.left}
     <div bind:this={left} class="left">
       <slot name="left" />
@@ -100,5 +108,21 @@
   .input > .left,
   .input > .right {
     position: absolute;
+  }
+
+  .input-inline {
+    display: grid;
+    gap: 8px;
+    grid-template-columns: 40% auto;
+  }
+
+  .input-inline :global(label) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .input-stacked {
+    display: inherit;
   }
 </style>


### PR DESCRIPTION
Use inline layout for activity directive metadata fields.

Changes:
- Add `layout` prop to Input component which accepts `stacked` or `inline`
- Wrap activity metadata description and simulation fields in `Input` components laid out in `inline` mode
- Add various tooltips for inlined Input fields to handle cases where the label is truncated
- Wrap `DatePickerField` contents in an `Input` and give `DatePickerField` a `layout` prop which is passed into the `Input`
<img width="350" alt="image" src="https://user-images.githubusercontent.com/4419607/187833040-95692122-3570-408d-bc29-e7c1e0e9ecbc.png">
