### PR TITLE
feat: add view menu to plan page

### DIFF
--- a/src/components/app/NavButton.svelte
+++ b/src/components/app/NavButton.svelte
@@ -14,6 +14,7 @@
     <slot />
   </span>
   {title}
+  <slot name="menu" />
 </div>
 
 <style>

--- a/src/components/menus/ViewMenu.svelte
+++ b/src/components/menus/ViewMenu.svelte
@@ -1,0 +1,56 @@
+<svelte:options accessors={true} immutable={true} />
+
+<script lang="ts">
+  import ChevronDownIcon from '@nasa-jpl/stellar/icons/chevron_down.svg?component';
+  import PlusIcon from 'bootstrap-icons/icons/plus.svg?component';
+  import SaveIcon from 'bootstrap-icons/icons/save.svg?component';
+  import { user as userStore } from '../../stores/app';
+  import { view } from '../../stores/views';
+  import effects from '../../utilities/effects';
+  import Menu from './Menu.svelte';
+  import MenuItem from './MenuItem.svelte';
+
+  let saveViewDisabled: boolean = true;
+  let viewMenu: Menu;
+
+  $: saveViewDisabled = $view?.name === '' || $view?.owner !== $userStore?.id;
+
+  function createView() {
+    if ($view) {
+      effects.createView($userStore?.id, $view.definition);
+    }
+  }
+
+  function saveView() {
+    if ($view && $view.owner === $userStore?.id && !saveViewDisabled) {
+      effects.updateView($view.id, { definition: $view.definition, name: $view.name });
+    }
+  }
+</script>
+
+<div class="view-menu st-typography-body" on:click|stopPropagation={() => viewMenu.toggle()}>
+  <ChevronDownIcon />
+
+  <Menu bind:this={viewMenu} offset={[-93, -5]}>
+    <MenuItem on:click={createView}>
+      <PlusIcon />
+      Create View
+    </MenuItem>
+    <MenuItem disabled={saveViewDisabled} on:click={saveView}>
+      <SaveIcon />
+      Save View
+    </MenuItem>
+  </Menu>
+</div>
+
+<style>
+  .view-menu {
+    align-items: center;
+    color: white;
+    cursor: pointer;
+    display: flex;
+    height: inherit;
+    justify-content: center;
+    position: relative;
+  }
+</style>

--- a/src/components/modals/CreateViewModal.svelte
+++ b/src/components/modals/CreateViewModal.svelte
@@ -1,0 +1,49 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import Modal from './Modal.svelte';
+  import ModalContent from './ModalContent.svelte';
+  import ModalFooter from './ModalFooter.svelte';
+  import ModalHeader from './ModalHeader.svelte';
+
+  export let height: number = 150;
+  export let width: number = 380;
+
+  const dispatch = createEventDispatcher();
+
+  let newViewName: string = '';
+  let createButtonDisabled: boolean = true;
+
+  $: createButtonDisabled = newViewName === '';
+
+  function create() {
+    if (!createButtonDisabled) {
+      dispatch('create', { name: newViewName });
+    }
+  }
+
+  function onKeydown(event: KeyboardEvent) {
+    const { key } = event;
+    if (key === 'Enter') {
+      event.preventDefault();
+      create();
+    }
+  }
+</script>
+
+<svelte:window on:keydown={onKeydown} />
+
+<Modal {height} {width}>
+  <ModalHeader on:close>Create View</ModalHeader>
+  <ModalContent>
+    <fieldset>
+      <label for="name">Name</label>
+      <input bind:value={newViewName} autocomplete="off" class="st-input w-100" name="name" required type="text" />
+    </fieldset>
+  </ModalContent>
+  <ModalFooter>
+    <button class="st-button secondary" on:click={() => dispatch('close')}> Cancel </button>
+    <button class="st-button" disabled={createButtonDisabled} on:click={create}> Create </button>
+  </ModalFooter>
+</Modal>

--- a/src/components/view/ViewEditorPanel.svelte
+++ b/src/components/view/ViewEditorPanel.svelte
@@ -1,18 +1,11 @@
 <script lang="ts">
