### PR TITLE
feat: add vertical timeline cursor

### DIFF
--- a/src/components/timeline/RowXAxisTicks.svelte
+++ b/src/components/timeline/RowXAxisTicks.svelte
@@ -11,7 +11,7 @@
 <g class="row-x-axis-ticks">
   {#each xTicksView as tick}
     <g class="tick" opacity="1" transform="translate({xScaleView(tick.date)}, 0)">
-      <line stroke="lightgrey" y2={drawHeight} />
+      <line stroke="rgba(0, 0, 0, 0.125)" y2={drawHeight} />
     </g>
   {/each}
 </g>

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -123,45 +123,44 @@
       on:viewTimeRangeChanged={onViewTimeRangeChanged}
     />
   </div>
-  <TimelineCursors {mouseOver} {xScaleView} {drawWidth} marginLeft={timeline?.marginLeft}>
-    <div
-      class="rows"
-      style="max-height: {rowsMaxHeight}px"
-      on:consider={handleDndConsiderRows}
-      on:finalize={handleDndFinalizeRows}
-      on:mouseenter={() => (timeline.gridId = gridId)}
-      use:dndzone={{
-        dragDisabled: rowDragMoveDisabled,
-        items: rows,
-        type: 'rows',
-      }}
-    >
-      {#each rows as row (row.id)}
-        <TimelineRow
-          autoAdjustHeight={row.autoAdjustHeight}
-          constraintViolations={$constraintViolations}
-          drawHeight={row.height}
-          {drawWidth}
-          horizontalGuides={row.horizontalGuides}
-          id={row.id}
-          layers={row.layers}
-          marginLeft={timeline?.marginLeft}
-          resources={$resources}
-          {rowDragMoveDisabled}
-          verticalGuides={timeline?.verticalGuides}
-          viewTimeRange={$viewTimeRange}
-          {xScaleView}
-          {xTicksView}
-          yAxes={row.yAxes}
-          on:mouseDown={onMouseDown}
-          on:mouseDownRowMove={onMouseDownRowMove}
-          on:mouseOver={e => (mouseOver = e.detail)}
-          on:mouseOverViolations={e => (mouseOverViolations = e.detail)}
-          on:updateRowHeight={onUpdateRowHeight}
-        />
-      {/each}
-    </div>
-  </TimelineCursors>
+  <TimelineCursors {mouseOver} {xScaleView} {drawWidth} marginLeft={timeline?.marginLeft} />
+  <div
+    class="rows"
+    style="max-height: {rowsMaxHeight}px"
+    on:consider={handleDndConsiderRows}
+    on:finalize={handleDndFinalizeRows}
+    on:mouseenter={() => (timeline.gridId = gridId)}
+    use:dndzone={{
+      dragDisabled: rowDragMoveDisabled,
+      items: rows,
+      type: 'rows',
+    }}
+  >
+    {#each rows as row (row.id)}
+      <TimelineRow
+        autoAdjustHeight={row.autoAdjustHeight}
+        constraintViolations={$constraintViolations}
+        drawHeight={row.height}
+        {drawWidth}
+        horizontalGuides={row.horizontalGuides}
+        id={row.id}
+        layers={row.layers}
+        marginLeft={timeline?.marginLeft}
+        resources={$resources}
+        {rowDragMoveDisabled}
+        verticalGuides={timeline?.verticalGuides}
+        viewTimeRange={$viewTimeRange}
+        {xScaleView}
+        {xTicksView}
+        yAxes={row.yAxes}
+        on:mouseDown={onMouseDown}
+        on:mouseDownRowMove={onMouseDownRowMove}
+        on:mouseOver={e => (mouseOver = e.detail)}
+        on:mouseOverViolations={e => (mouseOverViolations = e.detail)}
+        on:updateRowHeight={onUpdateRowHeight}
+      />
+    {/each}
+  </div>
 
   <!-- Timeline Tooltip. -->
   <Tooltip {mouseOver} {mouseOverViolations} />

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -29,6 +29,7 @@
   let xAxisDiv: HTMLDivElement;
   let xAxisDrawHeight: number = 90;
   let cursorHeaderHeight: number = 20;
+  let cursorEnabled: boolean = true;
 
   $: timeline = $view?.definition.plan.timelines.find(timeline => timeline.id === timelineId);
   $: rows = timeline?.rows || [];
@@ -124,7 +125,14 @@
       on:viewTimeRangeChanged={onViewTimeRangeChanged}
     />
   </div>
-  <TimelineCursors {mouseOver} {xScaleView} {drawWidth} {cursorHeaderHeight} marginLeft={timeline?.marginLeft} />
+  <TimelineCursors
+    {mouseOver}
+    {xScaleView}
+    {drawWidth}
+    {cursorHeaderHeight}
+    {cursorEnabled}
+    marginLeft={timeline?.marginLeft}
+  />
   <div
     class="rows"
     style="max-height: {rowsMaxHeight}px"

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -28,6 +28,7 @@
   let timelineDiv: HTMLDivElement;
   let xAxisDiv: HTMLDivElement;
   let xAxisDrawHeight: number = 90;
+  let cursorHeaderHeight: number = 20;
 
   $: timeline = $view?.definition.plan.timelines.find(timeline => timeline.id === timelineId);
   $: rows = timeline?.rows || [];
@@ -102,7 +103,7 @@
     if (timelineDiv && xAxisDiv && timelineDiv.parentElement) {
       const { clientHeight: parentHeight } = timelineDiv.parentElement;
       const offsetTop = xAxisDiv.clientHeight;
-      const maxHeight = parentHeight - offsetTop;
+      const maxHeight = parentHeight - offsetTop - cursorHeaderHeight;
       rowsMaxHeight = maxHeight;
     }
   }
@@ -123,7 +124,7 @@
       on:viewTimeRangeChanged={onViewTimeRangeChanged}
     />
   </div>
-  <TimelineCursors {mouseOver} {xScaleView} {drawWidth} marginLeft={timeline?.marginLeft} />
+  <TimelineCursors {mouseOver} {xScaleView} {drawWidth} {cursorHeaderHeight} marginLeft={timeline?.marginLeft} />
   <div
     class="rows"
     style="max-height: {rowsMaxHeight}px"

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -11,6 +11,7 @@
   import { getDoyTime } from '../../utilities/time';
   import { getXScale, MAX_CANVAS_SIZE } from '../../utilities/timeline';
   import TimelineRow from './Row.svelte';
+  import TimelineCursors from './TimelineCursors.svelte';
   import Tooltip from './Tooltip.svelte';
   import TimelineXAxis from './XAxis.svelte';
 
@@ -122,43 +123,45 @@
       on:viewTimeRangeChanged={onViewTimeRangeChanged}
     />
   </div>
-  <div
-    class="rows"
-    style="max-height: {rowsMaxHeight}px"
-    on:consider={handleDndConsiderRows}
-    on:finalize={handleDndFinalizeRows}
-    on:mouseenter={() => (timeline.gridId = gridId)}
-    use:dndzone={{
-      dragDisabled: rowDragMoveDisabled,
-      items: rows,
-      type: 'rows',
-    }}
-  >
-    {#each rows as row (row.id)}
-      <TimelineRow
-        autoAdjustHeight={row.autoAdjustHeight}
-        constraintViolations={$constraintViolations}
-        drawHeight={row.height}
-        {drawWidth}
-        horizontalGuides={row.horizontalGuides}
-        id={row.id}
-        layers={row.layers}
-        marginLeft={timeline?.marginLeft}
-        resources={$resources}
-        {rowDragMoveDisabled}
-        verticalGuides={timeline?.verticalGuides}
-        viewTimeRange={$viewTimeRange}
-        {xScaleView}
-        {xTicksView}
-        yAxes={row.yAxes}
-        on:mouseDown={onMouseDown}
-        on:mouseDownRowMove={onMouseDownRowMove}
-        on:mouseOver={e => (mouseOver = e.detail)}
-        on:mouseOverViolations={e => (mouseOverViolations = e.detail)}
-        on:updateRowHeight={onUpdateRowHeight}
-      />
-    {/each}
-  </div>
+  <TimelineCursors {mouseOver} {xScaleView} marginLeft={timeline?.marginLeft}>
+    <div
+      class="rows"
+      style="max-height: {rowsMaxHeight}px"
+      on:consider={handleDndConsiderRows}
+      on:finalize={handleDndFinalizeRows}
+      on:mouseenter={() => (timeline.gridId = gridId)}
+      use:dndzone={{
+        dragDisabled: rowDragMoveDisabled,
+        items: rows,
+        type: 'rows',
+      }}
+    >
+      {#each rows as row (row.id)}
+        <TimelineRow
+          autoAdjustHeight={row.autoAdjustHeight}
+          constraintViolations={$constraintViolations}
+          drawHeight={row.height}
+          {drawWidth}
+          horizontalGuides={row.horizontalGuides}
+          id={row.id}
+          layers={row.layers}
+          marginLeft={timeline?.marginLeft}
+          resources={$resources}
+          {rowDragMoveDisabled}
+          verticalGuides={timeline?.verticalGuides}
+          viewTimeRange={$viewTimeRange}
+          {xScaleView}
+          {xTicksView}
+          yAxes={row.yAxes}
+          on:mouseDown={onMouseDown}
+          on:mouseDownRowMove={onMouseDownRowMove}
+          on:mouseOver={e => (mouseOver = e.detail)}
+          on:mouseOverViolations={e => (mouseOverViolations = e.detail)}
+          on:updateRowHeight={onUpdateRowHeight}
+        />
+      {/each}
+    </div>
+  </TimelineCursors>
 
   <!-- Timeline Tooltip. -->
   <Tooltip {mouseOver} {mouseOverViolations} />

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import { afterUpdate, tick } from 'svelte';
+  import { afterUpdate, onMount, tick } from 'svelte';
   import { dndzone, SOURCES, TRIGGERS } from 'svelte-dnd-action';
   import { selectedActivityId } from '../../stores/activities';
   import { constraintViolations } from '../../stores/constraints';
@@ -46,6 +46,14 @@
     return { date, time, yearDay };
   });
 
+  onMount(() => {
+    document.addEventListener('keydown', onKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  });
+
   afterUpdate(() => {
     setRowsMaxHeight(timelineDiv, xAxisDiv);
   });
@@ -69,6 +77,12 @@
       rowDragMoveDisabled = true;
     }
     viewUpdateTimeline('rows', rows, timelineId);
+  }
+
+  function onKeyDown(event: KeyboardEvent) {
+    if (event.key === 't' && event.ctrlKey) {
+      cursorEnabled = !cursorEnabled;
+    }
   }
 
   function onMouseDown(event: CustomEvent<MouseDown>) {

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import { afterUpdate, onMount, tick } from 'svelte';
+  import { afterUpdate, tick } from 'svelte';
   import { dndzone, SOURCES, TRIGGERS } from 'svelte-dnd-action';
   import { selectedActivityId } from '../../stores/activities';
   import { constraintViolations } from '../../stores/constraints';
@@ -19,6 +19,8 @@
   export let timelineId: number;
 
   let clientWidth: number = 0;
+  let cursorEnabled: boolean = true;
+  let cursorHeaderHeight: number = 20;
   let mouseOver: MouseOver;
   let mouseOverViolations: MouseOverViolations;
   let rowDragMoveDisabled = true;
@@ -28,8 +30,6 @@
   let timelineDiv: HTMLDivElement;
   let xAxisDiv: HTMLDivElement;
   let xAxisDrawHeight: number = 90;
-  let cursorHeaderHeight: number = 20;
-  let cursorEnabled: boolean = true;
 
   $: timeline = $view?.definition.plan.timelines.find(timeline => timeline.id === timelineId);
   $: rows = timeline?.rows || [];
@@ -44,14 +44,6 @@
     const doyTimestamp = getDoyTime(date, false);
     const [yearDay, time] = doyTimestamp.split('T');
     return { date, time, yearDay };
-  });
-
-  onMount(() => {
-    document.addEventListener('keydown', onKeyDown);
-
-    return () => {
-      document.removeEventListener('keydown', onKeyDown);
-    };
   });
 
   afterUpdate(() => {
@@ -128,6 +120,8 @@
     }
   }
 </script>
