### PR TITLE
feat: create sequence from .seq.json file

### DIFF
--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -22,6 +22,7 @@
   export let mode: 'create' | 'edit' = 'create';
 
   let savedSequenceDefinition: string = mode === 'create' ? '' : initialSequenceDefinition;
+  let seqJsonFiles: FileList;
   let sequenceCreatedAt: string | null = initialSequenceCreatedAt;
   let sequenceDefinition: string = initialSequenceDefinition;
   let sequenceCommandDictionaryId: number | null = initialSequenceCommandDictionaryId;
@@ -42,6 +43,15 @@
       getUserSequenceSeqJson();
     }
   });
+
+  async function getUserSequenceFromSeqJson() {
+    const file: File = seqJsonFiles[0];
+    const text = await file.text();
+    const seqJson = JSON.parse(text);
+    const sequence = await effects.getUserSequenceFromSeqJson(seqJson);
+    sequenceDefinition = sequence;
+    sequenceSeqJson = text;
+  }
 
   async function getUserSequenceSeqJson(): Promise<void> {
     sequenceSeqJson = 'Generating Seq JSON...';
@@ -152,6 +162,17 @@
           name="sequenceName"
           placeholder="Enter Sequence Name"
           required
+        />
+      </fieldset>
+
+      <fieldset>
+        <label for="seqJsonFile">Create Sequence from Seq JSON (optional)</label>
+        <input
+          bind:files={seqJsonFiles}
+          class="w-100"
+          name="seqJsonFile"
+          type="file"
+          on:change={getUserSequenceFromSeqJson}
         />
       </fieldset>
     </svelte:fragment>

--- a/src/types/sequencing.d.ts
+++ b/src/types/sequencing.d.ts
@@ -7,6 +7,8 @@ type CommandDictionary = {
   version: string;
 };
 
+type SeqJson = any; // TODO: Strongly type.
+
 type UserSequence = {
   authoring_command_dict_id: number;
   created_at: string;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -982,6 +982,16 @@ const effects = {
     }
   },
 
+  async getUserSequenceFromSeqJson(seqJson: SeqJson): Promise<string> {
+    try {
+      const data = await reqHasura<string>(gql.GET_USER_SEQUENCE_FROM_SEQ_JSON, { seqJson });
+      const { sequence } = data;
+      return sequence;
+    } catch (e) {
+      return e.message;
+    }
+  },
+
   async getUserSequenceSeqJson(
     commandDictionaryId: number | null,
     sequenceDefinition: string | null,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -535,6 +535,12 @@ const gql = {
     }
   `,
 
+  GET_USER_SEQUENCE_FROM_SEQ_JSON: `#graphql
+    query GetUserSequenceFromSeqJson($seqJson: SequenceSeqJsonInput!) {
+      sequence: getEdslForSeqJson(seqJson: $seqJson)
+    }
+  `,
+
   GET_USER_SEQUENCE_SEQ_JSON: `#graphql
     query GetUserSequenceSeqJson($commandDictionaryId: Int!, $sequenceDefinition: String!) {
       seqJson: getUserSequenceSeqJson(commandDictionaryID: $commandDictionaryId, edslBody: $sequenceDefinition) {


### PR DESCRIPTION
- Add file upload to create a new sequence from `.seq.json`
- Use with: https://github.com/NASA-AMMOS/aerie/pull/338
- See: https://jira.jpl.nasa.gov/browse/AERIE-2102

To test:
1. Goto `/sequencing/new`
1. Upload a valid `.seq.json` file
1. Observe the sequence is shown and the `.seq.json` is shown
1. Repeat for the `/sequencing/edit/{id}` page