-  import { user as userStore } from '../../stores/app';
   import { view, viewDefinitionText } from '../../stores/views';
-  import effects from '../../utilities/effects';
+  import Input from '../form/Input.svelte';
   import GridMenu from '../menus/GridMenu.svelte';
   import MonacoEditor from '../ui/MonacoEditor.svelte';
   import Panel from '../ui/Panel.svelte';
 
   export let gridId: number;
-
-  let saveAsViewDisabled: boolean = true;
-  let saveViewDisabled: boolean = true;
-
-  $: saveAsViewDisabled = $view?.name === '';
-  $: saveViewDisabled = $view?.name === '' || $view?.owner !== $userStore?.id;
 
   function onDidChangeModelContent(event: CustomEvent<{ value: string }>): void {
     const { detail } = event;
@@ -25,46 +18,34 @@
       console.log(e);
     }
   }
-
-  function saveAsView() {
-    if ($view && !saveAsViewDisabled) {
-      effects.createView($view.name, $userStore?.id, $view.definition);
-    }
-  }
-
-  function saveView() {
-    if ($view && $view.owner === $userStore?.id && !saveViewDisabled) {
-      effects.updateView($view.id, { definition: $view.definition, name: $view.name });
-    }
-  }
 </script>
 
 <Panel overflowYBody="hidden">
   <svelte:fragment slot="header">
     <GridMenu {gridId} title="View Editor" />
-    <div class="right">
-      <button class="st-button secondary ellipsis" disabled={saveViewDisabled} on:click={saveView}> Save </button>
-      <button class="st-button secondary ellipsis" disabled={saveAsViewDisabled} on:click={saveAsView}>
-        Save As
-      </button>
-    </div>
   </svelte:fragment>
 
   <svelte:fragment slot="body">
     <div class="pb-2">
       <fieldset>
-        <label for="id">ID</label>
-        <input bind:value={$view.id} class="st-input w-100" disabled name="id" required type="text" />
+        <Input layout="inline">
+          <label for="id">ID</label>
+          <input bind:value={$view.id} class="st-input w-100" disabled name="id" required type="text" />
+        </Input>
       </fieldset>
 
       <fieldset>
-        <label for="owner">Owner</label>
-        <input bind:value={$view.owner} class="st-input w-100" disabled name="owner" required type="text" />
+        <Input layout="inline">
+          <label for="owner">Owner</label>
+          <input bind:value={$view.owner} class="st-input w-100" disabled name="owner" required type="text" />
+        </Input>
       </fieldset>
 
       <fieldset>
-        <label for="name">Name</label>
-        <input bind:value={$view.name} autocomplete="off" class="st-input w-100" name="name" required type="text" />
+        <Input layout="inline">
+          <label for="name">Name</label>
+          <input bind:value={$view.name} autocomplete="off" class="st-input w-100" name="name" required type="text" />
+        </Input>
       </fieldset>
     </div>
 
@@ -80,11 +61,3 @@
     />
   </svelte:fragment>
 </Panel>
-
-<style>
-  .right {
-    align-items: center;
-    display: inline-flex;
-    gap: 5px;
-  }
-</style>

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -16,6 +16,7 @@
   import ConstraintsPanel from '../../../components/constraints/ConstraintsPanel.svelte';
   import ConstraintViolationsPanel from '../../../components/constraints/ConstraintViolationsPanel.svelte';
   import ExpansionPanel from '../../../components/expansion/ExpansionPanel.svelte';
+  import ViewMenu from '../../../components/menus/ViewMenu.svelte';
   import SchedulingPanel from '../../../components/scheduling/SchedulingPanel.svelte';
   import SimulationPanel from '../../../components/simulation/SimulationPanel.svelte';
   import TimelineFormPanel from '../../../components/timeline/form/TimelineFormPanel.svelte';
@@ -159,6 +160,7 @@
         on:click={() => viewSetLayout('View')}
       >
         <ColumnsIcon />
