### PR TITLE
feat: plan collaboration branch creation workflow

### DIFF
--- a/src/components/app/Nav.svelte
+++ b/src/components/app/Nav.svelte
@@ -36,7 +36,6 @@
   .title {
     align-items: center;
     color: var(--st-gray-20);
-    opacity: 0.7;
   }
 
   .left {

--- a/src/components/menus/PlanMenu.svelte
+++ b/src/components/menus/PlanMenu.svelte
@@ -11,8 +11,8 @@
 
   let planMenu: Menu;
 
-  async function createBranch() {
-    await effects.duplicatePlan(plan);
+  function createBranch() {
+    effects.duplicatePlan(plan);
   }
 </script>
 
@@ -24,7 +24,7 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <div class="grid-menu st-typography-medium" on:click|stopPropagation={() => planMenu.toggle()}>
     <div class="plan-title">{plan.name}<ChevronDownIcon /></div>
-    <Menu bind:this={planMenu} hideAfterClick={false}>
+    <Menu bind:this={planMenu}>
       <MenuItem on:click={createBranch}>
         <div class="column-name">Create branch</div>
       </MenuItem>

--- a/src/components/menus/PlanMenu.svelte
+++ b/src/components/menus/PlanMenu.svelte
@@ -1,9 +1,11 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { base } from '$app/paths';
   import BranchIcon from '@nasa-jpl/stellar/icons/branch.svg?component';
   import ChevronDownIcon from '@nasa-jpl/stellar/icons/chevron_down.svg?component';
   import effects from '../../utilities/effects';
+  import { showPlanBranchesModal } from '../../utilities/modal';
   import Menu from '../menus/Menu.svelte';
   import MenuItem from '../menus/MenuItem.svelte';
 
@@ -14,11 +16,15 @@
   function createBranch() {
     effects.duplicatePlan(plan);
   }
+
+  function showPlanBranches() {
+    showPlanBranchesModal(plan);
+  }
 </script>
 
 <div class="plan-menu">
-  {#if plan.parent_id !== null}
-    <div>{plan.parent_id}</div>
+  {#if plan.parent_plan !== null}
+    <div><a href={`${base}/plans/${plan.parent_plan.id}`} class="link">{plan.parent_plan.name}</a></div>
     <BranchIcon />
   {/if}
   <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -37,6 +43,12 @@
       </MenuItem>
     </Menu>
   </div>
+  {#if plan.child_plans.length > 0}
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <div class="plan-branches" on:click|stopPropagation={showPlanBranches}>
+      {plan.child_plans.length} branch{plan.child_plans.length > 1 ? 'es' : ''}
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -45,6 +57,15 @@
     display: flex;
     flex-flow: row;
     gap: 20px;
+  }
+
+  .link {
+    color: var(--st-gray-30);
+    text-decoration: none;
+  }
+
+  .link:hover {
+    color: var(--st-gray-white);
   }
 
   .grid-menu {
@@ -65,5 +86,11 @@
     color: var(--st-white);
     display: flex;
     flex-flow: row;
+    font-weight: 500;
+  }
+
+  .plan-branches {
+    color: var(--st-white);
+    cursor: pointer;
   }
 </style>

--- a/src/components/menus/PlanMenu.svelte
+++ b/src/components/menus/PlanMenu.svelte
@@ -13,8 +13,8 @@
 
   let planMenu: Menu;
 
-  function createBranch() {
-    effects.duplicatePlan(plan);
+  function createPlanBranch() {
+    effects.createPlanBranch(plan);
   }
 
   function showPlanBranches() {
@@ -31,12 +31,12 @@
   <div class="grid-menu st-typography-medium" on:click|stopPropagation={() => planMenu.toggle()}>
     <div class="plan-title">{plan.name}<ChevronDownIcon /></div>
     <Menu bind:this={planMenu}>
-      <MenuItem on:click={createBranch}>
+      <MenuItem on:click={createPlanBranch}>
         <div class="column-name">Create branch</div>
       </MenuItem>
       <MenuItem
         on:click={() => {
-          console.log('merge');
+          console.log('See merge requests');
         }}
       >
         <div class="column-name">See merge requests</div>

--- a/src/components/menus/PlanMenu.svelte
+++ b/src/components/menus/PlanMenu.svelte
@@ -45,7 +45,6 @@
     display: flex;
     flex-flow: row;
     gap: 20px;
-    margin-left: 1rem;
   }
 
   .grid-menu {

--- a/src/components/menus/PlanMenu.svelte
+++ b/src/components/menus/PlanMenu.svelte
@@ -1,0 +1,70 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import BranchIcon from '@nasa-jpl/stellar/icons/branch.svg?component';
+  import ChevronDownIcon from '@nasa-jpl/stellar/icons/chevron_down.svg?component';
+  import effects from '../../utilities/effects';
+  import Menu from '../menus/Menu.svelte';
+  import MenuItem from '../menus/MenuItem.svelte';
+
+  export let plan: Plan;
+
+  let planMenu: Menu;
+
+  async function createBranch() {
+    await effects.duplicatePlan(plan);
+  }
+</script>
+
+<div class="plan-menu">
+  {#if plan.parent_id !== null}
+    <div>{plan.parent_id}</div>
+    <BranchIcon />
+  {/if}
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <div class="grid-menu st-typography-medium" on:click|stopPropagation={() => planMenu.toggle()}>
+    <div class="plan-title">{plan.name}<ChevronDownIcon /></div>
+    <Menu bind:this={planMenu} hideAfterClick={false}>
+      <MenuItem on:click={createBranch}>
+        <div class="column-name">Create branch</div>
+      </MenuItem>
+      <MenuItem
+        on:click={() => {
+          console.log('merge');
+        }}
+      >
+        <div class="column-name">See merge requests</div>
+      </MenuItem>
+    </Menu>
+  </div>
+</div>
+
+<style>
+  .plan-menu {
+    align-items: center;
+    display: flex;
+    flex-flow: row;
+    gap: 20px;
+    margin-left: 1rem;
+  }
+
+  .grid-menu {
+    --aerie-menu-item-template-columns: min-content;
+    align-items: center;
+    cursor: pointer;
+    display: flex;
+    font-size: 13px;
+    gap: 5px;
+    height: 24px;
+    justify-content: center;
+    position: relative;
+    user-select: none;
+  }
+
+  .plan-title {
+    align-items: center;
+    color: var(--st-white);
+    display: flex;
+    flex-flow: row;
+  }
+</style>

--- a/src/components/menus/PlanMenu.svelte
+++ b/src/components/menus/PlanMenu.svelte
@@ -22,13 +22,15 @@
   }
 </script>
 
-<div class="plan-menu">
+<div class="plan-menu-container">
   {#if plan.parent_plan !== null}
-    <div><a href={`${base}/plans/${plan.parent_plan.id}`} class="link">{plan.parent_plan.name}</a></div>
+    <div>
+      <a href={`${base}/plans/${plan.parent_plan.id}`} class="link">{plan.parent_plan.name}</a>
+    </div>
     <BranchIcon />
   {/if}
   <!-- svelte-ignore a11y-click-events-have-key-events -->
-  <div class="grid-menu st-typography-medium" on:click|stopPropagation={() => planMenu.toggle()}>
+  <div class="plan-menu st-typography-medium" on:click|stopPropagation={() => planMenu.toggle()}>
     <div class="plan-title">{plan.name}<ChevronDownIcon /></div>
     <Menu bind:this={planMenu}>
       <MenuItem on:click={createPlanBranch}>
@@ -52,7 +54,7 @@
 </div>
 
 <style>
-  .plan-menu {
+  .plan-menu-container {
     align-items: center;
     display: flex;
     flex-flow: row;
@@ -68,7 +70,7 @@
     color: var(--st-gray-white);
   }
 
-  .grid-menu {
+  .plan-menu {
     --aerie-menu-item-template-columns: min-content;
     align-items: center;
     cursor: pointer;

--- a/src/components/modals/CreatePlanBranchModal.svelte
+++ b/src/components/modals/CreatePlanBranchModal.svelte
@@ -37,7 +37,7 @@
 <svelte:window on:keydown={onKeydown} />
 
 <Modal {height} {width}>
-  <ModalHeader on:close>New Branch</ModalHeader>
+  <ModalHeader on:close>Create Branch</ModalHeader>
   <ModalContent>
     <fieldset>
       <label for="name">Name of branch</label>

--- a/src/components/modals/DuplicatePlanModal.svelte
+++ b/src/components/modals/DuplicatePlanModal.svelte
@@ -2,13 +2,14 @@
 
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import DatePicker from '../ui/DatePicker/DatePicker.svelte';
   import Modal from './Modal.svelte';
   import ModalContent from './ModalContent.svelte';
   import ModalFooter from './ModalFooter.svelte';
   import ModalHeader from './ModalHeader.svelte';
 
-  export let height: number = 150;
-  export let width: number = 380;
+  export let height: number = 270;
+  export let width: number = 280;
   export let plan: Plan;
 
   const dispatch = createEventDispatcher();
@@ -49,6 +50,14 @@
         required
         type="text"
       />
+    </fieldset>
+    <fieldset>
+      <label for="start">Start date</label>
+      <DatePicker name="start" disabled dateString={plan.start_time_doy} />
+    </fieldset>
+    <fieldset>
+      <label for="end">End date</label>
+      <DatePicker name="end" disabled dateString={plan.end_time_doy} />
     </fieldset>
   </ModalContent>
   <ModalFooter>

--- a/src/components/modals/DuplicatePlanModal.svelte
+++ b/src/components/modals/DuplicatePlanModal.svelte
@@ -1,0 +1,58 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import Modal from './Modal.svelte';
+  import ModalContent from './ModalContent.svelte';
+  import ModalFooter from './ModalFooter.svelte';
+  import ModalHeader from './ModalHeader.svelte';
+
+  export let height: number = 150;
+  export let width: number = 380;
+  export let plan: Plan;
+
+  const dispatch = createEventDispatcher();
+
+  let newBranchName: string = '';
+  let createButtonDisabled: boolean = true;
+
+  $: createButtonDisabled = newBranchName === '';
+
+  function create() {
+    if (!createButtonDisabled) {
+      dispatch('create', { name: newBranchName, plan });
+    }
+  }
+
+  function onKeydown(event: KeyboardEvent) {
+    const { key } = event;
+    if (key === 'Enter') {
+      event.preventDefault();
+      create();
+    }
+  }
+</script>
+
+<svelte:window on:keydown={onKeydown} />
+
+<Modal {height} {width}>
+  <ModalHeader on:close>New Branch</ModalHeader>
+  <ModalContent>
+    <fieldset>
+      <label for="name">Name of branch</label>
+      <input
+        bind:value={newBranchName}
+        placeholder="Name of branch"
+        autocomplete="off"
+        class="st-input w-100"
+        name="name"
+        required
+        type="text"
+      />
+    </fieldset>
+  </ModalContent>
+  <ModalFooter>
+    <button class="st-button secondary" on:click={() => dispatch('close')}> Cancel </button>
+    <button class="st-button" disabled={createButtonDisabled} on:click={create}> Create Branch </button>
+  </ModalFooter>
+</Modal>

--- a/src/components/modals/PlanBranchesModal.svelte
+++ b/src/components/modals/PlanBranchesModal.svelte
@@ -10,8 +10,8 @@
   import ModalHeader from './ModalHeader.svelte';
 
   export let height: number = 270;
-  export let width: number = 400;
   export let plan: Plan;
+  export let width: number = 400;
 </script>
 
 <Modal {height} {width}>
@@ -28,13 +28,13 @@
         <TabPanel disabled />
         <TabPanel disabled />
         <TabPanel disabled />
-        <TabPanel
-          ><div class="plan-branched-plans">
+        <TabPanel>
+          <div class="plan-branched-plans">
             {#each plan.child_plans as childPlan}
               <div class="branched-plan"><a href={`${base}/plans/${childPlan.id}`}>{childPlan.name}</a></div>
             {/each}
-          </div></TabPanel
-        >
+          </div>
+        </TabPanel>
       </Tabs>
     </div>
   </ModalContent>

--- a/src/components/modals/PlanBranchesModal.svelte
+++ b/src/components/modals/PlanBranchesModal.svelte
@@ -23,7 +23,7 @@
           <Tab disabled>Active</Tab>
           <Tab disabled>Merged</Tab>
           <Tab disabled>Rejected</Tab>
-          <Tab>All {plan.child_plans.length}</Tab>
+          <Tab>All</Tab>
         </svelte:fragment>
         <TabPanel disabled />
         <TabPanel disabled />

--- a/src/components/modals/PlanBranchesModal.svelte
+++ b/src/components/modals/PlanBranchesModal.svelte
@@ -1,0 +1,69 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { base } from '$app/paths';
+  import Tab from '../ui/Tabs/Tab.svelte';
+  import TabPanel from '../ui/Tabs/TabPanel.svelte';
+  import Tabs from '../ui/Tabs/Tabs.svelte';
+  import Modal from './Modal.svelte';
+  import ModalContent from './ModalContent.svelte';
+  import ModalHeader from './ModalHeader.svelte';
+
+  export let height: number = 270;
+  export let width: number = 400;
+  export let plan: Plan;
+</script>
+
+<Modal {height} {width}>
+  <ModalHeader on:close>Branches</ModalHeader>
+  <ModalContent>
+    <div class="plan-branches-container">
+      <Tabs>
+        <svelte:fragment slot="tab-list">
+          <Tab disabled>Active</Tab>
+          <Tab disabled>Merged</Tab>
+          <Tab disabled>Rejected</Tab>
+          <Tab>All {plan.child_plans.length}</Tab>
+        </svelte:fragment>
+        <TabPanel disabled />
+        <TabPanel disabled />
+        <TabPanel disabled />
+        <TabPanel
+          ><div class="plan-branched-plans">
+            {#each plan.child_plans as childPlan}
+              <div class="branched-plan"><a href={`${base}/plans/${childPlan.id}`}>{childPlan.name}</a></div>
+            {/each}
+          </div></TabPanel
+        >
+      </Tabs>
+    </div>
+  </ModalContent>
+</Modal>
+
+<style>
+  .plan-branches-container {
+    --tab-list-background-color: var(--st-white);
+    --tab-list-gap: 0 8px;
+    --tab-background-color: var(--st-white);
+    --tab-text-color: var(--st-gray-50);
+    --tab-hover-background-color: none;
+    --tab-selected-background-color: var(--st-white);
+    --tab-selected-text-color: var(--st-black);
+    --tab-padding: 2px 0;
+    --tab-height: auto;
+  }
+
+  .plan-branched-plans {
+    padding: 8px;
+  }
+
+  .branched-plan {
+    margin-bottom: 2rem;
+  }
+
+  .branched-plan a {
+    color: var(--st-black);
+    font-weight: var(--st-typography-medium-font-weight);
+    text-decoration: none;
+  }
+</style>

--- a/src/components/ui/Tabs/Tab.svelte
+++ b/src/components/ui/Tabs/Tab.svelte
@@ -5,9 +5,10 @@
   import { TabContextKey } from './Tabs.svelte';
 
   export { className as class };
+  export let disabled: boolean = false;
   export let tabId: TabId = {};
 
-  const { registerTab, selectTab, selectedTab } = getContext<TabContext>(TabContextKey);
+  const { registerTab, selectTab, selectedTab, unregisterTab } = getContext<TabContext>(TabContextKey);
 
   let className: string = '';
 
@@ -15,10 +16,14 @@
     selectTab(tabId);
   }
 
-  registerTab(tabId);
+  $: if (!disabled) {
+    registerTab(tabId);
+  } else {
+    unregisterTab(tabId);
+  }
 </script>
 
-<button class={className} class:selected={$selectedTab === tabId} on:click={onSelectTab}>
+<button class={className} class:selected={$selectedTab === tabId} on:click={onSelectTab} {disabled}>
   <slot />
 </button>
 
@@ -28,18 +33,25 @@
     border: none;
     color: var(--tab-text-color, var(--st-gray-60));
     cursor: pointer;
+    font-weight: var(--tab-text-weight, var(--st-typography-medium-font-weight));
     height: var(--tab-height, 36px);
     line-height: 1rem;
     margin: 0;
-    padding: 10px 1rem;
+    padding: var(--tab-padding, 10px 1rem);
+  }
+
+  button:disabled {
+    pointer-events: none;
   }
 
   button:hover {
     background-color: var(--tab-hover-background-color, var(--st-gray-15));
+    color: var(--tab-hover-text-color, var(--st-gray-60));
   }
 
   button.selected {
     background-color: var(--tab-selected-background-color, var(--st-gray-20));
     color: var(--tab-selected-text-color, var(--st-gray-100));
+    font-weight: var(--tab-selected-text-weight, var(--st-typography-medium-font-weight));
   }
 </style>

--- a/src/components/ui/Tabs/TabList.svelte
+++ b/src/components/ui/Tabs/TabList.svelte
@@ -15,5 +15,6 @@
     background-color: var(--tab-list-background-color, var(--st-primary-inverse-background-color));
     display: flex;
     flex-flow: row;
+    gap: var(--tab-list-gap, 0);
   }
 </style>

--- a/src/components/ui/Tabs/TabPanel.svelte
+++ b/src/components/ui/Tabs/TabPanel.svelte
@@ -4,11 +4,16 @@
   import { getContext } from 'svelte';
   import { TabContextKey } from './Tabs.svelte';
 
+  export let disabled: boolean = false;
   export let panelId: PanelId = {};
 
-  const { registerPanel, selectedPanel } = getContext<TabContext>(TabContextKey);
+  const { registerPanel, selectedPanel, unregisterPanel } = getContext<TabContext>(TabContextKey);
 
-  registerPanel(panelId);
+  $: if (!disabled) {
+    registerPanel(panelId);
+  } else {
+    unregisterPanel(panelId);
+  }
 </script>
 
 {#if $selectedPanel === panelId}

--- a/src/components/ui/Tabs/Tabs.svelte
+++ b/src/components/ui/Tabs/Tabs.svelte
@@ -18,15 +18,25 @@
   const selectedTab = writable<TabId>(null);
   const selectedPanel = writable<PanelId>(null);
 
+  function unregisterPanel(panelId: PanelId) {
+    const i = panels.indexOf(panelId);
+    panels.splice(i, 1);
+    selectedPanel.update(current => (current === panelId ? panels[i] || panels[panels.length - 1] : current));
+  }
+
+  function unregisterTab(tabId: TabId) {
+    const i = tabs.indexOf(tabId);
+    tabs.splice(i, 1);
+    selectedTab.update(current => (current === tabId ? tabs[i] || tabs[tabs.length - 1] : current));
+  }
+
   setContext<TabContext>(TabContextKey, {
     registerPanel: (panelId: PanelId) => {
       panels.push(panelId);
       selectedPanel.update(current => current || panelId);
 
       onDestroy(() => {
-        const i = panels.indexOf(panelId);
-        panels.splice(i, 1);
-        selectedPanel.update(current => (current === panelId ? panels[i] || panels[panels.length - 1] : current));
+        unregisterPanel(panelId);
       });
     },
     registerTab: (tabId: TabId) => {
@@ -38,9 +48,7 @@
         selectedTab.update(current => current || tabId);
 
         onDestroy(() => {
-          const i = tabs.indexOf(tabId);
-          tabs.splice(i, 1);
-          selectedTab.update(current => (current === tabId ? tabs[i] || tabs[tabs.length - 1] : current));
+          unregisterTab(tabId);
         });
       }
     },
@@ -53,6 +61,8 @@
     },
     selectedPanel,
     selectedTab,
+    unregisterPanel,
+    unregisterTab,
   });
 </script>
 

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -129,7 +129,7 @@
 
 <CssGrid class="plan-container" rows="42px auto 36px">
   <Nav>
-    <div class="plan-title" slot="title">
+    <div slot="title">
       <PlanMenu plan={data.initialPlan} />
     </div>
     <svelte:fragment slot="right">

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -18,6 +18,7 @@
   import ConstraintsPanel from '../../../components/constraints/ConstraintsPanel.svelte';
   import ConstraintViolationsPanel from '../../../components/constraints/ConstraintViolationsPanel.svelte';
   import ExpansionPanel from '../../../components/expansion/ExpansionPanel.svelte';
+  import PlanMenu from '../../../components/menus/PlanMenu.svelte';
   import ViewMenu from '../../../components/menus/ViewMenu.svelte';
   import SchedulingPanel from '../../../components/scheduling/SchedulingPanel.svelte';
   import SimulationPanel from '../../../components/simulation/SimulationPanel.svelte';
@@ -128,8 +129,9 @@
 
 <CssGrid class="plan-container" rows="42px auto 36px">
   <Nav>
-    <span class="plan-title" slot="title">{data.initialPlan.name}</span>
-
+    <div class="plan-title" slot="title">
+      <PlanMenu plan={data.initialPlan} />
+    </div>
     <svelte:fragment slot="right">
       <NavButton
         selected={$view.definition.plan.layout?.gridName === 'Activities'}

--- a/src/types/plan.d.ts
+++ b/src/types/plan.d.ts
@@ -8,6 +8,7 @@ type PlanSchema = {
   model: Model;
   model_id: number;
   name: string;
+  parent_id: number | null;
   revision: number;
   scheduling_specifications: Pick<SchedulingSpec, 'id'>[];
   simulations: [{ simulation_datasets: [{ id: number }] }];

--- a/src/types/plan.d.ts
+++ b/src/types/plan.d.ts
@@ -2,13 +2,19 @@ type Plan = PlanSchema & { end_time_doy: string; start_time_doy: string };
 
 type PlanInsertInput = Pick<PlanSchema, 'duration' | 'model_id' | 'name' | 'start_time'>;
 
+type RelatedPlan = {
+  id: number;
+  name: string;
+};
+
 type PlanSchema = {
+  child_plans: RelatedPlan[];
   duration: string;
   id: number;
   model: Model;
   model_id: number;
   name: string;
-  parent_id: number | null;
+  parent_plan: RelatedPlan | null;
   revision: number;
   scheduling_specifications: Pick<SchedulingSpec, 'id'>[];
   simulations: [{ simulation_datasets: [{ id: number }] }];

--- a/src/types/plan.d.ts
+++ b/src/types/plan.d.ts
@@ -2,19 +2,14 @@ type Plan = PlanSchema & { end_time_doy: string; start_time_doy: string };
 
 type PlanInsertInput = Pick<PlanSchema, 'duration' | 'model_id' | 'name' | 'start_time'>;
 
-type RelatedPlan = {
-  id: number;
-  name: string;
-};
-
 type PlanSchema = {
-  child_plans: RelatedPlan[];
+  child_plans: Pick<PlanSchema, 'id' | 'name'>[];
   duration: string;
   id: number;
   model: Model;
   model_id: number;
   name: string;
-  parent_plan: RelatedPlan | null;
+  parent_plan: Pick<PlanSchema, 'id' | 'name'> | null;
   revision: number;
   scheduling_specifications: Pick<SchedulingSpec, 'id'>[];
   simulations: [{ simulation_datasets: [{ id: number }] }];

--- a/src/types/tabs.d.ts
+++ b/src/types/tabs.d.ts
@@ -7,4 +7,6 @@ interface TabContext {
   selectTab: (tabId: TabId) => void;
   selectedPanel: Writable<TabId>;
   selectedTab: Writable<TabId>;
+  unregisterPanel: (panelId: PanelId) => void;
+  unregisterTab: (tabId: TabId) => void;
 }

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -706,17 +706,14 @@ const effects = {
 
       if (confirm && value) {
         const { name, plan } = value;
-        const data = await reqHasura(gql.DUPLICATE_PLAN, {
-          new_plan_name: name,
-          plan_id: plan.id,
-        });
-
-        goto(`${base}/plans/${data.duplicate_plan.new_plan_id}`);
-        showSuccessToast('View Created Successfully');
+        const data = await reqHasura(gql.DUPLICATE_PLAN, { new_plan_name: name, plan_id: plan.id });
+        const { duplicate_plan } = data;
+        goto(`${base}/plans/${duplicate_plan.new_plan_id}`);
+        showSuccessToast('Plan Duplicated Successfully');
       }
     } catch (e) {
       console.log(e);
-      showFailureToast('View Create Failed');
+      showFailureToast('Plan Duplicate Failed');
     }
   },
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -20,7 +20,7 @@ import { view } from '../stores/views';
 import { getActivityDirectiveUniqueId } from './activities';
 import { convertToQuery, formatHasuraStringArray, parseFloatOrNull, setQueryParam, sleep } from './generic';
 import gql from './gql';
-import { showConfirmModal, showCreateViewModal, showDuplicatePlanBranchModal } from './modal';
+import { showConfirmModal, showCreatePlanBranchModal, showCreateViewModal } from './modal';
 import { reqGateway, reqHasura } from './requests';
 import { Status } from './status';
 import { getDoyTime, getDoyTimeFromDuration, getIntervalFromDoyRange } from './time';
@@ -303,6 +303,23 @@ const effects = {
       creatingPlan.set(false);
 
       return null;
+    }
+  },
+
+  async createPlanBranch(plan: Plan): Promise<void> {
+    try {
+      const { confirm, value = null } = await showCreatePlanBranchModal(plan);
+
+      if (confirm && value) {
+        const { name, plan } = value;
+        const data = await reqHasura(gql.DUPLICATE_PLAN, { new_plan_name: name, plan_id: plan.id });
+        const { duplicate_plan } = data;
+        goto(`${base}/plans/${duplicate_plan.new_plan_id}`);
+        showSuccessToast('Branch Created Successfully');
+      }
+    } catch (e) {
+      console.log(e);
+      showFailureToast('Branch Creation Failed');
     }
   },
 
@@ -697,23 +714,6 @@ const effects = {
     } catch (e) {
       console.log(e);
       return false;
-    }
-  },
-
-  async duplicatePlan(plan: Plan): Promise<void> {
-    try {
-      const { confirm, value = null } = await showDuplicatePlanBranchModal(plan);
-
-      if (confirm && value) {
-        const { name, plan } = value;
-        const data = await reqHasura(gql.DUPLICATE_PLAN, { new_plan_name: name, plan_id: plan.id });
-        const { duplicate_plan } = data;
-        goto(`${base}/plans/${duplicate_plan.new_plan_id}`);
-        showSuccessToast('Plan Duplicated Successfully');
-      }
-    } catch (e) {
-      console.log(e);
-      showFailureToast('Plan Duplicate Failed');
     }
   },
 

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -286,7 +286,7 @@ const gql = {
 
   DUPLICATE_PLAN: `#graphql
     mutation DuplicatePlan($plan_id: Int!, $new_plan_name: String!) {
-      duplicate_plan(args: {plan_id: $plan_id, new_plan_name: $new_plan_name}) {
+      duplicate_plan(args: { new_plan_name: $new_plan_name, plan_id: $plan_id }) {
         new_plan_id
       }
     }

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -284,6 +284,14 @@ const gql = {
     }
   `,
 
+  DUPLICATE_PLAN: `#graphql
+    mutation DuplicatePlan($plan_id: Int!, $new_plan_name: String!) {
+      duplicate_plan(args: {plan_id: $plan_id, new_plan_name: $new_plan_name}) {
+        new_plan_id
+      }
+    }
+  `,
+
   EXPAND: `#graphql
     mutation Expand($expansionSetId: Int!, $simulationDatasetId: Int!) {
       expand: expandAllActivities(expansionSetId: $expansionSetId, simulationDatasetId: $simulationDatasetId) {
@@ -438,6 +446,7 @@ const gql = {
         }
         model_id
         name
+        parent_id
         revision
         scheduling_specifications {
           id

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -427,6 +427,10 @@ const gql = {
   GET_PLAN: `#graphql
     query GetPlan($id: Int!) {
       plan: plan_by_pk(id: $id) {
+        child_plans {
+          id
+          name
+        }
         duration
         id
         model: mission_model {
@@ -446,7 +450,10 @@ const gql = {
         }
         model_id
         name
-        parent_id
+        parent_plan {
+          id
+          name
+        }
         revision
         scheduling_specifications {
           id

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -3,6 +3,7 @@ import ConfirmModal from '../components/modals/ConfirmModal.svelte';
 import CreateViewModal from '../components/modals/CreateViewModal.svelte';
 import DuplicatePlanModal from '../components/modals/DuplicatePlanModal.svelte';
 import ExpansionSequenceModal from '../components/modals/ExpansionSequenceModal.svelte';
+import PlanBranchesModal from '../components/modals/PlanBranchesModal.svelte';
 
 /**
  * Listens for clicks on the document body and removes the modal children.
@@ -108,26 +109,6 @@ export async function showCreateViewModal(): Promise<ModalElementValue<{ name: s
 }
 
 /**
- * Shows a SequenceModal with the supplied arguments.
- */
-export async function showExpansionSequenceModal(expansionSequence: ExpansionSequence): Promise<ModalElementValue> {
-  return new Promise(resolve => {
-    const target: ModalElement = document.querySelector('#svelte-modal');
-
-    if (target) {
-      const sequenceModal = new ExpansionSequenceModal({ props: { expansionSequence }, target });
-      target.resolve = resolve;
-
-      sequenceModal.$on('close', () => {
-        target.replaceChildren();
-        target.resolve = null;
-        resolve({ confirm: true });
-      });
-    }
-  });
-}
-
-/**
  * Shows a DuplicatePlanBranchModal with the supplied arguments.
  */
 export async function showDuplicatePlanBranchModal(plan: Plan): Promise<
@@ -153,6 +134,46 @@ export async function showDuplicatePlanBranchModal(plan: Plan): Promise<
         target.replaceChildren();
         target.resolve = null;
         resolve({ confirm: true, value: e.detail });
+      });
+    }
+  });
+}
+
+/**
+ * Shows a SequenceModal with the supplied arguments.
+ */
+export async function showExpansionSequenceModal(expansionSequence: ExpansionSequence): Promise<ModalElementValue> {
+  return new Promise(resolve => {
+    const target: ModalElement = document.querySelector('#svelte-modal');
+
+    if (target) {
+      const sequenceModal = new ExpansionSequenceModal({ props: { expansionSequence }, target });
+      target.resolve = resolve;
+
+      sequenceModal.$on('close', () => {
+        target.replaceChildren();
+        target.resolve = null;
+        resolve({ confirm: true });
+      });
+    }
+  });
+}
+
+/**
+ * Shows an PlanBranchesModal component with the supplied arguments.
+ */
+export async function showPlanBranchesModal(plan: Plan): Promise<ModalElementValue> {
+  return new Promise(resolve => {
+    const target: ModalElement = document.querySelector('#svelte-modal');
+
+    if (target) {
+      const planBranchesModal = new PlanBranchesModal({ props: { plan }, target });
+      target.resolve = resolve;
+
+      planBranchesModal.$on('close', () => {
+        target.replaceChildren();
+        target.resolve = null;
+        resolve({ confirm: true });
       });
     }
   });

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -1,7 +1,7 @@
 import AboutModal from '../components/modals/AboutModal.svelte';
 import ConfirmModal from '../components/modals/ConfirmModal.svelte';
+import CreatePlanBranchModal from '../components/modals/CreatePlanBranchModal.svelte';
 import CreateViewModal from '../components/modals/CreateViewModal.svelte';
-import DuplicatePlanModal from '../components/modals/DuplicatePlanModal.svelte';
 import ExpansionSequenceModal from '../components/modals/ExpansionSequenceModal.svelte';
 import PlanBranchesModal from '../components/modals/PlanBranchesModal.svelte';
 
@@ -83,6 +83,32 @@ export async function showConfirmModal(
 }
 
 /**
+ * Shows a CreatePlanBranchModal with the supplied arguments.
+ */
+export async function showCreatePlanBranchModal(plan: Plan): Promise<ModalElementValue<{ name: string; plan: Plan }>> {
+  return new Promise(resolve => {
+    const target: ModalElement = document.querySelector('#svelte-modal');
+
+    if (target) {
+      const createPlanBranchModal = new CreatePlanBranchModal({ props: { plan }, target });
+      target.resolve = resolve;
+
+      createPlanBranchModal.$on('close', () => {
+        target.replaceChildren();
+        target.resolve = null;
+        resolve({ confirm: false });
+      });
+
+      createPlanBranchModal.$on('create', (e: CustomEvent<{ name: string; plan: Plan }>) => {
+        target.replaceChildren();
+        target.resolve = null;
+        resolve({ confirm: true, value: e.detail });
+      });
+    }
+  });
+}
+
+/**
  * Shows a CreateViewModal component.
  */
 export async function showCreateViewModal(): Promise<ModalElementValue<{ name: string }>> {
@@ -100,37 +126,6 @@ export async function showCreateViewModal(): Promise<ModalElementValue<{ name: s
       });
 
       createViewModal.$on('create', (e: CustomEvent<{ name: string }>) => {
-        target.replaceChildren();
-        target.resolve = null;
-        resolve({ confirm: true, value: e.detail });
-      });
-    }
-  });
-}
-
-/**
- * Shows a DuplicatePlanBranchModal with the supplied arguments.
- */
-export async function showDuplicatePlanBranchModal(plan: Plan): Promise<
-  ModalElementValue<{
-    name: string;
-    plan: Plan;
-  }>
-> {
-  return new Promise(resolve => {
-    const target: ModalElement = document.querySelector('#svelte-modal');
-
-    if (target) {
-      const planModal = new DuplicatePlanModal({ props: { plan }, target });
-      target.resolve = resolve;
-
-      planModal.$on('close', () => {
-        target.replaceChildren();
-        target.resolve = null;
-        resolve({ confirm: false });
-      });
-
-      planModal.$on('create', (e: CustomEvent<{ name: string; plan: Plan }>) => {
         target.replaceChildren();
         target.resolve = null;
         resolve({ confirm: true, value: e.detail });

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -1,6 +1,7 @@
 import AboutModal from '../components/modals/AboutModal.svelte';
 import ConfirmModal from '../components/modals/ConfirmModal.svelte';
 import CreateViewModal from '../components/modals/CreateViewModal.svelte';
+import DuplicatePlanModal from '../components/modals/DuplicatePlanModal.svelte';
 import ExpansionSequenceModal from '../components/modals/ExpansionSequenceModal.svelte';
 
 /**
@@ -121,6 +122,37 @@ export async function showExpansionSequenceModal(expansionSequence: ExpansionSeq
         target.replaceChildren();
         target.resolve = null;
         resolve({ confirm: true });
+      });
+    }
+  });
+}
+
+/**
+ * Shows a DuplicatePlanBranchModal with the supplied arguments.
+ */
+export async function showDuplicatePlanBranchModal(plan: Plan): Promise<
+  ModalElementValue<{
+    name: string;
+    plan: Plan;
+  }>
+> {
+  return new Promise(resolve => {
+    const target: ModalElement = document.querySelector('#svelte-modal');
+
+    if (target) {
+      const planModal = new DuplicatePlanModal({ props: { plan }, target });
+      target.resolve = resolve;
+
+      planModal.$on('close', () => {
+        target.replaceChildren();
+        target.resolve = null;
+        resolve({ confirm: false });
+      });
+
+      planModal.$on('create', (e: CustomEvent<{ name: string; plan: Plan }>) => {
+        target.replaceChildren();
+        target.resolve = null;
+        resolve({ confirm: true, value: e.detail });
       });
     }
   });


### PR DESCRIPTION
* add plan branches modal
* add `disable` flag to Tabs components

To test:
1. Create a plan
2. In the nav header, click on the plan name
3. Verify that a menu opens
4. Click on "Create Branch"
5. Verify that Plan Duplication modal opens
6. Input new plan name
7. Click "Create Branch" button
8. Verify that you are auto navigated to the new copied plan
9. Click on the parent name in the header, just to the left of the new plan name that was created
10. Verify that the correct number of branches appears to the right of the plan name
11. Click on the number of branches displayed
12. Verify that a modal (wip) opens and displays links of all the branched plans