### PR TITLE
Add draggable handle to console to resize the height

### DIFF
--- a/src/components/console/Console.svelte
+++ b/src/components/console/Console.svelte
@@ -8,11 +8,11 @@
 
   const consoleHeaderHeight: number = 36;
 
-  let isOpen: boolean = false;
   let consoleHeight: number = 0;
-  let previousConsoleHeight: number = 300;
   let consoleHeightString: string;
   let consolePositionString: string;
+  let isOpen: boolean = false;
+  let previousConsoleHeight: number = 300;
 
   $: {
     consoleHeightString = `${consoleHeight + consoleHeaderHeight}px`;

--- a/src/components/console/Console.svelte
+++ b/src/components/console/Console.svelte
@@ -52,9 +52,7 @@
     style:top={consolePositionString}
   >
     {#if isOpen}
-      <div class="console-drag-handle ">
-        <ConsoleDragHandle maxHeight="75%" rowHeight={consoleHeight} on:updateRowHeight={onUpdateRowHeight} />
-      </div>
+      <ConsoleDragHandle maxHeight="75%" rowHeight={consoleHeight} on:updateRowHeight={onUpdateRowHeight} />
     {/if}
     <Tabs on:select-tab={onSelectTab}>
       <svelte:fragment slot="tab-list">
@@ -93,18 +91,6 @@
     top: 0;
     width: 100%;
     z-index: 1;
-  }
-
-  .console-drag-handle {
-    align-items: center;
-    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAFAQMAAABo7865AAAABlBMVEVHcEzMzMzyAv2sAAAAAXRSTlMAQObYZgAAABBJREFUeF5jOAMEEAIEEFwAn3kMwcB6I2AAAAAASUVORK5CYII=');
-    background-position: 50% 50%;
-    background-repeat: no-repeat;
-    display: flex;
-    height: 3px;
-    justify-content: center;
-    position: absolute;
-    width: 100%;
   }
 
   .console-tabs-container {

--- a/src/components/console/Console.svelte
+++ b/src/components/console/Console.svelte
@@ -3,9 +3,21 @@
 <script lang="ts">
   import ChevronDownIcon from '@nasa-jpl/stellar/icons/chevron_down.svg?component';
   import ChevronUpIcon from '@nasa-jpl/stellar/icons/chevron_up.svg?component';
+  import RowDragHandleHeight from '../timeline/RowDragHandleHeight.svelte';
   import Tabs from '../ui/Tabs/Tabs.svelte';
 
+  const consoleHeaderHeight: number = 36;
+
   let isOpen: boolean = false;
+  let consoleHeight: number = 0;
+  let previousConsoleHeight: number = 300;
+  let consoleHeightString: string;
+  let consolePositionString: string;
+
+  $: {
+    consoleHeightString = `${consoleHeight + consoleHeaderHeight}px`;
+    consolePositionString = `${-consoleHeight}px`;
+  }
 
   function onSelectTab() {
     isOpen = true;
@@ -13,11 +25,32 @@
 
   function onToggle() {
     isOpen = !isOpen;
+
+    if (!isOpen) {
+      previousConsoleHeight = consoleHeight;
+      consoleHeight = 0;
+    } else {
+      consoleHeight = previousConsoleHeight;
+    }
+  }
+
+  function onUpdateRowHeight(event: CustomEvent<{ newHeight: number }>) {
+    consoleHeight = event.detail.newHeight;
   }
 </script>
 
 <div class="console-container">
-  <div class="console-expand-container" class:expanded={isOpen}>
+  <div
+    class="console-expand-container"
+    class:expanded={isOpen}
+    style:height={consoleHeightString}
+    style:top={consolePositionString}
+  >
+    {#if isOpen}
+      <div class="console-drag-handle ">
+        <RowDragHandleHeight position="top" rowHeight={consoleHeight} on:updateRowHeight={onUpdateRowHeight} />
+      </div>
+    {/if}
     <Tabs on:select-tab={onSelectTab}>
       <svelte:fragment slot="tab-list">
         <div class="console-tabs-container">
@@ -57,9 +90,16 @@
     z-index: 1;
   }
 
-  .console-expand-container.expanded {
-    height: 336px;
-    top: -300px;
+  .console-drag-handle {
+    align-items: center;
+    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAFAQMAAABo7865AAAABlBMVEVHcEzMzMzyAv2sAAAAAXRSTlMAQObYZgAAABBJREFUeF5jOAMEEAIEEFwAn3kMwcB6I2AAAAAASUVORK5CYII=');
+    background-position: 50% 50%;
+    background-repeat: no-repeat;
+    display: flex;
+    height: 3px;
+    justify-content: center;
+    position: absolute;
+    width: 100%;
   }
 
   .console-tabs-container {

--- a/src/components/console/Console.svelte
+++ b/src/components/console/Console.svelte
@@ -20,22 +20,26 @@
   }
 
   function onSelectTab() {
-    isOpen = true;
+    toggleConsole(true);
   }
 
   function onToggle() {
-    isOpen = !isOpen;
-
-    if (!isOpen) {
-      previousConsoleHeight = consoleHeight;
-      consoleHeight = 0;
-    } else {
-      consoleHeight = previousConsoleHeight;
-    }
+    toggleConsole(!isOpen);
   }
 
   function onUpdateRowHeight(event: CustomEvent<{ newHeight: number }>) {
     consoleHeight = event.detail.newHeight;
+  }
+
+  function toggleConsole(updatedOpenState: boolean) {
+    if (!updatedOpenState) {
+      previousConsoleHeight = consoleHeight;
+      consoleHeight = 0;
+    } else if (!isOpen) {
+      consoleHeight = previousConsoleHeight;
+    }
+
+    isOpen = updatedOpenState;
   }
 </script>
 

--- a/src/components/console/Console.svelte
+++ b/src/components/console/Console.svelte
@@ -3,8 +3,9 @@
 <script lang="ts">
   import ChevronDownIcon from '@nasa-jpl/stellar/icons/chevron_down.svg?component';
   import ChevronUpIcon from '@nasa-jpl/stellar/icons/chevron_up.svg?component';
-  import RowDragHandleHeight from '../timeline/RowDragHandleHeight.svelte';
+
   import Tabs from '../ui/Tabs/Tabs.svelte';
+  import ConsoleDragHandle from './ConsoleDragHandle.svelte';
 
   const consoleHeaderHeight: number = 36;
 
@@ -52,12 +53,7 @@
   >
     {#if isOpen}
       <div class="console-drag-handle ">
-        <RowDragHandleHeight
-          maxHeight={600}
-          position="top"
-          rowHeight={consoleHeight}
-          on:updateRowHeight={onUpdateRowHeight}
-        />
+        <ConsoleDragHandle maxHeight="75%" rowHeight={consoleHeight} on:updateRowHeight={onUpdateRowHeight} />
       </div>
     {/if}
     <Tabs on:select-tab={onSelectTab}>

--- a/src/components/console/Console.svelte
+++ b/src/components/console/Console.svelte
@@ -48,7 +48,12 @@
   >
     {#if isOpen}
       <div class="console-drag-handle ">
-        <RowDragHandleHeight position="top" rowHeight={consoleHeight} on:updateRowHeight={onUpdateRowHeight} />
+        <RowDragHandleHeight
+          maxHeight={600}
+          position="top"
+          rowHeight={consoleHeight}
+          on:updateRowHeight={onUpdateRowHeight}
+        />
       </div>
     {/if}
     <Tabs on:select-tab={onSelectTab}>

--- a/src/components/console/Console.svelte
+++ b/src/components/console/Console.svelte
@@ -3,7 +3,6 @@
 <script lang="ts">
   import ChevronDownIcon from '@nasa-jpl/stellar/icons/chevron_down.svg?component';
   import ChevronUpIcon from '@nasa-jpl/stellar/icons/chevron_up.svg?component';
-
   import Tabs from '../ui/Tabs/Tabs.svelte';
   import ConsoleDragHandle from './ConsoleDragHandle.svelte';
 

--- a/src/components/console/ConsoleDragHandle.svelte
+++ b/src/components/console/ConsoleDragHandle.svelte
@@ -47,10 +47,24 @@
 
 <svelte:window on:mouseup={onMouseUp} />
 
-<div class="row-drag-handle-height" on:mousedown|preventDefault={onMouseDown} />
+<div class="console-drag-handle-container">
+  <div class="console-drag-handle-height" on:mousedown|preventDefault={onMouseDown} />
+</div>
 
 <style>
-  div {
+  .console-drag-handle-container {
+    align-items: center;
+    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAFAQMAAABo7865AAAABlBMVEVHcEzMzMzyAv2sAAAAAXRSTlMAQObYZgAAABBJREFUeF5jOAMEEAIEEFwAn3kMwcB6I2AAAAAASUVORK5CYII=');
+    background-position: 50% 50%;
+    background-repeat: no-repeat;
+    display: flex;
+    height: 3px;
+    justify-content: center;
+    position: absolute;
+    width: 100%;
+  }
+
+  .console-drag-handle-height {
     background-color: var(--st-gray-20);
     cursor: row-resize;
     height: 3px;
@@ -58,7 +72,7 @@
     width: 100%;
   }
 
-  .row-drag-handle-height:hover {
+  .console-drag-handle-height:hover {
     background-color: var(--st-gray-30);
   }
 </style>

--- a/src/components/console/ConsoleDragHandle.svelte
+++ b/src/components/console/ConsoleDragHandle.svelte
@@ -2,12 +2,24 @@
 
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import { clamp } from '../../utilities/generic';
 
+  export let minHeight: number | string = 50;
+  export let maxHeight: number | string = Infinity;
   export let rowHeight: number = 0;
 
   const dispatch = createEventDispatcher();
 
   let clientY: number | null = null;
+
+  function getPixelHeight(value: string | number): number {
+    if (typeof value === 'string' && /%/.test(value)) {
+      const valuePercentage = parseInt(value.replace('%', '')) / 100;
+      return valuePercentage * document.body.clientHeight;
+    }
+
+    return parseInt(`${value}`);
+  }
 
   function onMouseMove(event: MouseEvent): void {
     if (clientY == null) {
@@ -15,10 +27,10 @@
     }
 
     const dy = event.clientY - clientY;
-    const newHeight = rowHeight + dy;
-    if (newHeight >= 50) {
-      dispatch('updateRowHeight', { newHeight });
-    }
+    const newHeight = rowHeight - dy;
+
+    dispatch('updateRowHeight', { newHeight: clamp(newHeight, getPixelHeight(minHeight), getPixelHeight(maxHeight)) });
+
     clientY = event.clientY;
   }
 
@@ -35,7 +47,7 @@
 
 <svelte:window on:mouseup={onMouseUp} />
 
-<div class="row-drag-handle-height" on:mousedown={onMouseDown} />
+<div class="row-drag-handle-height" on:mousedown|preventDefault={onMouseDown} />
 
 <style>
   div {

--- a/src/components/timeline/RowDragHandleHeight.svelte
+++ b/src/components/timeline/RowDragHandleHeight.svelte
@@ -3,6 +3,8 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
 
+  export let minHeight: number = 50;
+  export let maxHeight: number = Infinity;
   export let position: 'bottom' | 'top' = 'bottom';
   export let rowHeight: number = 0;
 
@@ -18,7 +20,7 @@
     const dy = event.clientY - clientY;
     const newHeight = rowHeight + (position === 'bottom' ? dy : -dy);
 
-    if (Math.abs(newHeight) >= 50) {
+    if (newHeight >= minHeight && newHeight <= maxHeight) {
       dispatch('updateRowHeight', { newHeight });
     }
     clientY = event.clientY;
@@ -37,7 +39,7 @@
 
 <svelte:window on:mouseup={onMouseUp} />
 
-<div class="row-drag-handle-height" on:mousedown={onMouseDown} />
+<div class="row-drag-handle-height" on:mousedown|preventDefault={onMouseDown} />
 
 <style>
   div {

--- a/src/components/timeline/RowDragHandleHeight.svelte
+++ b/src/components/timeline/RowDragHandleHeight.svelte
@@ -3,6 +3,7 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
 
+  export let position: 'bottom' | 'top' = 'bottom';
   export let rowHeight: number = 0;
 
   const dispatch = createEventDispatcher();
@@ -15,8 +16,9 @@
     }
 
     const dy = event.clientY - clientY;
-    const newHeight = rowHeight + dy;
-    if (newHeight >= 50) {
+    const newHeight = rowHeight + (position === 'bottom' ? dy : -dy);
+
+    if (Math.abs(newHeight) >= 50) {
       dispatch('updateRowHeight', { newHeight });
     }
     clientY = event.clientY;


### PR DESCRIPTION
Resolves #256 

This adds a drag handle to the console and allows the user to drag it up and down to resize the height of the console.

To test:

1. Create a plan
2. Verify that the console doesn't have a draggable handle when it's closed
3. Expand the console
4. Verify that the drag handle is present and draggable
5. Verify that the console resizes as expected
6. Make note of the current size of the console and close it
7. Verify that reopening the console reverts to the noted size prior to closing