### PR TITLE
fix: update simulation error derivation to return empty array instead of null

### DIFF
--- a/src/stores/errors.ts
+++ b/src/stores/errors.ts
@@ -9,14 +9,14 @@ export function parseErrorReason(error: string) {
 export const simulationDatasetErrors: Readable<SimulationDatasetError[]> = derived(
   [simulationDataset],
   ([$simulationDataset]) => {
-    return $simulationDataset
+    return $simulationDataset && $simulationDataset.reason
       ? [
           {
             ...$simulationDataset.reason,
             message: parseErrorReason($simulationDataset.reason.message),
           },
         ]
-      : null;
+      : [];
   },
   [],
 );


### PR DESCRIPTION
This adds another check on the presence of errors before attempting to format them