### PR TITLE
Prevent duplicate toast messages from filling screen

### DIFF
--- a/src/utilities/toast.test.ts
+++ b/src/utilities/toast.test.ts
@@ -1,6 +1,5 @@
 import { screen } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
-
 import { showFailureToast, showSuccessToast } from './toast';
 
 interface ElementLikeObject {

--- a/src/utilities/toast.test.ts
+++ b/src/utilities/toast.test.ts
@@ -1,0 +1,57 @@
+import { screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+
+import { showFailureToast, showSuccessToast } from './toast';
+
+interface ElementLikeObject {
+  textContent: string;
+}
+
+interface ToastifyOptions {
+  callback: (toastElement: ElementLikeObject) => void;
+  text: string;
+}
+
+vi.mock('toastify-js', () => {
+  const Toastify = vi.fn().mockImplementation((options: ToastifyOptions) => {
+    if (options.callback) {
+      setTimeout(() => options.callback({ textContent: options.text }), 1000);
+    }
+
+    const toastDiv = document.createElement('div');
+    toastDiv.className = 'toast';
+    toastDiv.textContent = options.text;
+
+    return {
+      hideToast: () => {
+        if (options.callback) {
+          options.callback({ textContent: options.text });
+        }
+
+        document.body.removeChild(toastDiv);
+      },
+      options: { text: options.text },
+      showToast: () => {
+        document.body.appendChild(toastDiv);
+      },
+    };
+  });
+
+  return { default: Toastify };
+});
+
+describe('Toastify utility', () => {
+  it('Should properly show a failure toast without showing duplicates', () => {
+    showFailureToast('Failed!');
+    showFailureToast('Failed!');
+    const failedToasts = screen.getAllByText('Failed!');
+
+    expect(failedToasts.length).toEqual(1);
+
+    showSuccessToast('Success!');
+    showSuccessToast('Success!');
+    const successToasts = screen.getAllByText('Success!');
+
+    expect(successToasts.length).toEqual(1);
+  });
+});

--- a/src/utilities/toast.ts
+++ b/src/utilities/toast.ts
@@ -1,25 +1,65 @@
 import Toastify from 'toastify-js';
 
+interface Toast {
+  hideToast: () => void;
+  readonly options: Toastify.Options;
+  showToast: () => void;
+  readonly toastElement: Element | null;
+}
+
+let currentToasts: Toast[] = [];
+
+function findToast(toastText: string) {
+  return currentToasts.findIndex(toast => toast.options.text === toastText);
+}
+
+function removeToast(toastText: string) {
+  const toastIndex = findToast(toastText);
+
+  if (toastIndex > -1) {
+    currentToasts[toastIndex].hideToast();
+    currentToasts = [...currentToasts.slice(0, toastIndex), ...currentToasts.slice(toastIndex + 1)];
+  }
+}
+
+function toastCallback(this: Element) {
+  removeToast(this.textContent);
+}
+
+function showToast(toast: Toast) {
+  const toastText = toast.options.text;
+  const existingToastIndex = findToast(toastText);
+
+  if (existingToastIndex > -1) {
+    currentToasts[existingToastIndex].hideToast();
+  }
+
+  toast.showToast();
+  currentToasts.push(toast);
+}
+
 export function showFailureToast(text: string): void {
   const toast = Toastify({
     backgroundColor: '#a32a2a',
+    callback: toastCallback,
     className: 'st-typography-body',
     duration: 3000,
     gravity: 'bottom',
     position: 'left',
     text,
   });
-  toast.showToast();
+  showToast(toast);
 }
 
 export function showSuccessToast(text: string): void {
   const toast = Toastify({
     backgroundColor: '#2da44e',
+    callback: toastCallback,
     className: 'st-typography-body',
     duration: 3000,
     gravity: 'bottom',
     position: 'left',
     text,
   });
-  toast.showToast();
+  showToast(toast);
 }


### PR DESCRIPTION
resolves #291

To test:
1. Quickly add a bunch of activities to a plan
2. Verify that the same toast message doesn't build up too much (if any)
3. Add an activity and try to quickly delete it from the table
4. Verify that two relevant separate toast messages are still displayed