### PR TITLE
feat: add filters on all tables

### DIFF
--- a/src/components/constraints/Constraints.svelte
+++ b/src/components/constraints/Constraints.svelte
@@ -25,16 +25,33 @@
   const columnDefs: DataGridColumnDef[] = [
     {
       field: 'id',
+      filter: 'number',
       headerName: 'ID',
       resizable: true,
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      width: 40,
+      width: 60,
     },
-    { field: 'name', filter: 'agTextColumnFilter', headerName: 'Name', resizable: true, sortable: true },
-    { field: 'model_id', headerName: 'Model ID', sortable: true, width: 120 },
-    { field: 'plan_id', headerName: 'Plan ID', sortable: true, width: 110 },
+    { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
+    {
+      field: 'model_id',
+      filter: 'number',
+      headerName: 'Model ID',
+      sortable: true,
+      suppressAutoSize: true,
+      suppressSizeToFit: true,
+      width: 95,
+    },
+    {
+      field: 'plan_id',
+      filter: 'number',
+      headerName: 'Plan ID',
+      sortable: true,
+      suppressAutoSize: true,
+      suppressSizeToFit: true,
+      width: 80,
+    },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: ConstraintsCellRendererParams) => {

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -26,14 +26,22 @@
   const columnDefs: DataGridColumnDef[] = [
     {
       field: 'simulation_dataset_id',
+      filter: 'number',
       headerName: 'Simulation ID',
       resizable: true,
       sortable: true,
-      width: 100,
     },
-    { field: 'seq_id', headerName: 'Seq ID', resizable: true, sortable: true, suppressSizeToFit: true, width: 70 },
-    { field: 'created_at', headerName: 'Created At', resizable: true, sortable: true },
-    { field: 'updated_at', headerName: 'Updated At', resizable: true, sortable: true },
+    {
+      field: 'seq_id',
+      filter: 'text',
+      headerName: 'Seq ID',
+      resizable: true,
+      sortable: true,
+      suppressSizeToFit: true,
+      width: 85,
+    },
+    { field: 'created_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
+    { field: 'updated_at', filter: 'text', headerName: 'Updated At', resizable: true, sortable: true },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: ExpansionSequenceCellRendererParams) => {

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -156,7 +156,7 @@
                   <div class="mt-2">
                     {#if $filteredExpansionSequences.length}
                       <DataGrid
-                        idKey="seq_id"
+                        getRowId={rowData => rowData.seq_id}
                         {columnDefs}
                         rowData={$filteredExpansionSequences}
                         rowSelection="single"

--- a/src/components/expansion/ExpansionRules.svelte
+++ b/src/components/expansion/ExpansionRules.svelte
@@ -24,23 +24,25 @@
   const columnDefs: DataGridColumnDef[] = [
     {
       field: 'id',
+      filter: 'number',
       headerName: 'Rule ID',
       resizable: true,
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      width: 65,
+      width: 80,
     },
-    { field: 'activity_type', headerName: 'Activity Type', resizable: true, sortable: true },
+    { field: 'activity_type', filter: 'text', headerName: 'Activity Type', resizable: true, sortable: true },
     {
       field: 'authoring_command_dict_id',
+      filter: 'number',
       headerName: 'Command Dictionary ID',
       resizable: true,
       sortable: true,
     },
-    { field: 'authoring_mission_model_id', headerName: 'Model ID', sortable: true },
-    { field: 'created_at', headerName: 'Created At', resizable: true, sortable: true },
-    { field: 'updated_at', headerName: 'Updated At', resizable: true, sortable: true },
+    { field: 'authoring_mission_model_id', filter: 'number', headerName: 'Model ID', sortable: true },
+    { field: 'created_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
+    { field: 'updated_at', filter: 'text', headerName: 'Updated At', resizable: true, sortable: true },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: ExpansionRuleCellRendererParams) => {

--- a/src/components/expansion/ExpansionSets.svelte
+++ b/src/components/expansion/ExpansionSets.svelte
@@ -22,6 +22,7 @@
   const columnDefs: DataGridColumnDef[] = [
     {
       field: 'id',
+      filter: 'number',
       headerName: 'Set ID',
       resizable: true,
       sortable: true,
@@ -29,9 +30,15 @@
       suppressSizeToFit: true,
       width: 100,
     },
-    { field: 'command_dict_id', headerName: 'Command Dictionary ID', resizable: true, sortable: true },
-    { field: 'mission_model_id', headerName: 'Model ID', resizable: true, sortable: true },
-    { field: 'created_at', headerName: 'Created At', resizable: true, sortable: true },
+    {
+      field: 'command_dict_id',
+      filter: 'number',
+      headerName: 'Command Dictionary ID',
+      resizable: true,
+      sortable: true,
+    },
+    { field: 'mission_model_id', filter: 'number', headerName: 'Model ID', resizable: true, sortable: true },
+    { field: 'created_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: ExpansionSetCellRendererParams) => {
@@ -147,14 +154,15 @@
             columnDefs={[
               {
                 field: 'id',
+                filter: 'number',
                 headerName: 'Rule ID',
                 resizable: true,
                 sortable: true,
                 suppressAutoSize: true,
                 suppressSizeToFit: true,
-                width: 65,
+                width: 80,
               },
-              { field: 'activity_type', headerName: 'Activity Type', sortable: true },
+              { field: 'activity_type', filter: 'text', headerName: 'Activity Type', sortable: true },
             ]}
             rowData={selectedExpansionSet?.expansion_rules}
             rowSelection="single"

--- a/src/components/scheduling/SchedulingGoals.svelte
+++ b/src/components/scheduling/SchedulingGoals.svelte
@@ -24,6 +24,7 @@
   const columnDefs: DataGridColumnDef[] = [
     {
       field: 'id',
+      filter: 'number',
       headerName: 'Goal ID',
       resizable: true,
       sortable: true,
@@ -31,8 +32,8 @@
       suppressSizeToFit: true,
       width: 100,
     },
-    { field: 'name', headerName: 'Name', resizable: true, sortable: true },
-    { field: 'model_id', headerName: 'Model ID', sortable: true, width: 120 },
+    { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
+    { field: 'model_id', filter: 'number', headerName: 'Model ID', sortable: true, width: 120 },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: SchedulingGoalsCellRendererParams) => {

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -24,17 +24,24 @@
   const columnDefs: DataGridColumnDef[] = [
     {
       field: 'id',
+      filter: 'text',
       headerName: 'ID',
       resizable: true,
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      width: 100,
+      width: 60,
     },
-    { field: 'name', headerName: 'Name', resizable: true, sortable: true },
-    { field: 'authoring_command_dict_id', headerName: 'Command Dictionary ID', resizable: true, sortable: true },
-    { field: 'created_at', headerName: 'Created At', resizable: true, sortable: true },
-    { field: 'updated_at', headerName: 'Created At', resizable: true, sortable: true },
+    { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
+    {
+      field: 'authoring_command_dict_id',
+      filter: 'number',
+      headerName: 'Command Dictionary ID',
+      resizable: true,
+      sortable: true,
+    },
+    { field: 'created_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
+    { field: 'updated_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: SequencesCellRendererParams) => {

--- a/src/components/view/ViewsPanel.svelte
+++ b/src/components/view/ViewsPanel.svelte
@@ -21,16 +21,17 @@
   const columnDefs: DataGridColumnDef[] = [
     {
       field: 'id',
+      filter: 'number',
       headerName: 'ID',
       resizable: true,
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      width: 40,
+      width: 60,
     },
-    { field: 'name', headerName: 'Name', resizable: true, sortable: true },
-    { field: 'owner', headerName: 'Owner', resizable: true, sortable: true },
-    { field: 'updated_at', headerName: 'Last Updated', resizable: true, sortable: true },
+    { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
+    { field: 'owner', filter: 'text', headerName: 'Owner', resizable: true, sortable: true },
+    { field: 'updated_at', filter: 'text', headerName: 'Last Updated', resizable: true, sortable: true },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: ViewCellRendererParams) => {

--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -20,17 +20,25 @@
   const columnDefs: DataGridColumnDef[] = [
     {
       field: 'id',
+      filter: 'number',
       headerName: 'Dictionary ID',
       resizable: true,
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      width: 100,
+      width: 120,
     },
-    { field: 'mission', headerName: 'Mission', sortable: true, width: 100 },
-    { field: 'version', headerName: 'Version', sortable: true, suppressAutoSize: true, width: 100 },
-    { field: 'command_types_typescript_path', headerName: 'Types Path', resizable: true, sortable: true, width: 220 },
-    { field: 'created_at', headerName: 'Created At', resizable: true, sortable: true },
+    { field: 'mission', filter: 'text', headerName: 'Mission', sortable: true, width: 100 },
+    { field: 'version', filter: 'text', headerName: 'Version', sortable: true, suppressAutoSize: true, width: 100 },
+    {
+      field: 'command_types_typescript_path',
+      filter: 'text',
+      headerName: 'Types Path',
+      resizable: true,
+      sortable: true,
+      width: 220,
+    },
+    { field: 'created_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: CommandDictionaryCellRendererParams) => {

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -23,9 +23,10 @@
   type ModelCellRendererParams = ICellRendererParams<ModelList> & CellRendererParams;
 
   const columnDefs: DataGridColumnDef[] = [
-    { field: 'name', headerName: 'Name', resizable: true, sortable: true },
+    { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
     {
       field: 'id',
+      filter: 'number',
       headerName: 'Model ID',
       resizable: true,
       sortable: true,
@@ -33,7 +34,7 @@
       suppressSizeToFit: true,
       width: 100,
     },
-    { field: 'version', headerName: 'Version', sortable: true, width: 120 },
+    { field: 'version', filter: 'number', headerName: 'Version', sortable: true, width: 120 },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: ModelCellRendererParams) => {

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -33,9 +33,10 @@
   type PlanCellRendererParams = ICellRendererParams<Plan> & CellRendererParams;
 
   const columnDefs: DataGridColumnDef[] = [
-    { field: 'name', headerName: 'Name', resizable: true, sortable: true },
+    { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
     {
       field: 'id',
+      filter: 'number',
       headerName: 'Plan ID',
       resizable: true,
       sortable: true,
@@ -43,9 +44,9 @@
       suppressSizeToFit: true,
       width: 100,
     },
-    { field: 'model_id', headerName: 'Model ID', sortable: true, suppressAutoSize: true, width: 120 },
-    { field: 'start_time', headerName: 'Start Time', resizable: true, sortable: true },
-    { field: 'end_time', headerName: 'End Time', resizable: true, sortable: true },
+    { field: 'model_id', filter: 'number', headerName: 'Model ID', sortable: true, suppressAutoSize: true, width: 120 },
+    { field: 'start_time', filter: 'text', headerName: 'Start Time', resizable: true, sortable: true },
+    { field: 'end_time', filter: 'text', headerName: 'End Time', resizable: true, sortable: true },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: PlanCellRendererParams) => {


### PR DESCRIPTION
This resolves https://jira.jpl.nasa.gov/browse/AERIE-2065.

All the tables should have a text/number filter based on what's appropriate for the column.

This also fixes a small bug in the way the row ID was getting set for the ExpansionPanel table. By default the DataGrid table component expects an ID field to contain only numbers, so it was parsing `seq_id` into a number when it's supposed to be text. This was fixed by passing in a custom `getRowId` function prop that does not attempt to parse the string.