+
+<svelte:window on:keydown={onKeyDown} />
 
 <div bind:this={timelineDiv} bind:clientWidth class="timeline" id={`timeline-${timelineId}`}>
   <div bind:this={xAxisDiv} class="x-axis" style="height: {xAxisDrawHeight}px">

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -123,7 +123,7 @@
       on:viewTimeRangeChanged={onViewTimeRangeChanged}
     />
   </div>
-  <TimelineCursors {mouseOver} {xScaleView} marginLeft={timeline?.marginLeft}>
+  <TimelineCursors {mouseOver} {xScaleView} {drawWidth} marginLeft={timeline?.marginLeft}>
     <div
       class="rows"
       style="max-height: {rowsMaxHeight}px"

--- a/src/components/timeline/TimelineCursors.svelte
+++ b/src/components/timeline/TimelineCursors.svelte
@@ -1,0 +1,69 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import type { ScaleTime } from 'd3-scale';
+  import { select } from 'd3-selection';
+  // import { getDoyTime } from '../../utilities/time';
+
+  export let mouseOver: MouseOver;
+  export let xScaleView: ScaleTime<number, number> | null = null;
+  export let marginLeft: number = 50;
+
+  $: onMouseOver(mouseOver);
+
+  let raf: number = null;
+
+  function onMouseOver(event: MouseOver | undefined) {
+    if (event && xScaleView) {
+      const { offsetX } = event.e;
+      // const unixEpochTime = xScaleView.invert(offsetX).getTime();
+      // const doyTime = getDoyTime(new Date(unixEpochTime));
+      cancelAnimationFrame(raf);
+
+      if (offsetX >= 0) {
+        raf = window.requestAnimationFrame(() => {
+          const cursorDiv = getCursor();
+          cursorDiv.style('opacity', 1.0).style('left', `${offsetX + marginLeft - 1}px`);
+        });
+      } else {
+        raf = window.requestAnimationFrame(() => {
+          const cursorDiv = getCursor();
+          cursorDiv.style('opacity', 0);
+        });
+      }
+    }
+  }
+
+  function getCursor() {
+    const cursorDiv = select(`.timeline-cursor`);
+    if (cursorDiv.empty()) {
+      const body = select('body');
+      return body.append('div').attr('class', 'timeline-cursor');
+    } else {
+      return cursorDiv;
+    }
+  }
+</script>
+
+<div class="timeline-cursor-container">
+  <div class="timeline-cursor" />
+  <slot />
+</div>
+
+<style>
+  .timeline-cursor-container {
+    height: 100%;
+    position: relative;
+    width: 100%;
+  }
+
+  .timeline-cursor {
+    background-color: var(--st-gray-50);
+    height: 100%;
+    left: 0px;
+    opacity: 0;
+    pointer-events: none;
+    position: absolute;
+    width: 1px;
+  }
+</style>

