### PR TITLE
Add table resize options to context menus

### DIFF
--- a/src/components/activity/ActivityTablePanel.svelte
+++ b/src/components/activity/ActivityTablePanel.svelte
@@ -218,12 +218,12 @@
       <div class="size-actions">
         <button
           class="st-button secondary"
-          use:tooltip={{ content: 'Auto Size Columns to Fit Content', placement: 'top' }}
+          use:tooltip={{ content: 'Fit Columns to Content', placement: 'top' }}
           on:click={onAutoSizeContent}><CollapseIcon /></button
         >
         <button
           class="st-button secondary"
-          use:tooltip={{ content: 'Auto Size Columns to Fit Space', placement: 'top' }}
+          use:tooltip={{ content: 'Fit Columns to Available Space', placement: 'top' }}
           on:click={onAutoSizeSpace}><ExpandIcon /></button
         >
       </div>

--- a/src/components/expansion/ExpansionSetForm.svelte
+++ b/src/components/expansion/ExpansionSetForm.svelte
@@ -3,19 +3,16 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import CollapseIcon from '@nasa-jpl/stellar/icons/collapse.svg?component';
-  import ExpandIcon from '@nasa-jpl/stellar/icons/expand.svg?component';
   import type { ValueGetterParams } from 'ag-grid-community';
   import { expansionSetsColumns, savingExpansionSet } from '../../stores/expansion';
   import { models } from '../../stores/plan';
   import { commandDictionaries } from '../../stores/sequencing';
   import effects from '../../utilities/effects';
   import ContextMenu from '../context-menu/ContextMenu.svelte';
-  import ContextMenuHeader from '../context-menu/ContextMenuHeader.svelte';
-  import ContextMenuItem from '../context-menu/ContextMenuItem.svelte';
   import Chip from '../ui/Chip.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
+  import ColumnResizeContextMenu from '../ui/DataGrid/column-menu/ColumnResizeContextMenu.svelte';
   import DataGrid from '../ui/DataGrid/DataGrid.svelte';
   import Panel from '../ui/Panel.svelte';
   import ExpansionLogicEditor from './ExpansionLogicEditor.svelte';
@@ -192,13 +189,7 @@
             on:cellContextMenu={onCellContextMenu}
           />
           <ContextMenu bind:this={contextMenu}>
-            <ContextMenuHeader>Table Actions</ContextMenuHeader>
-            <ContextMenuItem on:click={onAutoSizeContent}>
-              <div class="table-action"><CollapseIcon />Fit Columns to Content</div>
-            </ContextMenuItem>
-            <ContextMenuItem on:click={onAutoSizeSpace}>
-              <div class="table-action"><ExpandIcon />Fit Columns to Available Space</div>
-            </ContextMenuItem>
+            <ColumnResizeContextMenu on:autoSizeContent={onAutoSizeContent} on:autoSizeSpace={onAutoSizeSpace} />
           </ContextMenu>
         {/if}
       </fieldset>
@@ -228,12 +219,5 @@
 
   .expansion-rules-table :global(.ag-theme-stellar .ag-row.ag-selectable-row input) {
     cursor: pointer;
-  }
-
-  .table-action {
-    align-items: center;
-    column-gap: 4px;
-    display: grid;
-    grid-template-columns: min-content auto;
   }
 </style>

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -1,8 +1,6 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import CollapseIcon from '@nasa-jpl/stellar/icons/collapse.svg?component';
-  import ExpandIcon from '@nasa-jpl/stellar/icons/expand.svg?component';
   import type { ColDef, ColumnState, RowNode } from 'ag-grid-community';
   import { keyBy } from 'lodash-es';
   import { createEventDispatcher } from 'svelte';
@@ -10,6 +8,7 @@
   import ContextMenuHeader from '../../context-menu/ContextMenuHeader.svelte';
   import ContextMenuItem from '../../context-menu/ContextMenuItem.svelte';
   import DataGrid from '../../ui/DataGrid/DataGrid.svelte';
+  import ColumnResizeContextMenu from './column-menu/ColumnResizeContextMenu.svelte';
 
   export let columnDefs: ColDef[];
   export let columnStates: ColumnState[] = [];
@@ -122,25 +121,6 @@
         {selectedItemIds.length > 1 ? pluralItemDisplayText : singleItemDisplayText}
       </ContextMenuItem>
     {/if}
