### PR TITLE
feat: subscribable store vars

### DIFF
--- a/e2e-tests/fixtures/Plans.ts
+++ b/e2e-tests/fixtures/Plans.ts
@@ -117,6 +117,6 @@ export class Plans {
     this.tableRowDeleteButton = page.locator(
       `.ag-row:has-text("${this.planName}") >> button[aria-label="Delete Plan"]`,
     );
-    this.tableRowPlanId = page.locator(`.ag-row:has-text("${this.planName}") > div >> nth=1`);
+    this.tableRowPlanId = page.locator(`.ag-row:has-text("${this.planName}") > div >> nth=0`);
   }
 }

--- a/src/components/activity/ActivityTypesPanel.svelte
+++ b/src/components/activity/ActivityTypesPanel.svelte
@@ -4,7 +4,6 @@
   import PlusIcon from 'bootstrap-icons/icons/plus.svg?component';
   import { plan } from '../../stores/plan';
   import effects from '../../utilities/effects';
-  import { compare } from '../../utilities/generic';
   import { tooltip } from '../../utilities/tooltip';
   import GridMenu from '../menus/GridMenu.svelte';
   import ListItem from '../ui/ListItem.svelte';
@@ -12,11 +11,11 @@
 
   export let gridId: number;
 
-  let activityTypes: ActivityType[] = $plan.model.activity_types;
+  let activityTypes: ActivityType[];
   let filterText: string = '';
 
+  $: activityTypes = $plan?.model?.activity_types ?? [];
   $: filteredActivityTypes = activityTypes.filter(({ name }) => name.toLowerCase().includes(filterText.toLowerCase()));