+        <ViewMenu slot="menu" />
       </NavButton>
     </svelte:fragment>
   </Nav>

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -1,5 +1,3 @@
-type HtmlModalElement = HTMLDivElement & { resolve: (value: boolean | PromiseLike<boolean>) => void };
-
 type User = {
   id: string;
   ssoToken: string;

--- a/src/types/modal.d.ts
+++ b/src/types/modal.d.ts
@@ -1,0 +1,10 @@
+type ModalElementValue<T = any> = {
+  confirm: boolean;
+  value?: T;
+};
+
+type ModalElementResolve = {
+  resolve: (value: ModalElementValue | PromiseLike<ModalElementValue>) => void;
+};
+
+type ModalElement = HTMLDivElement & ModalElementResolve;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -19,7 +19,7 @@ import { view } from '../stores/views';
 import { activityDirectiveToActivity, activitySimulatedToActivity, getChildIdsFn, getParentIdFn } from './activities';
 import { formatHasuraStringArray, parseFloatOrNull, setQueryParam, sleep } from './generic';
 import gql from './gql';
-import { showConfirmModal } from './modal';
+import { showConfirmModal, showCreateViewModal } from './modal';
 import { reqGateway, reqHasura } from './requests';
 import { sampleProfiles } from './resources';
 import { Status } from './status';
@@ -374,15 +374,20 @@ const effects = {
     }
   },
 
