### PR TITLE
fix: e2e scheduling test

### DIFF
--- a/e2e-tests/fixtures/SchedulingGoals.ts
+++ b/e2e-tests/fixtures/SchedulingGoals.ts
@@ -7,7 +7,7 @@ export class SchedulingGoals {
   closeButton: Locator;
   confirmModal: Locator;
   confirmModalDeleteButton: Locator;
-  goalDefinition: string = `export default (): Goal => Goal.ActivityRecurrenceGoal({ activityTemplate: ActivityTemplates.BakeBananaBread({ temperature: 325.0, tbSugar: 2, glutenFree: false }), interval: 12 * 60 * 60 * 1000 * 1000 })`;
+  goalDefinition: string = `export default (): Goal => Goal.ActivityRecurrenceGoal({ activityTemplate: ActivityTemplates.BakeBananaBread({ temperature: 325.0, tbSugar: 2, glutenFree: false }), interval: Temporal.Duration.from({ hours: 12 }) })`;
   goalDescription: string = 'Add a BakeBananaBread activity every 12 hours';
   goalName: string;
   goalsNavButton: Locator;

--- a/e2e-tests/tests/scheduling.test.ts
+++ b/e2e-tests/tests/scheduling.test.ts
@@ -58,12 +58,12 @@ test.describe.serial('Scheduling', () => {
     await plan.schedulingGoalEnabledCheckbox.check();
   });
 
-  test('Running the same scheduling goal twice in a row should show +0 in that goals badge', async () => {
+  test('Running the same scheduling goal twice in a row should show +10 in that goals badge', async () => {
     await expect(plan.schedulingGoalEnabledCheckbox).toBeChecked();
     await plan.runScheduling();
     await expect(plan.schedulingGoalDifferenceBadge).toHaveText('+10');
     await plan.runScheduling();
-    await expect(plan.schedulingGoalDifferenceBadge).toHaveText('+0');
+    await expect(plan.schedulingGoalDifferenceBadge).toHaveText('+10');
   });
 
   test('Running analyze-only should show +0 in that goals badge', async () => {


### PR DESCRIPTION
- Use to new Temporal API in scheduling goal eDSL
- Update scheduling test from `+0` to `+10` since that is how the scheduler is working for recurrence goals on develop

Needed change: https://github.com/NASA-AMMOS/aerie/pull/187