### PR TITLE
feat: prevent users from editing locked plan

### DIFF
--- a/src/components/modals/ModalHeader.svelte
+++ b/src/components/modals/ModalHeader.svelte
@@ -2,14 +2,18 @@
   import XIcon from 'bootstrap-icons/icons/x.svg?component';
   import { createEventDispatcher } from 'svelte';
 
+  export let showClose: boolean = true;
+
   const dispatch = createEventDispatcher();
 </script>
 
 <div class="modal-header st-typography-header">
   <slot />
-  <button class="st-button icon fs-6" on:click|stopPropagation={() => dispatch('close')}>
-    <XIcon />
-  </button>
+  {#if showClose}
+    <button class="st-button icon fs-6" on:click|stopPropagation={() => dispatch('close')}>
+      <XIcon />
+    </button>
+  {/if}
 </div>
 
 <style>

--- a/src/components/modals/PlanLockedModal.svelte
+++ b/src/components/modals/PlanLockedModal.svelte
@@ -1,0 +1,49 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { goto } from '$app/navigation';
+  import { base } from '$app/paths';
+  import { createEventDispatcher } from 'svelte';
+  import Modal from './Modal.svelte';
+  import ModalContent from './ModalContent.svelte';
+  import ModalFooter from './ModalFooter.svelte';
+  import ModalHeader from './ModalHeader.svelte';
+
+  export let planId: number = -1;
+
+  const dispatch = createEventDispatcher();
+
+  function gotoReview() {
+    goto(`${base}/plans/${planId}/merge`);
+    dispatch('close');
+  }
+
+  function gotoPlans() {
+    goto(`${base}/plans`);
+    dispatch('close');
+  }
+
+  function onKeydown(event: KeyboardEvent) {
+    const { key } = event;
+    if (key === 'Enter') {
+      event.preventDefault();
+      gotoReview();
+    }
+  }
+</script>
+
+<svelte:window on:keydown={onKeydown} />
+
+<Modal height={150} width={380}>
+  <ModalHeader showClose={false}>Plan Locked</ModalHeader>
+  <ModalContent>
+    <div>
+      The plan you are viewing is locked and under review. Once the review has ended this plan will become editable
+      again.
+    </div>
+  </ModalContent>
+  <ModalFooter>
+    <button class="st-button secondary" on:click={gotoPlans}>View all plans</button>
+    <button class="st-button" on:click={gotoReview}>Take me to the review</button>
+  </ModalFooter>
+</Modal>

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -6,7 +6,6 @@
   import BracesAsteriskIcon from 'bootstrap-icons/icons/braces-asterisk.svg?component';
   import ColumnsIcon from 'bootstrap-icons/icons/columns.svg?component';
   import GearWideConnectedIcon from 'bootstrap-icons/icons/gear-wide-connected.svg?component';
-  import { closeActiveModal, showPlanLockedModal } from '../../../utilities/modal';
   import { onDestroy, onMount } from 'svelte';
   import ActivityFormPanel from '../../../components/activity/ActivityFormPanel.svelte';
   import ActivityTablePanel from '../../../components/activity/ActivityTablePanel.svelte';
@@ -55,6 +54,7 @@
   import { createActivitiesMap } from '../../../utilities/activities';
   import effects from '../../../utilities/effects';
   import { setQueryParam } from '../../../utilities/generic';
+  import { closeActiveModal, showPlanLockedModal } from '../../../utilities/modal';
   import { getUnixEpochTime } from '../../../utilities/time';
   import type { PageData } from './$types';
 

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -6,6 +6,7 @@
   import BracesAsteriskIcon from 'bootstrap-icons/icons/braces-asterisk.svg?component';
   import ColumnsIcon from 'bootstrap-icons/icons/columns.svg?component';
   import GearWideConnectedIcon from 'bootstrap-icons/icons/gear-wide-connected.svg?component';
+  import { closeActiveModal, showPlanLockedModal } from '../../../utilities/modal';
   import { onDestroy, onMount } from 'svelte';
   import ActivityFormPanel from '../../../components/activity/ActivityFormPanel.svelte';
   import ActivityTablePanel from '../../../components/activity/ActivityTablePanel.svelte';
@@ -37,6 +38,7 @@
     maxTimeRange,
     plan,
     planEndTimeMs,
+    planLocked,
     planStartTimeMs,
     resetPlanStores,
     viewTimeRange,
@@ -74,6 +76,8 @@
     ViewsPanel,
   };
 
+  let planHasBeenLocked = false;
+
   $: if (data.initialPlan) {
     $modelParametersMap = data.initialPlan.model.parameters.parameters;
     $plan = data.initialPlan;
@@ -90,6 +94,14 @@
   }
 
   $: $activitiesMap = createActivitiesMap($plan, $activityDirectives, $simulationSpans);
