### PR TITLE
Account for leap year when validating timestamps

### DIFF
--- a/src/utilities/time.test.ts
+++ b/src/utilities/time.test.ts
@@ -2,6 +2,8 @@ import { expect, test } from 'vitest';
 import {
   convertDurationStringToUs,
   convertUsToDurationString,
+  getDaysInMonth,
+  getDaysInYear,
   getDoy,
   getDoyTime,
   getUnixEpochTime,
@@ -19,6 +21,23 @@ test('convertUsToDurationString', () => {
   expect(convertUsToDurationString(90577779200000)).toEqual('2y 318d 6h 16m 19s 200ms');
   expect(convertUsToDurationString(200000)).toEqual('200ms');
   expect(convertUsToDurationString(3e7)).toEqual('30s');
+});
+
+test('getDaysInMonth', () => {
+  expect(getDaysInMonth(2022, 0)).toEqual(31);
+  expect(getDaysInMonth(2022, 1)).toEqual(28);
+
+  expect(getDaysInMonth(2024, 0)).toEqual(31);
+  expect(getDaysInMonth(2024, 1)).toEqual(29);
+});
+
+test('getDaysInYear', () => {
+  expect(getDaysInYear(2020)).toEqual(366);
+  expect(getDaysInYear(2021)).toEqual(365);
+  expect(getDaysInYear(2022)).toEqual(365);
+  expect(getDaysInYear(2023)).toEqual(365);
+  expect(getDaysInYear(2024)).toEqual(366);
+  expect(getDaysInYear(2025)).toEqual(365);
 });
 
 test('getDoy', () => {

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -118,6 +118,25 @@ export function convertUsToDurationString(durationUs: number, includeZeros: bool
 }
 
 /**
+ * Get the number of days in a given month (0-11) of a specific year.
+ * @example getDaysInMonth(2020, 5) -> 3
+ */
+export function getDaysInMonth(year: number, month: number): number {
+  const lastOfMonth = new Date(Date.UTC(year, month + 1, 0));
+
+  return lastOfMonth.getUTCDate();
+}
+
+export function getDaysInYear(year: number): number {
+  let daysInYear = 0;
+  for (let month: number = 0; month < 12; month++) {
+    daysInYear += getDaysInMonth(year, month);
+  }
+
+  return daysInYear;
+}
+
+/**
  * Get the day-of-year for a given date.
  * @example getDoy(new Date('1/3/2019')) -> 3
  * @see https://stackoverflow.com/a/8619946

--- a/src/utilities/validators.test.ts
+++ b/src/utilities/validators.test.ts
@@ -44,16 +44,25 @@ describe('required', () => {
 
 describe('timestamp', () => {
   const doyError = 'DOY format required: YYYY-DDDThh:mm:ss';
-  const rangeError = 'Day-of-year must be between 0 and 365';
 
   test('Should return an error message if input is not in DOY format', async () => {
     const invalidMsg = await timestamp('2020-001');
     expect(invalidMsg).toEqual(doyError);
   });
 
-  test('Should return an error message if input is out of DOY range', async () => {
+  test('Should return an error message if input is out of DOY range not during leap year', async () => {
+    const invalidMsg = await timestamp('2019-400T00:00:00.000');
+    expect(invalidMsg).toEqual('Day-of-year must be between 0 and 365');
+  });
+
+  test('Should return an error message if input is out of DOY range during leap year', async () => {
     const invalidMsg = await timestamp('2020-400T00:00:00.000');
-    expect(invalidMsg).toEqual(rangeError);
+    expect(invalidMsg).toEqual('Day-of-year must be between 0 and 366');
+  });
+
+  test('Should not return an error message if input day is 366 during a leap year', async () => {
+    const invalidMsg = await timestamp('2024-366T00:00:00.000');
+    expect(invalidMsg).toEqual(null);
   });
 
   test('Should return null if input is a valid DOY string', async () => {

--- a/src/utilities/validators.ts
+++ b/src/utilities/validators.ts
@@ -1,3 +1,5 @@
+import { getDaysInYear } from './time';
+
 export function min(min: number, errorMessage?: string): (value: number) => Promise<ValidationResult> {
   return (value: number): Promise<ValidationResult> =>
     new Promise(resolve => {
@@ -27,12 +29,15 @@ export function timestamp(value: string): Promise<ValidationResult> {
     const error = 'DOY format required: YYYY-DDDThh:mm:ss';
 
     if (match) {
-      const [, , doy] = match;
+      const [, year, doy] = match;
+
+      const daysInYear = getDaysInYear(Number.parseInt(year));
+
       const dayOfYear = parseInt(doy, 10);
-      if (dayOfYear > 0 && dayOfYear < 366) {
+      if (dayOfYear > 0 && dayOfYear <= daysInYear) {
         return resolve(null);
       } else {
-        return resolve('Day-of-year must be between 0 and 365');
+        return resolve(`Day-of-year must be between 0 and ${daysInYear}`);
       }
     } else {
       return resolve(error);


### PR DESCRIPTION
This fixes the timestamp validation logic to account for leap years. This resolves #309.

To test:
1. Open the plan creation page
2. Open a date picker
3. Select a year that's a leap year (2020, 2024, etc.)
4. Select day 366 using the calendar
5. Verify that a validation error is not presented upon DOY 366 selection