-  $: sortedActivityTypes = filteredActivityTypes.sort((a, b) => compare(a.name, b.name));
 
   async function createActivityDirectiveAtPlanStart(activityType: ActivityType) {
     const { start_time } = $plan;
@@ -50,8 +49,8 @@
       <input bind:value={filterText} class="st-input w-100" name="search" placeholder="Filter activity types" />
     </fieldset>
 
-    {#if sortedActivityTypes.length}
-      {#each sortedActivityTypes as activityType}
+    {#if filteredActivityTypes.length}
+      {#each filteredActivityTypes as activityType}
         <ListItem
           draggable
           style="cursor: move;"

--- a/src/components/constraints/ConstraintsPanel.svelte
+++ b/src/components/constraints/ConstraintsPanel.svelte
@@ -2,9 +2,7 @@
 
 <script lang="ts">
   import { base } from '$app/paths';
-  import { onMount } from 'svelte';
   import { checkConstraintsStatus, constraints } from '../../stores/constraints';
-  import { plan } from '../../stores/plan';
   import effects from '../../utilities/effects';
   import GridMenu from '../menus/GridMenu.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
@@ -22,10 +20,6 @@
     const filterTextLowerCase = filterText.toLowerCase();
     const includesName = constraint.name.toLocaleLowerCase().includes(filterTextLowerCase);
     return includesName;
-  });
-
-  onMount(() => {
-    constraints.setVariables({ modelId: $plan.model.id, planId: $plan.id });
   });
 </script>
 

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -26,13 +26,6 @@
 
   const columnDefs: DataGridColumnDef[] = [
     {
-      field: 'simulation_dataset_id',
-      filter: 'number',
-      headerName: 'Simulation ID',
-      resizable: true,
-      sortable: true,
-    },
-    {
       field: 'seq_id',
       filter: 'text',
       headerName: 'Seq ID',
@@ -40,6 +33,13 @@
       sortable: true,
       suppressSizeToFit: true,
       width: 85,
+    },
+    {
+      field: 'simulation_dataset_id',
+      filter: 'number',
+      headerName: 'Simulation ID',
+      resizable: true,
+      sortable: true,
     },
     { field: 'created_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
     { field: 'updated_at', filter: 'text', headerName: 'Updated At', resizable: true, sortable: true },

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -4,8 +4,8 @@
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import { activityTypeNames, expansionRulesColumns, savingExpansionRule } from '../../stores/expansion';
-  import { sortedModels } from '../../stores/plan';
-  import { sortedCommandDictionaries } from '../../stores/sequencing';
+  import { models } from '../../stores/plan';
+  import { commandDictionaries } from '../../stores/sequencing';
   import effects from '../../utilities/effects';
   import Chip from '../ui/Chip.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
@@ -111,7 +111,7 @@
         <label for="commandDictionary">Command Dictionary</label>
         <select bind:value={ruleDictionaryId} class="st-select w-100" name="commandDictionary">
           <option value={null} />
-          {#each $sortedCommandDictionaries as commandDictionary}
+          {#each $commandDictionaries as commandDictionary}
             <option value={commandDictionary.id}>
               {commandDictionary.mission} -
               {commandDictionary.version}
@@ -129,7 +129,7 @@
           on:change={() => (ruleActivityType = null)}
         >
           <option value={null} />
-          {#each $sortedModels as model}
+          {#each $models as model}
             <option value={model.id}>
               {model.name}
             </option>

--- a/src/components/expansion/ExpansionRules.svelte
+++ b/src/components/expansion/ExpansionRules.svelte
@@ -5,7 +5,6 @@
   import { base } from '$app/paths';
   import { expansionRules, expansionRulesColumns } from '../../stores/expansion';
   import effects from '../../utilities/effects';
-  import { compare } from '../../utilities/generic';
   import Input from '../form/Input.svelte';
   import Chip from '../ui/Chip.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
@@ -25,12 +24,12 @@
     {
       field: 'id',
       filter: 'number',
-      headerName: 'Rule ID',
+      headerName: 'ID',
       resizable: true,
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      width: 80,
+      width: 60,
     },
     { field: 'activity_type', filter: 'text', headerName: 'Activity Type', resizable: true, sortable: true },
     {
@@ -84,7 +83,6 @@
   let filteredRules: ExpansionRule[] = [];
   let filterText: string = '';
   let selectedExpansionRule: ExpansionRule | null = null;
-  let sortedRules: ExpansionRule[] = [];
 
   $: filteredRules = $expansionRules.filter(rule => {
     const filterTextLowerCase = filterText.toLowerCase();
@@ -92,13 +90,12 @@
     const includesId = `${rule.id}`.includes(filterTextLowerCase);
     return includesActivityType || includesId;
   });
-  $: sortedRules = filteredRules.sort((a, b) => compare(a.id, b.id));
 
   async function deleteRule({ id }: Pick<ExpansionRule, 'id'>) {
     const success = await effects.deleteExpansionRule(id);
 
     if (success) {
-      sortedRules = sortedRules.filter(rule => rule.id !== id);
+      expansionRules.filterValueById(id);
 
       if (id === selectedExpansionRule?.id) {
         selectedExpansionRule = null;
@@ -151,12 +148,12 @@
     </svelte:fragment>
 
     <svelte:fragment slot="body">
-      {#if sortedRules.length}
+      {#if filteredRules.length}
         <SingleActionDataGrid
           {columnDefs}
           hasEdit={true}
           itemDisplayText="Rule"
-          items={sortedRules}
+          items={filteredRules}
           on:deleteItem={deleteRuleContext}
           on:editItem={editRuleContext}
           on:rowSelected={toggleRule}

--- a/src/components/expansion/ExpansionSetForm.svelte
+++ b/src/components/expansion/ExpansionSetForm.svelte
@@ -4,8 +4,8 @@
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import { expansionSetsColumns, savingExpansionSet } from '../../stores/expansion';
-  import { sortedModels } from '../../stores/plan';
-  import { sortedCommandDictionaries } from '../../stores/sequencing';
+  import { models } from '../../stores/plan';
+  import { commandDictionaries } from '../../stores/sequencing';
   import effects from '../../utilities/effects';
   import Chip from '../ui/Chip.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
@@ -83,7 +83,7 @@
         <label for="commandDictionary">Command Dictionary</label>
         <select bind:value={setDictionaryId} class="st-select w-100" name="commandDictionary">
           <option value={null} />
-          {#each $sortedCommandDictionaries as commandDictionary}
+          {#each $commandDictionaries as commandDictionary}
             <option value={commandDictionary.id}>
               {commandDictionary.mission} -
               {commandDictionary.version}
@@ -101,7 +101,7 @@
           on:change={() => (selectedExpansionRules = {})}
         >
           <option value={null} />
-          {#each $sortedModels as model}
+          {#each $models as model}
             <option value={model.id}>
               {model.name}
             </option>

--- a/src/components/expansion/ExpansionSets.svelte
+++ b/src/components/expansion/ExpansionSets.svelte
@@ -5,7 +5,6 @@
   import { base } from '$app/paths';
   import { expansionSets, expansionSetsColumns } from '../../stores/expansion';
   import effects from '../../utilities/effects';
-  import { compare } from '../../utilities/generic';
   import Chip from '../ui/Chip.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
@@ -24,12 +23,12 @@
     {
       field: 'id',
       filter: 'number',
-      headerName: 'Set ID',
+      headerName: 'ID',
       resizable: true,
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      width: 100,
+      width: 60,
     },
     {
       field: 'command_dict_id',
@@ -72,19 +71,17 @@
     },
   ];
 
-  let sortedSets: ExpansionSet[] = [];
   let selectedExpansionRule: ExpansionRule | null = null;
   let selectedExpansionRuleIds: number[] = [];
   let selectedExpansionSet: ExpansionSet | null = null;
 
-  $: sortedSets = $expansionSets.sort((a, b) => compare(a.id, b.id));
   $: selectedExpansionRuleIds = selectedExpansionRule ? [selectedExpansionRule.id] : [];
 
   async function deleteSet({ id }: Pick<ExpansionSet, 'id'>) {
     const success = await effects.deleteExpansionSet(id);
 
     if (success) {
-      sortedSets = sortedSets.filter(set => set.id !== id);
+      expansionSets.filterValueById(id);
 
       if (id === selectedExpansionSet?.id) {
         selectedExpansionRule = null;
@@ -138,11 +135,11 @@
       </svelte:fragment>
 
       <svelte:fragment slot="body">
-        {#if sortedSets.length}
+        {#if $expansionSets.length}
           <SingleActionDataGrid
             {columnDefs}
             itemDisplayText="Expansion Set"
-            items={sortedSets}
+            items={$expansionSets}
             on:deleteItem={deleteSetContext}
             on:rowSelected={toggleSet}
           />
@@ -166,12 +163,12 @@
               {
                 field: 'id',
                 filter: 'number',
-                headerName: 'Rule ID',
+                headerName: 'ID',
                 resizable: true,
                 sortable: true,
                 suppressAutoSize: true,
                 suppressSizeToFit: true,
-                width: 80,
+                width: 60,
               },
               { field: 'activity_type', filter: 'text', headerName: 'Activity Type', sortable: true },
             ]}

--- a/src/components/scheduling/SchedulingGoals.svelte
+++ b/src/components/scheduling/SchedulingGoals.svelte
@@ -5,7 +5,6 @@
   import { base } from '$app/paths';
   import { schedulingGoals, schedulingGoalsColumns } from '../../stores/scheduling';
   import effects from '../../utilities/effects';
-  import { compare } from '../../utilities/generic';
   import Input from '../form/Input.svelte';
   import Chip from '../ui/Chip.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
@@ -25,12 +24,12 @@
     {
       field: 'id',
       filter: 'number',
-      headerName: 'Goal ID',
+      headerName: 'ID',
       resizable: true,
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      width: 100,
+      width: 60,
     },
     { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
     { field: 'model_id', filter: 'number', headerName: 'Model ID', sortable: true, width: 120 },
@@ -75,7 +74,6 @@
   let filteredGoals: SchedulingGoal[] = [];
   let filterText: string = '';
   let selectedGoal: SchedulingGoal | null = null;
-  let sortedGoals: SchedulingGoal[] = [];
 
   $: filteredGoals = $schedulingGoals.filter(goal => {
     const filterTextLowerCase = filterText.toLowerCase();
@@ -83,7 +81,6 @@
     const includesName = goal.name.toLocaleLowerCase().includes(filterTextLowerCase);
     return includesId || includesName;
   });
-  $: sortedGoals = filteredGoals.sort((a, b) => compare(a.id, b.id));
   $: if (selectedGoal !== null) {
     const found = $schedulingGoals.findIndex(goal => goal.id === selectedGoal.id);
     if (found === -1) {
@@ -95,7 +92,7 @@
     const success = await effects.deleteSchedulingGoal(id);
 
     if (success) {
-      sortedGoals = sortedGoals.filter(goal => goal.id !== id);
+      schedulingGoals.filterValueById(id);
 
       if (id === selectedGoal?.id) {
         selectedGoal = null;
@@ -148,12 +145,12 @@
     </svelte:fragment>
 
     <svelte:fragment slot="body">
-      {#if sortedGoals.length}
+      {#if filteredGoals.length}
         <SingleActionDataGrid
           {columnDefs}
           hasEdit={true}
           itemDisplayText="Goal"
-          items={sortedGoals}
+          items={filteredGoals}
           on:deleteItem={deleteGoalContext}
           on:editItem={editGoalContext}
           on:rowSelected={toggleGoal}

--- a/src/components/scheduling/SchedulingPanel.svelte
+++ b/src/components/scheduling/SchedulingPanel.svelte
@@ -3,7 +3,6 @@
 <script lang="ts">
   import { base } from '$app/paths';
   import ChecklistIcon from '@nasa-jpl/stellar/icons/checklist.svg?component';
-  import { onMount } from 'svelte';
   import { plan } from '../../stores/plan';
   import { schedulingSpecGoals, schedulingStatus, selectedSpecId } from '../../stores/scheduling';
   import effects from '../../utilities/effects';
@@ -23,10 +22,6 @@
     const filterTextLowerCase = filterText.toLowerCase();
     const includesName = spec.goal.name.toLocaleLowerCase().includes(filterTextLowerCase);
     return includesName;
-  });
-
-  onMount(() => {
-    schedulingSpecGoals.setVariables({ specification_id: $selectedSpecId });
   });
 </script>
 

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -5,7 +5,7 @@
   import { base } from '$app/paths';
   import { onMount } from 'svelte';
   import { user as userStore } from '../../stores/app';
-  import { sortedCommandDictionaries, userSequencesColumns } from '../../stores/sequencing';
+  import { commandDictionaries, userSequencesColumns } from '../../stores/sequencing';
   import effects from '../../utilities/effects';
   import Chip from '../ui/Chip.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
@@ -134,7 +134,7 @@
         <label for="commandDictionary">Command Dictionary (required)</label>
         <select bind:value={sequenceCommandDictionaryId} class="st-select w-100" name="commandDictionary">
           <option value={null} />
-          {#each $sortedCommandDictionaries as commandDictionary}
+          {#each $commandDictionaries as commandDictionary}
             <option value={commandDictionary.id}>
               {commandDictionary.mission} -
               {commandDictionary.version}

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -5,7 +5,6 @@
   import { base } from '$app/paths';
   import { userSequences, userSequencesColumns } from '../../stores/sequencing';
   import effects from '../../utilities/effects';
-  import { compare } from '../../utilities/generic';
   import Input from '../form/Input.svelte';
   import Chip from '../ui/Chip.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
@@ -85,7 +84,6 @@
   let filteredSequences: UserSequence[] = [];
   let selectedSequence: UserSequence | null = null;
   let selectedSequenceSeqJson: string = 'No Sequence Selected';
-  let sortedSequences: UserSequence[] = [];
 
   $: filteredSequences = $userSequences.filter(sequence => {
     const filterTextLowerCase = filterText.toLowerCase();
@@ -93,7 +91,6 @@
     const includesName = sequence.name.toLocaleLowerCase().includes(filterTextLowerCase);
     return includesId || includesName;
   });
-  $: sortedSequences = filteredSequences.sort((a, b) => compare(a.id, b.id));
   $: if (selectedSequence !== null) {
     const found = $userSequences.findIndex(sequence => sequence.id === selectedSequence.id);
     if (found === -1) {
@@ -105,7 +102,7 @@
     const success = await effects.deleteUserSequence(id);
 
     if (success) {
-      sortedSequences = sortedSequences.filter(sequence => sequence.id !== id);
+      userSequences.filterValueById(id);
 
       if (id === selectedSequence?.id) {
         selectedSequence = null;
@@ -179,12 +176,12 @@
     </svelte:fragment>
 
     <svelte:fragment slot="body">
-      {#if sortedSequences.length}
+      {#if filteredSequences.length}
         <SingleActionDataGrid
           {columnDefs}
           hasEdit={true}
           itemDisplayText="Sequence"
-          items={sortedSequences}
+          items={filteredSequences}
           on:deleteItem={deleteSequenceContext}
           on:editItem={editSequenceContext}
           on:rowSelected={toggleSequence}

--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -9,7 +9,7 @@
   import SingleActionDataGrid from '../../components/ui/DataGrid/SingleActionDataGrid.svelte';
   import Panel from '../../components/ui/Panel.svelte';
   import { createDictionaryError, creatingDictionary } from '../../stores/expansion';
-  import { sortedCommandDictionaries } from '../../stores/sequencing';
+  import { commandDictionaries } from '../../stores/sequencing';
   import effects from '../../utilities/effects';
 
   type CellRendererParams = {
@@ -21,12 +21,12 @@
     {
       field: 'id',
       filter: 'number',
-      headerName: 'Dictionary ID',
+      headerName: 'ID',
       resizable: true,
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      width: 120,
+      width: 60,
     },
     { field: 'mission', filter: 'text', headerName: 'Mission', sortable: true, width: 100 },
     { field: 'version', filter: 'text', headerName: 'Version', sortable: true, suppressAutoSize: true, width: 100 },
@@ -120,11 +120,11 @@
       </svelte:fragment>
 
       <svelte:fragment slot="body">
-        {#if $sortedCommandDictionaries.length}
+        {#if $commandDictionaries.length}
           <SingleActionDataGrid
             {columnDefs}
             itemDisplayText="Command Dictionary"
-            items={$sortedCommandDictionaries}
+            items={$commandDictionaries}
             on:deleteItem={deleteCommandDictionaryContext}
           />
         {:else}

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -12,7 +12,7 @@
   import DataGridActions from '../../components/ui/DataGrid/DataGridActions.svelte';
   import SingleActionDataGrid from '../../components/ui/DataGrid/SingleActionDataGrid.svelte';
   import Panel from '../../components/ui/Panel.svelte';
-  import { createModelError, creatingModel, models, sortedModels } from '../../stores/plan';
+  import { createModelError, creatingModel, models } from '../../stores/plan';
   import effects from '../../utilities/effects';
   import type { PageData } from './$types';
 
@@ -24,17 +24,17 @@
   type ModelCellRendererParams = ICellRendererParams<ModelList> & CellRendererParams;
 
   const columnDefs: DataGridColumnDef[] = [
-    { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
     {
       field: 'id',
       filter: 'number',
-      headerName: 'Model ID',
+      headerName: 'ID',
       resizable: true,
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      width: 100,
+      width: 60,
     },
+    { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
     { field: 'version', filter: 'number', headerName: 'Version', sortable: true, width: 120 },
     {
       cellClass: 'action-cell-container',
@@ -85,11 +85,7 @@
 
   function deleteModelContext(event: CustomEvent<number[]>) {
     const selectedModelListId = event.detail[0];
-
-    const modelListToDelete = $sortedModels.find((modelList: ModelList) => {
-      return modelList.id === selectedModelListId;
-    });
-
+    const modelListToDelete = $models.find((modelList: ModelList) => modelList.id === selectedModelListId);
     deleteModel(modelListToDelete);
   }
 
@@ -153,11 +149,11 @@
       </svelte:fragment>
 
       <svelte:fragment slot="body">
-        {#if $sortedModels.length}
+        {#if $models.length}
           <SingleActionDataGrid
             {columnDefs}
             itemDisplayText="Model"
-            items={$sortedModels}
+            items={$models}
             on:deleteItem={deleteModelContext}
             on:rowClicked={({ detail }) => showModel(detail.data)}
           />

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -20,7 +20,7 @@
   import { createPlanError, creatingPlan } from '../../stores/plan';
   import { simulationTemplates } from '../../stores/simulation';
   import effects from '../../utilities/effects';
-  import { compare, removeQueryParam } from '../../utilities/generic';
+  import { removeQueryParam } from '../../utilities/generic';
   import { convertUsToDurationString, getUnixEpochTime } from '../../utilities/time';
   import { min, required, timestamp } from '../../utilities/validators';
   import type { PageData } from './$types';
@@ -33,17 +33,17 @@
   type PlanCellRendererParams = ICellRendererParams<Plan> & CellRendererParams;
 
   const columnDefs: DataGridColumnDef[] = [
-    { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
     {
       field: 'id',
       filter: 'number',
-      headerName: 'Plan ID',
+      headerName: 'ID',
       resizable: true,
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      width: 100,
+      width: 60,
     },
+    { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
     { field: 'model_id', filter: 'number', headerName: 'Model ID', sortable: true, suppressAutoSize: true, width: 120 },
     { field: 'start_time', filter: 'text', headerName: 'Start Time', resizable: true, sortable: true },
     { field: 'end_time', filter: 'text', headerName: 'End Time', resizable: true, sortable: true },
@@ -109,8 +109,6 @@
     );
   });
   $: simulationTemplates.setVariables({ modelId: $modelIdField.value });
-  $: sortedModels = models.sort((a, b) => compare(a.name, b.name));
-  $: sortedPlans = filteredPlans.sort((a, b) => compare(a.name, b.name));
 
   onMount(() => {
     const queryModelId = $page.url.searchParams.get('modelId');
@@ -192,7 +190,7 @@
             <label for="model" slot="label">Models</label>
             <select class="st-select w-100" data-type="number" name="model">
               <option value="-1" />
-              {#each sortedModels as model}
+              {#each models as model}
                 <option value={model.id}>
                   {model.name}
                 </option>
@@ -268,11 +266,11 @@
       </svelte:fragment>
 
       <svelte:fragment slot="body">
-        {#if sortedPlans.length}
+        {#if filteredPlans.length}
           <SingleActionDataGrid
             {columnDefs}
             itemDisplayText="Plan"
-            items={sortedPlans}
+            items={filteredPlans}
             on:cellMouseOver={({ detail }) => prefetchPlan(detail.data)}
             on:deleteItem={deletePlanContext}
             on:rowClicked={({ detail }) => showPlan(detail.data)}

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -35,15 +35,9 @@
     resetPlanStores,
     viewTimeRange,
   } from '../../../stores/plan';
-  import { externalResources, resetResourceStores } from '../../../stores/resources';
+  import { resetResourceStores } from '../../../stores/resources';
   import { resetSchedulingStores, schedulingStatus } from '../../../stores/scheduling';
-  import {
-    modelParametersMap,
-    resetSimulationStores,
-    simulation,
-    simulationStatus,
-    simulationTemplates,
-  } from '../../../stores/simulation';
+  import { modelParametersMap, resetSimulationStores, simulation, simulationStatus } from '../../../stores/simulation';
   import { view, viewLayout, viewSetLayout, viewUpdateLayout } from '../../../stores/views';
   import effects from '../../../utilities/effects';
   import { setQueryParam } from '../../../utilities/generic';
@@ -78,10 +72,6 @@
     $planStartTimeMs = getUnixEpochTime(data.initialPlan.start_time);
     $maxTimeRange = { end: $planEndTimeMs, start: $planStartTimeMs };
     $viewTimeRange = $maxTimeRange;
-
-    externalResources.setVariables({ planId: data.initialPlan.id });
-    simulation.setVariables({ planId: data.initialPlan.id });
-    simulationTemplates.setVariables({ modelId: data.initialPlan.model.id });
   }
 
   $: if (data.initialView) {

--- a/src/stores/constraints.ts
+++ b/src/stores/constraints.ts
@@ -1,12 +1,12 @@
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
 import gql from '../utilities/gql';
 import type { Status } from '../utilities/status';
-import { planStartTimeMs } from './plan';
+import { modelId, planId, planStartTimeMs } from './plan';
 import { gqlSubscribable } from './subscribable';
 
 /* Subscriptions. */
 
-export const constraints = gqlSubscribable<Constraint[]>(gql.SUB_CONSTRAINTS, { modelId: -1, planId: -1 }, []);
+export const constraints = gqlSubscribable<Constraint[]>(gql.SUB_CONSTRAINTS, { modelId, planId }, []);
 
 export const constraintsAll = gqlSubscribable<Constraint[]>(gql.SUB_CONSTRAINTS_ALL, {}, []);
 

--- a/src/stores/expansion.ts
+++ b/src/stores/expansion.ts
@@ -1,5 +1,6 @@
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
 import gql from '../utilities/gql';
+import { modelId } from './plan';
 import { simulationDatasetId } from './simulation';
 import { gqlSubscribable } from './subscribable';
 
@@ -7,7 +8,7 @@ import { gqlSubscribable } from './subscribable';
 
 export const activityTypeNames = gqlSubscribable<Pick<ActivityType, 'name'>[]>(
   gql.SUB_ACTIVITY_TYPE_NAMES,
-  { modelId: -1 },
+  { modelId },
   [],
 );
 

--- a/src/stores/plan.ts
+++ b/src/stores/plan.ts
@@ -1,6 +1,5 @@
 import { keyBy } from 'lodash-es';
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
-import { compare } from '../utilities/generic';
 import gql from '../utilities/gql';
 import { gqlSubscribable } from './subscribable';
 
@@ -37,12 +36,9 @@ export const activityTypesMap: Readable<ActivityTypesMap> = derived(plan, $plan 
   return {};
 });
 
-export const sortedModels: Readable<ModelList[]> = derived(models, $models => {
-  if ($models) {
-    return $models.sort((a, b) => compare(a.name, b.name));
-  }
-  return [];
-});
+export const modelId: Readable<number> = derived(plan, $plan => ($plan ? $plan.model.id : -1));
+
+export const planId: Readable<number> = derived(plan, $plan => ($plan ? $plan.id : -1));
 
 /* Helper Functions. */
 

--- a/src/stores/resources.ts
+++ b/src/stores/resources.ts
@@ -1,13 +1,14 @@
 import { derived, writable, type Writable } from 'svelte/store';
 import gql from '../utilities/gql';
 import { sampleProfiles } from '../utilities/resources';
+import { planId } from './plan';
 import { gqlSubscribable } from './subscribable';
 
 /* Subscriptions. */
 
 export const externalResources = gqlSubscribable<Resource[]>(
   gql.SUB_PROFILES_EXTERNAL,
-  { planId: -1 },
+  { planId },
   [],
   (data: ProfilesExternalResponse) => {
     const { datasets, duration, start_time } = data;

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -1,21 +1,8 @@
 import { derived, writable, type Writable } from 'svelte/store';
 import { plan } from '../stores/plan';
-import { compare } from '../utilities/generic';
 import gql from '../utilities/gql';
 import type { Status } from '../utilities/status';
 import { gqlSubscribable } from './subscribable';
-
-/* Subscriptions. */
-
-export const schedulingGoals = gqlSubscribable<SchedulingGoal[]>(gql.SUB_SCHEDULING_GOALS, {}, []);
-
-export const schedulingSpecGoals = gqlSubscribable<SchedulingSpecGoal[]>(
-  gql.SUB_SCHEDULING_SPEC_GOALS,
-  { specification_id: -1 },
-  [],
-  (specGoals: SchedulingSpecGoal[]) =>
-    specGoals.sort((specGoalA, specGoalB) => compare(specGoalA.priority, specGoalB.priority)),
-);
 
 /* Writeable. */
 
@@ -26,6 +13,16 @@ export const schedulingStatus: Writable<Status | null> = writable(null);
 /* Derived. */
 
 export const selectedSpecId = derived(plan, $plan => $plan?.scheduling_specifications[0]?.id ?? null);
+
+/* Subscriptions. */
+
+export const schedulingGoals = gqlSubscribable<SchedulingGoal[]>(gql.SUB_SCHEDULING_GOALS, {}, []);
+
+export const schedulingSpecGoals = gqlSubscribable<SchedulingSpecGoal[]>(
+  gql.SUB_SCHEDULING_SPEC_GOALS,
+  { specification_id: selectedSpecId },
+  [],
+);
 
 /* Helper Functions. */
 

--- a/src/stores/sequencing.ts
+++ b/src/stores/sequencing.ts
@@ -1,5 +1,4 @@
-import { derived, writable, type Readable, type Writable } from 'svelte/store';
-import { compare } from '../utilities/generic';
+import { writable, type Writable } from 'svelte/store';
 import gql from '../utilities/gql';
 import { gqlSubscribable } from './subscribable';
 
@@ -14,15 +13,3 @@ export const userSequences = gqlSubscribable<UserSequence[]>(gql.SUB_USER_SEQUEN
 export const userSequencesColumns: Writable<string> = writable('1fr 1px 2fr');
 
 export const userSequencesRows: Writable<string> = writable('1fr 1px 1fr');
-
-/* Derived. */
-
-export const sortedCommandDictionaries: Readable<CommandDictionary[]> = derived(
-  commandDictionaries,
-  $commandDictionaries => {
-    if ($commandDictionaries) {
-      return $commandDictionaries.sort((a, b) => compare(a.version, b.version));
-    }
-    return [];
-  },
-);

--- a/src/stores/simulation.ts
+++ b/src/stores/simulation.ts
@@ -1,18 +1,19 @@
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
 import gql from '../utilities/gql';
 import type { Status } from '../utilities/status';
+import { modelId, planId } from './plan';
 import { gqlSubscribable } from './subscribable';
 
 /* Subscriptions. */
 
 export const simulation = gqlSubscribable<Simulation | null>(
   gql.SUB_SIMULATION,
-  { planId: -1 },
+  { planId },
   null,
   (simulations: Simulation[]) => simulations[0],
 );
 
-export const simulationTemplates = gqlSubscribable<SimulationTemplate[]>(gql.SUB_SIM_TEMPLATES, { modelId: -1 }, []);
+export const simulationTemplates = gqlSubscribable<SimulationTemplate[]>(gql.SUB_SIM_TEMPLATES, { modelId }, []);
 
 /* Writeable. */
 

--- a/src/types/subscribable.d.ts
+++ b/src/types/subscribable.d.ts
@@ -7,7 +7,7 @@ type GqlSubscribable<T> = {
 
 type NextValue<T> = { [key: string]: T };
 
-type QueryVariables = Record<string, unknown>;
+type QueryVariables = Record<string, any>;
 
 type Subscription<T> = {
   next: import('svelte/store').Subscriber<T>;

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -463,7 +463,7 @@ const gql = {
         duration
         id
         model: mission_model {
-          activity_types {
+          activity_types(order_by: { name: asc }) {
             computed_attributes_value_schema
             name
             parameters
@@ -498,13 +498,13 @@ const gql = {
 
   GET_PLANS_AND_MODELS: `#graphql
     query GetPlansAndModels {
-      models: mission_model {
+      models: mission_model(order_by: { id: desc }) {
         id
         jar_id
         name
         version
       }
-      plans: plan {
+      plans: plan(order_by: { id: desc }) {
         duration
         id
         model_id
@@ -731,7 +731,7 @@ const gql = {
 
   SUB_COMMAND_DICTIONARIES: `#graphql
     subscription SubCommandDictionaries {
-      command_dictionary {
+      command_dictionary(order_by: { id: desc }) {
         command_types_typescript_path
         created_at
         id
@@ -777,7 +777,7 @@ const gql = {
 
   SUB_EXPANSION_RULES: `#graphql
     subscription SubExpansionRules {
-      expansionRules: expansion_rule {
+      expansionRules: expansion_rule(order_by: { id: desc }) {
         activity_type
         authoring_command_dict_id
         authoring_mission_model_id
@@ -803,7 +803,7 @@ const gql = {
 
   SUB_EXPANSION_SETS: `#graphql
     subscription SubExpansionSets {
-      expansionSets: expansion_set {
+      expansionSets: expansion_set(order_by: { id: desc }) {
         command_dict_id
         created_at
         expansion_rules {
@@ -821,7 +821,7 @@ const gql = {
 
   SUB_MODELS: `#graphql
     subscription SubModels {
-      models: mission_model {
+      models: mission_model(order_by: { name: asc }) {
         id
         jar_id,
         name
@@ -854,7 +854,7 @@ const gql = {
 
   SUB_SCHEDULING_GOALS: `#graphql
     subscription SubSchedulingGoals {
-      goals: scheduling_goal {
+      goals: scheduling_goal(order_by: { id: desc }) {
         analyses(limit: 0) {
           analysis_id
         }
@@ -874,7 +874,7 @@ const gql = {
 
   SUB_SCHEDULING_SPEC_GOALS: `#graphql
     subscription SubSchedulingSpecGoals($specification_id: Int!) {
-      specGoals: scheduling_specification_goals(where: { specification_id: { _eq: $specification_id } }) {
+      specGoals: scheduling_specification_goals(where: { specification_id: { _eq: $specification_id } }, order_by: { priority: asc }) {
         enabled
         goal {
           analyses(order_by: { request: { specification_revision: desc } }, limit: 2) {
@@ -930,7 +930,7 @@ const gql = {
 
   SUB_USER_SEQUENCES: `#graphql
     subscription SubUserSequences {
-      user_sequence {
+      user_sequence(order_by: { id: desc }) {
         authoring_command_dict_id
         created_at
         definition


### PR DESCRIPTION
* Allow gqlSubscribable to accept store variables in addition to regular variables
* Move some data sorts out of JavaScript and into GQL queries
* Rename id column for most data tables to just 'ID'
* Make id first column in most data tables
* Update e2e test fixture now that column id order changed
* Remove obsolete 'setVariables' store code where able