### PR TITLE
feat: timeline row headers

### DIFF
--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -89,7 +89,8 @@
 
 <div class="row-root">
   <!-- Row Header. -->
-  <RowHeader title={name} {rowDragMoveDisabled} on:mouseDownRowMove on:toggleRowExpansion />
+  <RowHeader {expanded} rowId={id} title={name} {rowDragMoveDisabled} on:mouseDownRowMove on:toggleRowExpansion />
+
   <div class={rowClasses} id={`row-${id}`} style="height: {drawHeight}px;">
     <!-- Overlay for Pointer Events. -->
     <svg
@@ -191,7 +192,9 @@
   </div>
 
   <!-- Drag Handle for Row Height Resizing. -->
-  <RowDragHandleHeight rowHeight={drawHeight} on:updateRowHeight={onUpdateRowHeightDrag} />
+  {#if !autoAdjustHeight && expanded}
+    <RowDragHandleHeight rowHeight={drawHeight} on:updateRowHeight={onUpdateRowHeightDrag} />
+  {/if}
 </div>
 
 <style>
@@ -224,11 +227,15 @@
     z-index: 1;
   }
 
-  :global(.row-root:hover .row-header .row-hover-menu) {
+  :global(.row-root:hover .row-header .row-drag-handle-container) {
     opacity: 1;
   }
 
   .row.row-collapsed {
     display: none;
+  }
+
+  :global(.right) {
+    z-index: 0;
   }
 </style>

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -10,6 +10,7 @@
   import LayerXRange from './LayerXRange.svelte';
   import RowDragHandleHeight from './RowDragHandleHeight.svelte';
   import RowDragHandleMove from './RowDragHandleMove.svelte';
+  import RowHeader from './RowHeader.svelte';
   import RowHorizontalGuides from './RowHorizontalGuides.svelte';
   import RowVerticalGuides from './RowVerticalGuides.svelte';
   import RowXAxisTicks from './RowXAxisTicks.svelte';
@@ -84,6 +85,9 @@
 
 <div>
   <div class="row" id={`row-${id}`} style="height: {drawHeight}px;">
+    <!-- Row Header. -->
+    <RowHeader />
+
     <!-- Hover Menu. -->
     <div class="row-hover-menu">
       <RowDragHandleMove disabled={rowDragMoveDisabled} on:mouseDownRowMove />

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -53,6 +53,7 @@
     heightsByLayer,
     layers.map(({ id }) => id),
   );
+  $: rowClasses = classNames('row', { 'row-collapsed': !expanded });
 
   function onMouseDown(event: CustomEvent<MouseDown>) {
     const { detail } = event;
@@ -83,8 +84,6 @@
       dispatch('updateRowHeight', { newHeight, rowId: id });
     }
   }
-
-  $: rowClasses = classNames('row', { 'row-collapsed': !expanded });
 </script>
 
 <div class="row-root">

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -4,6 +4,7 @@
   import type { ScaleTime } from 'd3-scale';
   import { pick } from 'lodash-es';
   import { createEventDispatcher } from 'svelte';
+  import { classNames } from '../../utilities/generic';
   import ConstraintViolations from './ConstraintViolations.svelte';
   import LayerActivity from './LayerActivity.svelte';
   import LayerLine from './LayerLine.svelte';
@@ -19,9 +20,11 @@
   export let constraintViolations: ConstraintViolation[] = [];
   export let drawHeight: number = 0;
   export let drawWidth: number = 0;
+  export let expanded: boolean = true;
   export let horizontalGuides: HorizontalGuide[] = [];
   export let id: number;
   export let layers: Layer[] = [];
+  export let name: string = '';
   export let marginLeft: number = 50;
   export let resources: Resource[] = [];
   export let rowDragMoveDisabled = true;
@@ -80,18 +83,14 @@
       dispatch('updateRowHeight', { newHeight, rowId: id });
     }
   }
+
+  $: rowClasses = classNames('row', { 'row-collapsed': !expanded });
 </script>
 
 <div class="row-root">
-  <RowHeader {rowDragMoveDisabled} on:mouseDownRowMove />
-  <div class="row" id={`row-${id}`} style="height: {drawHeight}px;">
-    <!-- Row Header. -->
-
-    <!-- Hover Menu. -->
-    <!-- <div class="row-hover-menu">
-      <RowDragHandleMove disabled={rowDragMoveDisabled} on:mouseDownRowMove />
-    </div> -->
-
+  <!-- Row Header. -->
+  <RowHeader title={name} {rowDragMoveDisabled} on:mouseDownRowMove on:toggleRowExpansion />
+  <div class={rowClasses} id={`row-${id}`} style="height: {drawHeight}px;">
     <!-- Overlay for Pointer Events. -->
     <svg
       bind:this={overlaySvg}
