### PR TITLE
feat: auto query scheduling and simulation results

### DIFF
--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -106,7 +106,7 @@
 
     <details open>
       <summary>Arguments</summary>
-      <div>
+      <div class="mt-3 mb-3">
         {#if formParameters.length}
           <Parameters {formParameters} on:change={onChangeFormParameters} />
         {:else}

--- a/src/components/ui/StatusBadge.svelte
+++ b/src/components/ui/StatusBadge.svelte
@@ -1,39 +1,39 @@
 <script lang="ts">
   import CheckIcon from '@nasa-jpl/stellar/icons/check.svg?component';
   import EditingIcon from '@nasa-jpl/stellar/icons/editing.svg?component';
-  import MinusIcon from '@nasa-jpl/stellar/icons/minus.svg?component';
-  import QuestionIcon from '@nasa-jpl/stellar/icons/question.svg?component';
+  import SpinnerIcon from '@nasa-jpl/stellar/icons/spinner.svg?component';
   import ThreeDotsIcon from '@nasa-jpl/stellar/icons/three_dot_horizontal.svg?component';
   import WarningIcon from '@nasa-jpl/stellar/icons/warning.svg?component';
   import { getColorForStatus, Status, statusColors } from '../../utilities/status';
   import { tooltip } from '../../utilities/tooltip';
 
-  export let status: Status = Status.Clean;
+  export let status: Status | null = null;
 
-  let color: string = statusColors.blue;
+  let color: string = statusColors.gray;
 
   $: color = getColorForStatus(status);
 </script>
 
-<span
-  class="status-badge {status}"
-  style="background: {status === Status.Failed ? 'transparent' : color}"
-  use:tooltip={{ content: status, placement: 'bottom' }}
->
-  {#if status === Status.Clean || status === Status.Complete}
-    <CheckIcon />
-  {:else if status === Status.Executing || status === Status.Pending}
-    <ThreeDotsIcon />
-  {:else if status === Status.Incomplete}
-    <MinusIcon />
-  {:else if status === Status.Dirty}
-    <EditingIcon />
-  {:else if status === Status.Failed}
-    <WarningIcon style="color: {color}" />
-  {:else}
-    <QuestionIcon />
-  {/if}
-</span>
+{#if status !== null}
+  <span
+    aria-label={status}
+    class="status-badge {status}"
+    style="background: {status === Status.Failed ? 'transparent' : color}"
+    use:tooltip={{ content: status, placement: 'bottom' }}
+  >
+    {#if status === Status.Complete}
+      <CheckIcon />
+    {:else if status === Status.Failed}
+      <WarningIcon style="color: {color}" />
+    {:else if status === Status.Incomplete}
+      <SpinnerIcon />
+    {:else if status === Status.Modified}
+      <EditingIcon />
+    {:else if status === Status.Pending}
+      <ThreeDotsIcon />
+    {/if}
+  </span>
+{/if}
 
 <style>
   .status-badge {

--- a/src/stores/constraints.ts
+++ b/src/stores/constraints.ts
@@ -1,6 +1,6 @@
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
 import gql from '../utilities/gql';
-import { Status } from '../utilities/status';
+import type { Status } from '../utilities/status';
 import { planStartTimeMs } from './plan';
 import { gqlSubscribable } from './subscribable';
 
@@ -12,7 +12,7 @@ export const constraintsAll = gqlSubscribable<Constraint[]>(gql.SUB_CONSTRAINTS_
 
 /* Writeable. */
 
-export const checkConstraintsStatus: Writable<Status> = writable(Status.Clean);
+export const checkConstraintsStatus: Writable<Status | null> = writable(null);
 
 export const constraintViolationsMap: Writable<ConstraintViolationsMap> = writable({});
 
@@ -38,6 +38,6 @@ export const constraintViolations: Readable<ConstraintViolation[]> = derived(
 /* Helper Functions. */
 
 export function resetConstraintStores(): void {
-  checkConstraintsStatus.set(Status.Clean);
+  checkConstraintsStatus.set(null);
   constraintViolationsMap.set({});
 }

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -2,7 +2,7 @@ import { derived, writable, type Writable } from 'svelte/store';
 import { plan } from '../stores/plan';
 import { compare } from '../utilities/generic';
 import gql from '../utilities/gql';
-import { Status } from '../utilities/status';
+import type { Status } from '../utilities/status';
 import { gqlSubscribable } from './subscribable';
 
 /* Subscriptions. */
@@ -21,7 +21,7 @@ export const schedulingSpecGoals = gqlSubscribable<SchedulingSpecGoal[]>(
 
 export const schedulingGoalsColumns: Writable<string> = writable('1fr 1px 2fr');
 
-export const schedulingStatus: Writable<Status> = writable(Status.Clean);
+export const schedulingStatus: Writable<Status | null> = writable(null);
 
 /* Derived. */
 
@@ -30,5 +30,5 @@ export const selectedSpecId = derived(plan, $plan => $plan?.scheduling_specifica
 /* Helper Functions. */
 
 export function resetSchedulingStores() {
-  schedulingStatus.set(Status.Clean);
+  schedulingStatus.set(null);
 }

--- a/src/stores/simulation.ts
+++ b/src/stores/simulation.ts
@@ -1,6 +1,6 @@
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
 import gql from '../utilities/gql';
-import { Status } from '../utilities/status';
+import type { Status } from '../utilities/status';
 import { gqlSubscribable } from './subscribable';
 
 /* Subscriptions. */
@@ -18,28 +18,7 @@ export const simulationTemplates = gqlSubscribable<SimulationTemplate[]>(gql.SUB
 
 export const modelParametersMap: Writable<ParametersMap> = writable({});
 
-export const simulationStatus = (() => {
-  const { set, subscribe, update: updateStore } = writable<Status>(Status.Clean);
-
-  return {
-    set,
-    subscribe,
-    update(newStatus: Status) {
-      updateStore(currentStatus => {
-        switch (currentStatus) {
-          case Status.Clean:
-            if (newStatus === Status.Dirty) {
-              return currentStatus;
-            } else {
-              return newStatus;
-            }
-          default:
-            return newStatus;
-        }
-      });
-    },
-  };
-})();
+export const simulationStatus: Writable<Status | null> = writable(null);
 
 /* Derived. */
 
@@ -54,5 +33,5 @@ export const simulationDatasetId: Readable<number | null> = derived(simulation, 
 
 export function resetSimulationStores() {
   modelParametersMap.set({});
-  simulationStatus.set(Status.Clean);
+  simulationStatus.set(null);
 }

--- a/src/types/scheduling.d.ts
+++ b/src/types/scheduling.d.ts
@@ -22,11 +22,9 @@ type SchedulingGoalInsertInput = Omit<
   'analyses' | 'created_date' | 'id' | 'modified_date' | 'revision'
 >;
 
-type SchedulingResponseStatus = 'complete' | 'failed' | 'incomplete';
-
 type SchedulingResponse = {
   reason: string;
-  status: SchedulingResponseStatus;
+  status: 'complete' | 'failed' | 'incomplete';
 };
 
 type SchedulingSpec = {

--- a/src/types/simulation.d.ts
+++ b/src/types/simulation.d.ts
@@ -63,8 +63,8 @@ type SimulationDataset = {
   id: number;
 };
 
-type SimulationStatus = 'complete' | 'failed' | 'incomplete' | 'pending';
-
 type SimulationResponse = {
-  status: SimulationStatus;
+  reason: string;
+  simulationDatasetId: number;
+  status: 'complete' | 'failed' | 'incomplete' | 'pending';
 };

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -714,6 +714,8 @@ const gql = {
   SIMULATE: `#graphql
     query Simulate($planId: Int!) {
       simulate(planId: $planId) {
+        reason
+        simulationDatasetId
         status
       }
     }

--- a/src/utilities/status.ts
+++ b/src/utilities/status.ts
@@ -1,41 +1,33 @@
 export enum Status {
-  Clean = 'Clean',
   Complete = 'Complete',
-  Dirty = 'Dirty',
-  Executing = 'Executing',
   Failed = 'Failed',
   Incomplete = 'Incomplete',
+  Modified = 'Modified',
   Pending = 'Pending',
-  Unknown = 'Unknown',
 }
 
 export const statusColors: Record<string, string> = {
-  blue: '#007bff',
-  gray: '#545F64',
-  green: '#28a745',
-  red: '#dc3545',
-  yellow: '#ffc107',
+  gray: '#bec0c2',
+  green: '#0eaf0a',
+  red: '#db5139',
+  yellow: '#e6b300',
 };
 
 /**
  * Helper function that maps a status to a color.
  */
 export function getColorForStatus(status: Status): string {
-  if (status === Status.Clean) {
-    return statusColors.blue;
-  } else if (status === Status.Complete) {
+  if (status === Status.Complete) {
     return statusColors.green;
-  } else if (status === Status.Dirty) {
-    return statusColors.red;
-  } else if (status === Status.Executing) {
-    return statusColors.gray;
   } else if (status === Status.Failed) {
     return statusColors.red;
-  } else if (Status.Incomplete) {
+  } else if (status === Status.Incomplete) {
     return statusColors.gray;
-  } else if (Status.Pending) {
+  } else if (status === Status.Modified) {
+    return statusColors.yellow;
+  } else if (status === Status.Pending) {
     return statusColors.gray;
   } else {
-    return statusColors.red;
+    return statusColors.gray;
   }
 }


### PR DESCRIPTION
- Remove waiting semantics for scheduling and simulation runs
- Auto re-query for simulation and scheduling results every half-second
- Add padding to SimulationPanel arguments
- Remove obsolete Status.Executing, Status.Dirty, Status.Clean, and Status.Unknown states
- Add toast for success/failure of simulation and scheduling runs
- Make status icons in-line with current designs