### PR TITLE
Show plan association for scheduling goals/conditions

### DIFF
--- a/src/components/scheduling/conditions/SchedulingConditionForm.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditionForm.svelte
@@ -184,7 +184,7 @@
 
       <fieldset>
         <label for="plan">Plan</label>
-        <select bind:value={specId} class="st-select w-100" name="model">
+        <select bind:value={specId} class="st-select w-100" name="plan">
           <option value={null} />
           {#each planOptions as plan}
             <option value={plan.specId}>

--- a/src/components/scheduling/conditions/SchedulingConditionForm.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditionForm.svelte
@@ -21,9 +21,10 @@
   export let initialConditionModelId: number | null = null;
   export let initialConditionModifiedDate: string | null = null;
   export let initialConditionName: string = '';
-  export let initialModels: ModelSlim[] = [];
   export let initialSpecId: number | null = null;
   export let mode: 'create' | 'edit' = 'create';
+  export let models: ModelSlim[] = [];
+  export let plans: PlanSchedulingSpec[] = [];
 
   let conditionAuthor: string | null = initialConditionAuthor;
   let conditionCreatedDate: string | null = initialConditionCreatedDate;
@@ -33,9 +34,9 @@
   let conditionModelId: number | null = initialConditionModelId;
   let conditionModifiedDate: string | null = initialConditionModifiedDate;
   let conditionName: string = initialConditionName;
-  let models: ModelSlim[] = initialModels;
   let saveButtonEnabled: boolean = false;
   let specId: number | null = initialSpecId;
+  let savedSpecId: number | null = initialSpecId;
   let savedCondition: Partial<SchedulingCondition> = {
     definition: conditionDefinition,
     description: conditionDescription,
@@ -43,13 +44,20 @@
     name: conditionName,
   };
 
-  $: saveButtonEnabled = conditionDefinition !== '' && conditionModelId !== null && conditionName !== '';
-  $: conditionModified = diffConditions(savedCondition, {
-    definition: conditionDefinition,
-    description: conditionDescription,
-    model_id: conditionModelId,
-    name: conditionName,
-  });
+  $: planOptions = plans
+    .filter(plan => plan.model_id === conditionModelId)
+    .map(({ id, name, scheduling_specifications }) => ({ id, name, specId: scheduling_specifications[0].id }));
+  $: specId = planOptions.some(plan => plan.specId === specId) ? specId : null; // Null the specId value if the filtered plan list no longer includes the chosen spec
+
+  $: saveButtonEnabled =
+    conditionDefinition !== '' && conditionModelId !== null && conditionName !== '' && specId !== null;
+  $: conditionModified =
+    diffConditions(savedCondition, {
+      definition: conditionDefinition,
+      description: conditionDescription,
+      model_id: conditionModelId,
+      name: conditionName,
+    }) || specId !== savedSpecId;
   $: saveButtonText = mode === 'edit' && !conditionModified ? 'Saved' : 'Save';
   $: saveButtonClass = conditionModified && saveButtonEnabled ? 'primary' : 'secondary';
 
@@ -87,14 +95,12 @@
         if (newCondition !== null) {
           const { id: newConditionId } = newCondition;
 
-          if (specId !== null) {
-            const specConditionInsertInput: SchedulingSpecConditionInsertInput = {
-              condition_id: newConditionId,
-              enabled: true,
-              specification_id: specId,
-            };
-            await effects.createSchedulingSpecCondition(specConditionInsertInput);
-          }
+          const specConditionInsertInput: SchedulingSpecConditionInsertInput = {
+            condition_id: newConditionId,
+            enabled: true,
+            specification_id: specId,
+          };
+          await effects.createSchedulingSpecCondition(specConditionInsertInput);
 
           goto(`${base}/scheduling/conditions/edit/${newConditionId}`);
         }
@@ -107,6 +113,11 @@
         };
         const updatedCondition = await effects.updateSchedulingCondition(conditionId, condition);
         if (updatedCondition) {
+          if (specId !== savedSpecId) {
+            await effects.updateSchedulingSpecConditionId(conditionId, savedSpecId, specId);
+            savedSpecId = specId;
+          }
+
           conditionModifiedDate = updatedCondition.modified_date;
           savedCondition = { ...condition };
         }
