### PR TITLE
feat: track editor metadata dirty states

### DIFF
--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -71,6 +71,9 @@
     ) {
       return true;
     } else if (constraintA.plan_id === null && constraintB.plan_id === null) {
+      // only diff model_id if both plan_ids are null
+      // to replicate the behavior where when saving a constraint, the model_id is ignored
+      // if a plan_id is supplied
       return constraintA.model_id !== constraintB.model_id;
     }
   }

--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -23,7 +23,6 @@
   export let mode: 'create' | 'edit' = 'create';
 
   let constraintDefinition: string = initialConstraintDefinition;
-  let savedConstraintDefinition: string = mode === 'create' ? '' : initialConstraintDefinition;
   let constraintDescription: string = initialConstraintDescription;
   let constraintId: number | null = initialConstraintId;
   let constraintName: string = initialConstraintName;
@@ -33,10 +32,25 @@
   let models: ModelSlim[] = initialModels;
   let plans: PlanSlim[] = initialPlans;
   let saveButtonEnabled: boolean = false;
+  let savedConstraint: Partial<Constraint> = {
+    definition: constraintDefinition,
+    description: constraintDescription,
+    model_id: constraintModelId,
+    name: constraintName,
+    plan_id: constraintPlanId,
+    summary: constraintSummary,
+  };
 
   $: saveButtonEnabled =
     constraintDefinition !== '' && constraintName !== '' && (constraintModelId !== null || constraintPlanId !== null);
-  $: constraintModified = constraintDefinition !== savedConstraintDefinition;
+  $: constraintModified = diffConstraints(savedConstraint, {
+    definition: constraintDefinition,
+    description: constraintDescription,
+    model_id: constraintModelId,
+    name: constraintName,
+    plan_id: constraintPlanId,
+    summary: constraintSummary,
+  });
   $: saveButtonText = mode === 'edit' && !constraintModified ? 'Saved' : 'Save';
   $: saveButtonClass = saveButtonEnabled && constraintModified ? 'primary' : 'secondary';
 
@@ -44,6 +58,20 @@
     const plan = initialPlans.find(plan => plan.id === constraintPlanId);
     if (plan) {
       constraintModelId = plan.model_id;
+    }
+  }
+
+  function diffConstraints(constraintA: Partial<Constraint>, constraintB: Partial<Constraint>) {
+    if (
+      constraintA.definition !== constraintB.definition ||
+      constraintA.description !== constraintB.description ||
+      constraintA.name !== constraintB.name ||
+      constraintA.summary !== constraintB.summary ||
+      constraintA.plan_id !== constraintB.plan_id
+    ) {
+      return true;
+    } else if (constraintA.plan_id === null && constraintB.plan_id === null) {
+      return constraintA.model_id !== constraintB.model_id;
     }
   }
 
@@ -87,7 +115,14 @@
           constraintSummary,
         );
 
-        savedConstraintDefinition = constraintDefinition;
+        savedConstraint = {
+          definition: constraintDefinition,
+          description: constraintDescription,
+          model_id: constraintModelId,
+          name: constraintName,
+          plan_id: constraintPlanId,
+          summary: constraintSummary,
+        };
       }
     }
   }

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -28,16 +28,32 @@
   let ruleDictionaryId: number | null = initialRuleDictionaryId;
   let ruleId: number | null = initialRuleId;
   let ruleLogic: string = initialRuleLogic;
-  let savedRuleLogic: string = mode === 'create' ? '' : initialRuleLogic;
   let ruleModelId: number | null = initialRuleModelId;
   let ruleUpdatedAt: string | null = initialRuleUpdatedAt;
   let saveButtonEnabled: boolean = false;
+  let savedRule: Partial<ExpansionRule> = {
+    activity_type: ruleActivityType,
+    authoring_command_dict_id: ruleDictionaryId,
+    authoring_mission_model_id: ruleModelId,
+    expansion_logic: ruleLogic,
+  };
 
   $: activityTypeNames.setVariables({ modelId: ruleModelId ?? -1 });
   $: saveButtonEnabled = ruleActivityType !== null && ruleLogic !== '';
-  $: ruleModified = ruleLogic !== savedRuleLogic;
+  $: ruleModified = diffRule(savedRule, {
+    activity_type: ruleActivityType,
+    authoring_command_dict_id: ruleDictionaryId,
+    authoring_mission_model_id: ruleModelId,
+    expansion_logic: ruleLogic,
+  });
   $: saveButtonText = mode === 'edit' && !ruleModified ? 'Saved' : 'Save';
   $: saveButtonClass = ruleModified && saveButtonEnabled ? 'primary' : 'secondary';
+
+  function diffRule(ruleA: Partial<ExpansionRule>, ruleB: Partial<ExpansionRule>) {
+    return Object.entries(ruleA).some(([key, value]) => {
+      return ruleB[key] !== value;
+    });
+  }
 
   function onDidChangeModelContent(event: CustomEvent<{ value: string }>) {
     const { detail } = event;
@@ -77,7 +93,7 @@
         const updated_at = await effects.updateExpansionRule(ruleId, updatedRule);
         if (updated_at !== null) {
           ruleUpdatedAt = updated_at;
-          savedRuleLogic = ruleLogic;
+          savedRule = updatedRule;
         }
       }
     }

