### PR TITLE
Delete activity with keyboard `Delete`

### DIFF
--- a/src/components/activity/ActivityTable.svelte
+++ b/src/components/activity/ActivityTable.svelte
@@ -57,13 +57,23 @@
     width: 25,
   };
 
-  function deleteActivityDirective({ id, plan_id }: Activity) {
-    effects.deleteActivityDirective(plan_id, id);
+  let isDeletingDirective: boolean = false;
+
+  async function deleteActivityDirective({ id, plan_id }: Activity) {
+    if (!isDeletingDirective) {
+      isDeletingDirective = true;
+      await effects.deleteActivityDirective(plan_id, id);
+      isDeletingDirective = false;
+    }
   }
 
-  function deleteActivityDirectives({ detail: activities }: CustomEvent<Activity[]>) {
-    const ids = activities.map(({ id }) => id);
-    effects.deleteActivityDirectives(planId, ids);
+  async function deleteActivityDirectives({ detail: activities }: CustomEvent<Activity[]>) {
+    if (!isDeletingDirective) {
+      isDeletingDirective = true;
+      const ids = activities.map(({ id }) => id);
+      await effects.deleteActivityDirectives(planId, ids);
+      isDeletingDirective = false;
+    }
   }
 
   function getRowId(activity: Activity): ActivityUniqueId {

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -12,6 +12,7 @@
   import type { ActivityLayerFilter, ActivityPoint, BoundingBox, QuadtreeRect, TimeRange } from '../../types/timeline';
   import { decomposeActivityDirectiveId, sortActivities } from '../../utilities/activities';
   import effects from '../../utilities/effects';
+  import { isDeleteEvent } from '../../utilities/keyboardEvents';
   import { getDoyTime, getDurationInMs, getUnixEpochTime } from '../../utilities/time';
   import { searchQuadtreeRect, TimelineLockStatus } from '../../utilities/timeline';
 
@@ -214,9 +215,7 @@
   }
 
   function onKeyDown(event: KeyboardEvent): void {
-    const { key } = event;
-
-    if (key === 'Delete' && !!selectedActivityId) {
+    if (isDeleteEvent(event) && !!selectedActivityId) {
       dispatch('delete', selectedActivityId);
     }
   }

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -1,10 +1,11 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { browser } from '$app/environment';
   import { quadtree as d3Quadtree, type Quadtree } from 'd3-quadtree';
   import type { ScaleTime } from 'd3-scale';
   import { select } from 'd3-selection';
-  import { createEventDispatcher, onMount, tick } from 'svelte';
+  import { createEventDispatcher, onDestroy, onMount, tick } from 'svelte';
   import { activitiesMap } from '../../stores/activities';
   import { timelineLockStatus } from '../../stores/views';
   import type { Activity, ActivityUniqueId } from '../../types/activity';
@@ -20,6 +21,7 @@
   export let activityRowPadding: number = 20;
   export let activitySelectedColor: string = '#81D4FA';
   export let activityUnfinishedColor: string = '#ff7760';
+  export let blur: FocusEvent | undefined;
   export let dragenter: DragEvent | undefined;
   export let dragleave: DragEvent | undefined;
   export let dragover: DragEvent | undefined;
@@ -28,6 +30,7 @@
   export let drawWidth: number = 0;
   export let filter: ActivityLayerFilter | undefined;
   export let id: number;
+  export let focus: FocusEvent | undefined;
   export let mousedown: MouseEvent | undefined;
   export let mousemove: MouseEvent | undefined;
   export let mouseout: MouseEvent | undefined;
@@ -49,10 +52,12 @@
   let quadtree: Quadtree<QuadtreeRect>;
   let visiblePointsByUniqueId: Record<ActivityUniqueId, ActivityPoint> = {};
 
+  $: onBlur(blur);
   $: onDragenter(dragenter);
   $: onDragleave(dragleave);
   $: onDragover(dragover);
   $: onDrop(drop);
+  $: onFocus(focus);
   $: onMousedown(mousedown);
   $: onMousemove(mousemove);
   $: onMouseout(mouseout);
@@ -86,6 +91,8 @@
       dpr = window.devicePixelRatio;
     }
   });
