### PR TITLE
Handle case for undefined columnStates in table menu

### DIFF
--- a/src/components/activity/ActivityTableMenu.svelte
+++ b/src/components/activity/ActivityTableMenu.svelte
@@ -25,7 +25,7 @@
   let tableMenu: Menu;
 
   $: columnMenuItems = columnDefs.map((derivedColumnDef: ColDef) => {
-    const columnState = columnStates.find((columnState: ColumnState) => columnState.colId === derivedColumnDef.field);
+    const columnState = columnStates?.find((columnState: ColumnState) => columnState.colId === derivedColumnDef.field);
 
     if (columnState) {
       return {

--- a/src/components/activity/ActivityTableMenu.svelte
+++ b/src/components/activity/ActivityTableMenu.svelte
@@ -8,8 +8,8 @@
   import Menu from '../menus/Menu.svelte';
   import MenuItem from '../menus/MenuItem.svelte';
 
-  export let columnDefs: ColDef[] = [];
-  export let columnStates: ColumnState[] = [];
+  export let columnDefs: ColDef[] | undefined = [];
+  export let columnStates: ColumnState[] | undefined = [];
 
   type ColumnMenuItem = {
     field: keyof Activity;
@@ -24,7 +24,7 @@
   let searchFilter: string = '';
   let tableMenu: Menu;
 
-  $: columnMenuItems = columnDefs.map((derivedColumnDef: ColDef) => {
+  $: columnMenuItems = (columnDefs ?? []).map((derivedColumnDef: ColDef) => {
     const columnState = columnStates?.find((columnState: ColumnState) => columnState.colId === derivedColumnDef.field);
 
     if (columnState) {


### PR DESCRIPTION
resolves #267 

To test:

1. Open a plan and a view containing an Activity Table panel
2. Open the View Editor
3. Delete `columnStates` definition from the JSON in the editor under `activityTables`
4. Verify that the UI doesn't lock up and that no error `TypeError: Cannot read properties of undefined (reading 'find'` is thrown from `ActivityTableMenu.svelte`