--- a/src/components/scheduling/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/SchedulingGoalForm.svelte
@@ -43,7 +43,7 @@
   };
 
   $: saveButtonEnabled = goalDefinition !== '' && goalModelId !== null && goalName !== '';
-  $: goalModified = diffPartialGoals(savedGoal, {
+  $: goalModified = diffGoals(savedGoal, {
     definition: goalDefinition,
     description: goalDescription,
     model_id: goalModelId,
@@ -52,13 +52,10 @@
   $: saveButtonText = mode === 'edit' && !goalModified ? 'Saved' : 'Save';
   $: saveButtonClass = goalModified && saveButtonEnabled ? 'primary' : 'secondary';
 
-  function diffPartialGoals(goalA: Partial<SchedulingGoal>, goalB: Partial<SchedulingGoal>) {
-    return (
-      goalA.definition !== goalB.definition ||
-      goalA.description !== goalB.description ||
-      goalA.model_id !== goalB.model_id ||
-      goalA.name !== goalB.name
-    );
+  function diffGoals(goalA: Partial<SchedulingGoal>, goalB: Partial<SchedulingGoal>) {
+    return Object.entries(goalA).some(([key, value]) => {
+      return goalB[key] !== value;
+    });
   }
 
   function onDidChangeModelContent(event: CustomEvent<{ value: string }>) {

--- a/src/components/scheduling/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/SchedulingGoalForm.svelte
@@ -27,7 +27,6 @@
   let goalAuthor: string | null = initialGoalAuthor;
   let goalCreatedDate: string | null = initialGoalCreatedDate;
   let goalDefinition: string = initialGoalDefinition;
-  let savedGoalDefinition: string = mode === 'create' ? '' : initialGoalDefinition;
   let goalDescription: string = initialGoalDescription;
   let goalId: number | null = initialGoalId;
   let goalModelId: number | null = initialGoalModelId;
@@ -36,11 +35,31 @@
   let models: ModelSlim[] = initialModels;
   let saveButtonEnabled: boolean = false;
   let specId: number | null = initialSpecId;
+  let savedGoal: Partial<SchedulingGoal> = {
+    definition: goalDefinition,
+    description: goalDescription,
+    model_id: goalModelId,
+    name: goalName,
+  };
 
   $: saveButtonEnabled = goalDefinition !== '' && goalModelId !== null && goalName !== '';
-  $: goalModified = goalDefinition !== savedGoalDefinition;
+  $: goalModified = diffPartialGoals(savedGoal, {
+    definition: goalDefinition,
+    description: goalDescription,
+    model_id: goalModelId,
+    name: goalName,
+  });
   $: saveButtonText = mode === 'edit' && !goalModified ? 'Saved' : 'Save';
   $: saveButtonClass = goalModified && saveButtonEnabled ? 'primary' : 'secondary';
+
+  function diffPartialGoals(goalA: Partial<SchedulingGoal>, goalB: Partial<SchedulingGoal>) {
+    return (
+      goalA.definition !== goalB.definition ||
+      goalA.description !== goalB.description ||
+      goalA.model_id !== goalB.model_id ||
+      goalA.name !== goalB.name
+    );
+  }
 
   function onDidChangeModelContent(event: CustomEvent<{ value: string }>) {
     const { detail } = event;
@@ -91,7 +110,7 @@
         const updatedGoal = await effects.updateSchedulingGoal(goalId, goal);
         if (updatedGoal) {
           goalModifiedDate = updatedGoal.modified_date;
-          savedGoalDefinition = goalDefinition;
+          savedGoal = { ...goal };
         }
       }
     }

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -28,13 +28,14 @@
   let sequenceCommandDictionaryId: number | null = initialSequenceCommandDictionaryId;
   let sequenceId: number | null = initialSequenceId;
   let sequenceName: string = initialSequenceName;
+  let savedSequenceName: string = sequenceName;
   let sequenceSeqJson: string = 'Seq JSON has not been generated yet';
   let sequenceUpdatedAt: string | null = initialSequenceUpdatedAt;
   let saveButtonEnabled: boolean = false;
   let savingSequence: boolean = false;
 
   $: saveButtonEnabled = sequenceCommandDictionaryId !== null && sequenceDefinition !== '' && sequenceName !== '';
-  $: sequenceModified = sequenceDefinition !== savedSequenceDefinition;
+  $: sequenceModified = sequenceDefinition !== savedSequenceDefinition || sequenceName !== savedSequenceName;
   $: saveButtonText = mode === 'edit' && !sequenceModified ? 'Saved' : 'Save';
   $: saveButtonClass = sequenceModified && saveButtonEnabled ? 'primary' : 'secondary';
 
@@ -99,6 +100,7 @@
         }
         await getUserSequenceSeqJson();
         savedSequenceDefinition = sequenceDefinition;
+        savedSequenceName = sequenceName;
       }
       savingSequence = false;
     }


### PR DESCRIPTION
This expands our logic for determining if editors contain savable changes to include all editable metadata fields as well as editor contents. In most cases I tried to make this more generic by saving typed objects, instead of saving individual fields, and then diffing the objects. So this should be a bit easier to expand later if we add new fields that need to be considered.