### PR TITLE
feat: Filter out gaps in simulation datasets

### DIFF
--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -890,7 +890,7 @@ const gql = {
           dataset {
             profiles {
               name
-              profile_segments(order_by: { start_offset: asc }) {
+              profile_segments(where: { is_gap: { _eq: false } }, order_by: { start_offset: asc }) {
                 dynamics
                 start_offset
               }


### PR DESCRIPTION
This is for an incoming change to allow external profiles to have gaps. In order to represent the end of a profile that does not align with the end of the plan, we need to add an extra segment at the end which adds an explicit gap. This now means that all simulation dataset profiles also end in an explicit gap that aligns with the end of the plan.

The UI subscription for sim datasets throws an error when it encounters that gap, so I added a filter to remove it.

I tested this manually against the new changes. It should be merged at the same time as [the main PR](https://github.com/NASA-AMMOS/aerie/pull/397).