@@ -126,7 +137,11 @@
         <button class="st-button secondary ellipsis" on:click={() => goto(`${base}/scheduling/conditions`)}>
           {mode === 'create' ? 'Cancel' : 'Close'}
         </button>
-        <button class="st-button {saveButtonClass} ellipsis" disabled={!saveButtonEnabled} on:click={saveCondition}>
+        <button
+          class="st-button {saveButtonClass} ellipsis"
+          disabled={!saveButtonEnabled}
+          on:click|stopPropagation={saveCondition}
+        >
           {saveButtonText}
         </button>
       </div>
@@ -162,6 +177,18 @@
           {#each models as model}
             <option value={model.id}>
               {model.name} ({model.id})
+            </option>
+          {/each}
+        </select>
+      </fieldset>
+
+      <fieldset>
+        <label for="plan">Plan</label>
+        <select bind:value={specId} class="st-select w-100" name="model">
+          <option value={null} />
+          {#each planOptions as plan}
+            <option value={plan.specId}>
+              {plan.name} ({plan.id})
             </option>
           {/each}
         </select>

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte
@@ -44,7 +44,11 @@
     name: goalName,
   };
 
-  $: saveButtonEnabled = goalDefinition !== '' && goalModelId !== null && goalName !== '';
+  $: planOptions = plans
+    .filter(plan => plan.model_id === goalModelId)
+    .map(({ id, name, scheduling_specifications }) => ({ id, name, specId: scheduling_specifications[0].id }));
+  $: specId = planOptions.some(plan => plan.specId === specId) ? specId : null; // Null the specId value if the filtered plan list no longer includes the chosen spec
+  $: saveButtonEnabled = goalDefinition !== '' && goalModelId !== null && goalName !== '' && specId !== null;
   $: goalModified = diffGoals(savedGoal, {
     definition: goalDefinition,
     description: goalDescription,
@@ -167,6 +171,18 @@
           {#each models as model}
             <option value={model.id}>
               {model.name} ({model.id})
+            </option>
+          {/each}
+        </select>
+      </fieldset>
+
+      <fieldset>
+        <label for="plan">Plan</label>
+        <select bind:value={specId} class="st-select w-100" name="model">
+          <option value={null} />
+          {#each planOptions as plan}
+            <option value={plan.specId}>
+              {plan.name} ({plan.id})
             </option>
           {/each}
         </select>

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte
@@ -7,6 +7,7 @@
   import { schedulingGoalsColumns } from '../../../stores/scheduling';
   import effects from '../../../utilities/effects';
   import { isMacOs } from '../../../utilities/generic';
+  import { showConfirmModal } from '../../../utilities/modal';
   import PageTitle from '../../app/PageTitle.svelte';
   import Chip from '../../ui/Chip.svelte';
   import CssGrid from '../../ui/CssGrid.svelte';
@@ -106,6 +107,19 @@
           goto(`${base}/scheduling/goals/edit/${newGoalId}`);
         }
       } else if (mode === 'edit') {
+        if (specId !== savedSpecId) {
+          const { confirm } = await showConfirmModal(
+            'Confirm',
+            'Updating the plan will reset the priority of this scheduling goal.',
+            'Updating Plan',
+            true,
+          );
+
+          if (!confirm) {
+            return;
+          }
+        }
+
         const goal: Partial<SchedulingGoal> = {
           definition: goalDefinition,
           description: goalDescription,
@@ -145,7 +159,11 @@
         <button class="st-button secondary ellipsis" on:click={() => goto(`${base}/scheduling/goals`)}>
           {mode === 'create' ? 'Cancel' : 'Close'}
         </button>
-        <button class="st-button {saveButtonClass} ellipsis" disabled={!saveButtonEnabled} on:click={saveGoal}>
+        <button
+          class="st-button {saveButtonClass} ellipsis"
+          disabled={!saveButtonEnabled}
+          on:click|stopPropagation={saveGoal}
+        >
           {saveButtonText}
         </button>
       </div>

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte
@@ -22,9 +22,10 @@
   export let initialGoalModelId: number | null = null;
   export let initialGoalModifiedDate: string | null = null;
   export let initialGoalName: string = '';
-  export let initialModels: ModelSlim[] = [];
   export let initialSpecId: number | null = null;
   export let mode: 'create' | 'edit' = 'create';
+  export let plans: PlanSchedulingSpec[] = [];
+  export let models: ModelSlim[] = [];
 
   let goalAuthor: string | null = initialGoalAuthor;
   let goalCreatedDate: string | null = initialGoalCreatedDate;
@@ -34,7 +35,6 @@
   let goalModelId: number | null = initialGoalModelId;
   let goalModifiedDate: string | null = initialGoalModifiedDate;
   let goalName: string = initialGoalName;
-  let models: ModelSlim[] = initialModels;
   let saveButtonEnabled: boolean = false;
   let specId: number | null = initialSpecId;
   let savedGoal: Partial<SchedulingGoal> = {

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte
@@ -206,7 +206,7 @@
 
       <fieldset>
         <label for="plan">Plan</label>
-        <select bind:value={specId} class="st-select w-100" name="model">
+        <select bind:value={specId} class="st-select w-100" name="plan">
           <option value={null} />
           {#each planOptions as plan}
             <option value={plan.specId}>

--- a/src/routes/scheduling/conditions/edit/[id]/+page.svelte
+++ b/src/routes/scheduling/conditions/edit/[id]/+page.svelte
@@ -19,6 +19,8 @@
   initialConditionName={data.initialCondition.name}
   initialConditionModelId={data.initialCondition.model_id}
   initialConditionModifiedDate={data.initialCondition.modified_date}
-  initialModels={data.initialModels}
+  initialSpecId={data.initialSpecId}
+  models={data.models}
+  plans={data.plans}
   mode="edit"
 />

--- a/src/routes/scheduling/conditions/edit/[id]/+page.ts
+++ b/src/routes/scheduling/conditions/edit/[id]/+page.ts
@@ -12,16 +12,19 @@ export const load: PageLoad = async ({ parent, params }) => {
   }
 
   const { id: conditionIdParam } = params;
+  const { models = [], plans = [] } = await effects.getPlansAndModelsForScheduling();
 
   if (conditionIdParam !== null && conditionIdParam !== undefined) {
     const conditionId = parseFloatOrNull(conditionIdParam);
     const initialCondition = await effects.getSchedulingCondition(conditionId);
-    const initialModels = await effects.getModels();
+    const schedulingSpecConditions = await effects.getSchedulingSpecConditionsForCondition(conditionId);
 
     if (initialCondition !== null) {
       return {
         initialCondition,
-        initialModels,
+        initialSpecId: schedulingSpecConditions[0]?.specification_id,
+        models,
+        plans,
       };
     }
   }

--- a/src/routes/scheduling/conditions/new/+page.svelte
+++ b/src/routes/scheduling/conditions/new/+page.svelte
@@ -12,7 +12,8 @@
 
 <SchedulingConditionForm
   initialConditionModelId={data.initialModelId}
-  initialModels={data.initialModels}
   initialSpecId={data.initialSpecId}
+  models={data.models}
+  plans={data.plans}
   mode="create"
 />

--- a/src/routes/scheduling/conditions/new/+page.ts
+++ b/src/routes/scheduling/conditions/new/+page.ts
@@ -11,15 +11,17 @@ export const load: PageLoad = async ({ parent, url }) => {
     throw redirect(302, `${base}/login`);
   }
 
+  const { models = [], plans = [] } = await effects.getPlansAndModelsForScheduling();
+
   const modelId: string | null = url.searchParams.get('modelId');
   const specId: string | null = url.searchParams.get('specId');
   const initialModelId: number | null = parseFloatOrNull(modelId);
   const initialSpecId: number | null = parseFloatOrNull(specId);
-  const initialModels = await effects.getModels();
 
   return {
     initialModelId,
-    initialModels,
     initialSpecId,
+    models,
+    plans,
   };
 };

--- a/src/routes/scheduling/goals/edit/[id]/+page.svelte
+++ b/src/routes/scheduling/goals/edit/[id]/+page.svelte
@@ -19,6 +19,7 @@
   initialGoalName={data.initialGoal.name}
   initialGoalModelId={data.initialGoal.model_id}
   initialGoalModifiedDate={data.initialGoal.modified_date}
-  initialModels={data.initialModels}
+  models={data.models}
+  plans={data.plans}
   mode="edit"
 />

--- a/src/routes/scheduling/goals/edit/[id]/+page.svelte
+++ b/src/routes/scheduling/goals/edit/[id]/+page.svelte
@@ -19,6 +19,7 @@
   initialGoalName={data.initialGoal.name}
   initialGoalModelId={data.initialGoal.model_id}
   initialGoalModifiedDate={data.initialGoal.modified_date}
+  initialSpecId={data.initialSpecId}
   models={data.models}
   plans={data.plans}
   mode="edit"

--- a/src/routes/scheduling/goals/edit/[id]/+page.ts
+++ b/src/routes/scheduling/goals/edit/[id]/+page.ts
@@ -12,16 +12,17 @@ export const load: PageLoad = async ({ parent, params }) => {
   }
 
   const { id: goalIdParam } = params;
+  const { models = [], plans = [] } = await effects.getPlansAndModelsForScheduling();
 
   if (goalIdParam !== null && goalIdParam !== undefined) {
     const goalId = parseFloatOrNull(goalIdParam);
     const initialGoal = await effects.getSchedulingGoal(goalId);
-    const initialModels = await effects.getModels();
 
     if (initialGoal !== null) {
       return {
         initialGoal,
-        initialModels,
+        models,
+        plans,
       };
     }
   }

--- a/src/routes/scheduling/goals/edit/[id]/+page.ts
+++ b/src/routes/scheduling/goals/edit/[id]/+page.ts
@@ -17,10 +17,12 @@ export const load: PageLoad = async ({ parent, params }) => {
   if (goalIdParam !== null && goalIdParam !== undefined) {
     const goalId = parseFloatOrNull(goalIdParam);
     const initialGoal = await effects.getSchedulingGoal(goalId);
+    const schedulingSpecGoals = await effects.getSchedulingSpecGoalsForGoal(goalId);
 
     if (initialGoal !== null) {
       return {
         initialGoal,
+        initialSpecId: schedulingSpecGoals[0]?.specification_id,
         models,
         plans,
       };

--- a/src/routes/scheduling/goals/new/+page.svelte
+++ b/src/routes/scheduling/goals/new/+page.svelte
@@ -12,7 +12,8 @@
 
 <SchedulingGoalForm
   initialGoalModelId={data.initialModelId}
-  initialModels={data.initialModels}
   initialSpecId={data.initialSpecId}
   mode="create"
+  models={data.models}
+  plans={data.plans}
 />

--- a/src/routes/scheduling/goals/new/+page.ts
+++ b/src/routes/scheduling/goals/new/+page.ts
@@ -11,15 +11,17 @@ export const load: PageLoad = async ({ parent, url }) => {
     throw redirect(302, `${base}/login`);
   }
 
+  const { models = [], plans = [] } = await effects.getPlansAndModelsForScheduling();
+
   const modelId: string | null = url.searchParams.get('modelId');
   const specId: string | null = url.searchParams.get('specId');
   const initialModelId: number | null = parseFloatOrNull(modelId);
   const initialSpecId: number | null = parseFloatOrNull(specId);
-  const initialModels = await effects.getModels();
 
   return {
     initialModelId,
-    initialModels,
     initialSpecId,
+    models,
+    plans,
   };
 };

--- a/src/types/plan.d.ts
+++ b/src/types/plan.d.ts
@@ -68,3 +68,5 @@ type PlanSchema = {
 };
 
 type PlanSlim = Pick<Plan, 'end_time_doy' | 'id' | 'model_id' | 'name' | 'revision' | 'start_time' | 'start_time_doy'>;
+
+type PlanSchedulingSpec = Pick<Plan, 'id' | 'name' | 'scheduling_specifications' | 'model_id'>;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -774,6 +774,17 @@ const effects = {
     }
   },
 
+  async deleteSchedulingSpecGoal(goal_id: number, specification_id: number): Promise<boolean> {
+    try {
+      await reqHasura(gql.DELETE_SCHEDULING_SPEC_GOAL, { goal_id, specification_id });
+      return true;
+    } catch (e) {
+      catchError('Scheduling Goal Spec Delete Failed', e);
+      showFailureToast('Scheduling Goal Delete Failed');
+      return false;
+    }
+  },
+
   async deleteUserSequence(id: number): Promise<boolean> {
     try {
       const { confirm } = await showConfirmModal(
@@ -1112,6 +1123,21 @@ const effects = {
         const data = await reqHasura<SchedulingGoal>(gql.GET_SCHEDULING_GOAL, { id });
         const { goal } = data;
         return goal;
+      } catch (e) {
+        catchError(e);
+        return null;
+      }
+    } else {
+      return null;
+    }
+  },
+
+  async getSchedulingSpecGoalsForGoal(goal_id: number | null): Promise<SchedulingSpecGoal[] | null> {
+    if (goal_id !== null) {
+      try {
+        const data = await reqHasura<SchedulingSpecGoal[]>(gql.GET_SCHEDULING_SPEC_GOALS_FOR_GOAL, { goal_id });
+        const { scheduling_specification_goals } = data;
+        return scheduling_specification_goals;
       } catch (e) {
         catchError(e);
         return null;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -774,6 +774,17 @@ const effects = {
     }
   },
 
+  async deleteSchedulingSpecCondition(condition_id: number, specification_id: number): Promise<boolean> {
+    try {
+      await reqHasura(gql.DELETE_SCHEDULING_SPEC_CONDITION, { condition_id, specification_id });
+      return true;
+    } catch (e) {
+      catchError('Scheduling Condition Spec Delete Failed', e);
+      showFailureToast('Scheduling Condition Delete Failed');
+      return false;
+    }
+  },
+
   async deleteSchedulingSpecGoal(goal_id: number, specification_id: number): Promise<boolean> {
     try {
       await reqHasura(gql.DELETE_SCHEDULING_SPEC_GOAL, { goal_id, specification_id });
@@ -1123,6 +1134,25 @@ const effects = {
         const data = await reqHasura<SchedulingGoal>(gql.GET_SCHEDULING_GOAL, { id });
         const { goal } = data;
         return goal;
+      } catch (e) {
+        catchError(e);
+        return null;
+      }
+    } else {
+      return null;
+    }
+  },
+
+  async getSchedulingSpecConditionsForCondition(
+    condition_id: number | null,
+  ): Promise<SchedulingSpecCondition[] | null> {
+    if (condition_id !== null) {
+      try {
+        const data = await reqHasura<SchedulingSpecCondition[]>(gql.GET_SCHEDULING_SPEC_CONDITIONS_FOR_CONDITION, {
+          condition_id,
+        });
+        const { scheduling_specification_conditions } = data;
+        return scheduling_specification_conditions;
       } catch (e) {
         catchError(e);
         return null;
@@ -1657,6 +1687,24 @@ const effects = {
   ): Promise<void> {
     try {
       await reqHasura(gql.UPDATE_SCHEDULING_SPEC_CONDITION, { condition_id, spec_condition, specification_id });
+      showSuccessToast('Scheduling Spec Condition Updated Successfully');
+    } catch (e) {
+      catchError('Scheduling Spec Condition Update Failed', e);
+      showFailureToast('Scheduling Spec Condition Update Failed');
+    }
+  },
+
+  async updateSchedulingSpecConditionId(
+    condition_id: number,
+    specification_id: number,
+    new_specification_id: number,
+  ): Promise<void> {
+    try {
+      await reqHasura(gql.UPDATE_SCHEDULING_SPEC_CONDITION_ID, {
+        condition_id,
+        new_specification_id,
+        specification_id,
+      });
       showSuccessToast('Scheduling Spec Condition Updated Successfully');
     } catch (e) {
       catchError('Scheduling Spec Condition Update Failed', e);

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -1073,6 +1073,24 @@ const effects = {
     }
   },
 
+  async getPlansAndModelsForScheduling(): Promise<{
+    models: ModelSlim[];
+    plans: PlanSchedulingSpec[];
+  }> {
+    try {
+      const data = (await reqHasura(gql.GET_PLANS_AND_MODELS_FOR_SCHEDULING)) as {
+        models: ModelSlim[];
+        plans: PlanSchedulingSpec[];
+      };
+
+      const { models, plans } = data;
+      return { models, plans };
+    } catch (e) {
+      catchError(e);
+      return { models: [], plans: [] };
+    }
+  },
+
   async getSchedulingCondition(id: number | null | undefined): Promise<SchedulingCondition | null> {
     if (id !== null && id !== undefined) {
       try {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -774,17 +774,6 @@ const effects = {
     }
   },
 
-  async deleteSchedulingSpecCondition(condition_id: number, specification_id: number): Promise<boolean> {
-    try {
-      await reqHasura(gql.DELETE_SCHEDULING_SPEC_CONDITION, { condition_id, specification_id });
-      return true;
-    } catch (e) {
-      catchError('Scheduling Condition Spec Delete Failed', e);
-      showFailureToast('Scheduling Condition Delete Failed');
-      return false;
-    }
-  },
-
   async deleteSchedulingSpecGoal(goal_id: number, specification_id: number): Promise<boolean> {
     try {
       await reqHasura(gql.DELETE_SCHEDULING_SPEC_GOAL, { goal_id, specification_id });

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -525,6 +525,25 @@ const gql = {
     }
   `,
 
+  GET_PLANS_AND_MODELS_FOR_SCHEDULING: `#graphql
+    query GetPlansAndSchedulingSpecifications {
+      models: mission_model(order_by: { id: desc }) {
+        id
+        jar_id
+        name
+        version
+      }
+      plans: plan(order_by: { id: desc }) {
+        scheduling_specifications {
+          id
+        }
+        model_id
+        name
+        id
+      }
+    }
+  `,
+
   GET_PLAN_MERGE_NON_CONFLICTING_ACTIVITIES: `#graphql
     query GetPlanMergeNonConflictingActivities($merge_request_id: Int!) {
       nonConflictingActivities: get_non_conflicting_activities(args: { merge_request_id: $merge_request_id } ) {

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -601,6 +601,16 @@ const gql = {
     }
   `,
 
+  GET_SCHEDULING_SPEC_CONDITIONS_FOR_CONDITION: `#graphql
+    query GetSchedulingSpecConditionsForCondition($condition_id: Int!) {
+      scheduling_specification_conditions(where: { condition_id: { _eq: $condition_id } }) {
+        enabled
+        condition_id
+        specification_id
+      }
+    }
+  `,
+
   GET_SCHEDULING_SPEC_GOALS_FOR_GOAL: `#graphql
     query GetSchedulingSpecGoalsForGoal($goal_id: Int!) {
       scheduling_specification_goals(where: { goal_id: { _eq: $goal_id } }) {
@@ -1351,6 +1361,22 @@ const gql = {
       updateSchedulingSpecCondition: update_scheduling_specification_conditions_by_pk(
         pk_columns: { condition_id: $condition_id, specification_id: $specification_id },
         _set: $spec_condition
+      ) {
+        condition_id
+        specification_id
+      }
+    }
+  `,
+
+  UPDATE_SCHEDULING_SPEC_CONDITION_ID: `#graphql
+    mutation UpdateSchedulingSpecConditionId(
+      $condition_id: Int!,
+      $specification_id: Int!,
+      $new_specification_id: Int!,
+    ) {
+      updateSchedulingSpecConditionId: update_scheduling_specification_conditions_by_pk(
+        pk_columns: { condition_id: $condition_id, specification_id: $specification_id },
+        _set: { specification_id: $new_specification_id },
       ) {
         condition_id
         specification_id

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -301,6 +301,15 @@ const gql = {
     }
   `,
 
+  DELETE_SCHEDULING_SPEC_GOAL: `#graphql
+    mutation DeleteSchedulingSpecGoal($goal_id: Int!, $specification_id: Int!) {
+      deleteSchedulingSpecGoal: delete_scheduling_specification_goals_by_pk(goal_id: $goal_id, specification_id: $specification_id) {
+        goal_id,
+        specification_id,
+      }
+    }
+  `,
+
   DELETE_USER_SEQUENCE: `#graphql
     mutation DeleteUserSequence($id: Int!) {
       deleteUserSequence: delete_user_sequence_by_pk(id: $id) {
@@ -588,6 +597,17 @@ const gql = {
         modified_date
         name
         revision
+      }
+    }
+  `,
+
+  GET_SCHEDULING_SPEC_GOALS_FOR_GOAL: `#graphql
+    query GetSchedulingSpecGoalsForGoal($goal_id: Int!) {
+      scheduling_specification_goals(where: { goal_id: { _eq: $goal_id } }) {
+        enabled
+        goal_id
+        priority
+        specification_id
       }
     }
   `,


### PR DESCRIPTION
Resolves #249

This adds UI to display the associated plan, and requires selecting a plan, when creating or editing a scheduling goal or global scheduling condition. This also allows changing the plan/scheduling_spec when editing. For scheduling goals, in order to ensure that the scheduling spec priorities are kept in order, we delete and re-insert a new record to allow the insert triggers to set priority. We warn the users in this case that changing the plan would reset the priority of the given scheduling spec.