### PR TITLE
Set valueSource to none for computed attributes

### DIFF
--- a/src/components/activity/ActivityForm.svelte
+++ b/src/components/activity/ActivityForm.svelte
@@ -273,7 +273,10 @@
     if (schema) {
       const parametersMap: ParametersMap = { Value: { order: 0, schema } };
       const argumentsMap: ArgumentsMap = computedAttributes ? { Value: computedAttributes } : { Value: {} };
-      formParametersComputedAttributes = getFormParameters(parametersMap, argumentsMap, []);
+      formParametersComputedAttributes = getFormParameters(parametersMap, argumentsMap, []).map(formParameter => ({
+        ...formParameter,
+        valueSource: 'none',
+      }));
     }
   }
 


### PR DESCRIPTION
Currently, computed attributes are shown with a "User Override" tooltip - this is because the `getArgument` logic doesn't quite apply to computed attributes - user override and mission model default simply don't make sense for them, since they are an output of simulation.

<img width="295" alt="Screen Shot 2022-11-14 at 6 45 57 PM" src="https://user-images.githubusercontent.com/1189602/201814092-fc488baa-ab9f-4a51-bec8-baa5943a94f8.png">

This PR marks the `valueSource` of all computed attributes as `none`, so that they don't show up with a misleading tooltip.

<img width="280" alt="Screen Shot 2022-11-14 at 6 49 47 PM" src="https://user-images.githubusercontent.com/1189602/201814557-3a5de23e-404a-42b8-88a4-a571919c86c2.png">

Perhaps we want a third dot color for "computed" - but in the meantime, I think `'none'` is the most honest option.