-    <ContextMenuHeader>Table Actions</ContextMenuHeader>
-    <ContextMenuItem on:click={onAutoSizeContent}>
-      <div class="table-action"><CollapseIcon />Fit Columns to Content</div>
-    </ContextMenuItem>
-    <ContextMenuItem on:click={onAutoSizeSpace}>
-      <div class="table-action"><ExpandIcon />Fit Columns to Available Space</div>
-    </ContextMenuItem>
+    <ColumnResizeContextMenu on:autoSizeContent={onAutoSizeContent} on:autoSizeSpace={onAutoSizeSpace} />
   </ContextMenu>
 {/if}
-
-<style>
-  :global(.context-menu .context-menu-header:not(:first-child)) {
-    padding-top: 8px;
-  }
-
-  .table-action {
-    align-items: center;
-    column-gap: 4px;
-    display: grid;
-    grid-template-columns: min-content auto;
-  }
-</style>

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -1,6 +1,8 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import CollapseIcon from '@nasa-jpl/stellar/icons/collapse.svg?component';
+  import ExpandIcon from '@nasa-jpl/stellar/icons/expand.svg?component';
   import type { ColDef, ColumnState, RowNode } from 'ag-grid-community';
   import { keyBy } from 'lodash-es';
   import { createEventDispatcher } from 'svelte';
@@ -49,6 +51,14 @@
     if (selectedRows.length) {
       dispatch('bulkDeleteItems', selectedRows);
     }
+  }
+
+  function onAutoSizeContent() {
+    dataGrid?.autoSizeAllColumns();
+  }
+
+  function onAutoSizeSpace() {
+    dataGrid?.sizeColumnsToFit();
   }
 
   function onCellContextMenu(event: CustomEvent) {
@@ -112,5 +122,25 @@
         {selectedItemIds.length > 1 ? pluralItemDisplayText : singleItemDisplayText}
       </ContextMenuItem>
     {/if}
+    <ContextMenuHeader>Table Actions</ContextMenuHeader>
+    <ContextMenuItem on:click={onAutoSizeContent}>
+      <div class="table-action"><CollapseIcon />Fit Columns to Content</div>
+    </ContextMenuItem>
+    <ContextMenuItem on:click={onAutoSizeSpace}>
+      <div class="table-action"><ExpandIcon />Fit Columns to Available Space</div>
+    </ContextMenuItem>
   </ContextMenu>
 {/if}
+
+<style>
+  :global(.context-menu .context-menu-header:not(:first-child)) {
+    padding-top: 8px;
+  }
+
+  .table-action {
+    align-items: center;
+    column-gap: 4px;
+    display: grid;
+    grid-template-columns: min-content auto;
+  }
+</style>

--- a/src/components/ui/DataGrid/SingleActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/SingleActionDataGrid.svelte
@@ -1,6 +1,8 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import CollapseIcon from '@nasa-jpl/stellar/icons/collapse.svg?component';
+  import ExpandIcon from '@nasa-jpl/stellar/icons/expand.svg?component';
   import type { ColDef, ColumnState, RowNode } from 'ag-grid-community';
   import { createEventDispatcher } from 'svelte';
   import ContextMenu from '../../context-menu/ContextMenu.svelte';
@@ -10,6 +12,7 @@
 
   export let columnDefs: ColDef[];
   export let columnStates: ColumnState[] = [];
+  export let dataGrid: DataGrid = undefined;
   export let idKey: keyof TRowData = 'id';
   export let hasEdit: boolean = false;
   export let items: TRowData[];
@@ -40,6 +43,14 @@
     dispatch('deleteItem', selectedItemIds);
   }
 
