### PR TITLE
Update Hasura from v2.12.0 to v2.12.1

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -182,7 +182,7 @@ services:
       HASURA_GRAPHQL_LOG_LEVEL: info
       HASURA_GRAPHQL_METADATA_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_hasura'
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
-    image: 'hasura/graphql-engine:v2.12.0.cli-migrations-v3'
+    image: 'hasura/graphql-engine:v2.12.1.cli-migrations-v3'
     ports: ['8080:8080']
     restart: always
     volumes:


### PR DESCRIPTION
Updates the Hasura image in `docker-compose-test.yml` from v2.12.0 to v2.12.1 as recommended by [this security advisory](https://github.com/hasura/graphql-engine/security/advisories/GHSA-g7mj-g7f4-hgrg) from Hasura.