### PR TITLE
Add buttons to clear console errors

### DIFF
--- a/src/components/console/ConsoleSection.svelte
+++ b/src/components/console/ConsoleSection.svelte
@@ -1,16 +1,31 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import RemoveAllIcon from '@nasa-jpl/stellar/icons/remove_all.svg?component';
+  import { createEventDispatcher } from 'svelte';
   import type { BaseError } from '../../types/errors';
   import TabPanel from '../ui/Tabs/TabPanel.svelte';
 
   export let errors: BaseError[] = [];
   export let title: string;
+  export let isClearable: boolean = true;
+
+  const dispatch = createEventDispatcher();
+
+  function onClear() {
+    dispatch('clearMessages');
+  }
 </script>
 
 <TabPanel>
   <div class="console-section">
-    <div class="console-header">{title}</div>
+    <div class="console-header">
+      <div>{title}</div>
+      {#if isClearable}
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <div class="clear-console" on:click={onClear}><RemoveAllIcon /></div>
+      {/if}
+    </div>
     <div class="errors">
       {#each errors as error}
         <div class="error">
@@ -37,11 +52,23 @@
 
   .console-header {
     color: var(--st-gray-60);
+    display: grid;
     font-size: 11px;
     font-weight: 700;
+    grid-template-columns: auto min-content;
+    justify-content: space-between;
     line-height: 1rem;
     margin: 0.65rem 1rem;
     text-transform: uppercase;
+  }
+
+  .clear-console {
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .clear-console:hover {
+    color: var(--st-black);
   }
 
   .errors {

--- a/src/components/console/ConsoleSection.svelte
+++ b/src/components/console/ConsoleSection.svelte
@@ -4,6 +4,7 @@
   import RemoveAllIcon from '@nasa-jpl/stellar/icons/remove_all.svg?component';
   import { createEventDispatcher } from 'svelte';
   import type { BaseError } from '../../types/errors';
+  import { tooltip } from '../../utilities/tooltip';
   import TabPanel from '../ui/Tabs/TabPanel.svelte';
 
   export let errors: BaseError[] = [];
@@ -23,7 +24,9 @@
       <div>{title}</div>
       {#if isClearable}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
-        <div class="clear-console" on:click={onClear}><RemoveAllIcon /></div>
+        <div class="clear-console" on:click={onClear} use:tooltip={{ content: `Clear ${title}`, placement: 'left' }}>
+          <RemoveAllIcon />
+        </div>
       {/if}
     </div>
     <div class="errors">

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -35,7 +35,13 @@
   import ViewsPanel from '../../../components/view/ViewsPanel.svelte';
   import { activitiesMap, activityDirectives, resetActivityStores } from '../../../stores/activities';
   import { resetConstraintStores } from '../../../stores/constraints';
-  import { allErrors, schedulingErrors, simulationDatasetErrors } from '../../../stores/errors';
+  import {
+    allErrors,
+    clearAllErrors,
+    clearSchedulingErrors,
+    schedulingErrors,
+    simulationDatasetErrors,
+  } from '../../../stores/errors';
   import {
     activityTypes,
     maxTimeRange,
@@ -128,6 +134,14 @@
     viewUpdateLayout(gridId, { rowSizes: newSizes });
   }
 
+  function onClearAllErrors() {
+    clearAllErrors();
+  }
+
+  function onClearSchedulingErrors() {
+    clearSchedulingErrors();
+  }
+
   function onKeydown(event: KeyboardEvent): void {
     const { key, ctrlKey, metaKey } = event;
     if ((isMacOs() ? metaKey : ctrlKey) && key === 's') {
@@ -209,9 +223,9 @@
       </div>
     </svelte:fragment>
 
-    <ConsoleSection errors={$allErrors} title="All Errors" />
-    <ConsoleSection errors={$schedulingErrors} title="Scheduling Errors" />
-    <ConsoleSection errors={$simulationDatasetErrors} title="Simulation Errors" />
+    <ConsoleSection errors={$allErrors} title="All Errors" on:clearMessages={onClearAllErrors} />
+    <ConsoleSection errors={$schedulingErrors} title="Scheduling Errors" on:clearMessages={onClearSchedulingErrors} />
+    <ConsoleSection errors={$simulationDatasetErrors} isClearable={false} title="Simulation Errors" />
   </Console>
 </CssGrid>
 

--- a/src/stores/errors.ts
+++ b/src/stores/errors.ts
@@ -31,7 +31,8 @@ export const allErrors: Readable<BaseError[]> = derived(
   [simulationDatasetErrors, schedulingErrors, caughtErrors],
   ([$simulationDatasetErrors, $schedulingErrors, $caughtErrors]) =>
     [...($simulationDatasetErrors ?? []), ...($schedulingErrors ?? []), ...($caughtErrors ?? [])].sort(
-      (errorA: BaseError, errorB: BaseError) => compare(errorA.timestamp, errorB.timestamp, false),
+      (errorA: BaseError, errorB: BaseError) =>
+        compare(`${new Date(errorA.timestamp)}`, `${new Date(errorB.timestamp)}`, false),
     ),
 );
 
@@ -45,12 +46,22 @@ export function catchError(error: string | Error, details?: string | Error, shou
       ...(details ? { trace: `${details}` } : {}),
       type: ErrorTypes.CAUGHT_ERROR,
     });
-    return errors;
+    return [...errors];
   });
 
   if (shouldLog) {
     console.log(details ?? error);
   }
+}
+
+export function catchSchedulingError(error: SchedulingError) {
+  schedulingErrors.update(errors => {
+    errors.push({
+      ...error,
+      message: parseErrorReason(error.message),
+    });
+    return [...errors];
+  });
 }
 
 export function clearSchedulingErrors(): void {

--- a/src/stores/errors.ts
+++ b/src/stores/errors.ts
@@ -52,3 +52,12 @@ export function catchError(error: string | Error, details?: string | Error, shou
     console.log(details ?? error);
   }
 }
+
+export function clearSchedulingErrors(): void {
+  schedulingErrors.set([]);
+}
+
+export function clearAllErrors(): void {
+  clearSchedulingErrors();
+  caughtErrors.set([]);
+}

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -3,7 +3,7 @@ import { base } from '$app/paths';
 import { get } from 'svelte/store';
 import { activitiesMap, selectedActivityId } from '../stores/activities';
 import { checkConstraintsStatus, constraintViolationsMap } from '../stores/constraints';
-import { catchError, parseErrorReason, schedulingErrors } from '../stores/errors';
+import { catchError, catchSchedulingError } from '../stores/errors';
 import {
   createDictionaryError,
   creatingDictionary,
@@ -1548,8 +1548,6 @@ const effects = {
       let incomplete = true;
       schedulingStatus.set(Status.Incomplete);
 
-      schedulingErrors.set([]);
-
       do {
         const data = await reqHasura<SchedulingResponse>(gql.SCHEDULE, { specificationId });
         const { schedule } = data;
@@ -1561,12 +1559,7 @@ const effects = {
           showSuccessToast(`Scheduling ${analysis_only ? 'Analysis ' : ''}Complete`);
         } else if (status === 'failed') {
           schedulingStatus.set(Status.Failed);
-          schedulingErrors.set([
-            {
-              ...reason,
-              message: parseErrorReason(reason.message),
-            },
-          ]);
+          catchSchedulingError(reason);
           incomplete = false;
 
           showFailureToast(`Scheduling ${analysis_only ? 'Analysis ' : ''}Failed`);


### PR DESCRIPTION
resolves #287 

This will only clear errors that are caught in the UI. Errors that are derived from data in the DB are currently not clearable.

To test:
1. Create a plan with a `BakeBananaBread`
2. Run scheduling
3. Verify that errors are displayed in the Console component
4. View the `Scheduling` console tab
5. Click the `Clear Scheduling Errors` icon on the right side of the console
6. Verify that the displayed scheduling errors are cleared
7. View the `All Errors` console tab
8. Verify that scheduling errors are also gone here
9. Verify that "Scheduling Failed" errors are still present
10. Click on the `Clear All Errors` icon
11. Verify that the "Scheduling Failed" error have also been removed.