### PR TITLE
test: make e2e tests faster

### DIFF
--- a/e2e-tests/fixtures/AppNav.ts
+++ b/e2e-tests/fixtures/AppNav.ts
@@ -19,6 +19,11 @@ export class AppNav {
     this.updatePage(page);
   }
 
+  async goto() {
+    await this.page.goto('/plans', { waitUntil: 'networkidle' });
+    await this.page.waitForTimeout(250);
+  }
+
   updatePage(page: Page): void {
     this.aboutModal = page.locator(`.modal:has-text("About")`);
     this.aboutModalCloseButton = page.locator(`.modal:has-text("About") >> button:has-text("Close")`);

--- a/e2e-tests/fixtures/Constraints.ts
+++ b/e2e-tests/fixtures/Constraints.ts
@@ -90,10 +90,8 @@ export class Constraints {
   }
 
   async goto() {
-    await this.page.goto('/plans', { waitUntil: 'networkidle' });
-    await this.page.waitForTimeout(3000); // Wait for page load to finish.
     await this.page.goto('/constraints', { waitUntil: 'networkidle' });
-    await this.page.waitForTimeout(3000); // Wait for page load to finish.
+    await this.page.waitForTimeout(250);
   }
 
   async selectModel() {

--- a/e2e-tests/fixtures/Dictionaries.ts
+++ b/e2e-tests/fixtures/Dictionaries.ts
@@ -69,10 +69,8 @@ export class Dictionaries {
   }
 
   async goto() {
-    await this.page.goto('/plans', { waitUntil: 'networkidle' });
-    await this.page.waitForTimeout(3000); // Wait for page load to finish.
     await this.page.goto('/dictionaries', { waitUntil: 'networkidle' });
-    await this.page.waitForTimeout(3000); // Wait for page load to finish.
+    await this.page.waitForTimeout(250);
   }
 
   updatePage(page: Page): void {

--- a/e2e-tests/fixtures/ExpansionRules.ts
+++ b/e2e-tests/fixtures/ExpansionRules.ts
@@ -76,10 +76,8 @@ export class ExpansionRules {
   }
 
   async goto() {
-    await this.page.goto('/plans', { waitUntil: 'networkidle' });
-    await this.page.waitForTimeout(3000); // Wait for page load to finish.
     await this.page.goto('/expansion/rules', { waitUntil: 'networkidle' });
-    await this.page.waitForTimeout(3000); // Wait for page load to finish.
+    await this.page.waitForTimeout(250);
     await expect(this.rulesNavButton).toHaveClass(/selected/);
   }
 

--- a/e2e-tests/fixtures/ExpansionSets.ts
+++ b/e2e-tests/fixtures/ExpansionSets.ts
@@ -40,10 +40,8 @@ export class ExpansionSets {
   }
 
   async goto() {
-    await this.page.goto('/plans', { waitUntil: 'networkidle' });
-    await this.page.waitForTimeout(3000); // Wait for page load to finish.
     await this.page.goto('/expansion/sets', { waitUntil: 'networkidle' });
-    await this.page.waitForTimeout(3000); // Wait for page load to finish.
+    await this.page.waitForTimeout(250);
     await expect(this.setsNavButton).toHaveClass(/selected/);
   }
 

--- a/e2e-tests/fixtures/Models.ts
+++ b/e2e-tests/fixtures/Models.ts
@@ -73,10 +73,8 @@ export class Models {
   }
 
   async goto() {
-    await this.page.goto('/plans', { waitUntil: 'networkidle' });
-    await this.page.waitForTimeout(3000); // Wait for page load to finish.
     await this.page.goto('/models', { waitUntil: 'networkidle' });
-    await this.page.waitForTimeout(3000); // Wait for page load to finish.
+    await this.page.waitForTimeout(250);
   }
 
   updatePage(page: Page): void {

--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -79,10 +79,9 @@ export class Plan {
    * Re-run the tests and increase the timeout if you get consistent failures.
    */
   async goto() {
-    await this.page.goto('/plans', { waitUntil: 'networkidle' });
-    await this.page.waitForTimeout(3000); // Wait for page load to finish.
+    await this.page.waitForTimeout(1200);
     await this.page.goto(`/plans/${this.plans.planId}`, { waitUntil: 'networkidle' });
-    await this.page.waitForTimeout(3000); // Wait for page load to finish.
+    await this.page.waitForTimeout(250);
   }
 
   async runAnalysis() {

--- a/e2e-tests/fixtures/Plans.ts
+++ b/e2e-tests/fixtures/Plans.ts
@@ -89,7 +89,7 @@ export class Plans {
 
   async goto() {
     await this.page.goto('/plans', { waitUntil: 'networkidle' });
-    await this.page.waitForTimeout(3000); // Wait for page load to finish.
+    await this.page.waitForTimeout(250);
   }
 
   async selectInputModel() {

--- a/e2e-tests/fixtures/SchedulingGoals.ts
+++ b/e2e-tests/fixtures/SchedulingGoals.ts
@@ -83,10 +83,8 @@ export class SchedulingGoals {
   }
 
   async goto() {
-    await this.page.goto('/plans', { waitUntil: 'networkidle' });
-    await this.page.waitForTimeout(3000); // Wait for page load to finish.
     await this.page.goto('/scheduling/goals', { waitUntil: 'networkidle' });
-    await this.page.waitForTimeout(3000); // Wait for page load to finish.
+    await this.page.waitForTimeout(250);
     await expect(this.goalsNavButton).toHaveClass(/selected/);
   }
 

--- a/e2e-tests/tests/app-nav.test.ts
+++ b/e2e-tests/tests/app-nav.test.ts
@@ -1,22 +1,24 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
 import { AppNav } from '../fixtures/AppNav.js';
 
 let appNav: AppNav;
+let context: BrowserContext;
 let page: Page;
 
 test.beforeAll(async ({ browser }) => {
-  page = await browser.newPage();
+  context = await browser.newContext();
+  page = await context.newPage();
   appNav = new AppNav(page);
 });
 
 test.afterAll(async () => {
   await page.close();
+  await context.close();
 });
 
 test.describe.serial('App Nav', () => {
   test.beforeEach(async () => {
-    await page.goto('/plans', { waitUntil: 'networkidle' });
-    await page.waitForTimeout(3000); // Wait for page load to finish.
+    await appNav.goto();
   });
 
   test('Initially the app menu should hidden', async () => {
@@ -104,12 +106,14 @@ test.describe.serial('App Nav', () => {
     await playgroundPage.close();
   });
 
-  test(`Clicking on the app menu 'Logout' option should route to the login page`, async ({ baseURL }) => {
+  test(`Clicking on the app menu 'Logout' option should route to the plans page (auth disabled)`, async ({
+    baseURL,
+  }) => {
     await appNav.appMenuButton.click();
     await appNav.appMenu.waitFor({ state: 'attached' });
     await appNav.appMenu.waitFor({ state: 'visible' });
     await appNav.appMenuItemLogout.click();
-    await expect(page).toHaveURL(`${baseURL}/login`);
+    await expect(page).toHaveURL(`${baseURL}/plans`);
   });
 
   test(`Clicking on the app menu 'About' option should open the about modal`, async () => {

--- a/e2e-tests/tests/constraints.test.ts
+++ b/e2e-tests/tests/constraints.test.ts
@@ -1,4 +1,4 @@
-import { test, type Page } from '@playwright/test';
+import { test, type BrowserContext, type Page } from '@playwright/test';
 import { Constraints } from '../fixtures/Constraints.js';
 import { Models } from '../fixtures/Models.js';
 import { Plan } from '../fixtures/Plan.js';
@@ -6,6 +6,7 @@ import { Plans } from '../fixtures/Plans.js';
 import { SchedulingGoals } from '../fixtures/SchedulingGoals.js';
 
 let constraints: Constraints;
+let context: BrowserContext;
 let models: Models;
 let page: Page;
 let plan: Plan;
@@ -13,7 +14,8 @@ let plans: Plans;
 let schedulingGoals: SchedulingGoals;
 
 test.beforeAll(async ({ browser }) => {
-  page = await browser.newPage();
+  context = await browser.newContext();
+  page = await context.newPage();
 
   models = new Models(page);
   plans = new Plans(page, models);
@@ -33,6 +35,7 @@ test.afterAll(async () => {
   await models.goto();
   await models.deleteModel();
   await page.close();
+  await context.close();
 });
 
 test.describe.serial('Constraints', () => {

--- a/e2e-tests/tests/dictionaries.test.ts
+++ b/e2e-tests/tests/dictionaries.test.ts
@@ -1,17 +1,20 @@
-import { test, type Page } from '@playwright/test';
+import { test, type BrowserContext, type Page } from '@playwright/test';
 import { Dictionaries } from '../fixtures/Dictionaries.js';
 
+let context: BrowserContext;
 let dictionaries: Dictionaries;
 let page: Page;
 
 test.beforeAll(async ({ browser }) => {
-  page = await browser.newPage();
+  context = await browser.newContext();
+  page = await context.newPage();
   dictionaries = new Dictionaries(page);
   await dictionaries.goto();
 });
 
 test.afterAll(async () => {
   await page.close();
+  await context.close();
 });
 
 test.describe.serial('Dictionaries', () => {

--- a/e2e-tests/tests/expansion.test.ts
+++ b/e2e-tests/tests/expansion.test.ts
@@ -1,9 +1,10 @@
-import { test, type Page } from '@playwright/test';
+import { test, type BrowserContext, type Page } from '@playwright/test';
 import { Dictionaries } from '../fixtures/Dictionaries.js';
 import { ExpansionRules } from '../fixtures/ExpansionRules.js';
 import { ExpansionSets } from '../fixtures/ExpansionSets.js';
 import { Models } from '../fixtures/Models.js';
 
+let context: BrowserContext;
 let dictionaries: Dictionaries;
 let expansionRules: ExpansionRules;
 let expansionSets: ExpansionSets;
@@ -11,7 +12,8 @@ let models: Models;
 let page: Page;
 
 test.beforeAll(async ({ browser }) => {
-  page = await browser.newPage();
+  context = await browser.newContext();
+  page = await context.newPage();
 
   models = new Models(page);
   dictionaries = new Dictionaries(page);
@@ -31,6 +33,7 @@ test.afterAll(async () => {
   await dictionaries.goto();
   await dictionaries.deleteDictionary();
   await page.close();
+  await context.close();
 });
 
 test.describe.serial('Expansion', () => {

--- a/e2e-tests/tests/models.test.ts
+++ b/e2e-tests/tests/models.test.ts
@@ -1,17 +1,20 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
 import { Models } from '../fixtures/Models.js';
 
+let context: BrowserContext;
 let models: Models;
 let page: Page;
 
 test.beforeAll(async ({ browser }) => {
-  page = await browser.newPage();
+  context = await browser.newContext();
+  page = await context.newPage();
   models = new Models(page);
   await models.goto();
 });
 
 test.afterAll(async () => {
   await page.close();
+  await context.close();
 });
 
 test.describe.serial('Models', () => {

--- a/e2e-tests/tests/plan.test.ts
+++ b/e2e-tests/tests/plan.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
 import { Constraints } from '../fixtures/Constraints.js';
 import { Models } from '../fixtures/Models.js';
 import { Plan } from '../fixtures/Plan.js';
@@ -6,6 +6,7 @@ import { Plans } from '../fixtures/Plans.js';
 import { SchedulingGoals } from '../fixtures/SchedulingGoals.js';
 
 let constraints: Constraints;
+let context: BrowserContext;
 let models: Models;
 let page: Page;
 let plan: Plan;
@@ -13,7 +14,8 @@ let plans: Plans;
 let schedulingGoals: SchedulingGoals;
 
 test.beforeAll(async ({ browser }) => {
-  page = await browser.newPage();
+  context = await browser.newContext();
+  page = await context.newPage();
 
   models = new Models(page);
   plans = new Plans(page, models);
@@ -34,6 +36,7 @@ test.afterAll(async () => {
   await models.goto();
   await models.deleteModel();
   await page.close();
+  await context.close();
 });
 
 test.describe.serial('Plan', () => {

--- a/e2e-tests/tests/plans.test.ts
+++ b/e2e-tests/tests/plans.test.ts
@@ -1,32 +1,33 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
 import { Models } from '../fixtures/Models.js';
 import { Plans } from '../fixtures/Plans.js';
 
+let context: BrowserContext;
 let models: Models;
 let page: Page;
 let plans: Plans;
 
 test.beforeAll(async ({ browser }) => {
-  page = await browser.newPage();
+  context = await browser.newContext();
+  page = await context.newPage();
 
   models = new Models(page);
   plans = new Plans(page, models);
 
   await models.goto();
   await models.createModel();
-  await plans.goto();
 });
 
 test.afterAll(async () => {
   await models.goto();
   await models.deleteModel();
   await page.close();
+  await context.close();
 });
 
 test.describe.serial('Plans', () => {
   test.beforeEach(async () => {
-    await page.reload({ waitUntil: 'networkidle' });
-    await page.waitForTimeout(3000); // Wait for page load to finish.
+    await plans.goto();
   });
 
   test('Create plan button should be disabled with no errors', async () => {

--- a/e2e-tests/tests/scheduling.test.ts
+++ b/e2e-tests/tests/scheduling.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
 import { Constraints } from '../fixtures/Constraints.js';
 import { Models } from '../fixtures/Models.js';
 import { Plan } from '../fixtures/Plan.js';
@@ -6,6 +6,7 @@ import { Plans } from '../fixtures/Plans.js';
 import { SchedulingGoals } from '../fixtures/SchedulingGoals.js';
 
 let constraints: Constraints;
+let context: BrowserContext;
 let models: Models;
 let page: Page;
 let plan: Plan;
@@ -13,7 +14,8 @@ let plans: Plans;
 let schedulingGoals: SchedulingGoals;
 
 test.beforeAll(async ({ browser }) => {
-  page = await browser.newPage();
+  context = await browser.newContext();
+  page = await context.newPage();
 
   models = new Models(page);
   plans = new Plans(page, models);
@@ -33,6 +35,7 @@ test.afterAll(async () => {
   await models.goto();
   await models.deleteModel();
   await page.close();
+  await context.close();
 });
 
 test.describe.serial('Scheduling', () => {

--- a/src/routes/login/+page.ts
+++ b/src/routes/login/+page.ts
@@ -1,11 +1,9 @@
 import { base } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
-import { get } from 'svelte/store';
-import { user as userStore } from '../../stores/app';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async () => {
-  const user = get(userStore);
+export const load: PageLoad = async ({ parent }) => {
+  const { user } = await parent();
 
   if (user) {
     throw redirect(302, `${base}/plans`);

--- a/src/routes/models/+page.ts
+++ b/src/routes/models/+page.ts
@@ -1,12 +1,10 @@
 import { base } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
-import { get } from 'svelte/store';
-import { user as userStore } from '../../stores/app';
 import effects from '../../utilities/effects';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async () => {
-  const user = get(userStore);
+export const load: PageLoad = async ({ parent }) => {
+  const { user } = await parent();
 
   if (!user) {
     throw redirect(302, `${base}/login`);

--- a/src/routes/plans/+page.ts
+++ b/src/routes/plans/+page.ts
@@ -1,12 +1,10 @@
 import { base } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
-import { get } from 'svelte/store';
-import { user as userStore } from '../../stores/app';
 import effects from '../../utilities/effects';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async () => {
-  const user = get(userStore);
+export const load: PageLoad = async ({ parent }) => {
+  const { user } = await parent();
 
   if (!user) {
     throw redirect(302, `${base}/login`);

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -1,12 +1,10 @@
 import { base } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
-import { get } from 'svelte/store';
-import { user as userStore } from '../../../stores/app';
 import effects from '../../../utilities/effects';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async ({ params, url }) => {
-  const user = get(userStore);
+export const load: PageLoad = async ({ parent, params, url }) => {
+  const { user } = await parent();
 
   if (!user) {
     throw redirect(302, `${base}/login`);


### PR DESCRIPTION
* Remove busy waiting where applicable
* Create context in beforeAll
* Use parent 'user' in Svelte Kit pages to prevent reload loop
* e2e tests took `2m 8s` in CI, previously took `5m 58s` before this commit