### PR TITLE
ci: use Java 19 to build Aerie in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '18'
+          java-version: '19'
       - name: Build (Aerie)
         working-directory: ./aerie
         run: |


### PR DESCRIPTION
* See: https://github.com/NASA-AMMOS/aerie/pull/379
* See: https://github.com/NASA-AMMOS/aerie/pull/384