### PR TITLE
ci: add nasa-scrub conversion utilties

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,3 +35,13 @@ jobs:
         uses: github/codeql-action/autobuild@v2
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
+      - name: NASA Scrub
+        run: |
+          pip install nasa-scrub
+          python3 -m scrub.tools.parsers.translate_results /home/runner/work/aerie-ui/results/*.sarif /home/runner/work/aerie-ui/results/codeql.scrub ${{ github.workspace }} scrub
+          python3 -m scrub.tools.parsers.csv_parser /home/runner/work/aerie-ui/results
+      - name: Upload CodeQL Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: codeql-artifacts
+          path: /home/runner/work/aerie-ui/results/*


### PR DESCRIPTION
This is done so we can output CodeQL scanning results in both the SARIF format that Github can read, and the SCRUB format that internal NASA pipelines can read.