### PR TITLE
refactor: plan and model types

### DIFF
--- a/src/components/activity/ActivityTypesPanel.svelte
+++ b/src/components/activity/ActivityTypesPanel.svelte
@@ -18,8 +18,8 @@
   $: filteredActivityTypes = activityTypes.filter(({ name }) => name.toLowerCase().includes(filterText.toLowerCase()));
 
   async function createActivityDirectiveAtPlanStart(activityType: ActivityType) {
-    const { start_time } = $plan;
-    effects.createActivityDirective({}, start_time, activityType.name, activityType.name, [], {});
+    const { start_time_doy } = $plan;
+    effects.createActivityDirective({}, start_time_doy, activityType.name, activityType.name, [], {});
   }
 
   function onDragEnd(): void {

--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -18,8 +18,8 @@
   export let initialConstraintModelId: number | null = null;
   export let initialConstraintPlanId: number | null = null;
   export let initialConstraintSummary: string = '';
-  export let initialModels: ModelList[] = [];
-  export let initialPlans: PlanList[] = [];
+  export let initialModels: ModelSlim[] = [];
+  export let initialPlans: PlanSlim[] = [];
   export let mode: 'create' | 'edit' = 'create';
 
   let constraintDefinition: string = initialConstraintDefinition;
@@ -30,8 +30,8 @@
   let constraintModelId: number | null = initialConstraintModelId;
   let constraintPlanId: number | null = initialConstraintPlanId;
   let constraintSummary: string = initialConstraintSummary;
-  let models: ModelList[] = initialModels;
-  let plans: PlanList[] = initialPlans;
+  let models: ModelSlim[] = initialModels;
+  let plans: PlanSlim[] = initialPlans;
   let saveButtonEnabled: boolean = false;
 
   $: saveButtonEnabled =

--- a/src/components/constraints/Constraints.svelte
+++ b/src/components/constraints/Constraints.svelte
@@ -20,7 +20,7 @@
   };
   type ConstraintsCellRendererParams = ICellRendererParams<Constraint> & CellRendererParams;
 
