### PR TITLE
fix: invalidate all routes after login/logout

### DIFF
--- a/src/components/menus/AppMenu.svelte
+++ b/src/components/menus/AppMenu.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors={true} />
 
 <script lang="ts">
-  import { goto, prefetch } from '$app/navigation';
+  import { goto, invalidateAll, prefetch } from '$app/navigation';
   import { base } from '$app/paths';
   import { env } from '$env/dynamic/public';
   import CalendarIcon from '@nasa-jpl/stellar/icons/calendar.svg?component';
@@ -26,7 +26,8 @@
   async function logout() {
     await fetch(`${base}/auth/logout`, { method: 'POST' });
     $userStore = null;
-    goto(`${base}/login`);
+    await invalidateAll();
+    await goto(`${base}/login`);
   }
 </script>
 

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import { goto } from '$app/navigation';
+  import { goto, invalidateAll } from '$app/navigation';
   import { base } from '$app/paths';
   import { onMount } from 'svelte';
   import AlertError from '../../components/ui/AlertError.svelte';
@@ -35,7 +35,8 @@
 
       if (success) {
         $userStore = user;
-        goto(`${base}/plans`);
+        await invalidateAll();
+        await goto(`${base}/plans`);
       } else {
         console.log(message);
         error = message;


### PR DESCRIPTION
* Ensure app redirects when login/logout
* See the Svelte Kit [invalidateAll](https://kit.svelte.dev/docs/modules#$app-navigation-invalidateall) docs
* See https://jira.jpl.nasa.gov/browse/AERIE-2120

To test:
1. Enable CAM auth
    - Set `AUTH_TYPE: cam` for `aerie_gateway` in docker-compose
    - Set `PUBLIC_AUTH_TYPE=cam` for `.env` file in aerie-ui repo
3. Login with your JPL creds. Make sure you are redirected from `/login` to `/plans`
    - Also make sure entering invalid creds does not let you through to `/plans` 
5. Logout. Make sure you are redirected to `/login`
    - You should not be able to access `/plans` after logging out