### PR TITLE
feat: add save hot key to editors

### DIFF
--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -53,35 +53,47 @@
     constraintDefinition = value;
   }
 
+  function onKeydown(event: KeyboardEvent): void {
+    const { key, ctrlKey, metaKey } = event;
+    if ((window.navigator.platform.match(/mac/i) ? metaKey : ctrlKey) && key === 's') {
+      event.preventDefault();
+      saveConstraint();
+    }
+  }
+
   async function saveConstraint() {
-    if (mode === 'create') {
-      const newConstraintId = await effects.createConstraint(
-        constraintDefinition,
-        constraintDescription,
-        constraintModelId,
-        constraintName,
-        constraintPlanId,
-        constraintSummary,
-      );
+    if (saveButtonEnabled) {
+      if (mode === 'create') {
+        const newConstraintId = await effects.createConstraint(
+          constraintDefinition,
+          constraintDescription,
+          constraintModelId,
+          constraintName,
+          constraintPlanId,
+          constraintSummary,
+        );
 
-      if (newConstraintId !== null) {
-        goto(`${base}/constraints/edit/${newConstraintId}`);
+        if (newConstraintId !== null) {
+          goto(`${base}/constraints/edit/${newConstraintId}`);
+        }
+      } else if (mode === 'edit') {
+        await effects.updateConstraint(
+          constraintId,
+          constraintDefinition,
+          constraintDescription,
+          constraintModelId,
+          constraintName,
+          constraintPlanId,
+          constraintSummary,
+        );
+
+        savedConstraintDefinition = constraintDefinition;
       }
-    } else if (mode === 'edit') {
-      await effects.updateConstraint(
-        constraintId,
-        constraintDefinition,
-        constraintDescription,
-        constraintModelId,
-        constraintName,
-        constraintPlanId,
-        constraintSummary,
-      );
-
-      savedConstraintDefinition = constraintDefinition;
     }
   }
 </script>
+
+<svelte:window on:keydown={onKeydown} />
 
 <CssGrid bind:columns={$constraintsColumns}>
   <Panel overflowYBody="hidden">

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -45,34 +45,46 @@
     ruleLogic = value;
   }
 
-  async function saveRule() {
-    if (mode === 'create') {
-      const newRule: ExpansionRuleInsertInput = {
-        activity_type: ruleActivityType,
-        authoring_command_dict_id: ruleDictionaryId,
-        authoring_mission_model_id: ruleModelId,
-        expansion_logic: ruleLogic,
-      };
-      const newRuleId = await effects.createExpansionRule(newRule);
+  function onKeydown(event: KeyboardEvent): void {
+    const { key, ctrlKey, metaKey } = event;
+    if ((window.navigator.platform.match(/mac/i) ? metaKey : ctrlKey) && key === 's') {
+      event.preventDefault();
+      saveRule();
+    }
+  }
 
-      if (newRuleId !== null) {
-        goto(`${base}/expansion/rules/edit/${newRuleId}`);
-      }
-    } else if (mode === 'edit') {
-      const updatedRule: Partial<ExpansionRule> = {
-        activity_type: ruleActivityType,
-        authoring_command_dict_id: ruleDictionaryId,
-        authoring_mission_model_id: ruleModelId,
-        expansion_logic: ruleLogic,
-      };
-      const updated_at = await effects.updateExpansionRule(ruleId, updatedRule);
-      if (updated_at !== null) {
-        ruleUpdatedAt = updated_at;
-        savedRuleLogic = ruleLogic;
+  async function saveRule() {
+    if (saveButtonEnabled) {
+      if (mode === 'create') {
+        const newRule: ExpansionRuleInsertInput = {
+          activity_type: ruleActivityType,
+          authoring_command_dict_id: ruleDictionaryId,
+          authoring_mission_model_id: ruleModelId,
+          expansion_logic: ruleLogic,
+        };
+        const newRuleId = await effects.createExpansionRule(newRule);
+
+        if (newRuleId !== null) {
+          goto(`${base}/expansion/rules/edit/${newRuleId}`);
+        }
+      } else if (mode === 'edit') {
+        const updatedRule: Partial<ExpansionRule> = {
+          activity_type: ruleActivityType,
+          authoring_command_dict_id: ruleDictionaryId,
+          authoring_mission_model_id: ruleModelId,
+          expansion_logic: ruleLogic,
+        };
+        const updated_at = await effects.updateExpansionRule(ruleId, updatedRule);
+        if (updated_at !== null) {
+          ruleUpdatedAt = updated_at;
+          savedRuleLogic = ruleLogic;
+        }
       }
     }
   }
 </script>
+
+<svelte:window on:keydown={onKeydown} />
 
 <CssGrid bind:columns={$expansionRulesColumns}>
   <Panel overflowYBody="hidden">

--- a/src/components/scheduling/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/SchedulingGoalForm.svelte
@@ -48,45 +48,57 @@
     goalDefinition = value;
   }
 
+  function onKeydown(event: KeyboardEvent): void {
+    const { key, ctrlKey, metaKey } = event;
+    if ((window.navigator.platform.match(/mac/i) ? metaKey : ctrlKey) && key === 's') {
+      event.preventDefault();
+      saveGoal();
+    }
+  }
+
   async function saveGoal() {
-    if (mode === 'create') {
-      const newGoal = await effects.createSchedulingGoal(
-        goalDefinition,
-        goalDescription,
-        goalName,
-        $userStore?.id,
-        goalModelId,
-      );
+    if (saveButtonEnabled) {
+      if (mode === 'create') {
+        const newGoal = await effects.createSchedulingGoal(
+          goalDefinition,
+          goalDescription,
+          goalName,
+          $userStore?.id,
+          goalModelId,
+        );
 
-      if (newGoal !== null) {
-        const { id: newGoalId } = newGoal;
+        if (newGoal !== null) {
+          const { id: newGoalId } = newGoal;
 
-        if (specId !== null) {
-          const specGoalInsertInput: SchedulingSpecGoalInsertInput = {
-            enabled: true,
-            goal_id: newGoalId,
-            specification_id: specId,
-          };
-          await effects.createSchedulingSpecGoal(specGoalInsertInput);
+          if (specId !== null) {
+            const specGoalInsertInput: SchedulingSpecGoalInsertInput = {
+              enabled: true,
+              goal_id: newGoalId,
+              specification_id: specId,
+            };
+            await effects.createSchedulingSpecGoal(specGoalInsertInput);
+          }
+
+          goto(`${base}/scheduling/goals/edit/${newGoalId}`);
         }
-
-        goto(`${base}/scheduling/goals/edit/${newGoalId}`);
-      }
-    } else if (mode === 'edit') {
-      const goal: Partial<SchedulingGoal> = {
-        definition: goalDefinition,
-        description: goalDescription,
-        model_id: goalModelId,
-        name: goalName,
-      };
-      const updatedGoal = await effects.updateSchedulingGoal(goalId, goal);
-      if (updatedGoal) {
-        goalModifiedDate = updatedGoal.modified_date;
-        savedGoalDefinition = goalDefinition;
+      } else if (mode === 'edit') {
+        const goal: Partial<SchedulingGoal> = {
+          definition: goalDefinition,
+          description: goalDescription,
+          model_id: goalModelId,
+          name: goalName,
+        };
+        const updatedGoal = await effects.updateSchedulingGoal(goalId, goal);
+        if (updatedGoal) {
+          goalModifiedDate = updatedGoal.modified_date;
+          savedGoalDefinition = goalDefinition;
+        }
       }
     }
   }
 </script>
+
+<svelte:window on:keydown={onKeydown} />
 
 <CssGrid bind:columns={$schedulingGoalsColumns}>
   <Panel overflowYBody="hidden">


### PR DESCRIPTION
- Add cmd+s save hot key to editors for easy and quick saving

To test:
1. use cmd+s to save a constraint
2. use cms+s to save an expansion rule
3. use cms+s to save a scheduling goal