+  function onAutoSizeContent() {
+    dataGrid?.autoSizeAllColumns();
+  }
+
+  function onAutoSizeSpace() {
+    dataGrid?.sizeColumnsToFit();
+  }
+
   function onCellContextMenu(event: CustomEvent) {
     const { detail } = event;
     const { data: clickedRow } = detail;
@@ -53,6 +64,7 @@
 </script>
 
 <DataGrid
+  bind:this={dataGrid}
   {columnDefs}
   {columnStates}
   bind:currentSelectedRowId={selectedItemId}
@@ -84,4 +96,24 @@
   <ContextMenuItem on:click={deleteItem}>
     Delete {itemDisplayText}
   </ContextMenuItem>
+  <ContextMenuHeader>Table Actions</ContextMenuHeader>
+  <ContextMenuItem on:click={onAutoSizeContent}>
+    <div class="table-action"><CollapseIcon />Fit Columns to Content</div>
+  </ContextMenuItem>
+  <ContextMenuItem on:click={onAutoSizeSpace}>
+    <div class="table-action"><ExpandIcon />Fit Columns to Available Space</div>
+  </ContextMenuItem>
 </ContextMenu>
+
+<style>
+  :global(.context-menu .context-menu-header:not(:first-child)) {
+    padding-top: 8px;
+  }
+
+  .table-action {
+    align-items: center;
+    column-gap: 4px;
+    display: grid;
+    grid-template-columns: min-content auto;
+  }
+</style>

--- a/src/components/ui/DataGrid/SingleActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/SingleActionDataGrid.svelte
@@ -1,14 +1,13 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import CollapseIcon from '@nasa-jpl/stellar/icons/collapse.svg?component';
-  import ExpandIcon from '@nasa-jpl/stellar/icons/expand.svg?component';
   import type { ColDef, ColumnState, RowNode } from 'ag-grid-community';
   import { createEventDispatcher } from 'svelte';
   import ContextMenu from '../../context-menu/ContextMenu.svelte';
   import ContextMenuHeader from '../../context-menu/ContextMenuHeader.svelte';
   import ContextMenuItem from '../../context-menu/ContextMenuItem.svelte';
   import DataGrid from '../../ui/DataGrid/DataGrid.svelte';
+  import ColumnResizeContextMenu from './column-menu/ColumnResizeContextMenu.svelte';
 
   export let columnDefs: ColDef[];
   export let columnStates: ColumnState[] = [];
@@ -96,24 +95,5 @@
   <ContextMenuItem on:click={deleteItem}>
     Delete {itemDisplayText}
   </ContextMenuItem>
-  <ContextMenuHeader>Table Actions</ContextMenuHeader>
-  <ContextMenuItem on:click={onAutoSizeContent}>
-    <div class="table-action"><CollapseIcon />Fit Columns to Content</div>
-  </ContextMenuItem>
-  <ContextMenuItem on:click={onAutoSizeSpace}>
-    <div class="table-action"><ExpandIcon />Fit Columns to Available Space</div>
-  </ContextMenuItem>
+  <ColumnResizeContextMenu on:autoSizeContent={onAutoSizeContent} on:autoSizeSpace={onAutoSizeSpace} />
 </ContextMenu>
-
-<style>
-  :global(.context-menu .context-menu-header:not(:first-child)) {
-    padding-top: 8px;
-  }
-
-  .table-action {
-    align-items: center;
-    column-gap: 4px;
-    display: grid;
-    grid-template-columns: min-content auto;
-  }
-</style>

--- a/src/components/ui/DataGrid/column-menu/ColumnResizeContextMenu.svelte
+++ b/src/components/ui/DataGrid/column-menu/ColumnResizeContextMenu.svelte
@@ -1,0 +1,40 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import CollapseIcon from '@nasa-jpl/stellar/icons/collapse.svg?component';
+  import ExpandIcon from '@nasa-jpl/stellar/icons/expand.svg?component';
+  import { createEventDispatcher } from 'svelte';
+  import ContextMenuHeader from '../../../context-menu/ContextMenuHeader.svelte';
+  import ContextMenuItem from '../../../context-menu/ContextMenuItem.svelte';
+
+  const dispatch = createEventDispatcher();
+
+  function onAutoSizeContent() {
+    dispatch('autoSizeContent');
+  }
+
+  function onAutoSizeSpace() {
+    dispatch('autoSizeSpace');
+  }
+</script>
+
+<ContextMenuHeader>Table Actions</ContextMenuHeader>
+<ContextMenuItem on:click={onAutoSizeContent}>
+  <div class="table-action"><CollapseIcon />Fit Columns to Content</div>
+</ContextMenuItem>
+<ContextMenuItem on:click={onAutoSizeSpace}>
+  <div class="table-action"><ExpandIcon />Fit Columns to Available Space</div>
+</ContextMenuItem>
+
+<style>
+  :global(.context-menu .context-menu-header:not(:first-child)) {
+    padding-top: 8px;
+  }
+
+  .table-action {
+    align-items: center;
+    column-gap: 4px;
+    display: grid;
+    grid-template-columns: min-content auto;
+  }
+</style>


### PR DESCRIPTION
This resolves #311 by adding to the existing tables context menu options that allow for automatically resizing the columns to fit the available space or the content of the columns.

To test:
1. View any table (except a table with only 2 columns like the "Expansion Rules" table under "Sets"
2. Right click on any cell
3. Verify that the new menu items affect the table column sizes