### PR TITLE
feat: add custom ts worker for MonacoEditor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
+        "@nasa-jpl/aerie-monaco-editor-customizations": "^0.1.4",
         "@nasa-jpl/stellar": "^1.0.10",
         "@sveltejs/adapter-node": "1.0.0-next.92",
         "@sveltejs/kit": "1.0.0-next.490",
@@ -337,6 +338,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@nasa-jpl/aerie-monaco-editor-customizations": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-monaco-editor-customizations/-/aerie-monaco-editor-customizations-0.1.4.tgz",
+      "integrity": "sha512-AonxVpGFD7tjlml+iXJ94yFniYAMBqIHp54qH1FOaxz+FllnKkh1D2tZWW9XvFbk66Kv8yQYLPQ98iySmcBwXw==",
+      "dependencies": {
+        "monaco-editor-core": "0.34.0"
       }
     },
     "node_modules/@nasa-jpl/stellar": {
@@ -3712,6 +3721,11 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.0.tgz",
       "integrity": "sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ=="
     },
+    "node_modules/monaco-editor-core": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.34.0.tgz",
+      "integrity": "sha512-vyKwADMPe0oNGg+NgxWQCj00IvweeyEGeu0ZiJ14L8HUc5hNvkPAzc8RcSf9lRSpgy4Nc/S63AeqAvARsofObg=="
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -5860,6 +5874,14 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "@nasa-jpl/aerie-monaco-editor-customizations": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-monaco-editor-customizations/-/aerie-monaco-editor-customizations-0.1.4.tgz",
+      "integrity": "sha512-AonxVpGFD7tjlml+iXJ94yFniYAMBqIHp54qH1FOaxz+FllnKkh1D2tZWW9XvFbk66Kv8yQYLPQ98iySmcBwXw==",
+      "requires": {
+        "monaco-editor-core": "0.34.0"
       }
     },
     "@nasa-jpl/stellar": {
@@ -8242,6 +8264,11 @@
       "version": "0.34.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.0.tgz",
       "integrity": "sha512-VF+S5zG8wxfinLKLrWcl4WUizMx+LeJrG4PM/M78OhcwocpV0jiyhX/pG6Q9jIOhrb/ckYi6nHnaR5OojlOZCQ=="
+    },
+    "monaco-editor-core": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor-core/-/monaco-editor-core-0.34.0.tgz",
+      "integrity": "sha512-vyKwADMPe0oNGg+NgxWQCj00IvweeyEGeu0ZiJ14L8HUc5hNvkPAzc8RcSf9lRSpgy4Nc/S63AeqAvARsofObg=="
     },
     "mri": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "version": "node ./scripts/version.js"
   },
   "dependencies": {
+    "@nasa-jpl/aerie-monaco-editor-customizations": "^0.1.4",
     "@nasa-jpl/stellar": "^1.0.10",
     "@sveltejs/adapter-node": "1.0.0-next.92",
     "@sveltejs/kit": "1.0.0-next.490",

--- a/src/components/ui/MonacoEditor.svelte
+++ b/src/components/ui/MonacoEditor.svelte
@@ -1,10 +1,10 @@
 <svelte:options accessors={true} immutable={true} />
 
 <script lang="ts">
+  import tsWorker from '@nasa-jpl/aerie-monaco-editor-customizations/out/esm/vs/language/typescript/ts.worker?worker';
   import type { editor as Editor } from 'monaco-editor/esm/vs/editor/editor.api';
   import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
   import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
-  import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
   import { createEventDispatcher, onDestroy, onMount } from 'svelte';
 
   export { className as class };


### PR DESCRIPTION
- Worker includes custom diagnostics for command expansion
- Add @nasa-jpl/aerie-monaco-editor-customizations dependency
- Use custom tsWorker for TypeScript/JavaScript monaco editor instances
- See: https://jira.jpl.nasa.gov/browse/AERIE-2094