### PR TITLE
refactor: subscribe to activity directive metadata schemas

### DIFF
--- a/src/components/activity/ActivityDecomposition.svelte.test.ts
+++ b/src/components/activity/ActivityDecomposition.svelte.test.ts
@@ -1,6 +1,6 @@
 import { cleanup, getByText, render } from '@testing-library/svelte';
 import { keyBy } from 'lodash-es';
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { activitiesMap } from '../../stores/activities';
 import ActivityDecomposition from './ActivityDecomposition.svelte';
 
@@ -175,6 +175,8 @@ const activities: Activity[] = [
 
 describe('Activity Decomposition component', () => {
   beforeAll(() => {
+    // See: https://github.com/sveltejs/kit/issues/6259
+    vi.mock('$app/environment', () => ({ browser: 'window' in globalThis }));
     activitiesMap.set(keyBy(activities, 'id'));
   });
 

--- a/src/components/activity/ActivityFormPanel.svelte
+++ b/src/components/activity/ActivityFormPanel.svelte
@@ -4,8 +4,7 @@
   import CheckIcon from '@nasa-jpl/stellar/icons/check.svg?component';
   import PenIcon from '@nasa-jpl/stellar/icons/pen.svg?component';
   import TrashIcon from '@nasa-jpl/stellar/icons/trash.svg?component';
-  import { activitiesMap, allPlanTags, selectedActivity } from '../../stores/activities';
-  import { activityMetadataDefinitions } from '../../stores/activityMetadata';
+  import { activitiesMap, activityMetadataDefinitions, allPlanTags, selectedActivity } from '../../stores/activities';
   import { filteredExpansionSequences } from '../../stores/expansion';
   import { field } from '../../stores/form';
   import { activityTypesMap, plan } from '../../stores/plan';

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -26,7 +26,6 @@
   import ViewEditorPanel from '../../../components/view/ViewEditorPanel.svelte';
   import ViewsPanel from '../../../components/view/ViewsPanel.svelte';
   import { activitiesMap, resetActivityStores } from '../../../stores/activities';
-  import { activityMetadataDefinitions } from '../../../stores/activityMetadata';
   import { checkConstraintsStatus, resetConstraintStores } from '../../../stores/constraints';
   import {
     maxTimeRange,
@@ -88,10 +87,6 @@
   $: if (data.initialView) {
     $view = { ...data.initialView };
     $viewLayout = { ...data.initialView.definition.plan.layout };
-  }
-
-  $: if (data.initialMetadataDefinitions) {
-    activityMetadataDefinitions.set(data.initialMetadataDefinitions);
   }
 
   onMount(() => {

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -3,7 +3,6 @@ import { redirect } from '@sveltejs/kit';
 import { get } from 'svelte/store';
 import { user as userStore } from '../../../stores/app';
 import effects from '../../../utilities/effects';
-import { compare } from '../../../utilities/generic';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ params, url }) => {
@@ -21,11 +20,8 @@ export const load: PageLoad = async ({ params, url }) => {
 
     if (initialPlan) {
       const initialView = await effects.getView(user.id, url.searchParams);
-      const initialMetadataDefinitions = await effects.getActivityMetadataDefinitions();
-      initialMetadataDefinitions.sort((a, b) => compare(a.key, b.key));
 
       return {
-        initialMetadataDefinitions,
         initialPlan,
         initialView,
       };

--- a/src/stores/activities.ts
+++ b/src/stores/activities.ts
@@ -1,5 +1,15 @@
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
 import { activitiesToPoints } from '../utilities/activities';
+import gql from '../utilities/gql';
+import { gqlSubscribable } from './subscribable';
+
+/* Subscriptions. */
+
+export const activityMetadataDefinitions = gqlSubscribable<ActivityMetadataDefinition[]>(
+  gql.SUB_ACTIVITY_DIRECTIVE_METADATA_SCHEMAS,
+  {},
+  [],
+);
 
 /* Writeable. */
 

--- a/src/stores/activityMetadata.ts
+++ b/src/stores/activityMetadata.ts
@@ -1,5 +1,0 @@
-import { writable, type Writable } from 'svelte/store';
-
-/* Writeable. */
-
-export const activityMetadataDefinitions: Writable<ActivityMetadataDefinition[]> = writable([]);

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -725,17 +725,6 @@ const effects = {
     }
   },
 
-  async getActivityMetadataDefinitions(): Promise<ActivityMetadataDefinition[]> {
-    try {
-      const data = await reqHasura<ActivityMetadataDefinition[]>(gql.GET_ACTIVITY_DIRECTIVE_METADATA_SCHEMA);
-      const { activity_directive_metadata_schema } = data;
-      return activity_directive_metadata_schema;
-    } catch (e) {
-      console.log(e);
-      return [];
-    }
-  },
-
   async getActivityTypesExpansionRules(modelId: number | null | undefined): Promise<ActivityTypeExpansionRules[]> {
     if (modelId !== null && modelId !== undefined) {
       try {

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -327,15 +327,6 @@ const gql = {
     }
   `,
 
-  GET_ACTIVITY_DIRECTIVE_METADATA_SCHEMA: `#graphql
-    query GetActivityDirectiveMetadataSchema {
-      activity_directive_metadata_schema {
-        key
-        schema
-      }
-    }
-  `,
-
   GET_ACTIVITY_TYPES_EXPANSION_RULES: `#graphql
     query GetActivityTypesExpansionRules($modelId: Int!) {
       activity_types: activity_type(where: { model_id: { _eq: $modelId } }) {
@@ -717,6 +708,15 @@ const gql = {
         reason
         simulationDatasetId
         status
+      }
+    }
+  `,
+
+  SUB_ACTIVITY_DIRECTIVE_METADATA_SCHEMAS: `#graphql
+    subscription SubActivityDirectiveMetadataSchemas {
+      activity_directive_metadata_schema(order_by: { key: asc }) {
+        key
+        schema
       }
     }
   `,


### PR DESCRIPTION
* Replace activity metadata query with subscription
* Remove obsolete initial activity metadata code from plan page
* Move activity metadata definitions store to activities store file
* Fix decomposition test with mock