### PR TITLE
build: upgrade deps to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@nasa-jpl/stellar": "^1.0.8",
         "@sveltejs/adapter-node": "1.0.0-next.88",
-        "@sveltejs/kit": "1.0.0-next.449",
+        "@sveltejs/kit": "1.0.0-next.463",
         "ag-grid-community": "^28.1.1",
         "bootstrap": "^5.2.0",
         "bootstrap-icons": "^1.9.1",
@@ -72,7 +72,7 @@
         "tslib": "^2.4.0",
         "typescript": "^4.8.2",
         "unique-names-generator": "^4.7.1",
-        "vite": "^3.0.9",
+        "vite": "^3.1.0-beta.1",
         "vitest": "^0.22.1"
       },
       "engines": {
@@ -424,12 +424,12 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.0.0-next.449",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.449.tgz",
-      "integrity": "sha512-JcizmZHuSxj1utgKLZwm1smIVhfHCfUSvg3BwvWoOkHJudiJNkzbbZulZ2wnOR22b3LzvPHB84u08vfnhWkVcw==",
+      "version": "1.0.0-next.463",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.463.tgz",
+      "integrity": "sha512-r08t2FTbWC/eem1j70HcdsRPj+L0X/aXiTqQkyUgn5/3yBxxx4jXQqlkzBtYsjxZ4x+94yWQxYQTYXD6PxWM5g==",
       "hasInstallScript": true,
       "dependencies": {
-        "@sveltejs/vite-plugin-svelte": "^1.0.1",
+        "@sveltejs/vite-plugin-svelte": "^1.0.4",
         "cookie": "^0.5.0",
         "devalue": "^3.1.2",
         "kleur": "^4.1.4",
@@ -450,13 +450,13 @@
       },
       "peerDependencies": {
         "svelte": "^3.44.0",
-        "vite": "^3.0.0"
+        "vite": "^3.1.0-beta.1"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.3.tgz",
-      "integrity": "sha512-0Qu51m2W9RBlxWPp8i31KJpnqmjWMOne8vAzgmOX6ZM9uX+/RAv6BNhEMcNoP5MsyLjyW1ZTCiJoaZZ5EeqpFg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.4.tgz",
+      "integrity": "sha512-UZco2fdj0OVuRWC0SUJjEOftITc2IeHLFJNp00ym9MuQ9dShnlO4P29G8KUxRlcS7kSpzHuko6eCR9MOALj7lQ==",
       "dependencies": {
         "@rollup/pluginutils": "^4.2.1",
         "debug": "^4.3.4",
@@ -471,7 +471,7 @@
       "peerDependencies": {
         "diff-match-patch": "^1.0.5",
         "svelte": "^3.44.0",
-        "vite": "^3.0.0"
+        "vite": "^3.0.0 || ^3.1.0-beta.1"
       },
       "peerDependenciesMeta": {
         "diff-match-patch": {
@@ -1933,9 +1933,9 @@
       "dev": true
     },
     "node_modules/entities": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
-      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
       "dev": true,
       "engines": {
         "node": ">=0.12"
@@ -4439,9 +4439,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.77.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
-      "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+      "version": "2.78.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -5349,14 +5349,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.9.tgz",
-      "integrity": "sha512-waYABTM+G6DBTCpYAxvevpG50UOlZuynR0ckTK5PawNVt7ebX6X7wNXHaGIO6wYYFXSM7/WcuFuO2QzhBB6aMw==",
+      "version": "3.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.0-beta.1.tgz",
+      "integrity": "sha512-JGEnWSC0hfarcduTCQr6wnRjPLbT62iLCK59HBJXYt9oyWSUMtrvcnDqzvLFC+lHV6KGFQkmWlZucyIQmgUnLA==",
       "dependencies": {
         "esbuild": "^0.14.47",
         "postcss": "^8.4.16",
         "resolve": "^1.22.1",
-        "rollup": ">=2.75.6 <2.77.0 || ~2.77.0"
+        "rollup": "~2.78.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -5434,6 +5434,62 @@
           "optional": true
         },
         "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/rollup": {
+      "version": "2.77.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
+      "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.9.tgz",
+      "integrity": "sha512-waYABTM+G6DBTCpYAxvevpG50UOlZuynR0ckTK5PawNVt7ebX6X7wNXHaGIO6wYYFXSM7/WcuFuO2QzhBB6aMw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.14.47",
+        "postcss": "^8.4.16",
+        "resolve": "^1.22.1",
+        "rollup": ">=2.75.6 <2.77.0 || ~2.77.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "less": "*",
+        "sass": "*",
+        "stylus": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "terser": {
           "optional": true
         }
       }
@@ -5878,11 +5934,11 @@
       }
     },
     "@sveltejs/kit": {
-      "version": "1.0.0-next.449",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.449.tgz",
-      "integrity": "sha512-JcizmZHuSxj1utgKLZwm1smIVhfHCfUSvg3BwvWoOkHJudiJNkzbbZulZ2wnOR22b3LzvPHB84u08vfnhWkVcw==",
+      "version": "1.0.0-next.463",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.463.tgz",
+      "integrity": "sha512-r08t2FTbWC/eem1j70HcdsRPj+L0X/aXiTqQkyUgn5/3yBxxx4jXQqlkzBtYsjxZ4x+94yWQxYQTYXD6PxWM5g==",
       "requires": {
-        "@sveltejs/vite-plugin-svelte": "^1.0.1",
+        "@sveltejs/vite-plugin-svelte": "^1.0.4",
         "cookie": "^0.5.0",
         "devalue": "^3.1.2",
         "kleur": "^4.1.4",
@@ -5897,9 +5953,9 @@
       }
     },
     "@sveltejs/vite-plugin-svelte": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.3.tgz",
-      "integrity": "sha512-0Qu51m2W9RBlxWPp8i31KJpnqmjWMOne8vAzgmOX6ZM9uX+/RAv6BNhEMcNoP5MsyLjyW1ZTCiJoaZZ5EeqpFg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.4.tgz",
+      "integrity": "sha512-UZco2fdj0OVuRWC0SUJjEOftITc2IeHLFJNp00ym9MuQ9dShnlO4P29G8KUxRlcS7kSpzHuko6eCR9MOALj7lQ==",
       "requires": {
         "@rollup/pluginutils": "^4.2.1",
         "debug": "^4.3.4",
@@ -6974,9 +7030,9 @@
       "dev": true
     },
     "entities": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
-      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
       "dev": true
     },
     "error-ex": {
@@ -8698,9 +8754,9 @@
       }
     },
     "rollup": {
-      "version": "2.77.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
-      "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+      "version": "2.78.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -9357,15 +9413,15 @@
       }
     },
     "vite": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.9.tgz",