-  async createView(name: string, owner: string, definition: ViewDefinition): Promise<void> {
+  async createView(owner: string, definition: ViewDefinition): Promise<void> {
     try {
-      const viewInsertInput: ViewInsertInput = { definition, name, owner };
-      const data = await reqHasura<View>(gql.CREATE_VIEW, { view: viewInsertInput });
-      const { newView } = data;
+      const { confirm, value = null } = await showCreateViewModal();
 
-      view.update(() => newView);
-      setQueryParam('viewId', `${newView.id}`);
-      showSuccessToast('View Created Successfully');
+      if (confirm && value) {
+        const { name } = value;
+        const viewInsertInput: ViewInsertInput = { definition, name, owner };
+        const data = await reqHasura<View>(gql.CREATE_VIEW, { view: viewInsertInput });
+        const { newView } = data;
+
+        view.update(() => newView);
+        setQueryParam('viewId', `${newView.id}`);
+        showSuccessToast('View Created Successfully');
+      }
     } catch (e) {
       console.log(e);
       showFailureToast('View Create Failed');
@@ -391,7 +396,7 @@ const effects = {
 
   async deleteActivityDirective(id: number): Promise<boolean> {
     try {
-      const confirm = await showConfirmModal(
+      const { confirm } = await showConfirmModal(
         'Delete',
         'Are you sure you want to delete this activity directive?',
         'Delete Activity',
@@ -417,7 +422,7 @@ const effects = {
 
   async deleteActivityDirectives(ids: number[]): Promise<boolean> {
     try {
-      const confirm = await showConfirmModal(
+      const { confirm } = await showConfirmModal(
         'Delete',
         'Are you sure you want to delete the selected activity directives?',
         'Delete Activities',
@@ -445,7 +450,7 @@ const effects = {
 
   async deleteCommandDictionary(id: number): Promise<void> {
     try {
-      const confirm = await showConfirmModal(
+      const { confirm } = await showConfirmModal(
         'Delete',
         'Are you sure you want to delete this dictionary?',
         'Delete Command Dictionary',
@@ -464,7 +469,7 @@ const effects = {
 
   async deleteConstraint(id: number): Promise<boolean> {
     try {
-      const confirm = await showConfirmModal(
+      const { confirm } = await showConfirmModal(
         'Delete',
         'Are you sure you want to delete this constraint?',
         'Delete Constraint',
@@ -487,7 +492,7 @@ const effects = {
 
   async deleteExpansionRule(id: number): Promise<boolean> {
     try {
-      const confirm = await showConfirmModal(
+      const { confirm } = await showConfirmModal(
         'Delete',
         'Are you sure you want to delete this expansion rule?',
         'Delete Expansion Rule',
@@ -509,7 +514,7 @@ const effects = {
 
   async deleteExpansionSequence(sequence: ExpansionSequence): Promise<void> {
     try {
-      const confirm = await showConfirmModal(
+      const { confirm } = await showConfirmModal(
         'Delete',
         'Are you sure you want to delete this expansion sequence?',
         'Delete Expansion Sequence',
@@ -546,7 +551,7 @@ const effects = {
 
   async deleteExpansionSet(id: number): Promise<boolean> {
     try {
-      const confirm = await showConfirmModal(
+      const { confirm } = await showConfirmModal(
         'Delete',
         'Are you sure you want to delete this expansion set?',
         'Delete Expansion Set',
@@ -578,7 +583,11 @@ const effects = {
 
   async deleteModel(model: ModelList): Promise<void> {
     try {
-      const confirm = await showConfirmModal('Delete', 'Are you sure you want to delete this model?', 'Delete Model');
+      const { confirm } = await showConfirmModal(
+        'Delete',
+        'Are you sure you want to delete this model?',
+        'Delete Model',
+      );
 
       if (confirm) {
         const { id, jar_id } = model;
@@ -595,7 +604,7 @@ const effects = {
 
   async deletePlan(id: number): Promise<boolean> {
     try {
-      const confirm = await showConfirmModal('Delete', 'Are you sure you want to delete this plan?', 'Delete Plan');
+      const { confirm } = await showConfirmModal('Delete', 'Are you sure you want to delete this plan?', 'Delete Plan');
 
       if (confirm) {
         await reqHasura(gql.DELETE_PLAN, { id });
@@ -613,7 +622,7 @@ const effects = {
 
   async deleteSchedulingGoal(id: number): Promise<boolean> {
     try {
-      const confirm = await showConfirmModal(
+      const { confirm } = await showConfirmModal(
         'Delete',
         'Are you sure you want to delete this scheduling goal?',
         'Delete Scheduling Goal',
@@ -635,7 +644,7 @@ const effects = {
 
   async deleteUserSequence(id: number): Promise<boolean> {
     try {
-      const confirm = await showConfirmModal(
+      const { confirm } = await showConfirmModal(
         'Delete',
         'Are you sure you want to delete this user sequence?',
         'Delete User Sequence',
@@ -657,7 +666,7 @@ const effects = {
 
   async deleteView(id: number): Promise<boolean> {
     try {
-      const confirm = await showConfirmModal('Delete', 'Are you sure you want to delete this view?', 'Delete View');
+      const { confirm } = await showConfirmModal('Delete', 'Are you sure you want to delete this view?', 'Delete View');
 
       if (confirm) {
         await reqHasura(gql.DELETE_VIEW, { id });
@@ -671,7 +680,7 @@ const effects = {
 
   async deleteViews(ids: number[]): Promise<boolean> {
     try {
-      const confirm = await showConfirmModal(
+      const { confirm } = await showConfirmModal(
         'Delete',
         'Are you sure you want to delete the selected views?',
         'Delete Views',

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -1,15 +1,16 @@
 import AboutModal from '../components/modals/AboutModal.svelte';
 import ConfirmModal from '../components/modals/ConfirmModal.svelte';
+import CreateViewModal from '../components/modals/CreateViewModal.svelte';
 import ExpansionSequenceModal from '../components/modals/ExpansionSequenceModal.svelte';
 
 /**
  * Listens for clicks on the document body and removes the modal children.
  */
-export function modalBodyClickListener() {
-  const target: HtmlModalElement = document.querySelector('#svelte-modal');
+export function modalBodyClickListener(): void {
+  const target: ModalElement = document.querySelector('#svelte-modal');
   if (target && target.resolve) {
     target.replaceChildren();
-    target.resolve(false);
+    target.resolve({ confirm: false });
     target.resolve = null;
   }
 }
@@ -17,11 +18,11 @@ export function modalBodyClickListener() {
 /**
  * Listens for escape key presses on the document body and removes the modal children.
  */
-export function modalBodyKeyListener(event: KeyboardEvent) {
-  const target: HtmlModalElement = document.querySelector('#svelte-modal');
+export function modalBodyKeyListener(event: KeyboardEvent): void {
+  const target: ModalElement = document.querySelector('#svelte-modal');
   if (target && target.resolve && event.key == 'Escape') {
     target.replaceChildren();
-    target.resolve(false);
+    target.resolve({ confirm: false });
     target.resolve = null;
   }
 }
@@ -29,9 +30,9 @@ export function modalBodyKeyListener(event: KeyboardEvent) {
 /**
  * Shows an AboutModal component.
  */
-export async function showAboutModal(): Promise<boolean> {
+export async function showAboutModal(): Promise<ModalElementValue> {
   return new Promise(resolve => {
-    const target: HtmlModalElement = document.querySelector('#svelte-modal');
+    const target: ModalElement = document.querySelector('#svelte-modal');
 
     if (target) {
       const aboutModal = new AboutModal({ target });
@@ -40,7 +41,7 @@ export async function showAboutModal(): Promise<boolean> {
       aboutModal.$on('close', () => {
         target.replaceChildren();
         target.resolve = null;
-        resolve(true);
+        resolve({ confirm: true });
       });
     }
   });
@@ -49,9 +50,13 @@ export async function showAboutModal(): Promise<boolean> {
 /**
  * Shows a ConfirmModal component with the supplied arguments.
  */
-export async function showConfirmModal(confirmText: string, message: string, title: string): Promise<boolean> {
+export async function showConfirmModal(
+  confirmText: string,
+  message: string,
+  title: string,
+): Promise<ModalElementValue> {
   return new Promise(resolve => {
-    const target: HtmlModalElement = document.querySelector('#svelte-modal');
+    const target: ModalElement = document.querySelector('#svelte-modal');
 
     if (target) {
       const confirmModal = new ConfirmModal({
@@ -63,13 +68,39 @@ export async function showConfirmModal(confirmText: string, message: string, tit
       confirmModal.$on('close', () => {
         target.replaceChildren();
         target.resolve = null;
-        resolve(false);
+        resolve({ confirm: false });
       });
 
       confirmModal.$on('confirm', () => {
         target.replaceChildren();
         target.resolve = null;
-        resolve(true);
+        resolve({ confirm: true });
+      });
+    }
+  });
+}
+
+/**
+ * Shows a CreateViewModal component.
+ */
+export async function showCreateViewModal(): Promise<ModalElementValue<{ name: string }>> {
+  return new Promise(resolve => {
+    const target: ModalElement = document.querySelector('#svelte-modal');
+
+    if (target) {
+      const createViewModal = new CreateViewModal({ target });
+      target.resolve = resolve;
+
+      createViewModal.$on('close', () => {
+        target.replaceChildren();
+        target.resolve = null;
+        resolve({ confirm: false });
+      });
+
+      createViewModal.$on('create', (e: CustomEvent<{ name: string }>) => {
+        target.replaceChildren();
+        target.resolve = null;
+        resolve({ confirm: true, value: e.detail });
       });
     }
   });
@@ -78,9 +109,9 @@ export async function showConfirmModal(confirmText: string, message: string, tit
 /**
  * Shows a SequenceModal with the supplied arguments.
  */
-export async function showExpansionSequenceModal(expansionSequence: ExpansionSequence) {
+export async function showExpansionSequenceModal(expansionSequence: ExpansionSequence): Promise<ModalElementValue> {
   return new Promise(resolve => {
-    const target: HtmlModalElement = document.querySelector('#svelte-modal');
+    const target: ModalElement = document.querySelector('#svelte-modal');
 
     if (target) {
       const sequenceModal = new ExpansionSequenceModal({ props: { expansionSequence }, target });
@@ -89,7 +120,7 @@ export async function showExpansionSequenceModal(expansionSequence: ExpansionSeq
       sequenceModal.$on('close', () => {
         target.replaceChildren();
         target.resolve = null;
-        resolve(true);
+        resolve({ confirm: true });
       });
     }
   });


### PR DESCRIPTION
- Create or save view from top-level plan page
- Remove create or save view from view editor panel
- Add modal for creating new view
- Update modals to pass data back to caller
- Update develop banananation jar

To test:
1. Open plan page
2. Click the new menu button next to the 'View' tab in the top right
3. Create a new view and verify your viewId in the URL has changed
4. Open the View Editor panel and verify you are looking at your new view
5. Make a change to the view and save it using the view menu