--- a/src/components/timeline/TimelineCursors.svelte
+++ b/src/components/timeline/TimelineCursors.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import type { ScaleTime } from 'd3-scale';
-  import { select } from 'd3-selection';
   import { getDoyTime } from '../../utilities/time';
 
   export let mouseOver: MouseOver;
@@ -8,56 +7,56 @@
   export let marginLeft: number = 50;
   export let drawWidth: number = 0;
   export let cursorHeaderHeight: number = 20;
+  export let cursorEnabled: boolean = true;
 
   $: onMouseOver(mouseOver);
 
   let raf: number = null;
+  let cursorDiv: HTMLElement = null;
+  let cursorLabelDiv: HTMLElement = null;
 
   function onMouseOver(event: MouseOver | undefined) {
-    if (event && xScaleView) {
+    if (event && xScaleView && cursorDiv && cursorLabelDiv) {
       const { offsetX } = event.e;
       const unixEpochTime = xScaleView.invert(offsetX).getTime();
       const doyTime = getDoyTime(new Date(unixEpochTime));
-      cancelAnimationFrame(raf);
 
-      if (offsetX >= 0 && offsetX <= drawWidth) {
+      if (cursorEnabled && offsetX >= 0 && offsetX <= drawWidth) {
+        cancelAnimationFrame(raf);
         raf = window.requestAnimationFrame(() => {
-          const cursorDiv = getCursor();
-          const cursorLabel = cursorDiv.select('.timeline-cursor-label').node() as HTMLElement;
-          cursorLabel.textContent = doyTime;
-          const cursorLabelWidth = cursorLabel.getBoundingClientRect().width;
+          cursorLabelDiv.textContent = doyTime;
+          const cursorLabelWidth = cursorLabelDiv.getBoundingClientRect().width;
           if (offsetX + cursorLabelWidth + 10 > drawWidth) {
-            cursorLabel.style.left = 'calc(-100% - 10px)';
+            cursorLabelDiv.style.transform = 'translateX(calc(-100% - 10px))';
           } else {
-            cursorLabel.style.left = '10px';
+            cursorLabelDiv.style.transform = 'translateX(10px)';
           }
-          cursorDiv.style('opacity', 1.0).style('transform', `translateX(${offsetX + marginLeft - 1}px)`);
+          cursorDiv.style.opacity = '1.0';
+          cursorDiv.style.transform = `translateX(${offsetX + marginLeft - 1}px)`;
         });
       } else {
-        raf = window.requestAnimationFrame(() => {
-          const cursorDiv = getCursor();
-          cursorDiv.style('opacity', 0);
-        });
+        hideCursor();
       }
     }
   }
 
-  function getCursor() {
-    const cursorDiv = select(`.timeline-cursor`);
-    if (cursorDiv.empty()) {
-      const body = select('body');
-      return body.append('div').attr('class', 'timeline-cursor');
-    } else {
-      return cursorDiv;
+  function hideCursor() {
+    if (!cursorDiv) {
+      return;
     }
+
+    cancelAnimationFrame(raf);
+    raf = window.requestAnimationFrame(() => {
+      cursorDiv.style.opacity = '0';
+    });
   }
 </script>
 
 <div class="timeline-cursor-margin" style="height: {cursorHeaderHeight}px" />
 <div class="timeline-cursor-container">
   <div class="timeline-cursor-header" />
-  <div class="timeline-cursor">
-    <div class="timeline-cursor-label" />
+  <div bind:this={cursorDiv} class="timeline-cursor">
+    <div bind:this={cursorLabelDiv} class="timeline-cursor-label" />
   </div>
 </div>
 
@@ -112,7 +111,7 @@
 
   .timeline-cursor-label {
     font-size: 10px;
-    left: 10px;
+    left: 0;
     position: relative;
     top: -11px;
     white-space: nowrap;

--- a/src/components/timeline/TimelineCursors.svelte
+++ b/src/components/timeline/TimelineCursors.svelte
@@ -10,33 +10,47 @@
   export let cursorEnabled: boolean = true;
 
   $: onMouseOver(mouseOver);
+  $: onCursorEnableChange(cursorEnabled);
 
   let raf: number = null;
   let cursorDiv: HTMLElement = null;
   let cursorLabelDiv: HTMLElement = null;
+  let offsetX: number = -1;
 
   function onMouseOver(event: MouseOver | undefined) {
     if (event && xScaleView && cursorDiv && cursorLabelDiv) {
-      const { offsetX } = event.e;
+      offsetX = event.e.offsetX;
+      updateCursor();
+    }
+  }
+
+  function onCursorEnableChange(cursorEnabled) {
+    if (cursorEnabled) {
+      updateCursor();
+    } else {
+      hideCursor();
+    }
+  }
+
+  function updateCursor() {
+    if (cursorEnabled && offsetX >= 0 && offsetX <= drawWidth) {
       const unixEpochTime = xScaleView.invert(offsetX).getTime();
       const doyTime = getDoyTime(new Date(unixEpochTime));
 
-      if (cursorEnabled && offsetX >= 0 && offsetX <= drawWidth) {
-        cancelAnimationFrame(raf);
-        raf = window.requestAnimationFrame(() => {
-          cursorLabelDiv.textContent = doyTime;
-          const cursorLabelWidth = cursorLabelDiv.getBoundingClientRect().width;
-          if (offsetX + cursorLabelWidth + 10 > drawWidth) {
-            cursorLabelDiv.style.transform = 'translateX(calc(-100% - 10px))';
-          } else {
-            cursorLabelDiv.style.transform = 'translateX(10px)';
-          }
-          cursorDiv.style.opacity = '1.0';
-          cursorDiv.style.transform = `translateX(${offsetX + marginLeft - 1}px)`;
-        });
-      } else {
-        hideCursor();
-      }
+      cancelAnimationFrame(raf);
+      raf = window.requestAnimationFrame(() => {
+        cursorLabelDiv.textContent = doyTime;
+        const cursorLabelWidth = cursorLabelDiv.getBoundingClientRect().width;
+        if (offsetX + cursorLabelWidth + 10 > drawWidth) {
+          cursorLabelDiv.style.transform = 'translateX(calc(-100% - 10px))';
+        } else {
+          cursorLabelDiv.style.transform = 'translateX(10px)';
+        }
+        cursorDiv.style.opacity = '1.0';
+        cursorDiv.style.transform = `translateX(${offsetX + marginLeft - 1}px)`;
+      });
+    } else {
+      hideCursor();
     }
   }
 

--- a/src/components/timeline/TimelineCursors.svelte
+++ b/src/components/timeline/TimelineCursors.svelte
@@ -23,7 +23,7 @@
       if (offsetX >= 0) {
         raf = window.requestAnimationFrame(() => {
           const cursorDiv = getCursor();
-          cursorDiv.style('opacity', 1.0).style('left', `${offsetX + marginLeft - 1}px`);
+          cursorDiv.style('opacity', 1.0).style('transform', `translateX(${offsetX + marginLeft - 1}px)`);
         });
       } else {
         raf = window.requestAnimationFrame(() => {
@@ -60,10 +60,12 @@
   .timeline-cursor {
     background-color: var(--st-gray-50);
     height: 100%;
-    left: 0px;
+    left: 0;
     opacity: 0;
     pointer-events: none;
     position: absolute;
+    top: 0;
+    transform: translateX(0);
     width: 1px;
   }
 </style>

--- a/src/components/timeline/TimelineCursors.svelte
+++ b/src/components/timeline/TimelineCursors.svelte
@@ -52,18 +52,23 @@
   }
 </script>
 
+<div class="timeline-cursor-margin" />
 <div class="timeline-cursor-container">
   <div class="timeline-cursor-header" />
   <div class="timeline-cursor">
     <div class="timeline-cursor-label" />
   </div>
-  <slot />
 </div>
 
 <style>
+  .timeline-cursor-margin {
+    height: 20px;
+    position: relative;
+  }
+
   .timeline-cursor-container {
     height: 100%;
-    position: relative;
+    position: absolute;
     width: 100%;
   }
 
@@ -78,7 +83,7 @@
     opacity: 0;
     pointer-events: none;
     position: absolute;
-    top: 0.5rem;
+    top: -10px;
     transform: translateX(0);
   }
 

--- a/src/components/timeline/TimelineCursors.svelte
+++ b/src/components/timeline/TimelineCursors.svelte
@@ -2,20 +2,20 @@
   import type { ScaleTime } from 'd3-scale';
   import { getDoyTime } from '../../utilities/time';
 
+  export let cursorEnabled: boolean = true;
+  export let cursorHeaderHeight: number = 20;
+  export let drawWidth: number = 0;
+  export let marginLeft: number = 50;
   export let mouseOver: MouseOver;
   export let xScaleView: ScaleTime<number, number> | null = null;
-  export let marginLeft: number = 50;
-  export let drawWidth: number = 0;
-  export let cursorHeaderHeight: number = 20;
-  export let cursorEnabled: boolean = true;
 
-  $: onMouseOver(mouseOver);
   $: onCursorEnableChange(cursorEnabled);
+  $: onMouseOver(mouseOver);
 
-  let raf: number = null;
   let cursorDiv: HTMLElement = null;
   let cursorLabelDiv: HTMLElement = null;
   let offsetX: number = -1;
+  let raf: number = null;
 
   function onMouseOver(event: MouseOver | undefined) {
     if (event && xScaleView && cursorDiv && cursorLabelDiv) {
@@ -24,7 +24,7 @@
     }
   }
 
-  function onCursorEnableChange(cursorEnabled) {
+  function onCursorEnableChange(cursorEnabled: boolean) {
     if (cursorEnabled) {
       updateCursor();
     } else {

--- a/src/components/timeline/TimelineCursors.svelte
+++ b/src/components/timeline/TimelineCursors.svelte
@@ -1,13 +1,12 @@
-<svelte:options immutable={true} />
-
 <script lang="ts">
   import type { ScaleTime } from 'd3-scale';
   import { select } from 'd3-selection';
-  // import { getDoyTime } from '../../utilities/time';
+  import { getDoyTime } from '../../utilities/time';
 
   export let mouseOver: MouseOver;
   export let xScaleView: ScaleTime<number, number> | null = null;
   export let marginLeft: number = 50;
+  export let drawWidth: number = 0;
 
   $: onMouseOver(mouseOver);
 
@@ -16,13 +15,21 @@
   function onMouseOver(event: MouseOver | undefined) {
     if (event && xScaleView) {
       const { offsetX } = event.e;
-      // const unixEpochTime = xScaleView.invert(offsetX).getTime();
-      // const doyTime = getDoyTime(new Date(unixEpochTime));
+      const unixEpochTime = xScaleView.invert(offsetX).getTime();
+      const doyTime = getDoyTime(new Date(unixEpochTime));
       cancelAnimationFrame(raf);
 
-      if (offsetX >= 0) {
+      if (offsetX >= 0 && offsetX <= drawWidth) {
         raf = window.requestAnimationFrame(() => {
           const cursorDiv = getCursor();
+          const cursorLabel = cursorDiv.select('.timeline-cursor-label').node() as HTMLElement;
+          cursorLabel.textContent = doyTime;
+          const cursorLabelWidth = cursorLabel.getBoundingClientRect().width;
+          if (offsetX + cursorLabelWidth + 10 > drawWidth) {
+            cursorLabel.style.left = 'calc(-100% - 10px)';
+          } else {
+            cursorLabel.style.left = '10px';
+          }
           cursorDiv.style('opacity', 1.0).style('transform', `translateX(${offsetX + marginLeft - 1}px)`);
         });
       } else {
@@ -46,7 +53,10 @@
 </script>
 
 <div class="timeline-cursor-container">
-  <div class="timeline-cursor" />
+  <div class="timeline-cursor-header" />
+  <div class="timeline-cursor">
+    <div class="timeline-cursor-label" />
+  </div>
   <slot />
 </div>
 
@@ -57,15 +67,49 @@
     width: 100%;
   }
 
+  .timeline-cursor-header {
+    height: 1rem;
+    position: relative;
+  }
+
   .timeline-cursor {
-    background-color: var(--st-gray-50);
-    height: 100%;
+    height: calc(100% + 0.5rem);
     left: 0;
     opacity: 0;
     pointer-events: none;
     position: absolute;
-    top: 0;
+    top: 0.5rem;
     transform: translateX(0);
+  }
+
+  .timeline-cursor::before {
+    background-color: var(--st-gray-50);
+    border-radius: 100%;
+    content: '';
+    display: block;
+    height: 9px;
+    left: -4px;
+    position: absolute;
+    top: -0.5rem;
+    width: 9px;
+  }
+
+  .timeline-cursor::after {
+    background-color: var(--st-gray-50);
+    content: '';
+    display: block;
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: -0.5rem;
     width: 1px;
+  }
+
+  .timeline-cursor-label {
+    font-size: 10px;
+    left: 10px;
+    position: relative;
+    top: -11px;
+    white-space: nowrap;
   }
 </style>

--- a/src/components/timeline/TimelineCursors.svelte
+++ b/src/components/timeline/TimelineCursors.svelte
@@ -7,6 +7,7 @@
   export let xScaleView: ScaleTime<number, number> | null = null;
   export let marginLeft: number = 50;
   export let drawWidth: number = 0;
+  export let cursorHeaderHeight: number = 20;
 
   $: onMouseOver(mouseOver);
 
@@ -52,7 +53,7 @@
   }
 </script>
 
-<div class="timeline-cursor-margin" />
+<div class="timeline-cursor-margin" style="height: {cursorHeaderHeight}px" />
 <div class="timeline-cursor-container">
   <div class="timeline-cursor-header" />
   <div class="timeline-cursor">
@@ -62,7 +63,6 @@
 
 <style>
   .timeline-cursor-margin {
-    height: 20px;
     position: relative;
   }
 


### PR DESCRIPTION
I would consider this a first iteration of the timeline cursor, with only the current mouse position tracked. We should take a second pass once the more thorough timeline UI overhaul is completed to match the new styles. And also at a later point we can add the pin icons at the same time we introduce the pinned vertical guides functionality.

![2022-09-14 16 22 20](https://user-images.githubusercontent.com/888818/190280850-b7dd1d59-a08d-43c4-8513-c1aef07dfffb.gif)