### PR TITLE
fix: query id instead of dataset_id

### DIFF
--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -879,7 +879,7 @@ const gql = {
   SUB_SIMULATION_DATASETS: `#graphql
     subscription SubSimulationDatasets($planId: Int!, $simulationDatasetId: Int!) {
       simulation(where: { plan_id: { _eq: $planId } }, order_by: { id: desc }, limit: 1) {
-        simulation_datasets(where: { dataset_id: { _eq: $simulationDatasetId } }, limit: 1) {
+        simulation_datasets(where: { id: { _eq: $simulationDatasetId } }, limit: 1) {
           dataset {
             profiles {
               name


### PR DESCRIPTION
The simulation dataset id subscription queries for `simulation_dataset::id`, but the subscription for datasets themselves query for `simulation_dataset::dataset_id`. These fields get out of sync when external profiles are added.