### PR TITLE
feat: query constraint ts by optional plan ID

### DIFF
--- a/src/components/constraints/ConstraintEditor.svelte
+++ b/src/components/constraints/ConstraintEditor.svelte
@@ -8,13 +8,14 @@
 
   export let constraintDefinition: string = '';
   export let constraintModelId: number | null = null;
+  export let constraintPlanId: number | null = null;
   export let readOnly: boolean = false;
   export let title: string = 'Constraint - Definition Editor';
 
   let constraintsTsFiles: TypeScriptFile[];
   let monaco: Monaco;
 
-  $: effects.getTsFilesConstraints(constraintModelId).then(tsFiles => (constraintsTsFiles = tsFiles));
+  $: effects.getTsFilesConstraints(constraintModelId, constraintPlanId).then(tsFiles => (constraintsTsFiles = tsFiles));
 
   $: if (monaco !== undefined && constraintsTsFiles !== undefined) {
     const { languages } = monaco;

--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -188,6 +188,7 @@
   <ConstraintEditor
     {constraintDefinition}
     {constraintModelId}
+    {constraintPlanId}
     title="{mode === 'create' ? 'New' : 'Edit'} Constraint - Definition Editor"
     on:didChangeModelContent={onDidChangeModelContent}
   />

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -938,10 +938,10 @@ const effects = {
     }
   },
 
-  async getTsFilesConstraints(model_id: number): Promise<TypeScriptFile[]> {
+  async getTsFilesConstraints(model_id: number, plan_id: number | null): Promise<TypeScriptFile[]> {
     if (model_id !== null && model_id !== undefined) {
       try {
-        const data = await reqHasura<DslTypeScriptResponse>(gql.GET_TYPESCRIPT_CONSTRAINTS, { model_id });
+        const data = await reqHasura<DslTypeScriptResponse>(gql.GET_TYPESCRIPT_CONSTRAINTS, { model_id, plan_id });
         const { dslTypeScriptResponse } = data;
         const { reason, status, typescriptFiles } = dslTypeScriptResponse;
 

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -508,8 +508,8 @@ const gql = {
   `,
 
   GET_TYPESCRIPT_CONSTRAINTS: `#graphql
-    query GetTypeScriptConstraints($model_id: ID!) {
-      dslTypeScriptResponse: constraintsDslTypescript(missionModelId: $model_id) {
+    query GetTypeScriptConstraints($model_id: ID!, $plan_id: Int) {
+      dslTypeScriptResponse: constraintsDslTypescript(missionModelId: $model_id, planId: $plan_id) {
         reason
         status
         typescriptFiles {


### PR DESCRIPTION
The `constraintsDslTypescript` graphql query now accepts an optional/nullable `planId` argument, to include external resources in the code gen.

Merge at the same time as [the external profiles in constraints PR](https://github.com/NASA-AMMOS/aerie/pull/350)