### PR TITLE
fix: get activities by simulation dataset id

### DIFF
--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -670,7 +670,7 @@ const gql = {
           type
         }
         simulations(order_by: { id: desc }, limit: 1) {
-          simulation_datasets(where: { dataset_id: { _eq: $simulationDatasetId } }, limit: 1) {
+          simulation_datasets(where: { id: { _eq: $simulationDatasetId } }, limit: 1) {
             simulated_activities(where: { parent_id: {  _is_null: false } }) {
               activity_type_name
               attributes


### PR DESCRIPTION
- Not dataset_id, bad typo
- This works most times because simulation_dataset_id and dataset_id are in lockstep. But if you add external profiles it breaks.

Related to: https://github.com/NASA-AMMOS/aerie-ui/pull/164