### PR TITLE
fix: overlapping activities

### DIFF
--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -26,6 +26,7 @@
   let rowDragMoveDisabled = true;
   let rowsMaxHeight: number = 600;
   let rows: Row[] = [];
+  let tickCount: number = 5;
   let timeline: Timeline;
   let timelineDiv: HTMLDivElement;
   let xAxisDiv: HTMLDivElement;
@@ -40,7 +41,7 @@
   $: xDomainView = [new Date($viewTimeRange.start), new Date($viewTimeRange.end)];
   $: xScaleMax = getXScale(xDomainMax, drawWidth);
   $: xScaleView = getXScale(xDomainView, drawWidth);
-  $: xTicksView = xScaleView.ticks().map((date: Date) => {
+  $: xTicksView = xScaleView.ticks(tickCount).map((date: Date) => {
     const doyTimestamp = getDoyTime(date, false);
     const [yearDay, time] = doyTimestamp.split('T');
     return { date, time, yearDay };

--- a/src/types/timeline.d.ts
+++ b/src/types/timeline.d.ts
@@ -23,6 +23,11 @@ type Axis = {
   tickCount: number | null;
 };
 
+type BoundingBox = {
+  maxX: number;
+  maxY: number;
+};
+
 type HorizontalGuide = {
   id: number;
   label: Label;


### PR DESCRIPTION
- Make sure activities do not overlap in a decomposition tree
- Use fewer ticks in timeline so they do not bunch up
- See https://jira.jpl.nasa.gov/browse/AERIE-1425

Future work:
- If you drag an activity after it's decomposed there is a case where the children will overlap with another activity tree. We can fix this later if we render activity directives separately from simulated activities.  