@@ -227,5 +226,9 @@
 
   :global(.row-root:hover .row-header .row-hover-menu) {
     opacity: 1;
+  }
+
+  .row.row-collapsed {
+    display: none;
   }
 </style>

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -9,7 +9,6 @@
   import LayerLine from './LayerLine.svelte';
   import LayerXRange from './LayerXRange.svelte';
   import RowDragHandleHeight from './RowDragHandleHeight.svelte';
-  import RowDragHandleMove from './RowDragHandleMove.svelte';
   import RowHeader from './RowHeader.svelte';
   import RowHorizontalGuides from './RowHorizontalGuides.svelte';
   import RowVerticalGuides from './RowVerticalGuides.svelte';
@@ -83,15 +82,15 @@
   }
 </script>
 
-<div>
+<div class="row-root">
+  <RowHeader {rowDragMoveDisabled} on:mouseDownRowMove />
   <div class="row" id={`row-${id}`} style="height: {drawHeight}px;">
     <!-- Row Header. -->
-    <RowHeader />
 
     <!-- Hover Menu. -->
-    <div class="row-hover-menu">
+    <!-- <div class="row-hover-menu">
       <RowDragHandleMove disabled={rowDragMoveDisabled} on:mouseDownRowMove />
-    </div>
+    </div> -->
 
     <!-- Overlay for Pointer Events. -->
     <svg
@@ -226,15 +225,7 @@
     z-index: 1;
   }
 
-  .row-hover-menu {
-    color: var(--st-gray-50);
-    display: none;
-    font-size: 1.2rem;
-    position: absolute;
-    z-index: 2;
-  }
-
-  .row:hover > .row-hover-menu {
-    display: block;
+  :global(.row-root:hover .row-header .row-hover-menu) {
+    opacity: 1;
   }
 </style>

--- a/src/components/timeline/RowDragHandleHeight.svelte
+++ b/src/components/timeline/RowDragHandleHeight.svelte
@@ -45,4 +45,8 @@
     opacity: 0.5;
     width: 100%;
   }
+
+  .row-drag-handle-height:hover {
+    background-color: var(--st-gray-30);
+  }
 </style>

--- a/src/components/timeline/RowDragHandleMove.svelte
+++ b/src/components/timeline/RowDragHandleMove.svelte
@@ -20,5 +20,8 @@
 <style>
   .row-drag-handle-move {
     display: flex;
+    flex: 1;
+    justify-content: center;
+    width: 100%;
   }
 </style>

--- a/src/components/timeline/RowDragHandleMove.svelte
+++ b/src/components/timeline/RowDragHandleMove.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import GripVerticalIcon from 'bootstrap-icons/icons/grip-vertical.svg?component';
+  import GripHorizontalIcon from 'bootstrap-icons/icons/grip-horizontal.svg?component';
   import { createEventDispatcher } from 'svelte';
 
   export let disabled: boolean = true;
@@ -14,5 +14,11 @@
   style={disabled ? 'cursor: grab' : 'cursor: grabbing'}
   on:mousedown={() => dispatch('mouseDownRowMove')}
 >
-  <GripVerticalIcon />
+  <GripHorizontalIcon />
 </div>
+
+<style>
+  .row-drag-handle-move {
+    display: flex;
+  }
+</style>

--- a/src/components/timeline/RowHeader.svelte
+++ b/src/components/timeline/RowHeader.svelte
@@ -19,22 +19,24 @@
 </script>
 
 <div class="row-header">
+  <div class="row-drag-handle-container">
+    <RowDragHandleMove disabled={rowDragMoveDisabled} on:mouseDownRowMove />
+  </div>
+
   <button class="st-button icon" on:click={toggleExpansion}>
     {#if expanded}
       <CaretDownIcon class="row-header-collapse" />
     {:else}
       <CaretRightIcon class="row-header-collapse" />
     {/if}
+    <div class="row-header-title st-typography-medium">{title}</div>
   </button>
-
-  <div class="row-header-title st-typography-medium">{title}</div>
-  <div class="row-hover-menu">
-    <RowDragHandleMove disabled={rowDragMoveDisabled} on:mouseDownRowMove />
-  </div>
 
   {#if $$slots.right}
     <div class="right">
-      <slot name="right" />
+      <div>
+        <slot name="right" />
+      </div>
     </div>
   {/if}
 </div>
@@ -46,7 +48,7 @@
     border-bottom: 1px solid var(--st-gray-15);
     border-top: 1px solid var(--st-gray-15);
     display: flex;
-    height: 22px;
+    height: 24px;
     padding: 0px 8px 0px 4px;
     position: relative;
   }
@@ -62,12 +64,45 @@
     color: var(--st-gray-30);
   }
 
