### PR TITLE
Support conditional rendering of tooltips

### DIFF
--- a/src/components/timeline/TimelineLockControl.svelte
+++ b/src/components/timeline/TimelineLockControl.svelte
@@ -10,6 +10,7 @@
   const dispatch = createEventDispatcher();
   const lockTooltipContent = 'Click to unlock timeline, or press and hold the Shift key to temporarily unlock';
 
+  $: tooltipDisabled = timelineLockStatus !== TimelineLockStatus.Locked;
   $: lockClassName = timelineLockStatus === TimelineLockStatus.TemporaryUnlock ? 'temporary-unlock' : '';
 
   onMount(() => {
@@ -45,15 +46,17 @@
   }
 </script>
 
-{#if timelineLockStatus === TimelineLockStatus.Locked}
-  <button class="st-button icon" on:click={onClick} use:tooltip={{ content: lockTooltipContent, placement: 'bottom' }}>
+<button
+  class={`st-button icon ${lockClassName}`}
+  on:click={onClick}
+  use:tooltip={{ content: lockTooltipContent, disabled: tooltipDisabled, placement: 'bottom' }}
+>
+  {#if timelineLockStatus === TimelineLockStatus.Locked}
     <LockIcon />
-  </button>
-{:else}
-  <button class={`st-button icon ${lockClassName}`} on:click={onClick}>
+  {:else}
     <UnlockIcon />
-  </button>
-{/if}
+  {/if}
+</button>
 
 <style>
   .st-button {

--- a/src/utilities/tooltip.ts
+++ b/src/utilities/tooltip.ts
@@ -1,3 +1,4 @@
+import type { Plugin, Props } from 'tippy.js';
 import tippy from 'tippy.js';
 
 /**
@@ -44,7 +45,7 @@ export function tooltip(node: Element, params: any = {}): any {
   };
 }
 
-const disabled = {
+const disabled: Plugin<Props & { disabled: boolean }> = {
   defaultValue: false,
   fn(instance) {
     return {

--- a/src/utilities/tooltip.ts
+++ b/src/utilities/tooltip.ts
@@ -29,13 +29,29 @@ export function tooltip(node: Element, params: any = {}): any {
 
   // Support any of the Tippy props by forwarding all "params":
   // https://atomiks.github.io/tippyjs/v6/all-props/
-  const tip: any = tippy(node, { content, ...params });
+  const tip: any = tippy(node, {
+    content,
+    ...params,
+  });
+
+  // Initially disable tooltip if no content provided or explicitly disabled
+  if (!content || params.disabled) {
+    tip.disable();
+  }
 
   return {
     // Clean up the Tippy instance on unmount.
     destroy: () => tip.destroy(),
 
     // If the props change, let's update the Tippy instance.
-    update: (newParams: any) => tip.setProps({ content, ...newParams }),
+    update: (newParams: any) => {
+      // Enable/disable tooltip based on updating with empty content or disabled param
+      if ((typeof newParams.content !== 'undefined' && !newParams.content) || newParams.disabled) {
+        tip.disable();
+      } else {
+        tip.enable();
+      }
+      tip.setProps({ content, ...newParams });
+    },
   };
 }

--- a/src/utilities/tooltip.ts
+++ b/src/utilities/tooltip.ts
@@ -31,27 +31,36 @@ export function tooltip(node: Element, params: any = {}): any {
   // https://atomiks.github.io/tippyjs/v6/all-props/
   const tip: any = tippy(node, {
     content,
+    plugins: [disabled],
     ...params,
   });
-
-  // Initially disable tooltip if no content provided or explicitly disabled
-  if (!content || params.disabled) {
-    tip.disable();
-  }
 
   return {
     // Clean up the Tippy instance on unmount.
     destroy: () => tip.destroy(),
 
     // If the props change, let's update the Tippy instance.
-    update: (newParams: any) => {
-      // Enable/disable tooltip based on updating with empty content or disabled param
-      if ((typeof newParams.content !== 'undefined' && !newParams.content) || newParams.disabled) {
-        tip.disable();
-      } else {
-        tip.enable();
-      }
-      tip.setProps({ content, ...newParams });
-    },
+    update: (newParams: any) => tip.setProps({ content, ...newParams }),
   };
 }
+
+const disabled = {
+  defaultValue: false,
+  fn(instance) {
+    return {
+      onBeforeUpdate(instance, partialProps) {
+        if (partialProps.disabled || !partialProps.content) {
+          instance.disable();
+        } else {
+          instance.enable();
+        }
+      },
+      onCreate() {
+        if (instance.props.disabled || !instance.props.content) {
+          instance.disable();
+        }
+      },
+    };
+  },
+  name: 'disabled',
+};


### PR DESCRIPTION
Resolves #234

This adds this ability to disable rendering a tooltip by either providing empty content or passing a `disabled: true` property. I also updated the timeline lock button component to use this functionality as an example.