+
+  $: if ($planLocked) {
+    planHasBeenLocked = true;
+    showPlanLockedModal($plan.id);
+  } else if (planHasBeenLocked) {
+    closeActiveModal();
+    planHasBeenLocked = false;
+  }
 
   onMount(() => {
     if ($view) {

--- a/src/stores/plan.ts
+++ b/src/stores/plan.ts
@@ -40,6 +40,13 @@ export const planId: Readable<number> = derived(plan, $plan => ($plan ? $plan.id
 
 export const models = gqlSubscribable<ModelSlim[]>(gql.SUB_MODELS, {}, []);
 
+export const planLocked = gqlSubscribable<boolean>(
+  gql.SUB_PLAN_LOCKED,
+  { planId },
+  false,
+  ({ is_locked }) => is_locked,
+);
+
 export const planMergeRequestsIncoming = gqlSubscribable<PlanMergeRequest[]>(
   gql.SUB_PLAN_MERGE_REQUESTS_INCOMING,
   { planId },

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -900,6 +900,14 @@ const gql = {
     }
   `,
 
+  SUB_PLAN_LOCKED: `#graphql
+    subscription SubPlanLocked($planId: Int!) {
+      planLocked: plan_by_pk(id: $planId) {
+        is_locked
+      }
+    }
+  `,
+
   SUB_PLAN_MERGE_CONFLICTING_ACTIVITIES: `#graphql
     subscription SubPlanMergeConflictingActivities($merge_request_id: Int!) {
       conflictingActivities: get_conflicting_activities(args: { merge_request_id: $merge_request_id } ) {

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -13,7 +13,7 @@ import PlanMergeRequestsModal from '../components/modals/PlanMergeRequestsModal.
  */
 export function modalBodyClickListener(): void {
   const target: ModalElement = document.querySelector('#svelte-modal');
-  if (target && target.resolve && target.getAttribute('data-dismissable') !== 'false') {
+  if (target && target.resolve && target.getAttribute('data-dismissible') !== 'false') {
     target.replaceChildren();
     target.resolve({ confirm: false });
     target.resolve = null;
@@ -25,7 +25,7 @@ export function modalBodyClickListener(): void {
  */
 export function modalBodyKeyListener(event: KeyboardEvent): void {
   const target: ModalElement = document.querySelector('#svelte-modal');
-  if (target && target.resolve && event.key == 'Escape' && target.getAttribute('data-dismissable') !== 'false') {
+  if (target && target.resolve && event.key == 'Escape' && target.getAttribute('data-dismissible') !== 'false') {
     target.replaceChildren();
     target.resolve({ confirm: false });
     target.resolve = null;
@@ -38,7 +38,7 @@ export function modalBodyKeyListener(event: KeyboardEvent): void {
 export function closeActiveModal(): void {
   const target: ModalElement = document.querySelector('#svelte-modal');
   if (target && target.resolve) {
-    target.removeAttribute('data-dismissable');
+    target.removeAttribute('data-dismissible');
     target.replaceChildren();
     target.resolve = null;
   }
@@ -113,12 +113,12 @@ export async function showPlanLockedModal(planId: number): Promise<ModalElementV
       target.resolve = resolve;
 
       // Do not allow users to dismiss this modal
-      target.setAttribute('data-dismissable', 'false');
+      target.setAttribute('data-dismissible', 'false');
 
       planLockedModal.$on('close', () => {
         target.replaceChildren();
         target.resolve = null;
-        target.removeAttribute('data-dismissable');
+        target.removeAttribute('data-dismissible');
       });
     }
   });

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -1,4 +1,3 @@
-import PlanLockedModal from '../components/modals/PlanLockedModal.svelte';
 import AboutModal from '../components/modals/AboutModal.svelte';
 import ConfirmModal from '../components/modals/ConfirmModal.svelte';
 import CreatePlanBranchModal from '../components/modals/CreatePlanBranchModal.svelte';
@@ -6,6 +5,7 @@ import CreateViewModal from '../components/modals/CreateViewModal.svelte';
 import ExpansionSequenceModal from '../components/modals/ExpansionSequenceModal.svelte';
 import PlanBranchesModal from '../components/modals/PlanBranchesModal.svelte';
 import PlanBranchRequestModal from '../components/modals/PlanBranchRequestModal.svelte';
+import PlanLockedModal from '../components/modals/PlanLockedModal.svelte';
 import PlanMergeRequestsModal from '../components/modals/PlanMergeRequestsModal.svelte';
 
 /**


### PR DESCRIPTION
Closes #230
- Subscribe to plan locked status
- Implement PlanLockedModal which appears when plan is locked and gives the user the option to go to the review or go back to all plans. This modal is not dismissible. 