-      "integrity": "sha512-waYABTM+G6DBTCpYAxvevpG50UOlZuynR0ckTK5PawNVt7ebX6X7wNXHaGIO6wYYFXSM7/WcuFuO2QzhBB6aMw==",
+      "version": "3.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.0-beta.1.tgz",
+      "integrity": "sha512-JGEnWSC0hfarcduTCQr6wnRjPLbT62iLCK59HBJXYt9oyWSUMtrvcnDqzvLFC+lHV6KGFQkmWlZucyIQmgUnLA==",
       "requires": {
         "esbuild": "^0.14.47",
         "fsevents": "~2.3.2",
         "postcss": "^8.4.16",
         "resolve": "^1.22.1",
-        "rollup": ">=2.75.6 <2.77.0 || ~2.77.0"
+        "rollup": "~2.78.0"
       }
     },
     "vitest": {
@@ -9383,6 +9439,30 @@
         "tinypool": "^0.2.4",
         "tinyspy": "^1.0.2",
         "vite": "^2.9.12 || ^3.0.0-0"
+      },
+      "dependencies": {
+        "rollup": {
+          "version": "2.77.3",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.3.tgz",
+          "integrity": "sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==",
+          "dev": true,
+          "requires": {
+            "fsevents": "~2.3.2"
+          }
+        },
+        "vite": {
+          "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.9.tgz",
+          "integrity": "sha512-waYABTM+G6DBTCpYAxvevpG50UOlZuynR0ckTK5PawNVt7ebX6X7wNXHaGIO6wYYFXSM7/WcuFuO2QzhBB6aMw==",
+          "dev": true,
+          "requires": {
+            "esbuild": "^0.14.47",
+            "fsevents": "~2.3.2",
+            "postcss": "^8.4.16",
+            "resolve": "^1.22.1",
+            "rollup": ">=2.75.6 <2.77.0 || ~2.77.0"
+          }
+        }
       }
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@nasa-jpl/stellar": "^1.0.8",
     "@sveltejs/adapter-node": "1.0.0-next.88",
-    "@sveltejs/kit": "1.0.0-next.449",
+    "@sveltejs/kit": "1.0.0-next.463",
     "ag-grid-community": "^28.1.1",
     "bootstrap": "^5.2.0",
     "bootstrap-icons": "^1.9.1",
@@ -99,7 +99,7 @@
     "tslib": "^2.4.0",
     "typescript": "^4.8.2",
     "unique-names-generator": "^4.7.1",
-    "vite": "^3.0.9",
+    "vite": "^3.1.0-beta.1",
     "vitest": "^0.22.1"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ const config: PlaywrightTestConfig = {
     ['json', { outputFile: 'e2e-test-results/json-results.json' }],
     ['junit', { outputFile: 'e2e-test-results/junit-results.xml' }],
   ],
-  retries: 0,
+  retries: 2,
   testDir: './e2e-tests',
   use: {
     baseURL: 'http://localhost:3000',

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,20 +1,8 @@
 /* eslint @typescript-eslint/no-unused-vars: 0 */
 
-/// <reference types="@sveltejs/kit" />
-
 declare namespace App {
   interface Locals {
     user: User | null;
-  }
-
-  interface PublicEnv {
-    AUTH_TYPE: string;
-    GATEWAY_CLIENT_URL: string;
-    GATEWAY_SERVER_URL: string;
-    HASURA_CLIENT_URL: string;
-    HASURA_SERVER_URL: string;
-    HASURA_WEB_SOCKET_URL: string;
-    ORIGIN: string;
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,12 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "baseUrl": ".",
     "checkJs": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "importsNotUsedAsValues": "error",
-    "isolatedModules": true,
-    "lib": ["es2020", "dom"],
-    "moduleResolution": "node",
-    "module": "es2020",
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "sourceMap": true,
-    "target": "es2020"
+    "sourceMap": true
   },
-  "extends": "./.svelte-kit/tsconfig.json",
-  "include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.ts", "src/**/*.svelte"]
+  "extends": "./.svelte-kit/tsconfig.json"
 }


### PR DESCRIPTION
- Remove obsolete top-level `tsconfig.json` config props since the `.svelte-kit/tsconfig.json` handles them
- Remove obsolete `app.d.ts` types
- Retry Playwright tests twice if we have failures