-  .row-hover-menu {
+  .row-drag-handle-container {
+    align-items: center;
     color: var(--st-gray-50);
+    display: flex;
+    flex: 1;
     font-size: 1.2rem;
-    left: calc(50% - 8px);
+    height: 100%;
+    justify-content: center;
     opacity: 0.2;
     position: absolute;
-    z-index: 2;
+    width: 100%;
+    z-index: 0;
+  }
+
+  .right {
+    align-items: center;
+    display: flex;
+    flex: 1;
+    justify-content: flex-end;
+    pointer-events: none;
+  }
+
+  .right > div {
+    pointer-events: auto;
+  }
+
+  .row-header :global(.st-button) {
+    z-index: 1;
+  }
+
+  .row-header :global(.st-button):hover {
+    background: initial;
+  }
+
+  .row-header :global(.st-button):hover :global(svg) {
+    color: var(--st-gray-50);
+  }
+
+  .row-header :global(.st-button):hover :global(.row-header-title) {
+    color: var(--st-gray-100);
   }
 </style>

--- a/src/components/timeline/RowHeader.svelte
+++ b/src/components/timeline/RowHeader.svelte
@@ -1,0 +1,26 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import CaretDownIcon from '@nasa-jpl/stellar/icons/caret_down.svg?component';
+
+  export let autoAdjustHeight: boolean = false;
+
+  let overlaySvg: SVGElement;
+</script>
+
+<div class="row-header">
+  <CaretDownIcon class="row-header-collapse" />
+  <div class="row-header-title st-typography-medium">Row Name</div>
+</div>
+
+<style>
+  .row-header {
+    background-color: var(--st-gray-15);
+    display: flex;
+  }
+
+  :global(.row-header-collapse),
+  .row-header-title {
+    color: var(--st-gray-70);
+  }
+</style>

--- a/src/components/timeline/RowHeader.svelte
+++ b/src/components/timeline/RowHeader.svelte
@@ -2,25 +2,46 @@
 
 <script lang="ts">
   import CaretDownIcon from '@nasa-jpl/stellar/icons/caret_down.svg?component';
+  import RowDragHandleMove from './RowDragHandleMove.svelte';
 
-  export let autoAdjustHeight: boolean = false;
-
-  let overlaySvg: SVGElement;
+  export let rowDragMoveDisabled = false;
 </script>
 
 <div class="row-header">
   <CaretDownIcon class="row-header-collapse" />
   <div class="row-header-title st-typography-medium">Row Name</div>
+  <div class="row-hover-menu">
+    <RowDragHandleMove disabled={rowDragMoveDisabled} on:mouseDownRowMove />
+  </div>
 </div>
 
 <style>
   .row-header {
-    background-color: var(--st-gray-15);
+    align-items: center;
+    background-color: var(--st-gray-10);
+    border-bottom: 1px solid var(--st-gray-15);
+    border-top: 1px solid var(--st-gray-15);
     display: flex;
+    height: 22px;
+    padding: 0px 4px 0px 8px;
+    position: relative;
   }
 
-  :global(.row-header-collapse),
   .row-header-title {
     color: var(--st-gray-70);
+    user-select: none;
+  }
+
+  :global(.row-header-collapse) {
+    color: var(--st-gray-30);
+  }
+
+  .row-hover-menu {
+    color: var(--st-gray-50);
+    font-size: 1.2rem;
+    left: calc(50% - 8px);
+    opacity: 0.2;
+    position: absolute;
+    z-index: 2;
   }
 </style>

--- a/src/components/timeline/RowHeader.svelte
+++ b/src/components/timeline/RowHeader.svelte
@@ -2,17 +2,41 @@
 
 <script lang="ts">
   import CaretDownIcon from '@nasa-jpl/stellar/icons/caret_down.svg?component';
+  import CaretRightIcon from '@nasa-jpl/stellar/icons/caret_right.svg?component';
+  import { createEventDispatcher } from 'svelte';
   import RowDragHandleMove from './RowDragHandleMove.svelte';
 
-  export let rowDragMoveDisabled = false;
+  export let rowDragMoveDisabled: boolean = false;
+  export let title: string = '';
+  export let rowId: number = 0;
+  export let expanded: boolean = true;
+
+  const dispatch = createEventDispatcher();
+
+  function toggleExpansion() {
+    dispatch('toggleRowExpansion', { expanded: !expanded, rowId });
+  }
 </script>
 
 <div class="row-header">
-  <CaretDownIcon class="row-header-collapse" />
-  <div class="row-header-title st-typography-medium">Row Name</div>
+  <button class="st-button icon" on:click={toggleExpansion}>
+    {#if expanded}
+      <CaretDownIcon class="row-header-collapse" />
+    {:else}
+      <CaretRightIcon class="row-header-collapse" />
+    {/if}
+  </button>
+
+  <div class="row-header-title st-typography-medium">{title}</div>
   <div class="row-hover-menu">
     <RowDragHandleMove disabled={rowDragMoveDisabled} on:mouseDownRowMove />
   </div>
+
+  {#if $$slots.right}
+    <div class="right">
+      <slot name="right" />
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -23,12 +47,14 @@
     border-top: 1px solid var(--st-gray-15);
     display: flex;
     height: 22px;
-    padding: 0px 4px 0px 8px;
+    padding: 0px 8px 0px 4px;
     position: relative;
   }
 
   .row-header-title {
     color: var(--st-gray-70);
+    cursor: pointer;
+    flex: 1;
     user-select: none;
   }
 

--- a/src/components/timeline/RowHeader.svelte
+++ b/src/components/timeline/RowHeader.svelte
@@ -6,10 +6,10 @@
   import { createEventDispatcher } from 'svelte';
   import RowDragHandleMove from './RowDragHandleMove.svelte';
 
+  export let expanded: boolean = true;
+  export let rowId: number = 0;
   export let rowDragMoveDisabled: boolean = false;
   export let title: string = '';
-  export let rowId: number = 0;
-  export let expanded: boolean = true;
 
   const dispatch = createEventDispatcher();
 

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -85,6 +85,11 @@
     rowDragMoveDisabled = false;
   }
 
+  function onToggleRowExpansion(event: CustomEvent<{ expanded: boolean; rowId: number }>) {
+    const { rowId, expanded } = event.detail;
+    console.log(rowId, expanded, 'expansion');
+  }
+
   function onUpdateRowHeight(event: CustomEvent<{ newHeight: number; rowId: number }>) {
     const { newHeight, rowId } = event.detail;
     if (timeline.gridId === gridId && newHeight < MAX_CANVAS_SIZE) {
@@ -140,9 +145,11 @@
         constraintViolations={$constraintViolations}
         drawHeight={row.height}
         {drawWidth}
+        expanded={true}
         horizontalGuides={row.horizontalGuides}
         id={row.id}
         layers={row.layers}
+        name={'Row name TODO'}
         marginLeft={timeline?.marginLeft}
         resources={$resources}
         {rowDragMoveDisabled}
@@ -155,6 +162,7 @@
         on:mouseDownRowMove={onMouseDownRowMove}
         on:mouseOver={e => (mouseOver = e.detail)}
         on:mouseOverViolations={e => (mouseOverViolations = e.detail)}
+        on:toggleRowExpansion={onToggleRowExpansion}
         on:updateRowHeight={onUpdateRowHeight}
       />
     {/each}

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -87,7 +87,7 @@
 
   function onToggleRowExpansion(event: CustomEvent<{ expanded: boolean; rowId: number }>) {
     const { rowId, expanded } = event.detail;
-    console.log(rowId, expanded, 'expansion');
+    viewUpdateRow('expanded', expanded, timelineId, rowId);
   }
 
   function onUpdateRowHeight(event: CustomEvent<{ newHeight: number; rowId: number }>) {
@@ -145,11 +145,11 @@
         constraintViolations={$constraintViolations}
         drawHeight={row.height}
         {drawWidth}
-        expanded={true}
+        expanded={row.expanded}
         horizontalGuides={row.horizontalGuides}
         id={row.id}
         layers={row.layers}
-        name={'Row name TODO'}
+        name={row.name}
         marginLeft={timeline?.marginLeft}
         resources={$resources}
         {rowDragMoveDisabled}
@@ -175,6 +175,7 @@
 <style>
   .rows {
     min-height: 100px;
+    outline: none !important;
     overflow-x: hidden;
     overflow-y: auto;
   }

--- a/src/types/timeline.d.ts
+++ b/src/types/timeline.d.ts
@@ -104,10 +104,12 @@ type ResourceLayerFilter = {
 
 type Row = {
   autoAdjustHeight: boolean;
+  expanded: boolean;
   height: number;
   horizontalGuides: HorizontalGuide[];
   id: number;
   layers: Layer[];
+  name: string;
   yAxes: Axis[];
 };
 


### PR DESCRIPTION
Adds collapsible timeline row headers. A right slot is included but currently unused.

Closes [AERIE-2060](https://jira.jpl.nasa.gov/browse/AERIE-2060)

(note: some weird GIF recording issues make some of the background colors wonky)
![timelinedemo](https://user-images.githubusercontent.com/4419607/190511308-7ba78ad1-8775-4168-8c0c-18373d457ed1.gif)
