### PR TITLE
Timeline row view editing

### DIFF
--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -32,7 +32,7 @@ export class Plan {
   panelSchedulingGoals: Locator;
   panelSimulation: Locator;
   panelTimeline: Locator;
-  panelTimelineDetails: Locator;
+  panelTimelineEditor: Locator;
   panelTimelineForm: Locator;
   panelViewEditor: Locator;
   panelViews: Locator;
@@ -225,7 +225,7 @@ export class Plan {
     this.panelSimulation = page.locator('[data-component-name="SimulationPanel"]');
     this.panelTimeline = page.locator('[data-component-name="TimelinePanel"]');
     this.panelTimelineForm = page.locator('[data-component-name="TimelineFormPanel"]');
-    this.panelTimelineDetails = page.locator('[data-component-name="TimelineDetailsPanel"]');
+    this.panelTimelineEditor = page.locator('[data-component-name="TimelineEditorPanel"]');
     this.panelViewEditor = page.locator('[data-component-name="ViewEditorPanel"]');
     this.panelViews = page.locator('[data-component-name="ViewsPanel"]');
     this.planTitle = page.locator(`.plan-title:has-text("${this.plans.planName}")`);

--- a/e2e-tests/tests/plan.test.ts
+++ b/e2e-tests/tests/plan.test.ts
@@ -98,10 +98,10 @@ test.describe.serial('Plan', () => {
     await expect(plan.panelTimelineForm).toBeVisible();
   });
 
-  test(`Clicking on 'Timeline Details' in the grid menu should show the timeline details panel`, async () => {
-    await expect(plan.panelTimelineDetails).not.toBeVisible();
-    await plan.showPanel('Timeline Details');
-    await expect(plan.panelTimelineDetails).toBeVisible();
+  test(`Clicking on 'Timeline Editor' in the grid menu should show the timeline editor panel`, async () => {
+    await expect(plan.panelTimelineEditor).not.toBeVisible();
+    await plan.showPanel('Timeline Editor');
+    await expect(plan.panelTimelineEditor).toBeVisible();
   });
 
   test(`Clicking on 'Views' in the grid menu should show the views panel`, async () => {

--- a/e2e-tests/tests/timeline-view-editing.test.ts
+++ b/e2e-tests/tests/timeline-view-editing.test.ts
@@ -87,7 +87,7 @@ test.describe.serial('Timeline View Editing', () => {
     await page.locator('.timeline-row').last().locator("button[aria-label='Delete Row']").click();
 
     // Confirm deletion of row in modal
-    await page.getByRole('button', { name: 'Delete' }).click();
+    await page.locator('#svelte-modal').getByRole('button', { name: 'Delete' }).click();
 
     const newRowCount = await page.locator('.timeline-row').count();
     await expect(newRowCount - existingRowCount).toEqual(-1);

--- a/e2e-tests/tests/timeline-view-editing.test.ts
+++ b/e2e-tests/tests/timeline-view-editing.test.ts
@@ -1,0 +1,106 @@
+import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+import { Constraints } from '../fixtures/Constraints.js';
+import { Models } from '../fixtures/Models.js';
+import { Plan } from '../fixtures/Plan.js';
+import { Plans } from '../fixtures/Plans.js';
+import { SchedulingConditions } from '../fixtures/SchedulingConditions.js';
+import { SchedulingGoals } from '../fixtures/SchedulingGoals.js';
+
+let constraints: Constraints;
+let context: BrowserContext;
+let models: Models;
+let page: Page;
+let plan: Plan;
+let plans: Plans;
+let schedulingConditions: SchedulingConditions;
+let schedulingGoals: SchedulingGoals;
+
+test.beforeAll(async ({ browser }) => {
+  context = await browser.newContext();
+  page = await context.newPage();
+
+  models = new Models(page);
+  plans = new Plans(page, models);
+  constraints = new Constraints(page, models);
+  schedulingConditions = new SchedulingConditions(page, models);
+  schedulingGoals = new SchedulingGoals(page, models);
+  plan = new Plan(page, plans, constraints, schedulingGoals, schedulingConditions);
+
+  await models.goto();
+  await models.createModel();
+  await plans.goto();
+  await plans.createPlan();
+  await plan.goto();
+});
+
+test.afterAll(async () => {
+  await plans.goto();
+  await plans.deletePlan();
+  await models.goto();
+  await models.deleteModel();
+  await page.close();
+  await context.close();
+});
+
+test.describe.serial('Timeline View Editing', () => {
+  const newActivityStartTime: string = '2022-005T00:00:00.000';
+
+  test('Add an activity to the parent plan', async () => {
+    await plan.showPanel('Activity Types');
+    await page.getByRole('button', { name: 'CreateActivity-PickBanana' }).click();
+  });
+
+  test('Change the start time of the activity', async () => {
+    await page.getByRole('gridcell', { name: 'PickBanana' }).click();
+    await plan.showPanel('Selected Activity');
+    await page.locator('input[name="start-time"]').first().click();
+    await page.locator('input[name="start-time"]').first().fill(newActivityStartTime);
+    await page.locator('input[name="start-time"]').first().press('Enter');
+  });
+
+  test('Add a vertical guide', async () => {
+    await plan.showPanel('Timeline Details');
+    const existingGuideCount = await page.locator('.guide').count();
+    await page.getByRole('button', { name: 'New Vertical Guide' }).click();
+    const newGuideCount = await page.locator('.guide').count();
+    expect(newGuideCount - existingGuideCount).toEqual(1);
+  });
+
+  test('Remove a vertical guide', async () => {
+    const existingGuideCount = await page.locator('.guide').count();
+    await page.getByRole('button', { name: 'Delete Guide' }).click();
+    const newGuideCount = await page.locator('.guide').count();
+    await expect(newGuideCount - existingGuideCount).toEqual(-1);
+  });
+
+  test('Add a row', async () => {
+    const existingRowCount = await page.locator('.timeline-row').count();
+    await page.getByRole('button', { name: 'New Row' }).click();
+    const newRowCount = await page.locator('.timeline-row').count();
+    await expect(newRowCount - existingRowCount).toEqual(1);
+  });
+
+  test('Delete a row', async () => {
+    const existingRowCount = await page.locator('.timeline-row').count();
+
+    // Click on delete button of last row
+    await page.locator('.timeline-row').last().locator("button[aria-label='Delete Row']").click();
+
+    // Confirm deletion of row in modal
+    await page.getByRole('button', { name: 'Delete' }).click();
+
+    const newRowCount = await page.locator('.timeline-row').count();
+    await expect(newRowCount - existingRowCount).toEqual(-1);
+  });
+
+  test('Edit a row', async () => {
+    // Click on edit button of last row
+    await page.locator('.timeline-row').last().locator("button[aria-label='Edit Row']").click();
+
+    // Look for back button indicating that the row editor is active
+    await expect(page.locator('.section-back-button ').first()).toBeDefined();
+
+    // TODO fill out this test more when layer editing is possible so that
+    // rows can be constructed properly without relying on existing rows from the dummy model
+  });
+});

--- a/e2e-tests/tests/timeline-view-editing.test.ts
+++ b/e2e-tests/tests/timeline-view-editing.test.ts
@@ -68,7 +68,7 @@ test.describe.serial('Timeline View Editing', () => {
 
   test('Remove a vertical guide', async () => {
     const existingGuideCount = await page.locator('.guide').count();
-    await page.getByRole('button', { name: 'Delete Guide' }).click();
+    await page.getByRole('button', { name: 'Delete Guide' }).last().click();
     const newGuideCount = await page.locator('.guide').count();
     await expect(newGuideCount - existingGuideCount).toEqual(-1);
   });

--- a/e2e-tests/tests/timeline-view-editing.test.ts
+++ b/e2e-tests/tests/timeline-view-editing.test.ts
@@ -59,7 +59,7 @@ test.describe.serial('Timeline View Editing', () => {
   });
 
   test('Add a vertical guide', async () => {
-    await plan.showPanel('Timeline Details');
+    await plan.showPanel('Timeline Editor');
     const existingGuideCount = await page.locator('.guide').count();
     await page.getByRole('button', { name: 'New Vertical Guide' }).click();
     const newGuideCount = await page.locator('.guide').count();

--- a/src/components/form/ColorPicker.svelte
+++ b/src/components/form/ColorPicker.svelte
@@ -1,0 +1,67 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { classNames } from '../../utilities/generic';
+
+  export let className: string = '';
+  export let name: string = '';
+  export let value: string = '';
+
+  $: inputClasses = classNames('color-picker', {
+    [className]: !!className,
+  });
+</script>
+
+<div class={inputClasses}>
+  <input {value} class="color-picker-input" on:input on:change type="color" {name} />
+</div>
+
+<style>
+  .color-picker {
+    display: flex;
+    position: relative;
+  }
+
+  .color-picker:after {
+    border: 1px solid rgb(0 0 0 / 25%);
+    border-radius: 4px;
+    content: ' ';
+    height: 100%;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
+
+  .color-picker-input {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    flex-shrink: 0;
+    height: 24px;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    width: 24px;
+  }
+
+  .color-picker-input::-webkit-color-swatch {
+    border: none;
+    border-radius: 4px;
+  }
+
+  .color-picker-input::-moz-color-swatch {
+    border: none;
+    border-radius: 4px;
+  }
+
+  .color-picker-input::-webkit-color-swatch-wrapper {
+    border: none;
+    border-radius: 4px;
+    padding: 0;
+  }
+</style>

--- a/src/components/menus/GridMenu.svelte
+++ b/src/components/menus/GridMenu.svelte
@@ -93,9 +93,9 @@
       <ChecklistOnPageIcon />
       Timeline Form
     </MenuItem>
-    <MenuItem on:click={() => updateGridComponent('TimelineDetailsPanel')}>
+    <MenuItem on:click={() => updateGridComponent('TimelineEditorPanel')}>
       <ChecklistOnPageIcon />
-      Timeline Details
+      Timeline Editor
     </MenuItem>
     <MenuItem on:click={() => updateGridComponent('ViewsPanel')}>
       <ColumnsIcon />

--- a/src/components/timeline/LayerLine.svelte
+++ b/src/components/timeline/LayerLine.svelte
@@ -9,6 +9,7 @@
 
   export let drawHeight: number = 0;
   export let drawWidth: number = 0;
+  // TODO make an issue to remove these unneeded filters from LayerLine, LayerRange, etc
   export let filter: ResourceLayerFilter | undefined;
   export let id: number;
   export let lineColor: string = '';
@@ -37,6 +38,7 @@
   $: if (
     drawHeight &&
     drawWidth &&
+    // TODO swap filter out for resources which are recomputed when the view changes (i.e. filter changes)
     filter &&
     lineColor &&
     lineWidth &&

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -89,13 +89,13 @@
   }
 
   function onEditRow() {
-    // Open the timeline details panel on the right. For now we will assume
+    // Open the timeline editor panel on the right. For now we will assume
     // the right panel is the last component in the view and that the panel is open.
     // This will be improved after future layout enhancements.
     const gridColumns = $view.definition.plan.layout as GridColumns;
     const components = gridColumns.columns.filter(grid => grid.type === 'component');
     if (components.length) {
-      viewUpdateLayout(components[components.length - 1].id, { componentName: 'TimelineDetailsPanel' });
+      viewUpdateLayout(components[components.length - 1].id, { componentName: 'TimelineEditorsPanel' });
     }
 
     // Set row to edit

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -95,7 +95,7 @@
     const gridColumns = $view.definition.plan.layout as GridColumns;
     const components = gridColumns.columns.filter(grid => grid.type === 'component');
     if (components.length) {
-      viewUpdateLayout(components[components.length - 1].id, { componentName: 'TimelineEditorsPanel' });
+      viewUpdateLayout(components[components.length - 1].id, { componentName: 'TimelineEditorPanel' });
     }
 
     // Set row to edit

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -5,7 +5,7 @@
   import type { ScaleTime } from 'd3-scale';
   import { pick } from 'lodash-es';
   import { createEventDispatcher } from 'svelte';
-  import { viewSetSelectedRow } from '../../stores/views';
+  import { selectedRow, viewSetSelectedRow } from '../../stores/views';
   import { classNames } from '../../utilities/generic';
   import { tooltip } from '../../utilities/tooltip';
   import ConstraintViolations from './ConstraintViolations.svelte';
@@ -89,7 +89,7 @@
   }
 </script>
 
-<div class="row-root">
+<div class="row-root" class:active-row={$selectedRow ? $selectedRow.id === id : false}>
   <!-- Row Header. -->
   <RowHeader {expanded} rowId={id} title={name} {rowDragMoveDisabled} on:mouseDownRowMove on:toggleRowExpansion>
     <div slot="right">
@@ -226,6 +226,7 @@
   }
 
   .overlay {
+    outline: none;
     z-index: 2;
   }
 
@@ -264,5 +265,20 @@
 
   :global(.row-edit-button.st-button.icon:hover svg) {
     color: var(--st-gray-70);
+  }
+
+  .row-root {
+    position: relative;
+  }
+
+  .active-row:after {
+    border: 1px solid #2f80ed;
+    content: ' ';
+    height: 100%;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    width: 100%;
   }
 </style>

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -5,7 +5,7 @@
   import type { ScaleTime } from 'd3-scale';
   import { pick } from 'lodash-es';
   import { createEventDispatcher } from 'svelte';
-  import { selectedRow, viewSetSelectedRow } from '../../stores/views';
+  import { selectedRow, view, viewSetSelectedRow, viewUpdateLayout } from '../../stores/views';
   import { classNames } from '../../utilities/generic';
   import { tooltip } from '../../utilities/tooltip';
   import ConstraintViolations from './ConstraintViolations.svelte';
@@ -87,6 +87,20 @@
       dispatch('updateRowHeight', { newHeight, rowId: id });
     }
   }
+
+  function onEditRow() {
+    // Open the timeline details panel on the right. For now we will assume
+    // the right panel is the last component in the view and that the panel is open.
+    // This will be improved after future layout enhancements.
+    const gridColumns = $view.definition.plan.layout as GridColumns;
+    const components = gridColumns.columns.filter(grid => grid.type === 'component');
+    if (components.length) {
+      viewUpdateLayout(components[components.length - 1].id, { componentName: 'TimelineDetailsPanel' });
+    }
+
+    // Set row to edit
+    viewSetSelectedRow(id);
+  }
 </script>
 
 <div class="row-root" class:active-row={$selectedRow ? $selectedRow.id === id : false}>
@@ -96,9 +110,7 @@
       <button
         use:tooltip={{ content: 'Edit Row', placement: 'top' }}
         class="st-button icon row-edit-button"
-        on:click={() => {
-          viewSetSelectedRow(id);
-        }}
+        on:click={onEditRow}
       >
         <PenIcon />
       </button>

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -1,10 +1,13 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import PenIcon from '@nasa-jpl/stellar/icons/pen.svg?component';
   import type { ScaleTime } from 'd3-scale';
   import { pick } from 'lodash-es';
   import { createEventDispatcher } from 'svelte';
+  import { viewSetSelectedRow } from '../../stores/views';
   import { classNames } from '../../utilities/generic';
+  import { tooltip } from '../../utilities/tooltip';
   import ConstraintViolations from './ConstraintViolations.svelte';
   import LayerActivity from './LayerActivity.svelte';
   import LayerLine from './LayerLine.svelte';
@@ -88,7 +91,19 @@
 
 <div class="row-root">
   <!-- Row Header. -->
-  <RowHeader {expanded} rowId={id} title={name} {rowDragMoveDisabled} on:mouseDownRowMove on:toggleRowExpansion />
+  <RowHeader {expanded} rowId={id} title={name} {rowDragMoveDisabled} on:mouseDownRowMove on:toggleRowExpansion>
+    <div slot="right">
+      <button
+        use:tooltip={{ content: 'Edit Row', placement: 'top' }}
+        class="st-button icon row-edit-button"
+        on:click={() => {
+          viewSetSelectedRow(id);
+        }}
+      >
+        <PenIcon />
+      </button>
+    </div>
+  </RowHeader>
 
   <div class={rowClasses} id={`row-${id}`} style="height: {drawHeight}px;">
     <!-- Overlay for Pointer Events. -->
@@ -237,5 +252,17 @@
 
   :global(.right) {
     z-index: 0;
+  }
+
+  .row-edit-button {
+    display: flex;
+  }
+
+  :global(.row-edit-button.st-button.icon svg) {
+    color: var(--st-gray-50);
+  }
+
+  :global(.row-edit-button.st-button.icon:hover svg) {
+    color: var(--st-gray-70);
   }
 </style>

--- a/src/components/timeline/RowHorizontalGuides.svelte
+++ b/src/components/timeline/RowHorizontalGuides.svelte
@@ -34,6 +34,7 @@
           const lineGroup = gSelection.append('g').attr('class', horizontalGuideClass);
 
           const color = 'gray';
+          const dashColor = guide?.label?.color || color;
           const dashLength = 2;
           const width = 1.0;
           lineGroup
@@ -44,7 +45,7 @@
             .attr('y1', y)
             .attr('x2', drawWidth)
             .attr('y2', y)
-            .attr('stroke', color)
+            .attr('stroke', dashColor)
             .attr('stroke-dasharray', dashLength)
             .attr('stroke-width', width);
 

--- a/src/components/timeline/TimelineCursor.svelte
+++ b/src/components/timeline/TimelineCursor.svelte
@@ -7,13 +7,16 @@
   export let maxWidth = 0;
   export let label = '';
   export let activeCursor = false;
+  export let color = '';
 
   let hovered = false;
 </script>
 
 <div class="timeline-cursor" style="transform: translateX({x}px)">
+  <div class="timeline-cursor-line" style="background: {color}" />
   <button
     class="timeline-cursor-icon"
+    style="color: {color}"
     on:click
     on:mouseenter={() => (hovered = true)}
     on:mouseleave={() => (hovered = false)}
@@ -57,9 +60,8 @@
     width: 15px;
   }
 
-  .timeline-cursor::before {
+  .timeline-cursor-line {
     background-color: var(--st-gray-50);
-    content: '';
     display: block;
     height: 100%;
     left: -0.5px;

--- a/src/components/timeline/TimelineCursors.svelte
+++ b/src/components/timeline/TimelineCursors.svelte
@@ -151,6 +151,7 @@
   <div class="timeline-cursor-header" />
   {#each computedVerticalGuides as guide}
     <TimelineCursor
+      color={guide.label.color}
       x={guide.x}
       label={guide.label.text}
       maxWidth={guide.maxWidth}

--- a/src/components/timeline/form/TimelineDetailsPanel.svelte
+++ b/src/components/timeline/form/TimelineDetailsPanel.svelte
@@ -508,7 +508,7 @@
                 <div class="w-100">
                   <input
                     autocomplete="off"
-                    placeholder="Axis label"
+                    placeholder="Label"
                     class="st-input w-100"
                     name="label"
                     type="string"

--- a/src/components/timeline/form/TimelineDetailsPanel.svelte
+++ b/src/components/timeline/form/TimelineDetailsPanel.svelte
@@ -243,9 +243,9 @@
 
   // This is the JS way to style the dragged element, notice it is being passed into the dnd-zone
   function transformDraggedElement(draggedEl: Element) {
-    const el = draggedEl.querySelector('.row') as HTMLElement;
+    const el = draggedEl.querySelector('.timeline-row') as HTMLElement;
     el.style.background = 'var(--st-gray-10)';
-    el.classList.add('test');
+    el.classList.add('timeline-row-dragging');
   }
 
   onMount(() => {
@@ -729,7 +729,7 @@
   }
 
   .timeline-row:hover .drag-icon,
-  :global(.test) .drag-icon {
+  :global(.timeline-row-dragging) .drag-icon {
     display: flex;
   }
 

--- a/src/components/timeline/form/TimelineDetailsPanel.svelte
+++ b/src/components/timeline/form/TimelineDetailsPanel.svelte
@@ -481,7 +481,7 @@
                   >
                     {#each $selectedRow.yAxes as axis}
                       <option value={axis.id}>
-                        Y Axis {axis.id}
+                        {axis.label.text}
                       </option>
                     {/each}
                   </select>
@@ -500,7 +500,7 @@
 
         <fieldset class="editor-section">
           <div class="editor-section-header">
-            <div class="st-typography-medium">Y Axis Labels</div>
+            <div class="st-typography-medium">Y Axes</div>
           </div>
           {#if $selectedRow.yAxes.length}
             {#each $selectedRow.yAxes as yAxis (yAxis.id)}

--- a/src/components/timeline/form/TimelineDetailsPanel.svelte
+++ b/src/components/timeline/form/TimelineDetailsPanel.svelte
@@ -24,6 +24,7 @@
     viewUpdateTimeline,
   } from '../../../stores/views';
   import { getTarget } from '../../../utilities/generic';
+  import { showConfirmModal } from '../../../utilities/modal';
   import { getDoyTime } from '../../../utilities/time';
   import {
     createHorizontalGuide,
@@ -130,6 +131,23 @@
     const row = createRow($selectedTimeline.rows);
     rows = [...rows, row];
     viewUpdateTimeline('rows', rows);
+  }
+
+  function deleteTimelineRow(row) {
+    const filteredRows = rows.filter(r => r.id !== row.id);
+    viewUpdateTimeline('rows', filteredRows);
+  }
+
+  async function handleDeleteRowClick(row: Row) {
+    const { confirm } = await showConfirmModal(
+      'Delete',
+      'Are you sure you want to delete this timeline row?',
+      'Delete Row',
+      true,
+    );
+    if (confirm) {
+      deleteTimelineRow(row);
+    }
   }
 
   function handleDndConsiderRows(e: CustomEvent<DndEvent>) {
@@ -389,15 +407,24 @@
                     <GripVerticalIcon />
                   </span>
                   {row.name}
-                  <button
-                    use:tooltip={{ content: 'Edit Row', placement: 'top' }}
-                    class="st-button icon"
-                    on:click={() => {
-                      viewSetSelectedRow(row.id);
-                    }}
-                  >
-                    <PenIcon />
-                  </button>
+                  <div>
+                    <button
+                      use:tooltip={{ content: 'Edit Row', placement: 'top' }}
+                      class="st-button icon"
+                      on:click={() => {
+                        viewSetSelectedRow(row.id);
+                      }}
+                    >
+                      <PenIcon />
+                    </button>
+                    <button
+                      use:tooltip={{ content: 'Delete Row', placement: 'top' }}
+                      class="st-button icon"
+                      on:click|stopPropagation={() => handleDeleteRowClick(row)}
+                    >
+                      <TrashIcon />
+                    </button>
+                  </div>
                 </div>
               </div>
             {/each}

--- a/src/components/timeline/form/TimelineDetailsPanel.svelte
+++ b/src/components/timeline/form/TimelineDetailsPanel.svelte
@@ -388,7 +388,7 @@
             </button>
           </div>
           <div
-            class="rows"
+            class="timeline-rows"
             on:consider={handleDndConsiderRows}
             on:finalize={handleDndFinalizeRows}
             use:dndzone={{
@@ -399,7 +399,7 @@
           >
             {#each rows as row (row.id)}
               <div>
-                <div class="st-typography-body row">
+                <div class="st-typography-body timeline-row">
                   <span class="drag-icon">
                     <GripVerticalIcon />
                   </span>
@@ -679,7 +679,7 @@
   }
 
   .editor-section-header .st-button.icon,
-  .row .st-button.icon,
+  .timeline-row .st-button.icon,
   .guide .st-button.icon,
   .yAxisLabel .st-button.icon {
     color: var(--st-gray-50);
@@ -699,7 +699,7 @@
     padding: 16px 16px 0;
   }
 
-  .rows {
+  .timeline-rows {
     min-height: 100px;
     outline: none !important;
     overflow-x: hidden;
@@ -707,7 +707,7 @@
     padding-bottom: 16px;
   }
 
-  .row {
+  .timeline-row {
     align-items: center;
     display: flex;
     height: 40px;
@@ -723,12 +723,12 @@
     position: absolute;
   }
 
-  .row:hover,
-  .row:active {
+  .timeline-row:hover,
+  .timeline-row:active {
     background: var(--st-gray-10);
   }
 
-  .row:hover .drag-icon,
+  .timeline-row:hover .drag-icon,
   :global(.test) .drag-icon {
     display: flex;
   }

--- a/src/components/timeline/form/TimelineDetailsPanel.svelte
+++ b/src/components/timeline/form/TimelineDetailsPanel.svelte
@@ -119,7 +119,7 @@
     viewUpdateRow('yAxes', yAxes);
   }
 
-  function handleDeleteYAxisClick(yAxis) {
+  function handleDeleteYAxisClick(yAxis: Axis) {
     const filteredYAxes = yAxes.filter(axis => axis.id !== yAxis.id);
     viewUpdateRow('yAxes', filteredYAxes);
   }
@@ -134,7 +134,7 @@
     viewUpdateTimeline('rows', rows);
   }
 
-  function deleteTimelineRow(row) {
+  function deleteTimelineRow(row: Row) {
     const filteredRows = rows.filter(r => r.id !== row.id);
     viewUpdateTimeline('rows', filteredRows);
   }

--- a/src/components/timeline/form/TimelineDetailsPanel.svelte
+++ b/src/components/timeline/form/TimelineDetailsPanel.svelte
@@ -8,6 +8,7 @@
   import GripVerticalIcon from 'bootstrap-icons/icons/grip-vertical.svg?component';
   import { onMount } from 'svelte';
   import { dndzone } from 'svelte-dnd-action';
+  import ColorPicker from '../../../components/form/ColorPicker.svelte';
   import Input from '../../../components/form/Input.svelte';
   import DatePicker from '../../../components/ui/DatePicker/DatePicker.svelte';
   import { maxTimeRange, viewTimeRange } from '../../../stores/plan';
@@ -357,15 +358,11 @@
                     on:change={event => updateVerticalGuideTimestamp(event, verticalGuide)}
                     on:keydown={event => updateVerticalGuideTimestamp(event, verticalGuide)}
                   />
-                  <div class="editor-color-input-container">
-                    <input
-                      value={verticalGuide.label.color || '#969696'}
-                      class="editor-color-input"
-                      on:input={event => handleUpdateVerticalGuideLabel(event, verticalGuide)}
-                      type="color"
-                      name="color"
-                    />
-                  </div>
+                  <ColorPicker
+                    value={verticalGuide.label.color}
+                    on:input={event => handleUpdateVerticalGuideLabel(event, verticalGuide)}
+                    name="color"
+                  />
                   <button
                     on:click={() => handleDeleteVerticalGuideClick(verticalGuide)}
                     use:tooltip={{ content: 'Delete Guide', placement: 'top' }}
@@ -538,16 +535,11 @@
                     placeholder="Y value"
                     type="number"
                   />
-                  <div class="editor-color-input-container">
-                    <input
-                      value={horizontalGuide.label.color}
-                      class="editor-color-input"
-                      on:input={event => handleUpdateHorizontalGuideLabel(event, horizontalGuide)}
-                      type="color"
-                      name="color"
-                    />
-                  </div>
-
+                  <ColorPicker
+                    value={horizontalGuide.label.color}
+                    on:input={event => handleUpdateHorizontalGuideLabel(event, horizontalGuide)}
+                    name="color"
+                  />
                   <select
                     on:input={event => handleUpdateHorizontalGuideNumberValue(event, horizontalGuide)}
                     class="st-select w-100"
@@ -780,7 +772,7 @@
     align-items: flex-end;
     display: flex;
   }
-  .editor-color-input {
+  /* .editor-color-input {
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
@@ -793,14 +785,14 @@
     padding: 0;
     position: relative;
     width: 24px;
-  }
+  } */
 
-  .editor-color-input-container {
+  /* .st-color-input {
     display: flex;
     position: relative;
-  }
+  } */
   /* TODO make a standalone color picker component */
-  .editor-color-input-container:after {
+  /* .st-color-input:after {
     border: 1px solid rgb(0 0 0 / 25%);
     border-radius: 4px;
     content: ' ';
@@ -823,5 +815,5 @@
     border: none;
     border-radius: 4px;
     padding: 0;
-  }
+  } */
 </style>

--- a/src/components/timeline/form/TimelineDetailsPanel.svelte
+++ b/src/components/timeline/form/TimelineDetailsPanel.svelte
@@ -40,13 +40,11 @@
   $: rowHasNonActivityChartLayer = !!$selectedRow?.layers.find(layer => layer.chartType !== 'activity') || false;
 
   function updateRowEvent(event: Event) {
-    event.stopPropagation();
     const { name, value } = getTarget(event);
     viewUpdateRow(name, value);
   }
 
   function updateTimelineEvent(event: Event) {
-    event.stopPropagation();
     const { name, value } = getTarget(event);
     viewUpdateTimeline(name, value);
   }
@@ -241,7 +239,7 @@
                 name="marginLeft"
                 type="number"
                 value={$selectedTimeline.marginLeft}
-                on:input={updateTimelineEvent}
+                on:input|stopPropagation={updateTimelineEvent}
               />
             </Input>
 
@@ -253,7 +251,7 @@
                 name="marginRight"
                 type="number"
                 value={$selectedTimeline.marginRight}
-                on:input={updateTimelineEvent}
+                on:input|stopPropagation={updateTimelineEvent}
               />
             </Input>
           </CssGrid>
@@ -395,7 +393,7 @@
               autocomplete="off"
               type="string"
               value={$selectedRow.name}
-              on:input={updateRowEvent}
+              on:input|stopPropagation={updateRowEvent}
             />
           </Input>
         </div>
@@ -408,7 +406,7 @@
               name="height"
               type="number"
               value={$selectedRow.height}
-              on:input={updateRowEvent}
+              on:input|stopPropagation={updateRowEvent}
             />
           </Input>
           <Input class="row-height-select-wrapper">

--- a/src/components/timeline/form/TimelineDetailsPanel.svelte
+++ b/src/components/timeline/form/TimelineDetailsPanel.svelte
@@ -362,8 +362,8 @@
           <div>
             {#each horizontalGuides as horizontalGuide (horizontalGuide.id)}
               <div class="vertical-guide">
-                {horizontalGuide.id}
                 <!-- TODO implement hz guide editing once design is fleshed out -->
+                {horizontalGuide.label.text}
               </div>
             {/each}
           </div>
@@ -386,8 +386,8 @@
           <div>
             {#each $selectedRow.yAxes as yAxis (yAxis.id)}
               <div class="vertical-guide">
-                {yAxis.label.text}
                 <!-- TODO implement yAxis editing once design is fleshed out -->
+                {yAxis.label.text}
               </div>
             {/each}
           </div>
@@ -400,7 +400,7 @@
             on:click={() => {
               console.log('');
             }}
-            use:tooltip={{ content: 'New Y Axis Label', placement: 'top' }}
+            use:tooltip={{ content: 'New Layer', placement: 'top' }}
             class="st-button icon"
           >
             <PlusIcon />
@@ -410,7 +410,7 @@
           <div>
             {#each $selectedRow.layers as layer (layer.id)}
               <div class="vertical-guide">
-                Layer {layer.id}
+                Layer {layer.id}, chart type: {layer.chartType}
               </div>
             {/each}
           </div>

--- a/src/components/timeline/form/TimelineDetailsPanel.svelte
+++ b/src/components/timeline/form/TimelineDetailsPanel.svelte
@@ -277,6 +277,7 @@
             <Input>
               <label for="marginLeft">Margin Left</label>
               <input
+                min={0}
                 class="st-input w-100"
                 name="marginLeft"
                 type="number"
@@ -288,6 +289,7 @@
             <Input>
               <label for="marginRight">Margin Right</label>
               <input
+                min={0}
                 class="st-input w-100"
                 name="marginRight"
                 type="number"
@@ -488,7 +490,7 @@
                         autocomplete="off"
                         class="st-input w-100"
                         name="label"
-                        placeholder="Guide label"
+                        placeholder="Label"
                       />
                     </Field>
                   </div>
@@ -497,13 +499,7 @@
                     on:change={() => handleUpdateHorizontalGuide(horizontalGuide)}
                   >
                     <!-- TODO decimal input isn't working correctly.. -->
-                    <input
-                      autocomplete="off"
-                      class="st-input w-100"
-                      name="y"
-                      placeholder="Guide Y value"
-                      type="number"
-                    />
+                    <input autocomplete="off" class="st-input w-100" name="y" placeholder="Y value" type="number" />
                   </Field>
                   <Field
                     field={horizontalGuideFieldsMap[horizontalGuide.id].color}
@@ -516,6 +512,7 @@
                     }}
                   >
                     <input
+                      class="editor-color-input"
                       on:input={event => {
                         // console.log('input');
                         // const { name, value } = getTarget(event);
@@ -566,23 +563,27 @@
           </div>
           {#if $selectedRow.yAxes.length}
             {#each $selectedRow.yAxes as yAxis (yAxis.id)}
-              <div class="guide">
-                <input
-                  class="st-input w-100"
-                  name="label"
-                  type="string"
-                  value={yAxis.label.text}
-                  on:input={event => {
-                    const { value } = getTarget(event);
-                    const newRowYAxes = $selectedRow.yAxes.map(axis => {
-                      if (axis.id === yAxis.id) {
-                        axis.label.text = value.toString();
-                      }
-                      return axis;
-                    });
-                    viewUpdateRow('yAxes', newRowYAxes);
-                  }}
-                />
+              <div class="yAxisLabel">
+                <div class="w-100">
+                  <input
+                    autocomplete="off"
+                    placeholder="Axis label"
+                    class="st-input w-100"
+                    name="label"
+                    type="string"
+                    value={yAxis.label.text}
+                    on:input={event => {
+                      const { value } = getTarget(event);
+                      const newRowYAxes = $selectedRow.yAxes.map(axis => {
+                        if (axis.id === yAxis.id) {
+                          axis.label.text = value.toString();
+                        }
+                        return axis;
+                      });
+                      viewUpdateRow('yAxes', newRowYAxes);
+                    }}
+                  />
+                </div>
                 <Input>
                   <label for="domainMin">Min</label>
                   <input
@@ -618,29 +619,6 @@
           {/if}
         </fieldset>
       {/if}
-      <fieldset class="editor-section">
-        <div class="editor-section-header editor-section-header-with-button">
-          <div class="st-typography-medium">Layers</div>
-          <button
-            on:click={() => {
-              console.log('');
-            }}
-            use:tooltip={{ content: 'New Layer', placement: 'top' }}
-            class="st-button icon"
-          >
-            <PlusIcon />
-          </button>
-        </div>
-        {#if $selectedRow.layers.length}
-          <div>
-            {#each $selectedRow.layers as layer (layer.id)}
-              <div class="guide">
-                Layer {layer.id}, chart type: {layer.chartType}
-              </div>
-            {/each}
-          </div>
-        {/if}
-      </fieldset>
     {/if}
   </svelte:fragment>
 </Panel>
@@ -723,13 +701,15 @@
     gap: 16px;
   }
 
-  .guide {
+  .guide,
+  .yAxisLabel {
     align-items: center;
     display: flex;
     gap: 8px;
   }
 
   .guide :global(fieldset) {
+    display: flex;
     padding: 0;
   }
   .guide :global(fieldset select) {
@@ -737,8 +717,22 @@
     min-width: max-content;
   }
 
+  .guide :global(fieldset input[type='number']) {
+    flex-shrink: 0;
+    min-width: 80px;
+  }
+
   .guide :global(.date-picker-field) {
     flex: 1;
+  }
+
+  .yAxisLabel :global(.input-stacked) {
+    min-width: 80px;
+    width: auto;
+  }
+
+  .yAxisLabel :global(.input-stacked input) {
+    min-width: 32px;
   }
 
   .section-back-button {
@@ -751,5 +745,46 @@
   :global(.input.input-stacked.row-height-select-wrapper) {
     align-items: flex-end;
     display: flex;
+  }
+
+  :global(.input.input-stacked.row-height-select-wrapper) {
+    align-items: flex-end;
+    display: flex;
+  }
+  .editor-color-input {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    height: 24px;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    width: 24px;
+  }
+  .editor-color-input:after {
+    border: 1px inset rgb(0 0 0 / 25%);
+    border-radius: 4px;
+    content: ' ';
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
+  .editor-color-input::-webkit-color-swatch {
+    border: none;
+    border-radius: 4px;
+  }
+  .editor-color-input::-moz-color-swatch {
+    border: none;
+    border-radius: 4px;
+  }
+  .editor-color-input::-webkit-color-swatch-wrapper {
+    border: none;
+    border-radius: 4px;
+    padding: 0;
   }
 </style>

--- a/src/components/timeline/form/TimelineEditorPanel.svelte
+++ b/src/components/timeline/form/TimelineEditorPanel.svelte
@@ -258,7 +258,7 @@
   });
 </script>
 
-<Panel borderLeft padBody={false}>
+<Panel padBody={false}>
   <svelte:fragment slot="header">
     <GridMenu {gridId} title="Timeline Editor" />
   </svelte:fragment>

--- a/src/components/timeline/form/TimelineEditorPanel.svelte
+++ b/src/components/timeline/form/TimelineEditorPanel.svelte
@@ -8,9 +8,6 @@
   import GripVerticalIcon from 'bootstrap-icons/icons/grip-vertical.svg?component';
   import { onMount } from 'svelte';
   import { dndzone } from 'svelte-dnd-action';
-  import ColorPicker from '../../../components/form/ColorPicker.svelte';
-  import Input from '../../../components/form/Input.svelte';
-  import DatePicker from '../../../components/ui/DatePicker/DatePicker.svelte';
   import { maxTimeRange, viewTimeRange } from '../../../stores/plan';
   import { resourcesByViewLayerId, simulationDataset } from '../../../stores/simulation';
   import {
@@ -35,8 +32,11 @@
     getYAxisBounds,
   } from '../../../utilities/timeline';
   import { tooltip } from '../../../utilities/tooltip';
+  import ColorPicker from '../../form/ColorPicker.svelte';
+  import Input from '../../form/Input.svelte';
   import GridMenu from '../../menus/GridMenu.svelte';
   import CssGrid from '../../ui/CssGrid.svelte';
+  import DatePicker from '../../ui/DatePicker/DatePicker.svelte';
   import Panel from '../../ui/Panel.svelte';
 
   export let gridId: number;
@@ -260,7 +260,7 @@
 
 <Panel borderLeft padBody={false}>
   <svelte:fragment slot="header">
-    <GridMenu {gridId} title="Timeline Details" />
+    <GridMenu {gridId} title="Timeline Editor" />
   </svelte:fragment>
 
   <svelte:fragment slot="body">
@@ -772,48 +772,4 @@
     align-items: flex-end;
     display: flex;
   }
-  /* .editor-color-input {
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    appearance: none;
-    background-color: transparent;
-    border: none;
-    cursor: pointer;
-    flex-shrink: 0;
-    height: 24px;
-    margin: 0;
-    padding: 0;
-    position: relative;
-    width: 24px;
-  } */
-
-  /* .st-color-input {
-    display: flex;
-    position: relative;
-  } */
-  /* TODO make a standalone color picker component */
-  /* .st-color-input:after {
-    border: 1px solid rgb(0 0 0 / 25%);
-    border-radius: 4px;
-    content: ' ';
-    height: 100%;
-    left: 0;
-    pointer-events: none;
-    position: absolute;
-    top: 0;
-    width: 100%;
-  }
-  .editor-color-input::-webkit-color-swatch {
-    border: none;
-    border-radius: 4px;
-  }
-  .editor-color-input::-moz-color-swatch {
-    border: none;
-    border-radius: 4px;
-  }
-  .editor-color-input::-webkit-color-swatch-wrapper {
-    border: none;
-    border-radius: 4px;
-    padding: 0;
-  } */
 </style>

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -84,3 +84,8 @@ fieldset {
 .toastify {
   color: var(--st-white);
 }
+
+/* Remove safari input margin */
+.st-input {
+  margin: 0;
+}

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -25,7 +25,7 @@
   import SchedulingConditionsPanel from '../../../components/scheduling/SchedulingConditionsPanel.svelte';
   import SchedulingGoalsPanel from '../../../components/scheduling/SchedulingGoalsPanel.svelte';
   import SimulationPanel from '../../../components/simulation/SimulationPanel.svelte';
-  import TimelineDetailsPanel from '../../../components/timeline/form/TimelineDetailsPanel.svelte';
+  import TimelineEditorPanel from '../../../components/timeline/form/TimelineEditorPanel.svelte';
   import TimelineFormPanel from '../../../components/timeline/form/TimelineFormPanel.svelte';
   import TimelinePanel from '../../../components/timeline/TimelinePanel.svelte';
   import CssGrid from '../../../components/ui/CssGrid.svelte';
@@ -74,7 +74,7 @@
     SchedulingConditionsPanel,
     SchedulingGoalsPanel,
     SimulationPanel,
-    TimelineDetailsPanel,
+    TimelineEditorPanel,
     TimelineFormPanel,
     TimelinePanel,
     ViewEditorPanel,

--- a/src/stores/views.ts
+++ b/src/stores/views.ts
@@ -130,15 +130,6 @@ export function viewSetSelectedRow(rowId: number | null): void {
 
 export function viewSetSelectedTimeline(timelineId: number | null): void {
   selectedTimelineId.set(timelineId);
-  const currentTimeline = get(selectedTimeline);
-
-  if (currentTimeline) {
-    const firstRow = currentTimeline.rows[0];
-
-    if (firstRow) {
-      // viewSetSelectedRow(firstRow.id);
-    }
-  }
 }
 
 export function viewUpdateActivityTables(update: Partial<ViewActivityTable>, activityTableId: number): void {

--- a/src/stores/views.ts
+++ b/src/stores/views.ts
@@ -136,7 +136,7 @@ export function viewSetSelectedTimeline(timelineId: number | null): void {
     const firstRow = currentTimeline.rows[0];
 
     if (firstRow) {
-      viewSetSelectedRow(firstRow.id);
+      // viewSetSelectedRow(firstRow.id);
     }
   }
 }

--- a/src/utilities/timeline.test.ts
+++ b/src/utilities/timeline.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from 'vitest';
+import { createTimelineLayer, createYAxis, getNextID, getYAxisBounds } from './timeline';
+
+test('getNextID', () => {
+  const genIDs = (ids: number[]) => ids.map(id => ({ id }));
+
+  expect(getNextID([])).toEqual(0);
+  expect(getNextID(genIDs([0]))).toEqual(1);
+  expect(getNextID(genIDs([0, 1, 2, 3, 4]))).toEqual(5);
+  expect(getNextID(genIDs([0, 1, 3, 4, 6]))).toEqual(7);
+  expect(getNextID(genIDs([0, -1, -2, 2, -5]))).toEqual(3);
+});
+
+test('getYAxisBounds', () => {
+  const yAxis: Axis = createYAxis([]);
+  const layer1 = createTimelineLayer([], [yAxis]);
+  const layer2 = createTimelineLayer([layer1], [yAxis]);
+  const layers: Layer[] = [layer1, layer2];
+  const resource: Resource = {
+    name: 'test',
+    schema: {
+      items: { initial: { type: 'real' }, rate: { type: 'real' } },
+      type: 'struct',
+    },
+    values: [
+      { x: 1, y: 10 },
+      { x: 2, y: 11 },
+      { x: 3, y: 12 },
+      { x: 4, y: 13 },
+      { x: 5, y: 14 },
+      { x: 6, y: 15 },
+    ],
+  };
+  const resourceWithNoValues: Resource = {
+    name: 'test',
+    schema: {
+      items: { initial: { type: 'real' }, rate: { type: 'real' } },
+      type: 'struct',
+    },
+    values: [],
+  };
+  const resourcesByViewLayerId = { [layer1.id]: [resource], [layer2.id]: [] };
+  expect(getYAxisBounds(yAxis, [], {})).toEqual(yAxis.scaleDomain);
+  expect(getYAxisBounds(yAxis, layers, {})).toEqual(yAxis.scaleDomain);
+  expect(getYAxisBounds(yAxis, layers, resourcesByViewLayerId)).toEqual([10, 15]);
+  expect(getYAxisBounds(yAxis, layers, { [layer1.id]: [resourceWithNoValues] })).toEqual(yAxis.scaleDomain);
+});

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -249,3 +249,70 @@ export function createRow(rows: Row[]): Row {
     yAxes: [],
   };
 }
+
+/**
+ * Returns a new y axis
+ */
+export function createYAxis(yAxes: Axis[]): Axis {
+  const id = getNextID(yAxes);
+  return {
+    color: '',
+    id,
+    label: { text: 'Label' },
+
+    // TODO is there a sensible default for this since there are
+    // no associated layers for a new y axis?
+    scaleDomain: [0, 1],
+    tickCount: 4,
+  };
+}
+
+/**
+ * Returns the max bounds of the resources associated with an axis
+ */
+export function getYAxisBounds(
+  yAxis: Axis,
+  layers: Layer[],
+  resourcesByViewLayerId: Record<number, Resource[]>,
+): number[] {
+  // Find all layers that are associated with this y axis
+  const yAxisLayers = layers.filter(layer => layer.yAxisId === yAxis.id);
+
+  // Find min and max of associated layers
+  let minY = undefined;
+  let maxY = undefined;
+  yAxisLayers.forEach(layer => {
+    resourcesByViewLayerId[layer.id].forEach(resource => {
+      resource.values.forEach(value => {
+        if (minY === undefined || value.y < minY) {
+          minY = value.y;
+        }
+        if (maxY === undefined || value.y > maxY) {
+          maxY = value.y;
+        }
+      });
+    });
+  });
+
+  const scaleDomain = [...yAxis.scaleDomain];
+  if (minY !== undefined) {
+    scaleDomain[0] = minY;
+  }
+  if (maxY !== undefined) {
+    scaleDomain[1] = maxY;
+  }
+
+  return scaleDomain;
+}
+
+/**
+ * Returns the next available ID given an array of objects with ID keys
+ */
+export function getNextID(objects: { id: number }[]) {
+  return objects.reduce((prev, curr) => {
+    if (curr.id >= prev) {
+      return curr.id + 1;
+    }
+    return prev;
+  }, 0);
+}

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -197,6 +197,38 @@ export function createVerticalGuide(doyTimestamp: string, verticalGuides: Vertic
 }
 
 /*
+  Returns a new horizontal guide
+*/
+export function createHorizontalGuide(yAxes: Axis[], horizontalGuides: HorizontalGuide[]): HorizontalGuide {
+  // TODO make some getNextID fn util
+  const id = horizontalGuides.reduce((prev, curr) => {
+    if (curr.id >= prev) {
+      return curr.id + 1;
+    }
+    return prev;
+  }, 0);
+  const defaultLabel = `Guide ${id}`;
+
+  const firstAxis = yAxes.length > 0 ? yAxes[0] : 0;
+  let yAxisId = 0;
+  let y = 0;
+  if (firstAxis) {
+    yAxisId = firstAxis.id;
+    if (firstAxis.scaleDomain.length === 2) {
+      // Default y value to the middle of the domain
+      y = (firstAxis.scaleDomain[1] - firstAxis.scaleDomain[0]) / 2;
+    }
+  }
+
+  return {
+    id,
+    label: { text: defaultLabel },
+    y,
+    yAxisId,
+  };
+}
+
+/*
   Returns a new row
 */
 export function createRow(rows: Row[]): Row {

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -178,9 +178,9 @@ export function searchQuadtreeRect<T>(
   return points;
 }
 
-/*
-  Returns a new vertical guide
-*/
+/**
+ * Returns a new vertical guide
+ */
 export function createVerticalGuide(doyTimestamp: string, verticalGuides: VerticalGuide[]): VerticalGuide {
   const id = verticalGuides.reduce((prev, curr) => {
     if (curr.id >= prev) {
@@ -196,9 +196,9 @@ export function createVerticalGuide(doyTimestamp: string, verticalGuides: Vertic
   };
 }
 
-/*
-  Returns a new horizontal guide
-*/
+/**
+ * Returns a new horizontal guide
+ */
 export function createHorizontalGuide(yAxes: Axis[], horizontalGuides: HorizontalGuide[]): HorizontalGuide {
   // TODO make some getNextID fn util
   const id = horizontalGuides.reduce((prev, curr) => {
@@ -228,9 +228,9 @@ export function createHorizontalGuide(yAxes: Axis[], horizontalGuides: Horizonta
   };
 }
 
-/*
-  Returns a new row
-*/
+/**
+ * Returns a new row
+ */
 export function createRow(rows: Row[]): Row {
   const id = rows.reduce((prev, curr) => {
     if (curr.id >= prev) {

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -216,7 +216,7 @@ export function createHorizontalGuide(yAxes: Axis[], horizontalGuides: Horizonta
     yAxisId = firstAxis.id;
     if (firstAxis.scaleDomain.length === 2) {
       // Default y value to the middle of the domain
-      y = (firstAxis.scaleDomain[1] - firstAxis.scaleDomain[0]) / 2;
+      y = (firstAxis.scaleDomain[1] + firstAxis.scaleDomain[0]) / 2;
     }
   }
 

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -182,13 +182,9 @@ export function searchQuadtreeRect<T>(
  * Returns a new vertical guide
  */
 export function createVerticalGuide(doyTimestamp: string, verticalGuides: VerticalGuide[]): VerticalGuide {
-  const id = verticalGuides.reduce((prev, curr) => {
-    if (curr.id >= prev) {
-      return curr.id + 1;
-    }
-    return prev;
-  }, 0);
+  const id = getNextID(verticalGuides);
   const defaultLabel = `Guide ${id}`;
+
   return {
     id,
     label: { color: '#969696', text: defaultLabel },
@@ -200,15 +196,10 @@ export function createVerticalGuide(doyTimestamp: string, verticalGuides: Vertic
  * Returns a new horizontal guide
  */
 export function createHorizontalGuide(yAxes: Axis[], horizontalGuides: HorizontalGuide[]): HorizontalGuide {
-  // TODO make some getNextID fn util
-  const id = horizontalGuides.reduce((prev, curr) => {
-    if (curr.id >= prev) {
-      return curr.id + 1;
-    }
-    return prev;
-  }, 0);
+  const id = getNextID(horizontalGuides);
   const defaultLabel = `Guide ${id}`;
 
+  // Default the y value to the middle of the scale domain
   const firstAxis = yAxes.length > 0 ? yAxes[0] : 0;
   let yAxisId = 0;
   let y = 0;
@@ -232,12 +223,8 @@ export function createHorizontalGuide(yAxes: Axis[], horizontalGuides: Horizonta
  * Returns a new row
  */
 export function createRow(rows: Row[]): Row {
-  const id = rows.reduce((prev, curr) => {
-    if (curr.id >= prev) {
-      return curr.id + 1;
-    }
-    return prev;
-  }, 0);
+  const id = getNextID(rows);
+
   return {
     autoAdjustHeight: true,
     expanded: true,
@@ -255,6 +242,7 @@ export function createRow(rows: Row[]): Row {
  */
 export function createYAxis(yAxes: Axis[]): Axis {
   const id = getNextID(yAxes);
+
   return {
     color: '',
     id,

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -256,6 +256,21 @@ export function createYAxis(yAxes: Axis[]): Axis {
 }
 
 /**
+ * Returns a new layer
+ */
+export function createTimelineLayer(layers: Layer[], yAxes: Axis[]): Layer {
+  const id = getNextID(layers);
+  const yAxisId = yAxes.length > 0 ? yAxes[0].id : 0;
+
+  return {
+    chartType: 'activity',
+    filter: {},
+    id,
+    yAxisId,
+  };
+}
+
+/**
  * Returns the max bounds of the resources associated with an axis
  */
 export function getYAxisBounds(
@@ -270,16 +285,18 @@ export function getYAxisBounds(
   let minY = undefined;
   let maxY = undefined;
   yAxisLayers.forEach(layer => {
-    resourcesByViewLayerId[layer.id].forEach(resource => {
-      resource.values.forEach(value => {
-        if (minY === undefined || value.y < minY) {
-          minY = value.y;
-        }
-        if (maxY === undefined || value.y > maxY) {
-          maxY = value.y;
-        }
+    if (resourcesByViewLayerId[layer.id]) {
+      resourcesByViewLayerId[layer.id].forEach(resource => {
+        resource.values.forEach(value => {
+          if (minY === undefined || value.y < minY) {
+            minY = value.y;
+          }
+          if (maxY === undefined || value.y > maxY) {
+            maxY = value.y;
+          }
+        });
       });
-    });
+    }
   });
 
   const scaleDomain = [...yAxis.scaleDomain];
@@ -296,7 +313,7 @@ export function getYAxisBounds(
 /**
  * Returns the next available ID given an array of objects with ID keys
  */
-export function getNextID(objects: { id: number }[]) {
+export function getNextID(objects: { id: number }[]): number {
   return objects.reduce((prev, curr) => {
     if (curr.id >= prev) {
       return curr.id + 1;

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -191,7 +191,7 @@ export function createVerticalGuide(doyTimestamp: string, verticalGuides: Vertic
   const defaultLabel = `Guide ${id}`;
   return {
     id,
-    label: { text: defaultLabel },
+    label: { color: '#969696', text: defaultLabel },
     timestamp: doyTimestamp,
   };
 }
@@ -222,7 +222,7 @@ export function createHorizontalGuide(yAxes: Axis[], horizontalGuides: Horizonta
 
   return {
     id,
-    label: { text: defaultLabel },
+    label: { color: '#969696', text: defaultLabel },
     y,
     yAxisId,
   };


### PR DESCRIPTION
Closes #247 and https://jira.jpl.nasa.gov/browse/AERIE-1576

Implements timeline row editing.
- Add and remove row, removal shows confirmation modal
- Edit row name, height, and manual vs automatic height specification
- Add and remove horizontal guides
- Edit horizontal guide name, y value, color, and targeted y axis
- Edit color of vertical guides
- Highlight selected row in the timeline
- Add and remove y axes
- Edit y axis name, scale domain, and tick count. Option to auto fit domain to data.
- Edit a row using edit button in top right of the row. Opens timeline details panel on the right side.

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/4419607/207729010-d1192d89-2fb3-4f10-826f-ade5c4f7b990.png">

TODO:
  - [x] Add and remove a y axis
  - [x] Select hz guide y axis using y axis label
  - [x] Remove row with confirmation modal
  - [x] Color picker component