+
+  onDestroy(() => removeKeyDownEvent());
 
   /**
    * Recursively converts an Activity to an ActivityPoint.
@@ -194,6 +201,26 @@
     }
   }
 
+  function removeKeyDownEvent() {
+    if (browser) {
+      document.removeEventListener('keydown', onKeyDown);
+    }
+  }
+
+  function onBlur(e: FocusEvent | undefined) {
+    if (e) {
+      removeKeyDownEvent();
+    }
+  }
+
+  function onKeyDown(event: KeyboardEvent): void {
+    const { key } = event;
+
+    if (key === 'Delete' && !!selectedActivityId) {
+      dispatch('delete', selectedActivityId);
+    }
+  }
+
   function onDragenter(e: DragEvent | undefined): void {
     if (e) {
       const { offsetX } = e;
@@ -230,6 +257,12 @@
       const start_time = getDoyTime(new Date(unixEpochTime));
       const activityTypeName = e.dataTransfer.getData('activityTypeName');
       effects.createActivityDirective({}, start_time, activityTypeName, activityTypeName, [], {});
+    }
+  }
+
+  function onFocus(e: FocusEvent | undefined) {
+    if (e) {
+      document.addEventListener('keydown', onKeyDown);
     }
   }
 

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -53,10 +53,12 @@
 
   const dispatch = createEventDispatcher();
 
+  let blur: FocusEvent;
   let dragenter: DragEvent;
   let dragleave: DragEvent;
   let dragover: DragEvent;
   let drop: DragEvent;
+  let focus: FocusEvent;
   let heightsByLayer: Record<number, number> = {};
   let mousedown: MouseEvent;
   let mousemove: MouseEvent;
@@ -137,11 +139,12 @@
       bind:this={overlaySvg}
       class="overlay"
       style="transform: translate({marginLeft}px, 0px); width: {drawWidth}px"
-      on:blur={e => e}
+      on:blur={e => (blur = e)}
       on:dragenter|preventDefault={e => (dragenter = e)}
       on:dragleave={e => (dragleave = e)}
       on:dragover|preventDefault={e => (dragover = e)}
       on:drop|preventDefault={e => (drop = e)}
+      on:focus={e => (focus = e)}
       on:mousedown={e => (mousedown = e)}
       on:mousemove={e => (mousemove = e)}
       on:mouseout={e => (mouseout = e)}
@@ -176,6 +179,7 @@
           <LayerActivity
             {...layer}
             activities={activitiesByView?.byLayerId[layer.id] ?? []}
+            {blur}
             {drawHeight}
             {drawWidth}
             {dragenter}
@@ -183,6 +187,7 @@
             {dragover}
             {drop}
             filter={layer.filter.activity}
+            {focus}
             {mousedown}
             {mousemove}
             {mouseout}
@@ -191,6 +196,7 @@
             {selectedActivityId}
             {viewTimeRange}
             {xScaleView}
+            on:delete
             on:mouseDown={onMouseDown}
             on:mouseOver={onMouseOver}
             on:updateRowHeight={onUpdateRowHeightLayer}

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -265,6 +265,7 @@
         {xScaleView}
         {xTicksView}
         yAxes={row.yAxes}
+        on:delete
         on:mouseDown={onMouseDown}
         on:mouseDownRowMove={onMouseDownRowMove}
         on:mouseOver={e => (mouseOver = e.detail)}

--- a/src/components/timeline/TimelinePanel.svelte
+++ b/src/components/timeline/TimelinePanel.svelte
@@ -17,10 +17,16 @@
   export let gridId: number;
   export let timelineId: number;
 
+  let isDeletingDirective: boolean = false;
+
   $: timeline = $view?.definition.plan.timelines.find(timeline => timeline.id === timelineId);
 
-  function deleteActivityDirective() {
-    effects.deleteActivityDirective($planId, $selectedActivity.id);
+  async function deleteActivityDirective() {
+    if (!isDeletingDirective) {
+      isDeletingDirective = true;
+      await effects.deleteActivityDirective($planId, $selectedActivity.id);
+      isDeletingDirective = false;
+    }
   }
 </script>
 

--- a/src/components/timeline/TimelinePanel.svelte
+++ b/src/components/timeline/TimelinePanel.svelte
@@ -1,11 +1,12 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import { activitiesByView, selectedActivityId } from '../../stores/activities';
+  import { activitiesByView, selectedActivity, selectedActivityId } from '../../stores/activities';
   import { constraintViolations } from '../../stores/constraints';
-  import { maxTimeRange, viewTimeRange } from '../../stores/plan';
+  import { maxTimeRange, planId, viewTimeRange } from '../../stores/plan';
   import { resourcesByViewLayerId } from '../../stores/simulation';
   import { timelineLockStatus, view, viewUpdateRow, viewUpdateTimeline } from '../../stores/views';
+  import effects from '../../utilities/effects';
   import GridMenu from '../menus/GridMenu.svelte';
   import Panel from '../ui/Panel.svelte';
   import PanelHeaderActions from '../ui/PanelHeaderActions.svelte';
@@ -17,6 +18,10 @@
   export let timelineId: number;
 
   $: timeline = $view?.definition.plan.timelines.find(timeline => timeline.id === timelineId);
+
+  function deleteActivityDirective() {
+    effects.deleteActivityDirective($planId, $selectedActivity.id);
+  }
 </script>
 
 <Panel padBody={false}>
@@ -57,6 +62,7 @@
       resourcesByViewLayerId={$resourcesByViewLayerId}
       selectedActivityId={$selectedActivityId}
       viewTimeRange={$viewTimeRange}
+      on:delete={deleteActivityDirective}
       on:mouseDown={({ detail: newSelectedActivityId }) => {
         $selectedActivityId = newSelectedActivityId;
       }}

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -99,7 +99,7 @@
     dataGrid.selectAllVisible();
   }
 
-  onDestroy(() => onBlur);
+  onDestroy(() => onBlur());
 </script>
 
 <DataGrid

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -102,6 +102,7 @@
 
   function selectAllItems() {
     dataGrid.selectAllVisible();
+    dataGrid.focusDataGrid();
   }
 </script>
 

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -21,8 +21,8 @@
   export let selectedItemId: RowId | null = null;
   export let showContextMenu: boolean = true;
   export let singleItemDisplayText: string = '';
-  export let suppressRowClickSelection: boolean = false;
   export let suppressDragLeaveHidesColumns: boolean = true;
+  export let suppressRowClickSelection: boolean = false;
 
   export let getRowId: (data: TRowData) => RowId = (data: TRowData): RowId => parseInt(data[idKey]);
   export let isRowSelectable: (node: RowNode<TRowData>) => boolean = undefined;
@@ -108,18 +108,18 @@
 
 <DataGrid
   bind:this={dataGrid}
+  bind:currentSelectedRowId={selectedItemId}
+  bind:selectedRowIds={selectedItemIds}
   {columnDefs}
   {columnStates}
-  bind:currentSelectedRowId={selectedItemId}
   {getRowId}
   {idKey}
   {isRowSelectable}
-  rowSelection="multiple"
-  rowData={items}
-  bind:selectedRowIds={selectedItemIds}
   preventDefaultOnContextMenu={showContextMenu}
-  {suppressRowClickSelection}
+  rowData={items}
+  rowSelection="multiple"
   {suppressDragLeaveHidesColumns}
+  {suppressRowClickSelection}
   on:blur={onBlur}
   on:cellContextMenu={onCellContextMenu}
   on:cellMouseOver

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import type { ColDef, ColumnState, RowNode } from 'ag-grid-community';
   import { keyBy } from 'lodash-es';
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, onDestroy } from 'svelte';
   import type { RowId, TRowData } from '../../../types/data-grid';
   import ContextMenu from '../../context-menu/ContextMenu.svelte';
   import ContextMenuHeader from '../../context-menu/ContextMenuHeader.svelte';
@@ -61,6 +61,10 @@
     dataGrid?.sizeColumnsToFit();
   }
 
+  function onBlur() {
+    document.removeEventListener('keydown', onKeyDown);
+  }
+
   function onCellContextMenu(event: CustomEvent) {
     if (showContextMenu) {
       const { detail } = event;
@@ -79,9 +83,23 @@
     isFiltered = Object.keys(filterModel).length > 0;
   }
 
+  function onFocus() {
+    document.addEventListener('keydown', onKeyDown);
+  }
+
+  function onKeyDown(event: KeyboardEvent) {
+    const { key } = event;
+
+    if (key === 'Delete') {
+      bulkDeleteItems();
+    }
+  }
+
   function selectAllItems() {
     dataGrid.selectAllVisible();
   }
+
+  onDestroy(() => onBlur);
 </script>
 
 <DataGrid
@@ -98,13 +116,15 @@
   preventDefaultOnContextMenu={showContextMenu}
   {suppressRowClickSelection}
   {suppressDragLeaveHidesColumns}
-  on:filterChanged={onFilterChanged}
+  on:blur={onBlur}
   on:cellContextMenu={onCellContextMenu}
   on:cellMouseOver
   on:columnMoved
   on:columnPinned
   on:columnResized
   on:columnStateChange
+  on:filterChanged={onFilterChanged}
+  on:focus={onFocus}
   on:rowClicked
   on:rowDoubleClicked
   on:rowSelected

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { browser } from '$app/environment';
   import type { ColDef, ColumnState, RowNode } from 'ag-grid-community';
   import { keyBy } from 'lodash-es';
   import { createEventDispatcher, onDestroy } from 'svelte';
@@ -38,6 +39,8 @@
     selectedItemIds = [];
   }
 
+  onDestroy(() => onBlur());
+
   function bulkDeleteItems() {
     const selectedItemIdsMap = keyBy(selectedItemIds);
     const selectedRows: TRowData[] = items.reduce((selectedRows: TRowData[], row: TRowData) => {
@@ -62,7 +65,9 @@
   }
 
   function onBlur() {
-    document.removeEventListener('keydown', onKeyDown);
+    if (browser) {
+      document.removeEventListener('keydown', onKeyDown);
+    }
   }
 
   function onCellContextMenu(event: CustomEvent) {
@@ -98,8 +103,6 @@
   function selectAllItems() {
     dataGrid.selectAllVisible();
   }
-
-  onDestroy(() => onBlur());
 </script>
 
 <DataGrid

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -6,6 +6,7 @@
   import { keyBy } from 'lodash-es';
   import { createEventDispatcher, onDestroy } from 'svelte';
   import type { RowId, TRowData } from '../../../types/data-grid';
+  import { isDeleteEvent } from '../../../utilities/keyboardEvents';
   import ContextMenu from '../../context-menu/ContextMenu.svelte';
   import ContextMenuHeader from '../../context-menu/ContextMenuHeader.svelte';
   import ContextMenuItem from '../../context-menu/ContextMenuItem.svelte';
@@ -93,9 +94,7 @@
   }
 
   function onKeyDown(event: KeyboardEvent) {
-    const { key } = event;
-
-    if (key === 'Delete') {
+    if (isDeleteEvent(event)) {
       bulkDeleteItems();
     }
   }

--- a/src/components/ui/DataGrid/DataGrid.svelte
+++ b/src/components/ui/DataGrid/DataGrid.svelte
@@ -262,7 +262,7 @@
   });
 </script>
 
-<div bind:this={gridDiv} class="ag-theme-stellar table" class:highlightOnSelection />
+<div bind:this={gridDiv} class="ag-theme-stellar table" class:highlightOnSelection tabindex="-1" on:focus on:blur />
 
 <style>
   .table {

--- a/src/components/ui/DataGrid/DataGrid.svelte
+++ b/src/components/ui/DataGrid/DataGrid.svelte
@@ -33,6 +33,9 @@
   export function autoSizeAllColumns(skipHeader?: boolean) {
     gridOptions?.columnApi?.autoSizeAllColumns(skipHeader);
   }
+  export function focusDataGrid() {
+    gridDiv.focus();
+  }
   // expose ag-grid function to select all visible rows
   export function selectAllVisible() {
     gridOptions?.api?.selectAllFiltered();

--- a/src/components/ui/DataGrid/SingleActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/SingleActionDataGrid.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { browser } from '$app/environment';
   import type { ColDef, ColumnState, RowNode } from 'ag-grid-community';
   import { createEventDispatcher, onDestroy } from 'svelte';
   import type { TRowData } from '../../../types/data-grid';
@@ -35,6 +36,8 @@
     selectedItemIds = [];
   }
 
+  onDestroy(() => onBlur());
+
   function editItem() {
     dispatch('editItem', selectedItemIds);
   }
@@ -52,7 +55,9 @@
   }
 
   function onBlur() {
-    document.removeEventListener('keydown', onKeyDown);
+    if (browser) {
+      document.removeEventListener('keydown', onKeyDown);
+    }
   }
 
   function onCellContextMenu(event: CustomEvent) {
@@ -77,8 +82,6 @@
       deleteItem();
     }
   }
-
-  onDestroy(() => onBlur());
 </script>
 
 <DataGrid

--- a/src/components/ui/DataGrid/SingleActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/SingleActionDataGrid.svelte
@@ -5,6 +5,7 @@
   import type { ColDef, ColumnState, RowNode } from 'ag-grid-community';
   import { createEventDispatcher, onDestroy } from 'svelte';
   import type { TRowData } from '../../../types/data-grid';
+  import { isDeleteEvent } from '../../../utilities/keyboardEvents';
   import ContextMenu from '../../context-menu/ContextMenu.svelte';
   import ContextMenuHeader from '../../context-menu/ContextMenuHeader.svelte';
   import ContextMenuItem from '../../context-menu/ContextMenuItem.svelte';
@@ -76,9 +77,7 @@
   }
 
   function onKeyDown(event: KeyboardEvent) {
-    const { key } = event;
-
-    if (key === 'Delete') {
+    if (isDeleteEvent(event)) {
       deleteItem();
     }
   }

--- a/src/components/ui/DataGrid/SingleActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/SingleActionDataGrid.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import type { CellKeyPressEvent, ColDef, ColumnState, RowNode } from 'ag-grid-community';
+  import type { ColDef, ColumnState, RowNode } from 'ag-grid-community';
   import { createEventDispatcher, onDestroy } from 'svelte';
   import type { TRowData } from '../../../types/data-grid';
   import ContextMenu from '../../context-menu/ContextMenu.svelte';
@@ -70,18 +70,15 @@
     document.addEventListener('keydown', onKeyDown);
   }
 
-  function onKeyDown(event: CustomEvent<CellKeyPressEvent<TRowData>>) {
-    const {
-      detail: { event: keyboardEvent },
-    } = event;
-    const { key } = keyboardEvent as KeyboardEvent;
+  function onKeyDown(event: KeyboardEvent) {
+    const { key } = event;
 
     if (key === 'Delete') {
       deleteItem();
     }
   }
 
-  onDestroy(() => onBlur);
+  onDestroy(() => onBlur());
 </script>
 
 <DataGrid

--- a/src/components/ui/DataGrid/SingleActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/SingleActionDataGrid.svelte
@@ -14,11 +14,11 @@
   export let columnDefs: ColDef[];
   export let columnStates: ColumnState[] = [];
   export let dataGrid: DataGrid = undefined;
-  export let idKey: keyof TRowData = 'id';
   export let hasEdit: boolean = false;
+  export let idKey: keyof TRowData = 'id';
   export let items: TRowData[];
-  export let selectedItemId: number | null = null;
   export let itemDisplayText: string;
+  export let selectedItemId: number | null = null;
 
   export let getRowId: (data: TRowData) => number = (data: TRowData): number => {
     return parseInt(data[idKey]);
@@ -86,15 +86,15 @@
 
 <DataGrid
   bind:this={dataGrid}
+  bind:currentSelectedRowId={selectedItemId}
+  bind:selectedRowIds={selectedItemIds}
   {columnDefs}
   {columnStates}
-  bind:currentSelectedRowId={selectedItemId}
   {getRowId}
   {isRowSelectable}
-  rowSelection="single"
-  rowData={items}
-  bind:selectedRowIds={selectedItemIds}
   preventDefaultOnContextMenu
+  rowData={items}
+  rowSelection="single"
   on:blur={onBlur}
   on:cellContextMenu={onCellContextMenu}
   on:cellMouseOver

--- a/src/components/ui/DataGrid/SingleActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/SingleActionDataGrid.svelte
@@ -1,8 +1,8 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import type { ColDef, ColumnState, RowNode } from 'ag-grid-community';
-  import { createEventDispatcher } from 'svelte';
+  import type { CellKeyPressEvent, ColDef, ColumnState, RowNode } from 'ag-grid-community';
+  import { createEventDispatcher, onDestroy } from 'svelte';
   import type { TRowData } from '../../../types/data-grid';
   import ContextMenu from '../../context-menu/ContextMenu.svelte';
   import ContextMenuHeader from '../../context-menu/ContextMenuHeader.svelte';
@@ -51,6 +51,10 @@
     dataGrid?.sizeColumnsToFit();
   }
 
+  function onBlur() {
+    document.removeEventListener('keydown', onKeyDown);
+  }
+
   function onCellContextMenu(event: CustomEvent) {
     const { detail } = event;
     const { data: clickedRow } = detail;
@@ -61,6 +65,23 @@
       contextMenu.show(detail.event);
     }
   }
+
+  function onFocus() {
+    document.addEventListener('keydown', onKeyDown);
+  }
+
+  function onKeyDown(event: CustomEvent<CellKeyPressEvent<TRowData>>) {
+    const {
+      detail: { event: keyboardEvent },
+    } = event;
+    const { key } = keyboardEvent as KeyboardEvent;
+
+    if (key === 'Delete') {
+      deleteItem();
+    }
+  }
+
+  onDestroy(() => onBlur);
 </script>
 
 <DataGrid
@@ -74,13 +95,15 @@
   rowData={items}
   bind:selectedRowIds={selectedItemIds}
   preventDefaultOnContextMenu
-  on:filterChanged
+  on:blur={onBlur}
   on:cellContextMenu={onCellContextMenu}
   on:cellMouseOver
   on:columnMoved
   on:columnPinned
   on:columnResized
   on:columnStateChange
+  on:filterChanged
+  on:focus={onFocus}
   on:rowClicked
   on:rowDoubleClicked
   on:rowSelected

--- a/src/utilities/keyboardEvents.test.ts
+++ b/src/utilities/keyboardEvents.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test, vi } from 'vitest';
+import { isDeleteEvent, isSaveEvent } from './keyboardEvents';
+
+describe('isDeleteEvent', () => {
+  test('Should correctly determine if the current key presses equate to a "Delete" event or not', () => {
+    expect(isDeleteEvent(new KeyboardEvent('keydown', { key: 'Delete' }))).toEqual(true);
+    expect(isDeleteEvent(new KeyboardEvent('keydown', { key: 'Backspace' }))).toEqual(true);
+
+    expect(isDeleteEvent(new KeyboardEvent('keydown', { key: 'A' }))).toEqual(false);
+    expect(isDeleteEvent(new KeyboardEvent('keydown', { key: 'Enter' }))).toEqual(false);
+  });
+});
+
+describe('isSaveEvent', () => {
+  test('Should correctly determine if the current key presses equate to a "Save" event or not', () => {
+    expect(isSaveEvent(new KeyboardEvent('keydown', { ctrlKey: true, key: 's' }))).toEqual(true);
+
+    expect(isSaveEvent(new KeyboardEvent('keydown', { ctrlKey: true, key: 'a' }))).toEqual(false);
+
+    // check for Mac save events
+    vi.stubGlobal('navigator', { platform: 'MacIntel' });
+    expect(isSaveEvent(new KeyboardEvent('keydown', { key: 's', metaKey: true }))).toEqual(true);
+
+    expect(isSaveEvent(new KeyboardEvent('keydown', { key: 'a', metaKey: true }))).toEqual(false);
+  });
+});

--- a/src/utilities/keyboardEvents.ts
+++ b/src/utilities/keyboardEvents.ts
@@ -1,0 +1,9 @@
+import { isMacOs } from './generic';
+
+export function isDeleteEvent(event: KeyboardEvent) {
+  return event.key === 'Delete' || event.key === 'Backspace';
+}
+
+export function isSaveEvent(event: KeyboardEvent) {
+  return (isMacOs() ? event.metaKey : event.ctrlKey) && event.key === 's';
+}


### PR DESCRIPTION
resolves #292 

To test:
1. Open a plan with activities
2. Click on an activity on the timeline
3. Press `Delete` key
4. Verify that delete activity modal pops up and confirming deletes the correct activity
5. Click on an activity/activities on the activity table
6. Press `Delete` key
7. Verify that delete activity modal pops up and confirming deletes the correct activity