### PR TITLE
feat: merge review page

### DIFF
--- a/src/components/activity/ActivityForm.svelte
+++ b/src/components/activity/ActivityForm.svelte
@@ -1,0 +1,692 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import CheckIcon from '@nasa-jpl/stellar/icons/check.svg?component';
+  import PenIcon from '@nasa-jpl/stellar/icons/pen.svg?component';
+  import { field } from '../../stores/form';
+  import { getActivityMetadata, getActivityRootParent } from '../../utilities/activities';
+  import effects from '../../utilities/effects';
+  import { classNames } from '../../utilities/generic';
+  import { getArguments, getFormParameters } from '../../utilities/parameters';
+  import { getDoyTimeFromDuration, getUnixEpochTime } from '../../utilities/time';
+  import { tooltip } from '../../utilities/tooltip';
+  import { required, timestamp } from '../../utilities/validators';
+  import ActivityMetadataField from '../activityMetadata/ActivityMetadataField.svelte';
+  import DatePickerField from '../form/DatePickerField.svelte';
+  import Field from '../form/Field.svelte';
+  import Input from '../form/Input.svelte';
+  import Parameters from '../parameters/Parameters.svelte';
+  import Highlight from '../ui/Highlight.svelte';
+  import Tags from '../ui/Tags.svelte';
+  import ActivityDecomposition from './ActivityDecomposition.svelte';
+
+  export let activity: Activity;
+  export let activitiesMap: ActivitiesMap = {};
+  export let activityMetadataDefinitions: ActivityMetadataDefinition[] = [];
+  export let activityTypesMap: ActivityTypesMap = {};
+  export let allActivityTags: string[] = [];
+  export let editable: boolean = true;
+  export let filteredExpansionSequences: ExpansionSequence[] = [];
+  export let highlightKeys: string[] = [];
+  export let modelId: number;
+  export let showActivityName: boolean = false;
+  export let showHeader: boolean = true;
+  export let showDecomposition: boolean = true;
+  export let showSequencing: boolean = true;
+  export let simulationDatasetId: number = -1;
+
+  // Activity vars.
+  let activityName: string | null = null;
+  let argumentsMap: ArgumentsMap | null = null;
+  let creationTime: string | null = null;
+  let duration: string | null = null;
+  let hasComputedAttributes: boolean = false;
+  let highlightKeysMap: Record<string, boolean> = {};
+  let id: number | null = null;
+  let lastModifiedTime: string | null = null;
+  let metadata: ActivityMetadata = {};
+  let parentUniqueId: ActivityUniqueId | null = null;
+  let parent_id: ActivityId | null = null;
+  let plan_id: number | null = null;
+  let planTags: string[] = [];
+  let root_activity: Activity | null = null;
+  let seq_id: string | null = null;
+  let simulated_activity_id: number | null = null;
+  let sourceSchedulingGoalId: number | null = null;
+  let startTimeDoy: string | null = null;
+  let tags: string[] = [];
+  let type: string | null = null;
+  let unfinished: boolean | null = null;
+  let uniqueId: string | null = null;
+
+  // Other vars.
+  let editingActivityName: boolean = false;
+  let endTime: string | null = null;
+  let formParametersComputedAttributes: FormParameter[] = [];
+  let formParameters: FormParameter[] = [];
+  let isChild: boolean;
+  let parametersWithErrorsCount: number = 0;
+  let parameterErrorMap: Record<string, string[]> = {};
+  let rootActivityHasChildren: boolean;
+  let startTimeDoyField: FieldStore<string>;
+
+  $: if (activity) {
+    activityName = activity.name;
+    argumentsMap = activity.arguments;
+    creationTime = activity.created_at;
+    duration = activity.duration;
+    id = activity.id;
+    lastModifiedTime = activity.last_modified_at;
+    metadata = activity.metadata;
+    parentUniqueId = activity.parentUniqueId;
+    parent_id = activity.parent_id;
+    plan_id = activity.plan_id;
+    root_activity = getActivityRootParent(activitiesMap, activity.uniqueId);
+    simulated_activity_id = activity.simulated_activity_id;
+    sourceSchedulingGoalId = activity.source_scheduling_goal_id;
+    startTimeDoy = activity.start_time_doy;
+    tags = activity.tags;
+    type = activity.type;
+    unfinished = activity.unfinished;
+    uniqueId = activity.uniqueId;
+  } else {
+    activityName = null;
+    argumentsMap = null;
+    creationTime = null;
+    duration = null;
+    editingActivityName = false;
+    hasComputedAttributes = false;
+    id = null;
+    plan_id = null;
+    lastModifiedTime = null;
+    metadata = {};
+    parameterErrorMap = {};
+    parametersWithErrorsCount = 0;
+    parentUniqueId = null;
+    parent_id = null;
+    root_activity = null;
+    seq_id = null;
+    simulated_activity_id = null;
+    sourceSchedulingGoalId = null;
+    startTimeDoy = null;
+    type = null;
+    unfinished = null;
+    tags = [];
+    uniqueId = null;
+  }
+
+  $: if (allActivityTags) {
+    planTags = allActivityTags;
+  } else {
+    planTags = [];
+  }
+
+  $: if (highlightKeys) {
+    highlightKeysMap = highlightKeys.reduce((map, key) => {
+      if (!map[key]) {
+        map[key] = true;
+      }
+      return map;
+    }, {});
+  }
+
+  $: activityType = activityTypesMap[type] || null;
+  $: rootActivityHasChildren = root_activity?.childUniqueIds ? root_activity.childUniqueIds.length > 0 : false;
+  $: isChild = parentUniqueId !== null;
+  $: startTimeDoyField = field<string>(startTimeDoy, [required, timestamp]);
+  $: activityNameField = field<string>(activityName);
+  $: if (duration) {
+    const startTimeISO = new Date(getUnixEpochTime(startTimeDoy)).toISOString();
+    endTime = `${getDoyTimeFromDuration(startTimeISO, duration)}`;
+  } else {
+    endTime = null;
+  }
+
+  $: if (activityType && argumentsMap) {
+    effects
+      .getEffectiveActivityArguments(modelId, activityType.name, argumentsMap)
+      .then(({ arguments: defaultArgumentsMap }) => {
+        formParameters = getFormParameters(
+          activityType.parameters,
+          argumentsMap,
+          activityType.required_parameters,
+          defaultArgumentsMap,
+        );
+      });
+  }
+  $: validateArguments(argumentsMap);
+
+  $: if (parameterErrorMap) {
+    formParameters = formParameters.map((formParameter: FormParameter) => {
+      const errors = parameterErrorMap[formParameter.name];
+      return { ...formParameter, errors: errors || null };
+    });
+    parametersWithErrorsCount = Object.keys(parameterErrorMap).length;
+  }
+
+  $: if (simulated_activity_id !== null && simulationDatasetId !== null) {
+    effects.getExpansionSequenceId(simulated_activity_id, simulationDatasetId).then(seqId => {
+      seq_id = seqId;
+    });
+  }
+
+  $: getActivityMetadataValue = (key: string) => {
+    if (metadata) {
+      return metadata[key];
+    }
+  };
+
+  $: setFormParametersComputedAttributes(
+    activityType?.computed_attributes_value_schema,
+    activity?.attributes?.computedAttributes,
+  );
+
+  // Check to see if the activity has a single empty computed value
+  // which is the same as having no computed attributes
+  $: if (formParametersComputedAttributes) {
+    if (formParametersComputedAttributes.length > 0) {
+      if (
+        formParametersComputedAttributes.length === 1 &&
+        formParametersComputedAttributes[0].schema.type === 'struct' &&
+        Object.keys(formParametersComputedAttributes[0].schema.items).length === 0
+      ) {
+        hasComputedAttributes = false;
+      } else {
+        hasComputedAttributes = true;
+      }
+    } else {
+      hasComputedAttributes = false;
+    }
+  }
+
+  async function updateExpansionSequenceToActivity() {
+    if (seq_id === null) {
+      await effects.deleteExpansionSequenceToActivity(simulationDatasetId, simulated_activity_id);
+    } else {
+      await effects.insertExpansionSequenceToActivity(simulationDatasetId, simulated_activity_id, seq_id);
+    }
+  }
+
+  async function onChangeFormParameters(event: CustomEvent<FormParameter>) {
+    const { detail: formParameter } = event;
+    const newArguments = getArguments(argumentsMap, formParameter);
+    effects.updateActivityDirective(plan_id, id, { arguments: newArguments });
+  }
+
+  async function onChangeActivityMetadata(event: CustomEvent<{ key: string; value: any }>) {
+    const { detail } = event;
+    const { key, value } = detail;
+    const newActivityMetadata = getActivityMetadata(metadata, key, value);
+    effects.updateActivityDirective(plan_id, id, { metadata: newActivityMetadata });
+  }
+
+  function onUpdateStartTime() {
+    if ($startTimeDoyField.valid && startTimeDoy !== $startTimeDoyField.value) {
+      effects.updateActivityDirective(plan_id, id, { start_time_doy: $startTimeDoyField.value });
+    }
+  }
+
+  function onUpdateTags(event: CustomEvent<{ tags: string[] }>) {
+    const { detail } = event;
+    const { tags } = detail;
+    effects.updateActivityDirective(plan_id, id, { tags });
+  }
+
+  function editActivityName() {
+    editingActivityName = true;
+  }
+
+  function resetActivityName() {
+    const initialValue = $activityNameField.initialValue;
+    activityNameField.reset(initialValue);
+    effects.updateActivityDirective(plan_id, id, { name: initialValue });
+  }
+
+  async function onUpdateActivityName() {
+    if ($activityNameField.dirty) {
+      if ($activityNameField.value) {
+        effects.updateActivityDirective(plan_id, id, { name: $activityNameField.value });
+      } else {
+        resetActivityName();
+      }
+    }
+    editingActivityName = false;
+  }
+
+  async function onActivityNameKeyup(event: KeyboardEvent) {
+    if (event.key === 'Escape') {
+      if ($activityNameField.dirty) {
+        resetActivityName();
+      }
+      editingActivityName = false;
+    }
+  }
+
+  /**
+   * Transforms computed attributes to conform to ParametersMap and ArgumentsMap
+   * so we can render computed attributes as form parameters.
+   */
+  function setFormParametersComputedAttributes(
+    schema: ValueSchema | undefined,
+    computedAttributes: ArgumentsMap | undefined,
+  ) {
+    if (schema) {
+      const parametersMap: ParametersMap = { Value: { order: 0, schema } };
+      const argumentsMap: ArgumentsMap = computedAttributes ? { Value: computedAttributes } : { Value: {} };
+      formParametersComputedAttributes = getFormParameters(parametersMap, argumentsMap, []);
+    }
+  }
+
+  async function validateArguments(newArguments: ArgumentsMap | null): Promise<void> {
+    if (newArguments) {
+      const { errors, success } = await effects.validateActivityArguments(type, modelId, newArguments);
+
+      if (!success) {
+        parameterErrorMap = errors.reduce((map, error) => {
+          error.subjects?.forEach(subject => {
+            if (!map[subject]) {
+              map[subject] = [];
+            }
+            map[subject].push(error.message);
+          });
+          return map;
+        }, {});
+      } else {
+        parameterErrorMap = {};
+      }
+    }
+  }
+</script>
+
+{#if showHeader}
+  <div class="activity-header">
+    {#if activityName}
+      <div class={classNames('activity-header-title', { 'activity-header-title--editing': editingActivityName })}>
+        {#if !editingActivityName}
+          <button class="icon st-button activity-header-title-edit-button" on:click={editActivityName}>
+            <div class="activity-header-title-value st-typography-medium">
+              {$activityNameField.value}
+            </div>
+            <PenIcon />
+          </button>
+        {:else}
+          <Field field={activityNameField} on:change={onUpdateActivityName}>
+            <input
+              on:keyup={onActivityNameKeyup}
+              autocomplete="off"
+              class="st-input w-100"
+              name="activity-name"
+              placeholder="Enter activity name"
+            />
+          </Field>
+          <button
+            use:tooltip={{ content: 'Save', placement: 'top' }}
+            class="icon st-button"
+            on:click={onUpdateActivityName}><CheckIcon /></button
+          >
+        {/if}
+      </div>
+    {:else}
+      <div class="activity-header-title-placeholder st-typography-medium">{type}</div>
+    {/if}
+  </div>
+{/if}
+
+<div class="activity-form">
+  <fieldset>
+    <details open>
+      <summary>Definition</summary>
+
+      <div class="details-body">
+        {#if showActivityName}
+          <Highlight highlight={highlightKeysMap.name}>
+            <Input layout="inline">
+              <label use:tooltip={{ content: 'Activity Name', placement: 'top' }} for="activityName">
+                Activity Name</label
+              >
+              <input class="st-input w-100" disabled name="activityName" value={activityName} />
+            </Input>
+          </Highlight>
+        {/if}
+
+        <Highlight highlight={highlightKeysMap.id}>
+          <Input layout="inline">
+            <label use:tooltip={{ content: 'Activity ID', placement: 'top' }} for="id"> Activity ID</label>
+            <input class="st-input w-100" disabled name="id" value={id} />
+          </Input>
+        </Highlight>
+
+        <Highlight highlight={highlightKeysMap.type}>
+          <Input layout="inline">
+            <label use:tooltip={{ content: 'Activity Type', placement: 'top' }} for="activity-type">
+              Activity Type
+            </label>
+            <input class="st-input w-100" disabled name="activity-type" value={type} />
+          </Input>
+        </Highlight>
+
+        <Highlight highlight={highlightKeysMap.parent_id}>
+          <Input layout="inline">
+            <label use:tooltip={{ content: 'Parent ID', placement: 'top' }} for="parent-id">Parent ID</label>
+            <input
+              class="st-input w-100"
+              disabled
+              name="parent-id"
+              value={isChild ? parent_id : 'None (Root Activity)'}
+            />
+          </Input>
+        </Highlight>
+
+        <Highlight highlight={highlightKeysMap.duration}>
+          <Input layout="inline" class={highlightKeysMap.duration ? 'highlight' : null}>
+            <label use:tooltip={{ content: 'Duration', placement: 'top' }} for="duration">Duration</label>
+            <input class="st-input w-100" disabled name="duration" value={duration ?? 'None'} />
+          </Input>
+        </Highlight>
+
+        <Highlight highlight={highlightKeysMap.unfinished}>
+          <Input layout="inline">
+            <label use:tooltip={{ content: 'Simulation Status', placement: 'top' }} for="simulationStatus">
+              Simulation Status
+            </label>
+            <input
+              class="st-input w-100"
+              disabled
+              name="simulationStatus"
+              value={unfinished ? 'Unfinished' : duration ? 'Finished' : 'None'}
+            />
+          </Input>
+        </Highlight>
+
+        <Highlight highlight={highlightKeysMap.start_time_doy}>
+          <DatePickerField
+            disabled={isChild || !editable}
+            field={startTimeDoyField}
+            label="Start Time - YYYY-DDDThh:mm:ss"
+            layout="inline"
+            name="start-time"
+            on:change={onUpdateStartTime}
+            on:keydown={onUpdateStartTime}
+          />
+        </Highlight>
+
+        {#if duration !== null}
+          <Highlight highlight={highlightKeysMap.end_time}>
+            <Input layout="inline">
+              <label use:tooltip={{ content: 'End Time', placement: 'top' }} for="endTime">End Time</label>
+              <input class="st-input w-100" disabled name="endTime" value={endTime} />
+            </Input>
+          </Highlight>
+        {/if}
+
+        <Highlight highlight={highlightKeysMap.created_at}>
+          <Input layout="inline">
+            <label use:tooltip={{ content: 'Creation Time', placement: 'top' }} for="creationTime">
+              Creation Time
+            </label>
+            <input class="st-input w-100" disabled name="creationTime" value={creationTime ?? 'None'} />
+          </Input>
+        </Highlight>
+
+        <Highlight highlight={highlightKeysMap.last_modified_at}>
+          <Input layout="inline">
+            <label use:tooltip={{ content: 'Last Modified Time', placement: 'top' }} for="lastModifiedTime">
+              Last Modified Time
+            </label>
+            <input class="st-input w-100" disabled name="lastModifiedTime" value={lastModifiedTime ?? 'None'} />
+          </Input>
+        </Highlight>
+
+        <Highlight highlight={highlightKeysMap.source_scheduling_goal_id}>
+          <Input layout="inline">
+            <label
+              use:tooltip={{ content: 'Source Scheduling Goal ID', placement: 'top' }}
+              for="sourceSchedulingGoalId"
+            >
+              Source Scheduling Goal ID
+            </label>
+            <input
+              class="st-input w-100"
+              disabled
+              name="sourceSchedulingGoalId"
+              value={sourceSchedulingGoalId ?? 'None'}
+            />
+          </Input>
+        </Highlight>
+
+        <Highlight highlight={highlightKeysMap.tags}>
+          <Input layout="inline">
+            <label use:tooltip={{ content: 'Tags', placement: 'top' }} for="activityTags">Tags</label>
+            <!--
+              Make use of svelte's 'key' here and switch on activity ID in order to clear the
+              text input in the tags component which would otherwise remain populated with
+              dirty input when a user switches to a new activity.
+             -->
+            {#key id}
+              <Tags
+                disabled={isChild || !editable}
+                autocompleteValues={planTags}
+                name="activityTags"
+                on:change={onUpdateTags}
+                {tags}
+              />
+            {/key}
+          </Input>
+        </Highlight>
+      </div>
+    </details>
+  </fieldset>
+
+  <fieldset>
+    <details open>
+      <summary>Annotations</summary>
+      <div class="details-body">
+        {#if activityMetadataDefinitions.length === 0 || isChild}
+          <div class="st-typography-label">No Annotations Found</div>
+        {/if}
+        {#if !isChild}
+          {#each activityMetadataDefinitions as definition}
+            <Highlight highlight={highlightKeysMap[definition.key]}>
+              <ActivityMetadataField
+                disabled={!editable}
+                on:change={onChangeActivityMetadata}
+                value={getActivityMetadataValue(definition.key)}
+                {definition}
+              />
+            </Highlight>
+          {/each}
+        {/if}
+      </div>
+    </details>
+  </fieldset>
+
+  <fieldset>
+    <details open>
+      <summary>
+        <span class:error={parametersWithErrorsCount > 0}>
+          Parameters
+          {#if parametersWithErrorsCount > 0}
+            ({parametersWithErrorsCount} invalid)
+          {/if}
+        </span>
+      </summary>
+      <div class="details-body">
+        <Parameters
+          disabled={isChild || !editable}
+          {formParameters}
+          {highlightKeysMap}
+          on:change={onChangeFormParameters}
+        />
+        {#if formParameters.length === 0}
+          <div class="st-typography-label">No Parameters Found</div>
+        {/if}
+      </div>
+    </details>
+  </fieldset>
+
+  <fieldset>
+    <details open>
+      <summary>Computed Attributes</summary>
+      <div class="details-body">
+        {#if !hasComputedAttributes}
+          <div class="st-typography-label">No Computed Attributes Found</div>
+        {:else}
+          <Parameters
+            disabled
+            expanded
+            formParameters={formParametersComputedAttributes}
+            {highlightKeysMap}
+            levelPadding={0}
+            showName={false}
+          />
+        {/if}
+      </div>
+    </details>
+  </fieldset>
+
+  {#if showDecomposition}
+    <fieldset>
+      <details open={rootActivityHasChildren} style:cursor="pointer">
+        <summary>Decomposition</summary>
+        <div class="details-body">
+          {#if rootActivityHasChildren}
+            <ActivityDecomposition rootUniqueId={root_activity.uniqueId} selectedUniqueId={uniqueId} />
+          {:else}
+            <div class="st-typography-label">This activity has no children</div>
+          {/if}
+        </div>
+      </details>
+    </fieldset>
+  {/if}
+
+  {#if showSequencing}
+    <fieldset>
+      <details open>
+        <summary>Sequencing</summary>
+
+        <div class="details-body">
+          <Input layout="inline">
+            <label use:tooltip={{ content: 'Simulation Dataset ID', placement: 'top' }} for="simulationDatasetId">
+              Simulation Dataset ID
+            </label>
+            <input class="st-input w-100" disabled name="simulationDatasetId" value={simulationDatasetId ?? 'None'} />
+          </Input>
+
+          <Input layout="inline">
+            <label use:tooltip={{ content: 'Sequence ID', placement: 'top' }} for="expansionSet">Sequence ID</label>
+            <select
+              bind:value={seq_id}
+              class="st-select w-100"
+              name="sequences"
+              disabled={!filteredExpansionSequences.length || !editable}
+              on:change={updateExpansionSequenceToActivity}
+            >
+              {#if !filteredExpansionSequences.length}
+                <option value={null}>No Sequences for Simulation Dataset {simulationDatasetId ?? ''}</option>
+              {:else}
+                <option value={null} />
+                {#each filteredExpansionSequences as sequence}
+                  <option value={sequence.seq_id}>
+                    {sequence.seq_id}
+                  </option>
+                {/each}
+              {/if}
+            </select>
+          </Input>
+        </div>
+      </details>
+    </fieldset>
+  {/if}
+</div>
+
+<style>
+  .activity-form fieldset:last-child {
+    padding-bottom: 16px;
+  }
+
+  .activity-directive-definition {
+    padding: 0.5rem;
+  }
+
+  .activity-header {
+    align-items: center;
+    background: var(--st-gray-10);
+    border-bottom: 1px solid var(--st-gray-15);
+    display: flex;
+    flex-shrink: 0;
+    font-style: italic;
+    padding: 4px 8px;
+    padding-left: 8px;
+  }
+
+  .activity-header-title-placeholder,
+  .activity-header-title-value {
+    word-break: break-word;
+  }
+
+  .activity-header-title-value {
+    overflow: hidden;
+    padding: 4px 0px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    word-break: break-all;
+  }
+
+  .activity-header-title-placeholder {
+    padding: 4px 8px;
+  }
+
+  .activity-header-title {
+    align-items: flex-start;
+    border-radius: 4px;
+    display: flex;
+    width: 100%;
+  }
+
+  .activity-header-title :global(fieldset) {
+    padding: 0;
+    width: 100%;
+  }
+
+  .activity-header-title-edit-button:hover {
+    background-color: var(--st-white);
+  }
+
+  .activity-header-title:not(.activity-header-title--editing) .st-button :global(.st-icon) {
+    display: none;
+    flex-shrink: 0;
+  }
+
+  .activity-header-title:not(.activity-header-title--editing) .st-button {
+    display: flex;
+    gap: 8px;
+    height: inherit;
+    min-width: 0;
+    padding: 0px 8px;
+  }
+
+  .activity-header-title:not(.activity-header-title--editing) .st-button:hover {
+    background: var(--st-white);
+  }
+
+  .activity-header-title:not(.activity-header-title--editing):hover .st-button :global(.st-icon) {
+    display: inherit;
+  }
+
+  .activity-header-title--editing {
+    gap: 8px;
+    padding: 0;
+    width: 100%;
+  }
+
+  .activity-header-title--editing .st-input {
+    background-color: var(--st-white);
+    font-style: normal;
+  }
+
+  .annotations {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+</style>

--- a/src/components/activity/ActivityFormPanel.svelte
+++ b/src/components/activity/ActivityFormPanel.svelte
@@ -1,8 +1,6 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import CheckIcon from '@nasa-jpl/stellar/icons/check.svg?component';
-  import PenIcon from '@nasa-jpl/stellar/icons/pen.svg?component';
   import TrashIcon from '@nasa-jpl/stellar/icons/trash.svg?component';
   import {
     activitiesMap,
@@ -11,282 +9,35 @@
     selectedActivity,
   } from '../../stores/activities';
   import { filteredExpansionSequences } from '../../stores/expansion';
-  import { field } from '../../stores/form';
-  import { activityTypesMap, plan } from '../../stores/plan';
+  import { activityTypesMap, modelId } from '../../stores/plan';
   import { simulationDatasetId } from '../../stores/simulation';
-  import { getActivityMetadata, getActivityRootParent } from '../../utilities/activities';
   import effects from '../../utilities/effects';
-  import { classNames } from '../../utilities/generic';
-  import { getArguments, getFormParameters } from '../../utilities/parameters';
-  import { getDoyTimeFromDuration, getUnixEpochTime } from '../../utilities/time';
   import { tooltip } from '../../utilities/tooltip';
-  import { required, timestamp } from '../../utilities/validators';
-  import ActivityMetadataField from '../activityMetadata/ActivityMetadataField.svelte';
-  import DatePickerField from '../form/DatePickerField.svelte';
-  import Field from '../form/Field.svelte';
-  import Input from '../form/Input.svelte';
   import GridMenu from '../menus/GridMenu.svelte';
-  import Parameters from '../parameters/Parameters.svelte';
   import Panel from '../ui/Panel.svelte';
-  import Tags from '../ui/Tags.svelte';
-  import ActivityDecomposition from './ActivityDecomposition.svelte';
+  import ActivityForm from './ActivityForm.svelte';
 
   export let gridId: number;
 
   // Activity vars.
-  let activityName: string | null = null;
-  let argumentsMap: ArgumentsMap | null = null;
-  let creationTime: string | null = null;
-  let duration: string | null = null;
-  let hasComputedAttributes: boolean = false;
   let id: number | null = null;
-  let lastModifiedTime: string | null = null;
-  let metadata: ActivityMetadata = {};
   let parentUniqueId: ActivityUniqueId | null = null;
-  let parent_id: ActivityId | null = null;
   let plan_id: number | null = null;
-  let planTags: string[] = [];
-  let root_activity: Activity | null = null;
-  let seq_id: string | null = null;
-  let simulated_activity_id: number | null = null;
-  let sourceSchedulingGoalId: number | null = null;
-  let startTimeDoy: string | null = null;
-  let tags: string[] = [];
-  let type: string | null = null;
-  let unfinished: boolean | null = null;
-  let uniqueId: string | null = null;
 
   // Other vars.
-  let editingActivityName: boolean = false;
-  let endTime: string | null = null;
-  let formParametersComputedAttributes: FormParameter[] = [];
-  let formParameters: FormParameter[] = [];
   let isChild: boolean;
-  let model: Model;
-  let parametersWithErrorsCount: number = 0;
-  let parameterErrorMap: Record<string, string[]> = {};
-  let rootActivityHasChildren: boolean;
-  let startTimeDoyField: FieldStore<string>;
 
   $: if ($selectedActivity) {
-    activityName = $selectedActivity.name;
-    argumentsMap = $selectedActivity.arguments;
-    creationTime = $selectedActivity.created_at;
-    duration = $selectedActivity.duration;
     id = $selectedActivity.id;
-    lastModifiedTime = $selectedActivity.last_modified_at;
-    metadata = $selectedActivity.metadata;
     parentUniqueId = $selectedActivity.parentUniqueId;
-    parent_id = $selectedActivity.parent_id;
     plan_id = $selectedActivity.plan_id;
-    root_activity = getActivityRootParent($activitiesMap, $selectedActivity.uniqueId);
-    simulated_activity_id = $selectedActivity.simulated_activity_id;
-    sourceSchedulingGoalId = $selectedActivity.source_scheduling_goal_id;
-    startTimeDoy = $selectedActivity.start_time_doy;
-    tags = $selectedActivity.tags;
-    type = $selectedActivity.type;
-    unfinished = $selectedActivity.unfinished;
-    uniqueId = $selectedActivity.uniqueId;
   } else {
-    activityName = null;
-    argumentsMap = null;
-    creationTime = null;
-    duration = null;
-    editingActivityName = false;
-    hasComputedAttributes = false;
     id = null;
-    plan_id = null;
-    lastModifiedTime = null;
-    metadata = {};
-    parameterErrorMap = {};
-    parametersWithErrorsCount = 0;
     parentUniqueId = null;
-    parent_id = null;
-    root_activity = null;
-    seq_id = null;
-    simulated_activity_id = null;
-    sourceSchedulingGoalId = null;
-    startTimeDoy = null;
-    type = null;
-    unfinished = null;
-    tags = [];
-    uniqueId = null;
+    plan_id = null;
   }
 
-  $: if ($allActivityTags) {
-    planTags = $allActivityTags;
-  } else {
-    planTags = [];
-  }
-
-  $: model = $plan.model;
-
-  $: activityType = $activityTypesMap[type] || null;
-  $: rootActivityHasChildren = root_activity?.childUniqueIds ? root_activity.childUniqueIds.length > 0 : false;
   $: isChild = parentUniqueId !== null;
-  $: startTimeDoyField = field<string>(startTimeDoy, [required, timestamp]);
-  $: activityNameField = field<string>(activityName);
-  $: if (duration) {
-    const startTimeISO = new Date(getUnixEpochTime(startTimeDoy)).toISOString();
-    endTime = `${getDoyTimeFromDuration(startTimeISO, duration)}`;
-  } else {
-    endTime = null;
-  }
-
-  $: if (activityType && argumentsMap) {
-    effects
-      .getEffectiveActivityArguments(model.id, activityType.name, argumentsMap)
-      .then(({ arguments: defaultArgumentsMap }) => {
-        formParameters = getFormParameters(
-          activityType.parameters,
-          argumentsMap,
-          activityType.required_parameters,
-          defaultArgumentsMap,
-        );
-      });
-  }
-  $: validateArguments(argumentsMap);
-
-  $: if (parameterErrorMap) {
-    formParameters = formParameters.map((formParameter: FormParameter) => {
-      const errors = parameterErrorMap[formParameter.name];
-      return { ...formParameter, errors: errors || null };
-    });
-    parametersWithErrorsCount = Object.keys(parameterErrorMap).length;
-  }
-
-  $: if (simulated_activity_id !== null && $simulationDatasetId !== null) {
-    effects.getExpansionSequenceId(simulated_activity_id, $simulationDatasetId).then(seqId => {
-      seq_id = seqId;
-    });
-  }
-
-  $: getActivityMetadataValue = (key: string) => {
-    if (metadata) {
-      return metadata[key];
-    }
-  };
-
-  $: setFormParametersComputedAttributes(
-    activityType?.computed_attributes_value_schema,
-    $selectedActivity?.attributes?.computedAttributes,
-  );
-
-  // Check to see if the activity has a single empty computed value
-  // which is the same as having no computed attributes
-  $: if (formParametersComputedAttributes) {
-    if (formParametersComputedAttributes.length > 0) {
-      if (
-        formParametersComputedAttributes.length === 1 &&
-        formParametersComputedAttributes[0].schema.type === 'struct' &&
-        Object.keys(formParametersComputedAttributes[0].schema.items).length === 0
-      ) {
-        hasComputedAttributes = false;
-      } else {
-        hasComputedAttributes = true;
-      }
-    } else {
-      hasComputedAttributes = false;
-    }
-  }
-
-  async function updateExpansionSequenceToActivity() {
-    if (seq_id === null) {
-      await effects.deleteExpansionSequenceToActivity($simulationDatasetId, simulated_activity_id);
-    } else {
-      await effects.insertExpansionSequenceToActivity($simulationDatasetId, simulated_activity_id, seq_id);
-    }
-  }
-
-  async function onChangeFormParameters(event: CustomEvent<FormParameter>) {
-    const { detail: formParameter } = event;
-    const newArguments = getArguments(argumentsMap, formParameter);
-    effects.updateActivityDirective(plan_id, id, { arguments: newArguments });
-  }
-
-  async function onChangeActivityMetadata(event: CustomEvent<{ key: string; value: any }>) {
-    const { detail } = event;
-    const { key, value } = detail;
-    const newActivityMetadata = getActivityMetadata(metadata, key, value);
-    effects.updateActivityDirective(plan_id, id, { metadata: newActivityMetadata });
-  }
-
-  function onUpdateStartTime() {
-    if ($startTimeDoyField.valid && startTimeDoy !== $startTimeDoyField.value) {
-      effects.updateActivityDirective(plan_id, id, { start_time_doy: $startTimeDoyField.value });
-    }
-  }
-
-  function onUpdateTags(event: CustomEvent<{ tags: string[] }>) {
-    const { detail } = event;
-    const { tags } = detail;
-    effects.updateActivityDirective(plan_id, id, { tags });
-  }
-
-  function editActivityName() {
-    editingActivityName = true;
-  }
-
-  function resetActivityName() {
-    const initialValue = $activityNameField.initialValue;
-    activityNameField.reset(initialValue);
-    effects.updateActivityDirective(plan_id, id, { name: initialValue });
-  }
-
-  async function onUpdateActivityName() {
-    if ($activityNameField.dirty) {
-      if ($activityNameField.value) {
-        effects.updateActivityDirective(plan_id, id, { name: $activityNameField.value });
-      } else {
-        resetActivityName();
-      }
-    }
-    editingActivityName = false;
-  }
-
-  async function onActivityNameKeyup(event: KeyboardEvent) {
-    if (event.key === 'Escape') {
-      if ($activityNameField.dirty) {
-        resetActivityName();
-      }
-      editingActivityName = false;
-    }
-  }
-
-  /**
-   * Transforms computed attributes to conform to ParametersMap and ArgumentsMap
-   * so we can render computed attributes as form parameters.
-   */
-  function setFormParametersComputedAttributes(
-    schema: ValueSchema | undefined,
-    computedAttributes: ArgumentsMap | undefined,
-  ) {
-    if (schema) {
-      const parametersMap: ParametersMap = { Value: { order: 0, schema } };
-      const argumentsMap: ArgumentsMap = computedAttributes ? { Value: computedAttributes } : { Value: {} };
-      formParametersComputedAttributes = getFormParameters(parametersMap, argumentsMap, []);
-    }
-  }
-
-  async function validateArguments(newArguments: ArgumentsMap | null): Promise<void> {
-    if (newArguments) {
-      const { errors, success } = await effects.validateActivityArguments(type, model.id, newArguments);
-
-      if (!success) {
-        parameterErrorMap = errors.reduce((map, error) => {
-          error.subjects?.forEach(subject => {
-            if (!map[subject]) {
-              map[subject] = [];
-            }
-            map[subject].push(error.message);
-          });
-          return map;
-        }, {});
-      } else {
-        parameterErrorMap = {};
-      }
-    }
-  }
 </script>
 
 <Panel padBody={false}>
@@ -304,270 +55,16 @@
 
   <svelte:fragment slot="body">
     {#if $selectedActivity}
-      <div class="activity-header">
-        {#if activityName}
-          <div class={classNames('activity-header-title', { 'activity-header-title--editing': editingActivityName })}>
-            {#if !editingActivityName}
-              <button class="icon st-button activity-header-title-edit-button" on:click={editActivityName}>
-                <div class="activity-header-title-value st-typography-medium">
-                  {$activityNameField.value}
-                </div>
-                <PenIcon />
-              </button>
-            {:else}
-              <Field field={activityNameField} on:change={onUpdateActivityName}>
-                <input
-                  on:keyup={onActivityNameKeyup}
-                  autocomplete="off"
-                  class="st-input w-100"
-                  name="activity-name"
-                  placeholder="Enter activity name"
-                />
-              </Field>
-              <button
-                use:tooltip={{ content: 'Save', placement: 'top' }}
-                class="icon st-button"
-                on:click={onUpdateActivityName}><CheckIcon /></button
-              >
-            {/if}
-          </div>
-        {:else}
-          <div class="activity-header-title-placeholder st-typography-medium">{type}</div>
-        {/if}
-      </div>
-
-      <div class="activity-form">
-        <fieldset>
-          <details open>
-            <summary>Definition</summary>
-
-            <div class="details-body">
-              <Input layout="inline">
-                <label use:tooltip={{ content: 'Activity ID', placement: 'top' }} for="id"> Activity ID</label>
-                <input class="st-input w-100" disabled name="id" value={id} />
-              </Input>
-
-              <Input layout="inline">
-                <label use:tooltip={{ content: 'Activity Type', placement: 'top' }} for="activity-type">
-                  Activity Type
-                </label>
-                <input class="st-input w-100" disabled name="activity-type" value={type} />
-              </Input>
-
-              <Input layout="inline">
-                <label use:tooltip={{ content: 'Parent ID', placement: 'top' }} for="parent-id">Parent ID</label>
-                <input
-                  class="st-input w-100"
-                  disabled
-                  name="parent-id"
-                  value={isChild ? parent_id : 'None (Root Activity)'}
-                />
-              </Input>
-
-              <Input layout="inline">
-                <label use:tooltip={{ content: 'Duration', placement: 'top' }} for="duration">Duration</label>
-                <input class="st-input w-100" disabled name="duration" value={duration ?? 'None'} />
-              </Input>
-
-              <Input layout="inline">
-                <label use:tooltip={{ content: 'Simulation Status', placement: 'top' }} for="simulationStatus">
-                  Simulation Status
-                </label>
-                <input
-                  class="st-input w-100"
-                  disabled
-                  name="simulationStatus"
-                  value={unfinished ? 'Unfinished' : duration ? 'Finished' : 'None'}
-                />
-              </Input>
-
-              <DatePickerField
-                disabled={isChild}
-                field={startTimeDoyField}
-                label="Start Time - YYYY-DDDThh:mm:ss"
-                layout="inline"
-                name="start-time"
-                on:change={onUpdateStartTime}
-                on:keydown={onUpdateStartTime}
-              />
-
-              {#if duration !== null}
-                <Input layout="inline">
-                  <label use:tooltip={{ content: 'End Time', placement: 'top' }} for="endTime">End Time</label>
-                  <input class="st-input w-100" disabled name="endTime" value={endTime} />
-                </Input>
-              {/if}
-
-              <Input layout="inline">
-                <label use:tooltip={{ content: 'Creation Time', placement: 'top' }} for="creationTime">
-                  Creation Time
-                </label>
-                <input class="st-input w-100" disabled name="creationTime" value={creationTime ?? 'None'} />
-              </Input>
-
-              <Input layout="inline">
-                <label use:tooltip={{ content: 'Last Modified Time', placement: 'top' }} for="lastModifiedTime">
-                  Last Modified Time
-                </label>
-                <input class="st-input w-100" disabled name="lastModifiedTime" value={lastModifiedTime ?? 'None'} />
-              </Input>
-
-              <Input layout="inline">
-                <label
-                  use:tooltip={{ content: 'Source Scheduling Goal ID', placement: 'top' }}
-                  for="sourceSchedulingGoalId"
-                >
-                  Source Scheduling Goal ID
-                </label>
-                <input
-                  class="st-input w-100"
-                  disabled
-                  name="sourceSchedulingGoalId"
-                  value={sourceSchedulingGoalId ?? 'None'}
-                />
-              </Input>
-
-              {#if duration !== null}
-                <Input layout="inline">
-                  <label use:tooltip={{ content: 'End Time', placement: 'top' }} for="endTime">End Time</label>
-                  <input class="st-input w-100" disabled name="endTime" value={endTime} />
-                </Input>
-              {/if}
-
-              <Input layout="inline">
-                <label use:tooltip={{ content: 'Tags', placement: 'top' }} for="activityTags">Tags</label>
-                <!--
-              Make use of svelte's 'key' here and switch on activity ID in order to clear the
-              text input in the tags component which would otherwise remain populated with
-              dirty input when a user switches to a new activity.
-             -->
-                {#key id}
-                  <Tags
-                    disabled={isChild}
-                    autocompleteValues={planTags}
-                    name="activityTags"
-                    on:change={onUpdateTags}
-                    {tags}
-                  />
-                {/key}
-              </Input>
-            </div>
-          </details>
-        </fieldset>
-
-        <fieldset>
-          <details open>
-            <summary>Annotations</summary>
-            <div class="details-body">
-              {#if $activityMetadataDefinitions.length === 0 || isChild}
-                <div class="st-typography-label">No Annotations Found</div>
-              {/if}
-              {#if !isChild}
-                {#each $activityMetadataDefinitions as definition}
-                  <ActivityMetadataField
-                    on:change={onChangeActivityMetadata}
-                    value={getActivityMetadataValue(definition.key)}
-                    {definition}
-                  />
-                {/each}
-              {/if}
-            </div>
-          </details>
-        </fieldset>
-
-        <fieldset>
-          <details open>
-            <summary>
-              <span class:error={parametersWithErrorsCount > 0}>
-                Parameters
-                {#if parametersWithErrorsCount > 0}
-                  ({parametersWithErrorsCount} invalid)
-                {/if}
-              </span>
-            </summary>
-            <div class="details-body">
-              <Parameters disabled={isChild} {formParameters} on:change={onChangeFormParameters} />
-              {#if formParameters.length === 0}
-                <div class="st-typography-label">No Parameters Found</div>
-              {/if}
-            </div>
-          </details>
-        </fieldset>
-
-        <fieldset>
-          <details open>
-            <summary>Computed Attributes</summary>
-            <div class="details-body">
-              {#if !hasComputedAttributes}
-                <div class="st-typography-label">No Computed Attributes Found</div>
-              {:else}
-                <Parameters
-                  disabled={true}
-                  expanded
-                  formParameters={formParametersComputedAttributes}
-                  levelPadding={0}
-                  showName={false}
-                />
-              {/if}
-            </div>
-          </details>
-        </fieldset>
-
-        <fieldset>
-          <details open={rootActivityHasChildren} style:cursor="pointer">
-            <summary>Decomposition</summary>
-            <div class="details-body">
-              {#if rootActivityHasChildren}
-                <ActivityDecomposition rootUniqueId={root_activity.uniqueId} selectedUniqueId={uniqueId} />
-              {:else}
-                <div class="st-typography-label">This activity has no children</div>
-              {/if}
-            </div>
-          </details>
-        </fieldset>
-
-        <fieldset>
-          <details open>
-            <summary>Sequencing</summary>
-
-            <div class="details-body">
-              <Input layout="inline">
-                <label use:tooltip={{ content: 'Simulation Dataset ID', placement: 'top' }} for="simulationDatasetId">
-                  Simulation Dataset ID
-                </label>
-                <input
-                  class="st-input w-100"
-                  disabled
-                  name="simulationDatasetId"
-                  value={$simulationDatasetId ?? 'None'}
-                />
-              </Input>
-
-              <Input layout="inline">
-                <label use:tooltip={{ content: 'Sequence ID', placement: 'top' }} for="expansionSet">Sequence ID</label>
-                <select
-                  bind:value={seq_id}
-                  class="st-select w-100"
-                  name="sequences"
-                  disabled={!$filteredExpansionSequences.length}
-                  on:change={updateExpansionSequenceToActivity}
-                >
-                  {#if !$filteredExpansionSequences.length}
-                    <option value={null}>No Sequences for Simulation Dataset {$simulationDatasetId ?? ''}</option>
-                  {:else}
-                    <option value={null} />
-                    {#each $filteredExpansionSequences as sequence}
-                      <option value={sequence.seq_id}>
-                        {sequence.seq_id}
-                      </option>
-                    {/each}
-                  {/if}
-                </select>
-              </Input>
-            </div>
-          </details>
-        </fieldset>
-      </div>
+      <ActivityForm
+        activitiesMap={$activitiesMap}
+        activity={$selectedActivity}
+        activityMetadataDefinitions={$activityMetadataDefinitions}
+        activityTypesMap={$activityTypesMap}
+        allActivityTags={$allActivityTags}
+        filteredExpansionSequences={$filteredExpansionSequences}
+        modelId={$modelId}
+        simulationDatasetId={$simulationDatasetId}
+      />
     {:else}
       <div class="p-2 st-typography-label">No Activity Selected</div>
     {/if}
@@ -575,97 +72,7 @@
 </Panel>
 
 <style>
-  .activity-form fieldset:last-child {
-    padding-bottom: 16px;
-  }
-
-  .activity-directive-definition {
-    padding: 0.5rem;
-  }
-
-  .activity-header {
-    align-items: center;
-    background: var(--st-gray-10);
-    border-bottom: 1px solid var(--st-gray-15);
-    display: flex;
-    flex-shrink: 0;
-    font-style: italic;
-    padding: 4px 8px;
-    padding-left: 8px;
-  }
-
-  .activity-header-title-placeholder,
-  .activity-header-title-value {
-    word-break: break-word;
-  }
-
-  .activity-header-title-value {
-    overflow: hidden;
-    padding: 4px 0px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    word-break: break-all;
-  }
-
-  .activity-header-title-placeholder {
-    padding: 4px 8px;
-  }
-
-  .activity-header-title {
-    align-items: flex-start;
-    border-radius: 4px;
-    display: flex;
-    width: 100%;
-  }
-
-  .activity-header-title :global(fieldset) {
-    padding: 0;
-    width: 100%;
-  }
-
-  .activity-header-title-edit-button:hover {
-    background-color: var(--st-white);
-  }
-
-  .activity-header-title:not(.activity-header-title--editing) .st-button :global(.st-icon) {
-    display: none;
-    flex-shrink: 0;
-  }
-
-  .activity-header-title:not(.activity-header-title--editing) .st-button {
-    display: flex;
-    gap: 8px;
-    height: inherit;
-    min-width: 0;
-    padding: 0px 8px;
-  }
-
-  .activity-header-title:not(.activity-header-title--editing) .st-button:hover {
-    background: var(--st-white);
-  }
-
-  .activity-header-title:not(.activity-header-title--editing):hover .st-button :global(.st-icon) {
-    display: inherit;
-  }
-
-  .activity-header-title--editing {
-    gap: 8px;
-    padding: 0;
-    width: 100%;
-  }
-
-  .activity-header-title--editing .st-input {
-    background-color: var(--st-white);
-    font-style: normal;
-  }
-
   .activity-header-delete {
     border: 1px solid var(--st-gray-30);
-  }
-
-  .annotations {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
   }
 </style>

--- a/src/components/app/Nav.svelte
+++ b/src/components/app/Nav.svelte
@@ -5,7 +5,7 @@
 <div class="nav">
   <div class="left">
     <AppMenu />
-    <div class="divider">|</div>
+    <div class="divider" />
     <div class="title st-typography-medium">
       <slot name="title" />
     </div>
@@ -17,25 +17,30 @@
 </div>
 
 <style>
+  :root {
+    --nav-header-height: 48px;
+  }
   .nav {
     align-items: center;
     background: var(--st-primary);
     color: var(--st-primary-background-color);
     display: flex;
-    font-size: 1rem;
-    height: 42px;
+    height: var(--nav-header-height);
     padding: 1rem;
     z-index: 2;
   }
 
   .divider {
-    color: var(--st-gray-50);
-    font-size: 12px;
+    background: var(--st-white);
+    height: 16px;
+    opacity: 0.2;
+    width: 1px;
   }
 
   .title {
     align-items: center;
     color: var(--st-gray-20);
+    font-size: 14px;
   }
 
   .left {

--- a/src/components/app/NavButton.svelte
+++ b/src/components/app/NavButton.svelte
@@ -26,7 +26,7 @@
     display: inline-flex;
     font-size: 13px;
     gap: 8px;
-    height: 42px;
+    height: var(--nav-header-height);
     line-height: 14px;
     padding: 10px;
   }

--- a/src/components/form/Input.svelte
+++ b/src/components/form/Input.svelte
@@ -5,7 +5,9 @@
   import { classNames } from '../../utilities/generic';
 
   export let layout: 'inline' | 'stacked' | null = 'stacked';
+  export { className as class };
 
+  let className: string = '';
   let container: HTMLDivElement;
   let containerObserver: MutationObserver;
   let input: HTMLInputElement | null;
@@ -22,6 +24,7 @@
   }
 
   $: inputClasses = classNames('input', {
+    [className]: !!className,
     'input-inline': layout === 'inline',
     'input-stacked': layout === 'stacked',
   });

--- a/src/components/menus/Menu.svelte
+++ b/src/components/menus/Menu.svelte
@@ -95,6 +95,7 @@
     border-radius: 4px;
     box-shadow: 0 2px 4px -1px #0003, 0 4px 5px #00000024, 0 1px 10px #0000001f;
     outline: 0;
+    overflow: hidden;
     z-index: 1000;
   }
 </style>

--- a/src/components/menus/MenuItem.svelte
+++ b/src/components/menus/MenuItem.svelte
@@ -32,7 +32,6 @@
 
   .menu-item:hover {
     background: var(--st-gray-20);
-    border-radius: 4px;
   }
 
   .menu-item.disabled {

--- a/src/components/menus/PlanMenu.svelte
+++ b/src/components/menus/PlanMenu.svelte
@@ -35,7 +35,7 @@
 <div class="plan-menu-container">
   {#if plan.parent_plan !== null}
     <div>
-      <a href={`${base}/plans/${plan.parent_plan.id}`} class="link">{plan.parent_plan.name}</a>
+      <a href={`${base}/plans/${plan.parent_plan.id}`} class="link st-typography-medium">{plan.parent_plan.name}</a>
     </div>
     <BranchIcon />
   {/if}
@@ -62,7 +62,7 @@
   </div>
   {#if plan.child_plans.length > 0}
     <!-- svelte-ignore a11y-click-events-have-key-events -->
-    <div class="plan-branches" on:click|stopPropagation={showPlanBranches}>
+    <div class="plan-branches st-typography-medium" on:click|stopPropagation={showPlanBranches}>
       {plan.child_plans.length} branch{plan.child_plans.length > 1 ? 'es' : ''}
     </div>
   {/if}
@@ -70,6 +70,7 @@
 
 <style>
   hr.menu-divider {
+    opacity: 0.3;
     width: 90%;
   }
 
@@ -81,12 +82,14 @@
   }
 
   .link {
-    color: var(--st-gray-30);
+    color: var(--st-white);
+    font-size: 14px;
+    opacity: 0.7;
     text-decoration: none;
   }
 
   .link:hover {
-    color: var(--st-gray-white);
+    opacity: 1;
   }
 
   .plan-menu {
@@ -107,11 +110,13 @@
     color: var(--st-white);
     display: flex;
     flex-flow: row;
-    font-weight: 500;
+    font-size: 14px;
+    gap: 4px;
   }
 
   .plan-branches {
     color: var(--st-white);
     cursor: pointer;
+    user-select: none;
   }
 </style>

--- a/src/components/modals/ConfirmModal.svelte
+++ b/src/components/modals/ConfirmModal.svelte
@@ -7,6 +7,7 @@
   import ModalFooter from './ModalFooter.svelte';
   import ModalHeader from './ModalHeader.svelte';
 
+  export let actionCanBeUndone: boolean = false;
   export let cancelText: string = 'Cancel';
   export let confirmText: string = 'Yes';
   export let height: number = 150;
@@ -33,7 +34,9 @@
   </ModalHeader>
   <ModalContent>
     <div>{message}</div>
-    <div>This action cannot be undone.</div>
+    {#if !actionCanBeUndone}
+      <div>This action cannot be undone.</div>
+    {/if}
   </ModalContent>
   <ModalFooter>
     <button class="st-button secondary" on:click={() => dispatch('close')}>

--- a/src/components/modals/CreatePlanBranchModal.svelte
+++ b/src/components/modals/CreatePlanBranchModal.svelte
@@ -38,7 +38,7 @@
 
 <Modal {height} {width}>
   <ModalHeader on:close>Create Branch</ModalHeader>
-  <ModalContent>
+  <ModalContent style=" display: flex; flex-direction: column; gap: 8px; padding:8px 0 0 ;">
     <fieldset>
       <label for="name">Name of branch</label>
       <input

--- a/src/components/modals/Modal.svelte
+++ b/src/components/modals/Modal.svelte
@@ -1,18 +1,16 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  export let height = 350;
-  export let width = 400;
+  export let height: number | string = 350;
+  export let width: number | string = 400;
+
+  $: heightStyle = typeof height === 'number' ? `${height}px` : height;
+  $: widthStyle = typeof width === 'number' ? `${width}px` : width;
 </script>
 
 <div class="modal-container">
   <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <div
-    class="modal st-typography-body"
-    style:height={`${height}px`}
-    style:width={`${width}px`}
-    on:click|stopPropagation
-  >
+  <div class="modal st-typography-body" style:height={heightStyle} style:width={widthStyle} on:click|stopPropagation>
     <slot />
   </div>
 </div>

--- a/src/components/modals/ModalFooter.svelte
+++ b/src/components/modals/ModalFooter.svelte
@@ -17,6 +17,6 @@
   }
 
   .modal-footer > :global(.st-button) {
-    margin-left: 5px;
+    margin-left: 8px;
   }
 </style>

--- a/src/components/modals/PlanBranchesModal.svelte
+++ b/src/components/modals/PlanBranchesModal.svelte
@@ -2,9 +2,6 @@
 
 <script lang="ts">
   import { base } from '$app/paths';
-  import Tab from '../ui/Tabs/Tab.svelte';
-  import TabPanel from '../ui/Tabs/TabPanel.svelte';
-  import Tabs from '../ui/Tabs/Tabs.svelte';
   import Modal from './Modal.svelte';
   import ModalContent from './ModalContent.svelte';
   import ModalHeader from './ModalHeader.svelte';
@@ -16,54 +13,26 @@
 
 <Modal {height} {width}>
   <ModalHeader on:close>Branches</ModalHeader>
-  <ModalContent>
-    <div class="plan-branches-container">
-      <Tabs>
-        <svelte:fragment slot="tab-list">
-          <Tab disabled>Active</Tab>
-          <Tab disabled>Merged</Tab>
-          <Tab disabled>Rejected</Tab>
-          <Tab>All</Tab>
-        </svelte:fragment>
-        <TabPanel disabled />
-        <TabPanel disabled />
-        <TabPanel disabled />
-        <TabPanel>
-          <div class="plan-branched-plans">
-            {#each plan.child_plans as childPlan}
-              <div class="branched-plan"><a href={`${base}/plans/${childPlan.id}`}>{childPlan.name}</a></div>
-            {/each}
-          </div>
-        </TabPanel>
-      </Tabs>
+  <ModalContent style=" overflow: auto;padding: 0">
+    <div class="plan-branched-plans">
+      {#each plan.child_plans as childPlan}
+        <a class="branched-plan" href={`${base}/plans/${childPlan.id}`}>{childPlan.name}</a>
+      {/each}
     </div>
   </ModalContent>
 </Modal>
 
 <style>
-  .plan-branches-container {
-    --tab-list-background-color: var(--st-white);
-    --tab-list-gap: 0 8px;
-    --tab-background-color: var(--st-white);
-    --tab-text-color: var(--st-gray-50);
-    --tab-hover-background-color: none;
-    --tab-selected-background-color: var(--st-white);
-    --tab-selected-text-color: var(--st-black);
-    --tab-padding: 2px 0;
-    --tab-height: auto;
-  }
-
-  .plan-branched-plans {
-    padding: 8px;
-  }
-
-  .branched-plan {
-    margin-bottom: 2rem;
-  }
-
-  .branched-plan a {
+  a {
+    border-bottom: 1px solid var(--st-gray-20);
     color: var(--st-black);
+    display: block;
     font-weight: var(--st-typography-medium-font-weight);
+    padding: 8px 16px;
     text-decoration: none;
+  }
+
+  a:hover {
+    background: var(--st-gray-10);
   }
 </style>

--- a/src/components/modals/PlanMergeRequestsModal.svelte
+++ b/src/components/modals/PlanMergeRequestsModal.svelte
@@ -1,24 +1,43 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { goto } from '$app/navigation';
+  import { base } from '$app/paths';
+  import { createEventDispatcher } from 'svelte';
+  import { user } from '../../stores/app';
   import { planMergeRequestsIncoming, planMergeRequestsOutgoing } from '../../stores/plan';
+  import effects from '../../utilities/effects';
+  import { classNames } from '../../utilities/generic';
+  import { tooltip } from '../../utilities/tooltip';
+  import PlanMergeRequestStatusBadge from '../plan/PlanMergeRequestStatusBadge.svelte';
+  import UserBadge from '../ui/UserBadge.svelte';
   import Modal from './Modal.svelte';
   import ModalContent from './ModalContent.svelte';
   import ModalHeader from './ModalHeader.svelte';
 
-  type RequestTypeFilter = 'all' | 'incoming' | 'outgoing';
+  export let height: number = 550;
+  export let selectedFilter: PlanMergeRequestTypeFilter = 'all';
+  export let width: number = 550;
 
-  export let height: number = 400;
-  export let width: number = 400;
+  const dispatch = createEventDispatcher();
 
+  let combinedPlanMergeRequests: PlanMergeRequest[] = [];
   let filteredPlanMergeRequests: PlanMergeRequest[] = [];
-  let selectedFilter: RequestTypeFilter = 'all';
+  let showPending = true;
+  let showInProgress = true;
+  let showAccepted = true;
+  let showRejected = true;
+  let showWithdrawn = false;
 
   $: incomingMergeRequestCount = $planMergeRequestsIncoming.length;
   $: outgoingMergeRequestCount = $planMergeRequestsOutgoing.length;
-  $: selectedFilterClass = (filter: RequestTypeFilter): string =>
-    filter === selectedFilter ? 'st-typography-medium' : ' st-typography-label';
-  $: filteredPlanMergeRequests =
+
+  $: selectedFilterClass = (filter: PlanMergeRequestTypeFilter) =>
+    classNames('st-typography-medium', {
+      'plan-merge-requests-tab-active': filter === selectedFilter,
+    });
+
+  $: combinedPlanMergeRequests =
     selectedFilter === 'incoming'
       ? $planMergeRequestsIncoming
       : selectedFilter === 'outgoing'
@@ -26,60 +45,191 @@
       : selectedFilter === 'all'
       ? [...$planMergeRequestsIncoming, ...$planMergeRequestsOutgoing]
       : [];
+
+  $: if (
+    showAccepted !== undefined &&
+    showInProgress !== undefined &&
+    showPending !== undefined &&
+    showWithdrawn !== undefined &&
+    showRejected !== undefined
+  ) {
+    filteredPlanMergeRequests = combinedPlanMergeRequests.filter(mergeRequest => {
+      const status = mergeRequest.status;
+      if (status === 'accepted') {
+        return showAccepted;
+      } else if (status === 'in-progress') {
+        return showInProgress;
+      } else if (status === 'pending') {
+        return showPending;
+      } else if (status === 'withdrawn') {
+        return showWithdrawn;
+      } else if (status === 'rejected') {
+        return showRejected;
+      }
+    });
+  }
+
+  async function onReviewOrWithdraw(planMergeRequest: PlanMergeRequest) {
+    if (planMergeRequest.type === 'incoming') {
+      planMergeRequest.pending = true;
+      filteredPlanMergeRequests = [...filteredPlanMergeRequests];
+      const success = await effects.planMergeBegin(planMergeRequest.id, $user.id);
+      if (success) {
+        dispatch('close');
+        goto(`${base}/plans/${planMergeRequest.plan_receiving_changes.id}/merge`);
+      }
+    } else if (planMergeRequest.type === 'outgoing') {
+      await effects.planMergeRequestWithdraw(planMergeRequest.id);
+    }
+
+    planMergeRequest.pending = false;
+    filteredPlanMergeRequests = [...filteredPlanMergeRequests];
+  }
 </script>
 
 <Modal {height} {width}>
   <ModalHeader on:close>Merge Requests</ModalHeader>
-  <ModalContent style="padding: 0">
-    <div class="plan-merge-requesets-container">
+  <ModalContent style="overflow: auto;padding: 0">
+    <div class="plan-merge-requests-container">
       <!-- svelte-ignore a11y-click-events-have-key-events -->
-      <div class="plan-merge-requesets-row p-2">
-        <div on:click={() => (selectedFilter = 'incoming')} class={selectedFilterClass('incoming')}>
-          Incoming Requests ({incomingMergeRequestCount})
+      <div class="plan-merge-requests-row">
+        <div class="plan-merge-requests-tabs">
+          <button on:click={() => (selectedFilter = 'incoming')} class={selectedFilterClass('incoming')}>
+            <span>Incoming Requests</span>
+            <span class="st-badge">{incomingMergeRequestCount}</span>
+          </button>
+          <button on:click={() => (selectedFilter = 'outgoing')} class={selectedFilterClass('outgoing')}>
+            <span>Outgoing Requests</span>
+            <span class="st-badge">{outgoingMergeRequestCount}</span>
+          </button>
+          <button on:click={() => (selectedFilter = 'all')} class={selectedFilterClass('all')}>
+            <span>All</span>
+          </button>
         </div>
-        <div on:click={() => (selectedFilter = 'outgoing')} class={selectedFilterClass('outgoing')}>
-          Outgoing Requests ({outgoingMergeRequestCount})
+      </div>
+
+      <div class="plan-merge-requests-row">
+        <div class="plan-merge-request-filters">
+          <div class="plan-merge-request-filter">
+            <input id="showPending" bind:checked={showPending} type="checkbox" />
+            <label class="st-typography-label" for="showPending">Pending</label>
+          </div>
+          <div class="plan-merge-request-filter">
+            <input id="showInProgress" bind:checked={showInProgress} type="checkbox" />
+            <label class="st-typography-label" for="showInProgress">In Progress</label>
+          </div>
+          <div class="plan-merge-request-filter">
+            <input id="showAccepted" bind:checked={showAccepted} type="checkbox" />
+            <label class="st-typography-label" for="showAccepted">Accepted</label>
+          </div>
+          <div class="plan-merge-request-filter">
+            <input id="showRejected" bind:checked={showRejected} type="checkbox" />
+            <label class="st-typography-label" for="showRejected">Rejected</label>
+          </div>
+          <div class="plan-merge-request-filter">
+            <input id="showWithdrawn" bind:checked={showWithdrawn} type="checkbox" />
+            <label class="st-typography-label" for="showWithdrawn">Withdrawn</label>
+          </div>
         </div>
-        <div on:click={() => (selectedFilter = 'all')} class={selectedFilterClass('all')}>All</div>
       </div>
 
       {#if filteredPlanMergeRequests.length}
-        {#each filteredPlanMergeRequests as filteredPlanMergeRequest}
-          <div class="plan-merge-request p-2">
-            <div class="plan-merge-request-row st-typography-medium">
-              {#if filteredPlanMergeRequest.type === 'incoming'}
-                {filteredPlanMergeRequest.plan_snapshot_supplying_changes.name} ({filteredPlanMergeRequest.status})
-              {:else if filteredPlanMergeRequest.type === 'outgoing'}
-                {filteredPlanMergeRequest.plan_receiving_changes.name} ({filteredPlanMergeRequest.status})
-              {/if}
-              <button class="st-button secondary">Review</button>
+        <div class="plan-merge-requests">
+          {#each filteredPlanMergeRequests as planMergeRequest}
+            <div class="plan-merge-request">
+              <div class="plan-merge-request-row st-typography-medium">
+                <div class="plan-merge-request-row-metadata">
+                  <div
+                    class="plan-merge-request-row-branch-name"
+                    use:tooltip={{
+                      content:
+                        planMergeRequest.type === 'incoming'
+                          ? planMergeRequest.plan_snapshot_supplying_changes.name
+                          : planMergeRequest.plan_receiving_changes.name,
+                      placement: 'top',
+                    }}
+                  >
+                    {#if planMergeRequest.type === 'incoming'}
+                      {planMergeRequest.plan_snapshot_supplying_changes.name}
+                    {:else if planMergeRequest.type === 'outgoing'}
+                      {planMergeRequest.plan_receiving_changes.name}
+                    {/if}
+                  </div>
+                  <PlanMergeRequestStatusBadge status={planMergeRequest.status} />
+                </div>
+
+                {#if planMergeRequest.status === 'pending'}
+                  <button on:click={() => onReviewOrWithdraw(planMergeRequest)} class="st-button secondary">
+                    {#if planMergeRequest.pending}
+                      {planMergeRequest.type === 'outgoing' ? 'Withdrawing...' : 'Reviewing...'}
+                    {:else}
+                      {planMergeRequest.type === 'outgoing' ? 'Withdraw' : 'Review'}
+                    {/if}
+                  </button>
+                {/if}
+              </div>
+              <div class="plan-merge-request-row">
+                <UserBadge username={planMergeRequest.requester_username} />
+              </div>
             </div>
-            <div class="plan-merge-request-row">
-              {filteredPlanMergeRequest.requester_username}
-            </div>
-          </div>
-        {/each}
+          {/each}
+        </div>
       {:else}
-        <div class="p-2">No merge requests found</div>
+        <div class="plan-merge-requests-empty st-typography-label">No merge requests found</div>
       {/if}
     </div>
   </ModalContent>
 </Modal>
 
 <style>
-  .plan-merge-requesets-container {
+  .plan-merge-requests-container {
+    display: flex;
+    flex-direction: column;
     height: 100%;
     width: 100%;
   }
 
-  .plan-merge-requesets-row {
+  .plan-merge-requests-row {
     border-bottom: 1px solid var(--st-gray-15);
-    cursor: pointer;
     display: flex;
-    gap: 10px;
+    flex-direction: column;
+    padding-left: 8px;
   }
 
-  .plan-merge-request {
+  .plan-merge-requests-tabs {
+    display: inherit;
+  }
+
+  .plan-merge-requests-tabs button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    gap: 4px;
+    outline: none;
+    padding: 12px 8px;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  .plan-merge-requests-tabs button > span:first-child {
+    opacity: 0.5;
+  }
+
+  .plan-merge-requests-tabs button.plan-merge-requests-tab-active span {
+    opacity: 1 !important;
+  }
+
+  .plan-merge-requests-tabs button:hover span:first-child {
+    opacity: 0.7;
+  }
+
+  .plan-merge-requests-tabs .st-badge {
+    background: #e5b300;
+    color: var(--st-white);
+  }
+
+  .plan-merge-requests-tabs .plan-merge-request {
     align-items: center;
     display: grid;
     grid-template-rows: auto auto;
@@ -88,6 +238,68 @@
   .plan-merge-request-row {
     align-items: center;
     display: flex;
+    gap: 8px;
     justify-content: space-between;
+  }
+
+  .plan-merge-request-filters {
+    display: flex;
+    gap: 12px;
+    padding: 10px 8px;
+  }
+
+  .plan-merge-request-filter {
+    display: flex;
+    gap: 6px;
+  }
+
+  .plan-merge-request-filter input {
+    margin: 0;
+  }
+
+  .plan-merge-request-filter .st-typography-label {
+    color: var(--st-gray-60);
+    user-select: none;
+  }
+
+  .plan-merge-requests {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    overflow: auto;
+    padding: 16px;
+  }
+
+  .plan-merge-request {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .plan-merge-request-status {
+    background: var(--st-gray-15);
+    border-radius: 4px;
+    display: flex;
+    flex-direction: column;
+    grid-area: 4px;
+    padding: 4px 4px;
+  }
+
+  .plan-merge-request-row-metadata {
+    align-items: center;
+    display: flex;
+    gap: 8px;
+    overflow: hidden;
+  }
+
+  .plan-merge-request-row-branch-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: 100%;
+  }
+
+  .plan-merge-requests-empty {
+    padding: 16px;
   }
 </style>

--- a/src/components/parameters/ParameterRecSeries.svelte
+++ b/src/components/parameters/ParameterRecSeries.svelte
@@ -89,13 +89,14 @@
       <CssGrid gap="3px" columns="auto auto auto" class="parameter-rec-series-css-grid">
         <button
           class="st-button icon"
-          disabled={subFormParameters?.length === 0}
+          disabled={subFormParameters?.length === 0 || disabled}
           on:click|stopPropagation={valueRemove}
           use:tooltip={{ content: 'Remove Value', placement: 'left' }}
         >
           <DashIcon />
         </button>
         <button
+          {disabled}
           class="st-button icon"
           on:click|stopPropagation={valueAdd}
           use:tooltip={{ content: 'Add Value', placement: 'left' }}

--- a/src/components/parameters/Parameters.svelte
+++ b/src/components/parameters/Parameters.svelte
@@ -2,12 +2,14 @@
 
 <script lang="ts">
   import { compare } from '../../utilities/generic';
+  import Highlight from '../ui/Highlight.svelte';
   import ParameterBase from './ParameterBase.svelte';
   import ParameterRec from './ParameterRec.svelte';
 
   export let disabled: boolean = false;
   export let expanded: boolean = false;
   export let formParameters: FormParameter[] = [];
+  export let highlightKeysMap: Record<string, boolean> = {};
   export let levelPadding: number = 20;
   export let showName: boolean = true;
 
@@ -19,22 +21,24 @@
 </script>
 
 {#each sortedFormParameters as formParameter (formParameter.name)}
-  <div bind:clientWidth class="parameter">
-    {#if formParameter.schema.type === 'series' || formParameter.schema.type === 'struct'}
-      <ParameterRec
-        {disabled}
-        {expanded}
-        {formParameter}
-        {labelColumnWidth}
-        {level}
-        {levelPadding}
-        {showName}
-        on:change
-      />
-    {:else}
-      <ParameterBase {disabled} {formParameter} {labelColumnWidth} {level} {levelPadding} on:change />
-    {/if}
-  </div>
+  <Highlight highlight={highlightKeysMap[formParameter.name]}>
+    <div bind:clientWidth class="parameter">
+      {#if formParameter.schema.type === 'series' || formParameter.schema.type === 'struct'}
+        <ParameterRec
+          {disabled}
+          {expanded}
+          {formParameter}
+          {labelColumnWidth}
+          {level}
+          {levelPadding}
+          {showName}
+          on:change
+        />
+      {:else}
+        <ParameterBase {disabled} {formParameter} {labelColumnWidth} {level} {levelPadding} on:change />
+      {/if}
+    </div>
+  </Highlight>
 {/each}
 
 <style>

--- a/src/components/plan/PlanMergeRequestStatusBadge.svelte
+++ b/src/components/plan/PlanMergeRequestStatusBadge.svelte
@@ -1,0 +1,45 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  export let status: PlanMergeRequestStatus = 'withdrawn';
+
+  const statusToColors: Record<PlanMergeRequestStatus, string> = {
+    accepted: '#0EAF0A',
+    'in-progress': '#2FCBED',
+    pending: '#E5B300',
+    rejected: '#AF0A32',
+    withdrawn: '#A1A1A1',
+  };
+
+  $: dotColor = statusToColors[status];
+</script>
+
+<div class="plan-merge-request-status-badge">
+  <span class="dot" style={`background: ${dotColor}`} />
+  <div class="status">{status}</div>
+</div>
+
+<style>
+  .plan-merge-request-status-badge {
+    align-items: center;
+    background: var(--st-gray-10);
+    border-radius: 4px;
+    color: var(--st-gray-60);
+    display: flex;
+    gap: 4px;
+    padding: 4px 8px 4px 6px;
+    white-space: nowrap;
+  }
+
+  .dot {
+    border-radius: 16px;
+    height: 8px;
+    margin: 4px;
+    width: 8px;
+  }
+
+  .status {
+    text-transform: capitalize;
+    user-select: none;
+  }
+</style>

--- a/src/components/plan/PlanMergeRequestsStatusButton.svelte
+++ b/src/components/plan/PlanMergeRequestsStatusButton.svelte
@@ -1,3 +1,5 @@
+<svelte:options immutable={true} />
+
 <script lang="ts">
   import PlanWithDownArrowIcon from '@nasa-jpl/stellar/icons/plan_with_down_arrow.svg?component';
   import PlanWithUpArrowIcon from '@nasa-jpl/stellar/icons/plan_with_up_arrow.svg?component';
@@ -5,24 +7,25 @@
   import { showPlanMergeRequestsModal } from '../../utilities/modal';
   import { tooltip } from '../../utilities/tooltip';
 
-  $: incomingMergeRequestCount = $planMergeRequestsIncoming.length;
-  $: outgoingMergeRequestCount = $planMergeRequestsOutgoing.length;
+  $: incomingPendingMergeRequets = $planMergeRequestsIncoming.filter(request => request.status === 'pending');
+  $: outgoingPendingMergeRequets = $planMergeRequestsOutgoing.filter(request => request.status === 'pending');
+  $: incomingPendingMergeRequetCount = incomingPendingMergeRequets.length;
+  $: outgoingPendingMergeRequetCount = outgoingPendingMergeRequets.length;
 </script>
 
-{#if incomingMergeRequestCount > 0 || outgoingMergeRequestCount > 0}
-  <div class="divider">|</div>
+{#if incomingPendingMergeRequetCount > 0 || outgoingPendingMergeRequetCount > 0}
   <button
-    class="merge-requests-status-badge st-button tertiary st-typography-medium"
+    class="plan-merge-requests-status-button st-button tertiary st-typography-medium"
     on:click|stopPropagation={() => showPlanMergeRequestsModal()}
     use:tooltip={{
-      content: `${incomingMergeRequestCount} incoming, ${outgoingMergeRequestCount} outgoing`,
+      content: `${incomingPendingMergeRequetCount} incoming, ${outgoingPendingMergeRequetCount} outgoing`,
       placement: 'top',
     }}
   >
-    <span class="status-icon" class:active={incomingMergeRequestCount > 0}>
+    <span class="status-icon" class:active={incomingPendingMergeRequetCount > 0}>
       <PlanWithDownArrowIcon />
     </span>
-    <span class="status-icon" class:active={outgoingMergeRequestCount > 0}>
+    <span class="status-icon" class:active={outgoingPendingMergeRequetCount > 0}>
       <PlanWithUpArrowIcon />
     </span>
     <span>Merge requests</span>
@@ -30,7 +33,7 @@
 {/if}
 
 <style>
-  .merge-requests-status-badge {
+  .plan-merge-requests-status-button {
     align-items: center;
     background: rgba(255, 255, 255, 0.24);
     border-radius: 4px;
@@ -44,9 +47,10 @@
     letter-spacing: 0.025em;
     line-height: 16px;
     padding: 4px 8px;
+    white-space: nowrap;
   }
 
-  .merge-requests-status-badge.st-button.tertiary:hover:not([disabled]) {
+  .plan-merge-requests-status-button.st-button.tertiary:hover:not([disabled]) {
     background: rgba(255, 255, 255, 0.2);
   }
 

--- a/src/components/plan/PlanMergeReview.svelte
+++ b/src/components/plan/PlanMergeReview.svelte
@@ -1,0 +1,793 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { base } from '$app/paths';
+  import BranchIcon from '@nasa-jpl/stellar/icons/branch.svg?component';
+  import CheckIcon from '@nasa-jpl/stellar/icons/check.svg?component';
+  import PlanWithDownArrow from '@nasa-jpl/stellar/icons/plan_with_down_arrow.svg?component';
+  import { activityMetadataDefinitions } from '../../stores/activities';
+  import { activityTypesMap } from '../../stores/plan';
+  import { gqlSubscribable } from '../../stores/subscribable';
+  import { deriveActivityFromMergeActivityDirective } from '../../utilities/activities';
+  import effects from '../../utilities/effects';
+  import { changedKeys, getTarget } from '../../utilities/generic';
+  import gql from '../../utilities/gql';
+  import { tooltip } from '../../utilities/tooltip';
+  import ActivityForm from '../activity/ActivityForm.svelte';
+  import Nav from '../app/Nav.svelte';
+  import CssGrid from '../ui/CssGrid.svelte';
+  import CssGridGutter from '../ui/CssGridGutter.svelte';
+  import PlanMergeReviewUserInfo from './PlanMergeReviewUserInfo.svelte';
+
+  export let initialConflictingActivities: PlanMergeConflictingActivity[] = [];
+  export let initialMergeRequest: PlanMergeRequestSchema;
+  export let initialNonConflictingActivities: PlanMergeNonConflictingActivity[] = [];
+  export let initialPlan: Plan;
+
+  const conflictingMergeActivities = gqlSubscribable<PlanMergeConflictingActivity[]>(
+    gql.SUB_PLAN_MERGE_CONFLICTING_ACTIVITIES,
+    { merge_request_id: initialMergeRequest.id },
+    initialConflictingActivities,
+  );
+
+  let additions: PlanMergeNonConflictingActivity[] = [];
+  let computedSourceActivity: Activity | null;
+  let computedTargetActivity: Activity | null;
+  let conflicts: PlanMergeConflictingActivity[] = [];
+  let deletions: PlanMergeNonConflictingActivity[] = [];
+  let keysWithChanges: string[] = [];
+  let modifications: PlanMergeNonConflictingActivity[] = [];
+  let selectedActivityId: number | null;
+  let selectedConflictingActivity: PlanMergeConflictingActivity | null;
+  let selectedConflictingActivityResolution: PlanMergeResolution | null;
+  let selectedMergeType: 'conflict' | 'add' | 'modify' | 'delete' | 'none' | null;
+  let selectedNonConflictingActivity: PlanMergeNonConflictingActivity | null;
+  let unresolvedConflictsCount: number = 0;
+
+  let mergeComparisonSourceDiv: HTMLElement | null = null;
+  let mergeComparisonTargetDiv: HTMLElement | null = null;
+  let mergeComparisonScrollOrigin: 'source' | 'target' | null = null;
+
+  $: if (initialNonConflictingActivities) {
+    // Updated selectedNonConflictingActivity with the refeshed version if needed
+    if (selectedNonConflictingActivity) {
+      selectedNonConflictingActivity = initialNonConflictingActivities.find(
+        merge => merge.activity_id === selectedNonConflictingActivity.activity_id,
+      );
+    }
+
+    // Compute additions, deletions, and modifications
+    additions = [];
+    deletions = [];
+    modifications = [];
+    initialNonConflictingActivities
+      .slice()
+      .sort((a, b) => {
+        return (a.source?.name || a.target?.name || '').localeCompare(b.source?.name || b.target?.name || '');
+      })
+      .forEach(activity => {
+        if (activity.change_type === 'add') {
+          additions.push(activity);
+        } else if (activity.change_type === 'delete') {
+          deletions.push(activity);
+        } else if (activity.change_type === 'modify') {
+          modifications.push(activity);
+        }
+      });
+  }
+
+  $: if ($conflictingMergeActivities) {
+    // Sort conflicts by name
+    conflicts = $conflictingMergeActivities.slice().sort((a, b) => {
+      return a.merge_base.name.localeCompare(b.merge_base.name);
+    });
+
+    // Updated selectedConflictingActivity with the refeshed version if needed
+    if (selectedConflictingActivity) {
+      selectedConflictingActivity = $conflictingMergeActivities.find(
+        activity => activity.activity_id === selectedConflictingActivity.activity_id,
+      );
+      if (selectedConflictingActivity) {
+        selectedConflictingActivityResolution = selectedConflictingActivity.resolution;
+      } else {
+        selectedConflictingActivityResolution = null;
+      }
+    }
+
+    // Reset comparison scroll positions
+    resetMergeReviewComparisonScrollTops();
+  } else {
+    conflicts = [];
+  }
+
+  $: if (conflicts) {
+    unresolvedConflictsCount = conflicts.filter(conflict => conflict.resolution === 'none').length;
+  }
+
+  $: if (selectedNonConflictingActivity) {
+    selectedConflictingActivityResolution = null;
+    selectedActivityId = selectedNonConflictingActivity.activity_id;
+    selectedMergeType = selectedNonConflictingActivity.change_type;
+    if (selectedNonConflictingActivity.change_type === 'delete') {
+      computedTargetActivity = deriveActivityFromMergeActivityDirective(
+        selectedNonConflictingActivity.target,
+        initialPlan,
+      );
+      computedSourceActivity = null;
+    } else if (selectedNonConflictingActivity.change_type === 'add') {
+      computedSourceActivity = deriveActivityFromMergeActivityDirective(
+        selectedNonConflictingActivity.source,
+        initialPlan,
+      );
+      computedTargetActivity = null;
+    } else {
+      computedSourceActivity = deriveActivityFromMergeActivityDirective(
+        selectedNonConflictingActivity.source,
+        initialPlan,
+      );
+      computedTargetActivity = deriveActivityFromMergeActivityDirective(
+        selectedNonConflictingActivity.target,
+        initialPlan,
+      );
+    }
+
+    // Reset comparison scroll positions
+    resetMergeReviewComparisonScrollTops();
+  }
+
+  $: if (selectedConflictingActivity) {
+    selectedActivityId = selectedConflictingActivity.activity_id;
+    selectedMergeType = 'conflict';
+    // Derive source and target activities
+    if (selectedConflictingActivity.source) {
+      computedSourceActivity = deriveActivityFromMergeActivityDirective(
+        selectedConflictingActivity.source,
+        initialPlan,
+      );
+    } else {
+      computedSourceActivity = null;
+    }
+    if (selectedConflictingActivity.target) {
+      computedTargetActivity = deriveActivityFromMergeActivityDirective(
+        selectedConflictingActivity.target,
+        initialPlan,
+      );
+    } else {
+      computedTargetActivity = null;
+    }
+  }
+
+  // If this is a PlanMergeConflictingActivity where both source and target
+  // have modifications or it is a modified PlanMergeNonConflictingActivity we will compute the changed keys
+  $: if (
+    (selectedConflictingActivity &&
+      selectedConflictingActivity.change_type_target === 'modify' &&
+      selectedConflictingActivity.change_type_source === 'modify') ||
+    (selectedNonConflictingActivity && selectedMergeType === 'modify')
+  ) {
+    keysWithChanges = changedKeys(computedSourceActivity, computedTargetActivity, [
+      'arguments',
+      'metadata',
+      'created_at',
+      'id',
+      'snapshot_id',
+      'last_modified_arguments_at',
+      'last_modified_at',
+      'source_scheduling_goal_id',
+      'type',
+    ])
+      .concat(changedKeys(computedSourceActivity.arguments, computedTargetActivity.arguments))
+      .concat(changedKeys(computedSourceActivity.metadata, computedTargetActivity.metadata));
+  } else {
+    keysWithChanges = [];
+  }
+
+  async function onApproveChanges() {
+    const success = await effects.planMergeCommit(initialMergeRequest.id);
+    if (success) {
+      goto(`${base}/plans/${initialPlan.id}`);
+    }
+  }
+
+  async function onDenyChanges() {
+    const success = await effects.planMergeDeny(initialMergeRequest.id);
+    if (success) {
+      goto(`${base}/plans/${initialPlan.id}`);
+    }
+  }
+
+  async function onCancel() {
+    const success = await effects.planMergeCancel(initialMergeRequest.id);
+    if (success) {
+      goto(`${base}/plans/${initialPlan.id}`);
+    }
+  }
+
+  function onResolveAll(e: Event) {
+    const { value } = getTarget(e);
+    const resolution = value as PlanMergeResolution;
+    effects.planMergeResolveAllConflicts(initialMergeRequest.id, resolution);
+
+    // Set resolutions for all conflicts
+    if ($conflictingMergeActivities && $conflictingMergeActivities.length) {
+      const conflictActivityIdMap = conflicts.reduce((map, conflict) => {
+        map[conflict.activity_id] = true;
+        return map;
+      }, {});
+
+      // Optimistically update our store with the new resolution values
+      conflictingMergeActivities.updateValue((activities: PlanMergeConflictingActivity[]) => {
+        return activities.map(activity => {
+          if (conflictActivityIdMap[activity.activity_id]) {
+            activity.resolution = resolution;
+          }
+          return activity;
+        });
+      });
+    }
+
+    // Set select value back to Resolve All default
+    this.value = 'resolve_all';
+  }
+
+  async function onMergeReviewComparisonScroll(event: Event, origin: 'source' | 'target') {
+    if (mergeComparisonScrollOrigin === origin) {
+      const target = event.target as HTMLDivElement;
+      const scrollTop = target.scrollTop;
+      if (origin === 'source') {
+        mergeComparisonTargetDiv.scrollTop = scrollTop;
+      } else {
+        mergeComparisonSourceDiv.scrollTop = scrollTop;
+      }
+    }
+    mergeComparisonScrollOrigin = origin;
+  }
+
+  function resetMergeReviewComparisonScrollTops() {
+    if (mergeComparisonTargetDiv && mergeComparisonSourceDiv) {
+      mergeComparisonTargetDiv.scrollTop = 0;
+      mergeComparisonSourceDiv.scrollTop = 0;
+    }
+  }
+
+  async function resolveConflict(activityId: number, resolution: PlanMergeResolution) {
+    await effects.planMergeResolveConflict(initialMergeRequest.id, activityId, resolution);
+
+    conflictingMergeActivities.updateValue((activities: PlanMergeConflictingActivity[]) => {
+      return activities.map(activity => {
+        if (activity.activity_id === activityId) {
+          activity.resolution = resolution;
+        }
+        return activity;
+      });
+    });
+  }
+</script>
+
+<div class="flex">
+  <Nav>
+    <span class="" slot="title">Merge Review</span>
+  </Nav>
+  <div class="merge-review-content">
+    <CssGrid columns="0.5fr 3px 1fr 3px 1fr 3px 1fr" class="merge-review-content-grid">
+      <div class="merge-review-metadata">
+        <PlanMergeReviewUserInfo
+          label="Requested Merge"
+          title="Created By"
+          username={initialMergeRequest.requester_username}
+        />
+        <PlanMergeReviewUserInfo
+          label="Plan Owner"
+          title="Reviewed By"
+          username={initialMergeRequest.reviewer_username}
+        />
+        <div class="merge-review-branch-metadata">
+          <div class="st-typography-medium">Current Branch (Target)</div>
+          <div class="merge-review-branch-metadata-content st-typography-body">
+            <BranchIcon />
+            {initialMergeRequest.plan_receiving_changes.name}
+          </div>
+        </div>
+        <div class="merge-review-branch-metadata">
+          <div class="st-typography-medium">Source Branch</div>
+          <div class="merge-review-branch-metadata-content st-typography-body">
+            <PlanWithDownArrow />
+            {initialMergeRequest.plan_snapshot_supplying_changes.name}
+          </div>
+        </div>
+        <div class="merge-review-stats">
+          <div>
+            <div class="merge-review-stat">
+              <div class="st-typography-medium">Adds</div>
+              <div class="st-typography-body">{additions.length}</div>
+            </div>
+            <div class="merge-review-stat">
+              <div class="st-typography-medium">Modifies</div>
+              <div class="st-typography-body">{modifications.length}</div>
+            </div>
+          </div>
+          <div>
+            <div class="merge-review-stat">
+              <div class="st-typography-medium">Removes</div>
+              <div class="st-typography-body">{deletions.length}</div>
+            </div>
+            <div class="merge-review-stat">
+              <div class="st-typography-medium">Conflicts</div>
+              <div class="st-typography-body">{conflicts.length}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <CssGridGutter track={1} type="column" />
+      <div class="merge-review-changes">
+        <div class="merge-review-subheader">
+          <span class="st-typography-medium">
+            Conflicts
+            {#if unresolvedConflictsCount > 0}
+              <span class="merge-review-conflicts-badge st-badge">{unresolvedConflictsCount}</span>
+            {:else}
+              <span class="merge-review-no-conflicts-badge"><CheckIcon />None</span>
+            {/if}
+          </span>
+          <select class="st-select" value="resolve_all" on:change={onResolveAll}>
+            <option value="resolve_all">Resolve All</option>
+            <option value="source">Resolve All Using Source</option>
+            <option value="target">Resolve All Using Target</option>
+            <option value="none">Unresolve All</option>
+          </select>
+        </div>
+        <div class="merge-review-changes-content">
+          {#if conflicts.length}
+            <fieldset>
+              <details open style:cursor="pointer">
+                <summary class="st-typography-bold">Conflicts</summary>
+                <div class="details-body">
+                  {#each conflicts as merge}
+                    <button
+                      on:click={() => {
+                        selectedConflictingActivity = merge;
+                        selectedNonConflictingActivity = null;
+                      }}
+                      class="st-button tertiary merge-review-activity-item"
+                      class:active={selectedActivityId === merge.activity_id}
+                    >
+                      <!--
+                        TODO use the merge base activity name here instead? Even if it's renamed?
+                        Though I suppose we could be smart and choose the name of the chosen resolution?
+                        E.g. if we resolve a conflict using the source activity we display the source activity name
+                      -->
+                      {merge.merge_base.name}
+                      {#if merge.resolution !== 'none'}
+                        <span class="merge-review-activity-item-resolution st-typography-medium st-chip">
+                          {merge.resolution}
+                        </span>
+                      {/if}
+                    </button>
+                  {/each}
+                </div>
+              </details>
+            </fieldset>
+          {/if}
+          {#if additions.length}
+            <fieldset>
+              <details open style:cursor="pointer">
+                <summary class="st-typography-bold">New Activities</summary>
+                <div class="details-body">
+                  {#each additions as merge}
+                    <button
+                      on:click={() => {
+                        selectedNonConflictingActivity = merge;
+                        selectedConflictingActivity = null;
+                      }}
+                      class="st-button tertiary merge-review-activity-item"
+                      class:active={selectedActivityId === merge.activity_id}>{merge.source.name}</button
+                    >
+                  {/each}
+                </div>
+              </details>
+            </fieldset>
+          {/if}
+          {#if modifications.length}
+            <fieldset>
+              <details open style:cursor="pointer">
+                <summary class="st-typography-bold">Modified Activities</summary>
+                <div class="details-body">
+                  {#each modifications as merge}
+                    <button
+                      on:click={() => {
+                        selectedNonConflictingActivity = merge;
+                        selectedConflictingActivity = null;
+                      }}
+                      class="st-button tertiary merge-review-activity-item"
+                      class:active={selectedActivityId === merge.activity_id}>{merge.source.name}</button
+                    >
+                  {/each}
+                </div>
+              </details>
+            </fieldset>
+          {/if}
+          {#if deletions.length}
+            <fieldset>
+              <details open style:cursor="pointer">
+                <summary class="st-typography-bold">Removed Activities</summary>
+                <div class="details-body">
+                  {#each deletions as merge}
+                    <button
+                      on:click={() => {
+                        selectedNonConflictingActivity = merge;
+                        selectedConflictingActivity = null;
+                      }}
+                      class="st-button tertiary merge-review-activity-item"
+                      class:active={selectedActivityId === merge.activity_id}
+                    >
+                      {merge.target.name}
+                    </button>
+                  {/each}
+                </div>
+              </details>
+            </fieldset>
+          {/if}
+        </div>
+      </div>
+      <CssGridGutter track={3} type="column" />
+      <div class="merge-review-comparison-target">
+        <div class="merge-review-subheader">
+          <span style="gap: 8px">
+            <PlanWithDownArrow />
+            <span class="st-typography-medium">{initialMergeRequest.plan_snapshot_supplying_changes.name}</span>
+          </span>
+          <span class="st-chip st-typography-medium">Source</span>
+        </div>
+        {#if selectedConflictingActivity}
+          <div class="merge-review-button-container">
+            <button
+              class="st-button secondary w-100"
+              class:selected={selectedConflictingActivityResolution === 'source'}
+              on:click={() => {
+                const activityId =
+                  selectedConflictingActivity.change_type_source === 'delete'
+                    ? selectedConflictingActivity.merge_base.id
+                    : selectedConflictingActivity.source.id;
+                const resolution = selectedConflictingActivity?.resolution === 'source' ? 'none' : 'source';
+                resolveConflict(activityId, resolution);
+              }}
+            >
+              {#if selectedConflictingActivity?.resolution === 'source'}
+                <span>
+                  <CheckIcon />
+                </span>
+              {/if}
+              Keep Source Activity
+            </button>
+          </div>
+        {/if}
+        <div
+          bind:this={mergeComparisonSourceDiv}
+          class="merge-review-comparison-body"
+          class:selected={selectedConflictingActivityResolution === 'source'}
+          on:scroll={event => onMergeReviewComparisonScroll(event, 'source')}
+        >
+          {#if selectedConflictingActivity || selectedNonConflictingActivity}
+            {#if selectedMergeType === 'add' || selectedMergeType === 'modify' || (selectedMergeType === 'conflict' && selectedConflictingActivity.change_type_source !== 'delete')}
+              <ActivityForm
+                activity={computedSourceActivity}
+                activityMetadataDefinitions={$activityMetadataDefinitions}
+                activityTypesMap={$activityTypesMap}
+                editable={false}
+                highlightKeys={keysWithChanges}
+                modelId={initialPlan.model_id}
+                showActivityName
+                showDecomposition={false}
+                showHeader={false}
+                showSequencing={false}
+              />
+            {:else if (selectedMergeType === 'delete' && !computedSourceActivity) || (selectedMergeType === 'conflict' && selectedConflictingActivity.change_type_source === 'delete')}
+              <div class="st-typography-label merge-review-comparison-empty-state">Activity Deleted</div>
+            {:else}
+              <div class="st-typography-label merge-review-comparison-empty-state">No Target Activity</div>
+            {/if}
+          {:else}
+            <div class="st-typography-label merge-review-comparison-empty-state">No Activity Selected</div>
+          {/if}
+        </div>
+      </div>
+      <CssGridGutter track={5} type="column" />
+      <div class="merge-review-comparison-request">
+        <div class="merge-review-subheader">
+          <span style="gap: 8px">
+            <BranchIcon />
+            <span class="st-typography-medium">{initialMergeRequest.plan_receiving_changes.name}</span>
+          </span>
+          <span class="st-chip st-typography-medium">Current Branch (Target)</span>
+        </div>
+        {#if selectedConflictingActivity}
+          <div class="merge-review-button-container">
+            <button
+              class="st-button secondary w-100"
+              class:selected={selectedConflictingActivityResolution === 'target'}
+              on:click={() => {
+                const activityId =
+                  selectedConflictingActivity.change_type_target === 'delete'
+                    ? selectedConflictingActivity.merge_base.id
+                    : selectedConflictingActivity.target.id;
+                const resolution = selectedConflictingActivity?.resolution === 'target' ? 'none' : 'target';
+                resolveConflict(activityId, resolution);
+              }}
+            >
+              {#if selectedConflictingActivity?.resolution === 'target'}
+                <span>
+                  <CheckIcon />
+                </span>
+              {/if}
+              Keep Target Activity
+            </button>
+          </div>
+        {/if}
+        <div
+          bind:this={mergeComparisonTargetDiv}
+          class="merge-review-comparison-body"
+          class:selected={selectedConflictingActivityResolution === 'target'}
+          on:scroll={event => onMergeReviewComparisonScroll(event, 'target')}
+        >
+          {#if selectedConflictingActivity || selectedNonConflictingActivity}
+            {#if selectedMergeType === 'modify' || (selectedMergeType === 'delete' && !computedSourceActivity) || (selectedMergeType === 'conflict' && selectedConflictingActivity.change_type_target !== 'delete')}
+              <ActivityForm
+                activity={computedTargetActivity}
+                activityMetadataDefinitions={$activityMetadataDefinitions}
+                activityTypesMap={$activityTypesMap}
+                editable={false}
+                highlightKeys={!!selectedConflictingActivity && keysWithChanges}
+                modelId={initialPlan.model_id}
+                showActivityName
+                showDecomposition={false}
+                showHeader={false}
+                showSequencing={false}
+              />
+            {:else if (selectedMergeType === 'delete' && !computedTargetActivity) || (selectedMergeType === 'conflict' && selectedConflictingActivity.change_type_target === 'delete')}
+              <div class="st-typography-label merge-review-comparison-empty-state">Activity Deleted</div>
+            {:else}
+              <div class="st-typography-label merge-review-comparison-empty-state">No Target Activity</div>
+            {/if}
+          {:else}
+            <div class="st-typography-label merge-review-comparison-empty-state">No Activity Selected</div>
+          {/if}
+        </div>
+      </div>
+    </CssGrid>
+  </div>
+  <div class="merge-review-bottom-actions">
+    <button class="st-button secondary" on:click={onCancel}>Cancel</button>
+    <button class="st-button red" on:click={onDenyChanges}>Deny Changes</button>
+    {#if unresolvedConflictsCount > 0}
+      <span use:tooltip={{ content: 'Resolve all conflicts before approving', placement: 'top' }}>
+        <button disabled class="st-button" on:click={onApproveChanges}>Approve Changes</button>
+      </span>
+    {:else}
+      <button class="st-button" on:click={onApproveChanges}>Approve Changes</button>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .flex {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .merge-review-content {
+    display: flex;
+    flex: 1;
+    flex-direction: row;
+    overflow: hidden;
+    width: 100%;
+  }
+
+  .merge-review-content > div:not(:last-child) {
+    border-right: 1px solid var(--st-gray-20);
+  }
+
+  .merge-review-metadata {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    overflow: auto;
+    padding: 16px;
+  }
+
+  .merge-review-branch-metadata {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .merge-review-branch-metadata-content {
+    align-items: center;
+    display: flex;
+    gap: 8px;
+    word-break: break-all;
+  }
+
+  .merge-review-branch-metadata-content :global(svg) {
+    flex-shrink: 0;
+  }
+
+  .st-button.red {
+    background: var(--st-error-red);
+  }
+
+  .merge-review-stats {
+    display: flex;
+    flex-direction: row;
+    gap: 16px;
+  }
+
+  .merge-review-stats > div {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  .merge-review-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .merge-review-changes {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .merge-review-changes-content {
+    height: 100%;
+    overflow: auto;
+  }
+
+  .merge-review-subheader {
+    align-items: center;
+    border-bottom: 1px solid var(--st-gray-20);
+    display: flex;
+    flex-direction: row;
+    flex-shrink: 0;
+    gap: 16px;
+    height: 48px;
+    justify-content: space-between;
+    padding: 16px 16px 8px;
+  }
+
+  .merge-review-subheader span {
+    display: flex;
+    gap: 4px;
+  }
+
+  .merge-review-subheader :global(.st-icon) {
+    flex-shrink: 0;
+  }
+
+  .merge-review-conflicts-badge {
+    background: var(--st-error-red);
+    color: var(--st-white);
+  }
+
+  .merge-review-no-conflicts-badge {
+    align-items: center;
+    background-color: #0eaf0a;
+    border-radius: 9999px;
+    color: #fff;
+    height: 16px;
+    justify-content: center;
+    padding: 0px 8px 0px 4px;
+    user-select: none;
+  }
+
+  .st-chip {
+    color: var(--st-gray-50);
+  }
+
+  fieldset {
+    padding: 0;
+  }
+
+  summary {
+    padding: 8px 16px;
+  }
+
+  .details-body {
+    gap: 0;
+    margin: 0;
+  }
+
+  .merge-review-activity-item {
+    border-radius: 0;
+    gap: 8px;
+    height: 32px;
+    justify-content: space-between;
+    outline: none;
+    padding: 0px 33px;
+    text-align: left;
+  }
+
+  .merge-review-activity-item-resolution {
+    text-transform: capitalize;
+  }
+
+  .st-chip {
+    white-space: nowrap;
+  }
+
+  .merge-review-activity-item.active,
+  .st-button.tertiary.merge-review-activity-item.active:hover {
+    background: var(--st-primary-10);
+  }
+
+  .merge-review-comparison-target,
+  .merge-review-comparison-request {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .merge-review-comparison-body {
+    height: 100%;
+    overflow: auto;
+  }
+
+  .merge-review-comparison-body.selected :global(.highlight .highlight-bg.active) {
+    background: rgba(14, 175, 10, 0.24);
+  }
+
+  .merge-review-button-container {
+    background: var(--st-gray-10);
+    border-bottom: 1px solid var(--st-gray-20);
+    padding: 8px;
+    width: 100%;
+  }
+
+  .merge-review-button-container button.selected {
+    background-color: var(--st-gray-60);
+    color: var(--st-white);
+    gap: 8px;
+  }
+
+  .merge-review-button-container button.selected span {
+    align-items: center;
+    background-color: #0eaf0a;
+    border-radius: 9999px;
+    color: #fff;
+    display: inline-flex;
+    height: 16px;
+    justify-content: center;
+    width: 16px;
+  }
+
+  .merge-review-comparison-empty-state {
+    align-items: center;
+    background: var(--st-gray-10);
+    display: flex;
+    flex: 1;
+    height: 100%;
+    justify-content: center;
+    margin: 0px;
+  }
+
+  :global(.merge-review-content-grid) {
+    width: 100%;
+  }
+
+  .merge-review-comparison-body :global(.activity-form input.st-input),
+  .merge-review-comparison-body :global(.input .svelte-tags-input-layout) {
+    background: var(--st-white) !important;
+    opacity: 1;
+  }
+
+  .merge-review-bottom-actions {
+    border-top: 1px solid var(--st-gray-20);
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    padding: 8px;
+  }
+</style>

--- a/src/components/plan/PlanMergeReviewUserInfo.svelte
+++ b/src/components/plan/PlanMergeReviewUserInfo.svelte
@@ -1,0 +1,24 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import UserBadge from '../ui/UserBadge.svelte';
+
+  export let label: string = '';
+  export let title: string = '';
+  export let username: string = '';
+</script>
+
+<div class="plan-merge-review-user-info">
+  <div class="st-typography-medium">
+    {title}
+  </div>
+  <UserBadge {label} {username} />
+</div>
+
+<style>
+  .plan-merge-review-user-info {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+</style>

--- a/src/components/ui/CssGridGutter.svelte
+++ b/src/components/ui/CssGridGutter.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  export let track: number = 1;
+  export let track: number = 1; // Array index number in the children of CSSGrid
   export let type: 'column' | 'row' = 'column';
 </script>
 

--- a/src/components/ui/Highlight.svelte
+++ b/src/components/ui/Highlight.svelte
@@ -1,0 +1,29 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  export let highlight: boolean = false;
+</script>
+
+<div class="highlight">
+  <div class="highlight-bg" class:active={highlight} />
+  <slot />
+</div>
+
+<style>
+  .highlight {
+    position: relative;
+  }
+
+  .highlight-bg {
+    height: 100%;
+    left: -8px;
+    position: absolute;
+    top: 0;
+    width: calc(100% + 16px);
+    z-index: -1;
+  }
+
+  .active {
+    background: rgba(255, 237, 72, 0.24);
+  }
+</style>

--- a/src/components/ui/Panel.svelte
+++ b/src/components/ui/Panel.svelte
@@ -20,7 +20,7 @@
 <style>
   .panel {
     display: grid;
-    grid-template-rows: 42px calc(100% - 42px);
+    grid-template-rows: var(--nav-header-height) calc(100% - var(--nav-header-height));
     overflow: hidden;
     width: 100%;
   }
@@ -30,7 +30,7 @@
     border-bottom: 1px solid var(--st-gray-20);
     display: flex;
     gap: 0.5rem;
-    height: 42px;
+    height: var(--nav-header-height);
     justify-content: space-between;
   }
 

--- a/src/components/ui/UserBadge.svelte
+++ b/src/components/ui/UserBadge.svelte
@@ -1,0 +1,53 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  export let label: string = '';
+  export let username: string = 'Unknown';
+
+  $: usernameFirstChar = username.charAt(0).toLocaleUpperCase();
+</script>
+
+<div class="user-badge st-typography-body">
+  <div class="user-badge-avatar">
+    {usernameFirstChar}
+  </div>
+  <div class="user-badge-details">
+    <div class="user-badge-name">
+      {username}
+    </div>
+    {#if label}
+      <div class="user-badge-label">
+        {label}
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .user-badge {
+    align-items: center;
+    color: var(--st-gray-60);
+    display: flex;
+    gap: 8px;
+  }
+
+  .user-badge-avatar {
+    align-items: center;
+    background: #2f80ed;
+    border-radius: 24px;
+    color: var(--st-white);
+    display: flex;
+    flex-shrink: 0;
+    height: 24px;
+    justify-content: center;
+    width: 24px;
+  }
+
+  .user-badge-name {
+    color: var(--st-gray-100);
+  }
+
+  .user-badge-label {
+    color: var(--st-gray-60);
+  }
+</style>

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -12,6 +12,7 @@
 @import '@nasa-jpl/stellar/css/input.css';
 @import '@nasa-jpl/stellar/css/select.css';
 @import '@nasa-jpl/stellar/css/table.css';
+@import '@nasa-jpl/stellar/css/badge.css';
 
 @import 'modern-css-reset/dist/reset.min.css';
 

--- a/src/css/stellar.css
+++ b/src/css/stellar.css
@@ -1,6 +1,7 @@
 /* Aerie Stellar Custom Classes and Overrides. */
 
 :root {
+  --st-badge-padding: 0px 5px;
   --st-primary-100: #0d1667;
   --st-primary-90: #1a237e;
   --st-primary-80: #283593;

--- a/src/routes/constraints/+layout.svelte
+++ b/src/routes/constraints/+layout.svelte
@@ -5,7 +5,7 @@
   import CssGrid from '../../components/ui/CssGrid.svelte';
 </script>
 
-<CssGrid rows="42px calc(100vh - 42px)">
+<CssGrid rows="var(--nav-header-height) calc(100vh - var(--nav-header-height))">
   <Nav>
     <span class="constraints-title" slot="title">Constraints</span>
   </Nav>

--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -85,7 +85,7 @@
   }
 </script>
 
-<CssGrid rows="42px calc(100vh - 42px)">
+<CssGrid rows="var(--nav-header-height) calc(100vh - var(--nav-header-height))">
   <Nav>
     <span slot="title">Command Dictionaries</span>
   </Nav>

--- a/src/routes/expansion/+layout.svelte
+++ b/src/routes/expansion/+layout.svelte
@@ -11,7 +11,7 @@
   import CssGrid from '../../components/ui/CssGrid.svelte';
 </script>
 
-<CssGrid rows="42px calc(100vh - 42px)">
+<CssGrid rows="var(--nav-header-height) calc(100vh - var(--nav-header-height))">
   <Nav>
     <span class="expansion-title" slot="title">Expansion</span>
 

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -94,7 +94,7 @@
   }
 </script>
 
-<CssGrid rows="42px calc(100vh - 42px)">
+<CssGrid rows="var(--nav-header-height) calc(100vh - var(--nav-header-height))">
   <Nav>
     <span slot="title">Models</span>
   </Nav>

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -171,7 +171,7 @@
   }
 </script>
 
-<CssGrid rows="42px calc(100vh - 42px)">
+<CssGrid rows="var(--nav-header-height) calc(100vh - var(--nav-header-height))">
   <Nav>
     <span slot="title">Plans</span>
   </Nav>

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -20,13 +20,13 @@
   import ExpansionPanel from '../../../components/expansion/ExpansionPanel.svelte';
   import PlanMenu from '../../../components/menus/PlanMenu.svelte';
   import ViewMenu from '../../../components/menus/ViewMenu.svelte';
+  import PlanMergeRequestsStatusButton from '../../../components/plan/PlanMergeRequestsStatusButton.svelte';
   import SchedulingPanel from '../../../components/scheduling/SchedulingPanel.svelte';
   import SimulationPanel from '../../../components/simulation/SimulationPanel.svelte';
   import TimelineFormPanel from '../../../components/timeline/form/TimelineFormPanel.svelte';
   import TimelinePanel from '../../../components/timeline/TimelinePanel.svelte';
   import CssGrid from '../../../components/ui/CssGrid.svelte';
   import IFramePanel from '../../../components/ui/IFramePanel.svelte';
-  import MergeRequestsStatusBadge from '../../../components/ui/MergeRequestsStatusBadge.svelte';
   import SplitGrid from '../../../components/ui/SplitGrid.svelte';
   import ViewEditorPanel from '../../../components/view/ViewEditorPanel.svelte';
   import ViewsPanel from '../../../components/view/ViewsPanel.svelte';
@@ -128,13 +128,13 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<CssGrid class="plan-container" rows="42px auto 36px">
+<CssGrid class="plan-container" rows="var(--nav-header-height) auto 36px">
   <Nav>
     <div slot="title">
       <PlanMenu plan={data.initialPlan} />
     </div>
     <svelte:fragment slot="left">
-      <MergeRequestsStatusBadge />
+      <PlanMergeRequestsStatusButton />
     </svelte:fragment>
     <svelte:fragment slot="right">
       <NavButton

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -17,6 +17,9 @@ export const load: PageLoad = async ({ parent, params, url }) => {
     const initialPlan = await effects.getPlan(planId);
 
     if (initialPlan) {
+      if (initialPlan.is_locked) {
+        throw redirect(302, `${base}/plans/${id}/merge`);
+      }
       const initialView = await effects.getView(user.id, url.searchParams);
 
       return {

--- a/src/routes/plans/[id]/merge/+page.svelte
+++ b/src/routes/plans/[id]/merge/+page.svelte
@@ -1,0 +1,20 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import PlanMergeReview from '../../../../components/plan/PlanMergeReview.svelte';
+  import { plan } from '../../../../stores/plan';
+  import type { PageData } from './$types';
+
+  export let data: PageData;
+
+  $: if (data.initialPlan) {
+    $plan = data.initialPlan;
+  }
+</script>
+
+<PlanMergeReview
+  initialConflictingActivities={data.initialConflictingActivities}
+  initialPlan={data.initialPlan}
+  initialMergeRequest={data.initialMergeRequest}
+  initialNonConflictingActivities={data.initialNonConflictingActivities}
+/>

--- a/src/routes/plans/[id]/merge/+page.ts
+++ b/src/routes/plans/[id]/merge/+page.ts
@@ -1,0 +1,44 @@
+import { base } from '$app/paths';
+import { redirect } from '@sveltejs/kit';
+import effects from '../../../../utilities/effects';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ parent, params }) => {
+  const { user } = await parent();
+
+  if (!user) {
+    throw redirect(302, `${base}/login`);
+  }
+
+  const { id } = params;
+  const planId = parseFloat(id);
+
+  if (!Number.isNaN(planId)) {
+    const initialPlan = await effects.getPlan(planId);
+
+    if (initialPlan) {
+      if (!initialPlan.is_locked) {
+        throw redirect(302, `${base}/plans/${id}`);
+      }
+
+      const initialMergeRequest: PlanMergeRequestSchema = await effects.getPlanMergeRequestInProgress(planId);
+      let initialConflictingActivities: PlanMergeConflictingActivity[] = [];
+      let initialNonConflictingActivities: PlanMergeNonConflictingActivity[] = [];
+
+      if (initialMergeRequest) {
+        const { id: mergeRequestId } = initialMergeRequest;
+        initialConflictingActivities = await effects.getPlanMergeConflictingActivities(mergeRequestId);
+        initialNonConflictingActivities = await effects.getPlanMergeNonConflictingActivities(mergeRequestId);
+      }
+
+      return {
+        initialConflictingActivities,
+        initialMergeRequest,
+        initialNonConflictingActivities,
+        initialPlan,
+      };
+    }
+  }
+
+  throw redirect(302, `${base}/plans`);
+};

--- a/src/routes/scheduling/+layout.svelte
+++ b/src/routes/scheduling/+layout.svelte
@@ -10,7 +10,7 @@
   import CssGrid from '../../components/ui/CssGrid.svelte';
 </script>
 
-<CssGrid rows="42px calc(100vh - 42px)">
+<CssGrid rows="var(--nav-header-height) calc(100vh - var(--nav-header-height))">
   <Nav>
     <span class="scheduling-title" slot="title">Scheduling</span>
 

--- a/src/routes/sequencing/+layout.svelte
+++ b/src/routes/sequencing/+layout.svelte
@@ -5,7 +5,7 @@
   import CssGrid from '../../components/ui/CssGrid.svelte';
 </script>
 
-<CssGrid rows="42px calc(100vh - 42px)">
+<CssGrid rows="var(--nav-header-height) calc(100vh - var(--nav-header-height))">
   <Nav>
     <span class="sequencing-title" slot="title">Sequencing</span>
   </Nav>

--- a/src/stores/plan.ts
+++ b/src/stores/plan.ts
@@ -45,7 +45,7 @@ export const planMergeRequestsIncoming = gqlSubscribable<PlanMergeRequest[]>(
   { planId },
   [],
   (planMergeRequests: PlanMergeRequestSchema[]): PlanMergeRequest[] =>
-    planMergeRequests.map(planMergeRequest => ({ ...planMergeRequest, type: 'incoming' })),
+    planMergeRequests.map(planMergeRequest => ({ ...planMergeRequest, pending: false, type: 'incoming' })),
 );
 
 export const planMergeRequestsOutgoing = gqlSubscribable<PlanMergeRequest[]>(
@@ -53,7 +53,7 @@ export const planMergeRequestsOutgoing = gqlSubscribable<PlanMergeRequest[]>(
   { planId },
   [],
   (planMergeRequests: PlanMergeRequestSchema[]): PlanMergeRequest[] =>
-    planMergeRequests.map(planMergeRequest => ({ ...planMergeRequest, type: 'outgoing' })),
+    planMergeRequests.map(planMergeRequest => ({ ...planMergeRequest, pending: false, type: 'outgoing' })),
 );
 
 export const planRevision = gqlSubscribable<number>(

--- a/src/types/activity.d.ts
+++ b/src/types/activity.d.ts
@@ -18,7 +18,7 @@ type ActivityTypesMap = Record<string, ActivityType>;
 
 type Activity = {
   arguments: ArgumentsMap;
-  attributes: ActivitySimulatedAttributes | null;
+  attributes: SpanAttributes | null;
   childUniqueIds: ActivityUniqueId[];
   created_at: string;
   duration: string | null;

--- a/src/types/plan.d.ts
+++ b/src/types/plan.d.ts
@@ -4,9 +4,36 @@ type PlanBranchRequestAction = 'merge' | 'pull';
 
 type PlanInsertInput = Pick<PlanSchema, 'duration' | 'model_id' | 'name' | 'start_time'>;
 
+type PlanMergeActivityOutcome = 'add' | 'delete' | 'modify' | 'none';
+
+type PlanMergeActivityDirective = Omit<ActivityDirective, 'plan_id'> & { snapshot_id: number };
+
+type PlanMergeConflictingActivity = {
+  activity_id: number;
+  change_type_source: PlanMergeActivityOutcome;
+  change_type_target: PlanMergeActivityOutcome;
+  merge_base: PlanMergeActivityDirective;
+  merge_request_id: number;
+  resolution: PlanMergeResolution;
+  source: PlanMergeActivityDirective;
+  target: PlanMergeActivityDirective;
+};
+
+type PlanMergeNonConflictingActivity = {
+  activity_id: number;
+  change_type: PlanMergeActivityOutcome;
+  merge_request_id: number;
+  source: PlanMergeActivityDirective;
+  target: PlanMergeActivityDirective;
+};
+
 type PlanMergeRequestType = 'incoming' | 'outgoing';
 
-type PlanMergeRequest = PlanMergeRequestSchema & { type: PlanMergeRequestType };
+type PlanMergeRequestTypeFilter = PlanMergeRequestType | 'all';
+
+type PlanMergeRequest = PlanMergeRequestSchema & { pending: boolean; type: PlanMergeRequestType };
+
+type PlanMergeRequestStatus = 'accepted' | 'in-progress' | 'pending' | 'rejected' | 'withdrawn';
 
 type PlanMergeRequestSchema = {
   id: number;
@@ -19,13 +46,17 @@ type PlanMergeRequestSchema = {
     snapshot_id: number;
   };
   requester_username: string;
-  status: 'accepted' | 'in-progress' | 'pending' | 'rejected' | 'withdrawn';
+  reviewer_username: string;
+  status: PlanMergeRequestStatus;
 };
+
+type PlanMergeResolution = 'none' | 'source' | 'target';
 
 type PlanSchema = {
   child_plans: Pick<PlanSchema, 'id' | 'name'>[];
   duration: string;
   id: number;
+  is_locked: boolean;
   model: Model;
   model_id: number;
   name: string;

--- a/src/utilities/generic.ts
+++ b/src/utilities/generic.ts
@@ -10,6 +10,44 @@ export function attemptStringConversion(x: any) {
 }
 
 /**
+ * Utility function that returns a list of keys that have changed between two objects of the same type.
+ * Optionally keys can be ignored from the comparison.
+ */
+export function changedKeys<T>(objA: T, objB: T, ignoreKeys: string[] = []): string[] {
+  const changedKeys: string[] = [];
+
+  Object.keys(objA)
+    .filter(key => ignoreKeys.indexOf(key) < 0)
+    .forEach(key => {
+      const valueA = objA[key];
+      const valueB = objB[key];
+      if (
+        (typeof valueA === 'string' ||
+          typeof valueB === 'string' ||
+          typeof valueA === 'number' ||
+          typeof valueB === 'number' ||
+          valueA === null ||
+          valueB === null ||
+          valueA === undefined ||
+          valueB === undefined) &&
+        valueA !== valueB
+      ) {
+        changedKeys.push(key);
+      }
+
+      if (
+        typeof valueA === 'object' &&
+        typeof valueB === 'object' &&
+        JSON.stringify(valueA) !== JSON.stringify(valueB)
+      ) {
+        changedKeys.push(key);
+      }
+    });
+
+  return changedKeys;
+}
+
+/**
  * Comparator function for numbers or strings.
  * Defaults to ascending order.
  */

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -58,13 +58,14 @@ export async function showConfirmModal(
   confirmText: string,
   message: string,
   title: string,
+  actionCanBeUndone?: boolean,
 ): Promise<ModalElementValue> {
   return new Promise(resolve => {
     const target: ModalElement = document.querySelector('#svelte-modal');
 
     if (target) {
       const confirmModal = new ConfirmModal({
-        props: { confirmText, message, title },
+        props: { actionCanBeUndone, confirmText, message, title },
         target,
       });
       target.resolve = resolve;
@@ -208,12 +209,14 @@ export async function showPlanBranchesModal(plan: Plan): Promise<ModalElementVal
 /**
  * Shows a PlanMergeRequestsModal with the supplied arguments.
  */
-export async function showPlanMergeRequestsModal(): Promise<ModalElementValue> {
+export async function showPlanMergeRequestsModal(
+  selectedFilter?: PlanMergeRequestTypeFilter,
+): Promise<ModalElementValue> {
   return new Promise(resolve => {
     const target: ModalElement = document.querySelector('#svelte-modal');
 
     if (target) {
-      const planMergeRequestsModal = new PlanMergeRequestsModal({ target });
+      const planMergeRequestsModal = new PlanMergeRequestsModal({ props: { selectedFilter }, target });
       target.resolve = resolve;
 
       planMergeRequestsModal.$on('close', () => {


### PR DESCRIPTION
TODO:
- [x] Support highlighting fields in ActivityForm by key name and use to show which fields are conflicting
- [x] Update queries for MSA and conflicts to use new queries in aerie PR
- [x] Figure out what should happen if there's a conflict between activity names. Should we have a dedicated name field?
- [x] Disable editing in ActivityForm in MergeReviewModal and decide on a disabled styling
- [x] Implement "resolve all (source/target") functionality
- [x] Fix CSSGrid resizing for the various panels
- [x] Incorporate merge base data into merge review
- [x] Fix overflow issues coming from wrapping things in the CSSGrid
- [x] Decide how to render the number of conflicts (red badge) - should it display number of unresolved conflicts?
- [x] Decide how to render the conflicts label (second column) when there are no conflicts
- [x] Decide if we want to do optimistic updates for conflict resolution since those requests can take some time
- [x] Look into scroll syncing between activity forms
- [x] Wire up cancel, deny changes, and approve changes
- [x] Implement comment system
- [x] Potentially move merge review to a standalone page
- [x] Touch base with @lklyne about refactoring the modal -> page wrt design
- [x] `merge_staging_area.request_id -> merge_staging_area.merge_request_id`
- [x] Connect to plan status / general merge workflow from the rest of the app
- [x] Use the correct source branch name once available
- [x] Incorporate "plan owner" and "user who created merge request"
- [x] Add confirmation dialog after hitting "review" in Merge Request modal
- [ ] In the future, show a confirmation dialog when clicking on "review" in the Merge Requests modal
- [ ] Show a pending state while confirming/canceling/denying in MergeRequestReview
- [ ] Review the many TODOs in the code
- [ ] Refactor, make it drier, clean
- [ ] Note what will be required for the "Pull Changes" functionality
- [ ] Full width activity form highlight backgrounds (requires messing with all sorts of padding)
- [ ] Plan page needs to do _something_ when a user is on the plan page and someone else locks it
- [ ] Unit and e2e tests (next sprint)