-  export let initialPlans: PlanList[] = [];
+  export let initialPlans: PlanSlim[] = [];
 
   const columnDefs: DataGridColumnDef[] = [
     {

--- a/src/components/scheduling/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/SchedulingGoalForm.svelte
@@ -20,7 +20,7 @@
   export let initialGoalModelId: number | null = null;
   export let initialGoalModifiedDate: string | null = null;
   export let initialGoalName: string = '';
-  export let initialModels: ModelList[] = [];
+  export let initialModels: ModelSlim[] = [];
   export let initialSpecId: number | null = null;
   export let mode: 'create' | 'edit' = 'create';
 
@@ -33,7 +33,7 @@
   let goalModelId: number | null = initialGoalModelId;
   let goalModifiedDate: string | null = initialGoalModifiedDate;
   let goalName: string = initialGoalName;
-  let models: ModelList[] = initialModels;
+  let models: ModelSlim[] = initialModels;
   let saveButtonEnabled: boolean = false;
   let specId: number | null = initialSpecId;
 

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -19,9 +19,9 @@
   export let data: PageData;
 
   type CellRendererParams = {
-    deleteModel: (model: ModelList) => void;
+    deleteModel: (model: ModelSlim) => void;
   };
-  type ModelCellRendererParams = ICellRendererParams<ModelList> & CellRendererParams;
+  type ModelCellRendererParams = ICellRendererParams<ModelSlim> & CellRendererParams;
 
   const columnDefs: DataGridColumnDef[] = [
     {
@@ -79,17 +79,17 @@
     models.updateValue(() => data.initialModels);
   });
 
-  function deleteModel(model: ModelList) {
+  function deleteModel(model: ModelSlim) {
     effects.deleteModel(model);
   }
 
   function deleteModelContext(event: CustomEvent<number[]>) {
-    const selectedModelListId = event.detail[0];
-    const modelListToDelete = $models.find((modelList: ModelList) => modelList.id === selectedModelListId);
-    deleteModel(modelListToDelete);
+    const selectedModelId = event.detail[0];
+    const modelToDelete = $models.find((model: ModelSlim) => model.id === selectedModelId);
+    deleteModel(modelToDelete);
   }
 
-  function showModel(model: ModelList) {
+  function showModel(model: ModelSlim) {
     goto(`${base}/plans?modelId=${model.id}`);
   }
 </script>

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -45,8 +45,8 @@
     },
     { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
     { field: 'model_id', filter: 'number', headerName: 'Model ID', sortable: true, suppressAutoSize: true, width: 120 },
-    { field: 'start_time', filter: 'text', headerName: 'Start Time', resizable: true, sortable: true },
-    { field: 'end_time', filter: 'text', headerName: 'End Time', resizable: true, sortable: true },
+    { field: 'start_time_doy', filter: 'text', headerName: 'Start Time', resizable: true, sortable: true },
+    { field: 'end_time_doy', filter: 'text', headerName: 'End Time', resizable: true, sortable: true },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: PlanCellRendererParams) => {
@@ -81,31 +81,31 @@
 
   let durationString: string = 'None';
   let filterText: string = '';
-  let models: ModelList[];
+  let models: ModelSlim[];
   let nameInputField: HTMLInputElement;
-  let plans: PlanList[];
+  let plans: PlanSlim[];
 
-  let endTimeField = field<string>('', [required, timestamp]);
+  let endTimeDoyField = field<string>('', [required, timestamp]);
   let modelIdField = field<number>(-1, [min(1, 'Field is required')]);
   let nameField = field<string>('', [required]);
   let simTemplateField = field<number | null>(null);
-  let startTimeField = field<string>('', [required, timestamp]);
+  let startTimeDoyField = field<string>('', [required, timestamp]);
 
   $: plans = data.plans;
   $: models = data.models;
   $: createButtonEnabled =
-    $endTimeField.dirtyAndValid &&
+    $endTimeDoyField.dirtyAndValid &&
     $modelIdField.dirtyAndValid &&
     $nameField.dirtyAndValid &&
-    $startTimeField.dirtyAndValid;
+    $startTimeDoyField.dirtyAndValid;
   $: filteredPlans = plans.filter(plan => {
     const filterTextLowerCase = filterText.toLowerCase();
     return (
-      plan.end_time.includes(filterTextLowerCase) ||
+      plan.end_time_doy.includes(filterTextLowerCase) ||
       `${plan.id}`.includes(filterTextLowerCase) ||
       `${plan.model_id}`.includes(filterTextLowerCase) ||
       plan.name.toLowerCase().includes(filterTextLowerCase) ||
-      plan.start_time.includes(filterTextLowerCase)
+      plan.start_time_doy.includes(filterTextLowerCase)
     );
   });
   $: simulationTemplates.setVariables({ modelId: $modelIdField.value });
@@ -124,10 +124,10 @@
 
   async function createPlan() {
     const newPlan = await effects.createPlan(
-      $endTimeField.value,
+      $endTimeDoyField.value,
       $modelIdField.value,
       $nameField.value,
-      $startTimeField.value,
+      $startTimeDoyField.value,
       $simTemplateField.value,
     );
 
@@ -157,9 +157,9 @@
   }
 
   function updateDurationString() {
-    if ($startTimeField.valid && $endTimeField.valid) {
+    if ($startTimeDoyField.valid && $endTimeDoyField.valid) {
       durationString = convertUsToDurationString(
-        (getUnixEpochTime($endTimeField.value) - getUnixEpochTime($startTimeField.value)) * 1000,
+        (getUnixEpochTime($endTimeDoyField.value) - getUnixEpochTime($startTimeDoyField.value)) * 1000,
       );
 
       if (!durationString) {
@@ -205,7 +205,7 @@
 
           <fieldset>
             <DatePickerField
-              field={startTimeField}
+              field={startTimeDoyField}
               label="Start Time - YYYY-DDDThh:mm:ss"
               name="start-time"
               on:change={updateDurationString}
@@ -215,7 +215,7 @@
 
           <fieldset>
             <DatePickerField
-              field={endTimeField}
+              field={endTimeDoyField}
               label="End Time - YYYY-DDDThh:mm:ss"
               name="end-time"
               on:change={updateDurationString}

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -69,8 +69,8 @@
   $: if (data.initialPlan) {
     $modelParametersMap = data.initialPlan.model.parameters.parameters;
     $plan = data.initialPlan;
-    $planEndTimeMs = getUnixEpochTime(data.initialPlan.end_time);
-    $planStartTimeMs = getUnixEpochTime(data.initialPlan.start_time);
+    $planEndTimeMs = getUnixEpochTime(data.initialPlan.end_time_doy);
+    $planStartTimeMs = getUnixEpochTime(data.initialPlan.start_time_doy);
     $maxTimeRange = { end: $planEndTimeMs, start: $planStartTimeMs };
     $simulationDatasetId = data.initialPlan.simulations[0]?.simulation_datasets[0]?.id ?? -1;
     $viewTimeRange = $maxTimeRange;

--- a/src/stores/plan.ts
+++ b/src/stores/plan.ts
@@ -38,7 +38,7 @@ export const planId: Readable<number> = derived(plan, $plan => ($plan ? $plan.id
 
 /* Subscriptions. */
 
-export const models = gqlSubscribable<ModelList[]>(gql.SUB_MODELS, {}, []);
+export const models = gqlSubscribable<ModelSlim[]>(gql.SUB_MODELS, {}, []);
 
 export const planRevision = gqlSubscribable<number>(
   gql.SUB_PLAN_REVISION,

--- a/src/stores/simulation.ts
+++ b/src/stores/simulation.ts
@@ -79,14 +79,14 @@ export const simulationResources: Readable<Resource[]> = derived(
   [plan, simulationDataset],
   ([$plan, $simulationDataset]) => {
     if ($plan) {
-      const { duration, start_time_ymd } = $plan;
+      const { duration, start_time } = $plan;
 
       if ($simulationDataset) {
         const { dataset } = $simulationDataset;
 
         if (dataset) {
           const { profiles } = dataset;
-          return sampleProfiles(profiles, start_time_ymd, duration);
+          return sampleProfiles(profiles, start_time, duration);
         }
       }
     }

--- a/src/types/model.d.ts
+++ b/src/types/model.d.ts
@@ -1,19 +1,14 @@
-type ModelList = {
-  id: number;
-  jar_id: number;
-  name: string;
-  version: string;
-};
+type Model = ModelSchema;
 
-type ModelInsertInput = {
-  jar_id: number;
-  mission: string;
-  name: string;
-  version: string;
-};
+type ModelInsertInput = Pick<Model | 'jar_id' | 'mission' | 'name' | 'version'>;
 
-type Model = {
+type ModelSchema = {
   activity_types: ActivityType[];
   id: number;
+  jar_id: number;
+  name: string;
   parameters: { parameters: ParametersMap };
+  version: string;
 };
+
+type ModelSlim = Pick<Model, 'id' | 'jar_id' | 'name' | 'version'>;

--- a/src/types/plan.d.ts
+++ b/src/types/plan.d.ts
@@ -1,28 +1,17 @@
-type PlanList = {
-  end_time: string;
-  id: number;
-  model_id: number;
-  name: string;
-  revision: number;
-  start_time: string;
-};
+type Plan = PlanSchema & { end_time_doy: string; start_time_doy: string };
 
-type Plan = {
+type PlanInsertInput = Pick<PlanSchema, 'duration' | 'model_id' | 'name' | 'start_time'>;
+
+type PlanSchema = {
   duration: string;
-  end_time: string;
   id: number;
   model: Model;
+  model_id: number;
   name: string;
   revision: number;
   scheduling_specifications: Pick<SchedulingSpec, 'id'>[];
   simulations: [{ simulation_datasets: [{ id: number }] }];
   start_time: string;
-  start_time_ymd: string;
 };
 
-type PlanInsertInput = {
-  duration: string;
-  model_id: number;
-  name: string;
-  start_time: string;
-};
+type PlanSlim = Pick<Plan, 'end_time_doy' | 'id' | 'model_id' | 'name' | 'revision' | 'start_time' | 'start_time_doy'>;

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -81,6 +81,7 @@ const gql = {
       createPlan: insert_plan_one(object: $plan) {
         id
         revision
+        start_time
       }
     }
   `,
@@ -424,10 +425,14 @@ const gql = {
             required_parameters
           }
           id
+          jar_id
+          name
           parameters {
             parameters
           }
+          version
         }
+        model_id
         name
         revision
         scheduling_specifications {
@@ -456,6 +461,7 @@ const gql = {
         id
         model_id
         name
+        revision
         start_time
       }
     }

--- a/src/utilities/resources.ts
+++ b/src/utilities/resources.ts
@@ -1,11 +1,16 @@
-import { getDoyTime, getDurationInMs, getUnixEpochTime } from './time';
+import { getDurationInMs } from './time';
 
 /**
  * Samples a list of profiles at their change points. Converts the sampled profiles to Resources.
  */
-export function sampleProfiles(profiles: Profile[], startTime: string, duration: string, offset?: string): Resource[] {
+export function sampleProfiles(
+  profiles: Profile[],
+  planStartTimeYmd: string,
+  duration: string,
+  offset?: string,
+): Resource[] {
   const planOffset = getDurationInMs(offset);
-  const planStart = getUnixEpochTime(getDoyTime(new Date(startTime))) + planOffset;
+  const planStart = new Date(planStartTimeYmd).getTime() + planOffset;
   const planDuration = getDurationInMs(duration);
   const resources: Resource[] = [];
 


### PR DESCRIPTION
- Update plan and model types to more clearly reflect back-end
- Use consistent date DOY types and naming for plan

This PR starts to get more strict with back-end types vs. derived front-end types. Types that reflect what is stored in the back-end are suffixed with `*Schema`.
