### PR TITLE
Replace keyboard save checks to use util function

### DIFF
--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -8,7 +8,7 @@
   import type { ModelSlim } from '../../types/model';
   import type { PlanSlim } from '../../types/plan';
   import effects from '../../utilities/effects';
-  import { isMacOs } from '../../utilities/generic';
+  import { isSaveEvent } from '../../utilities/keyboardEvents';
   import PageTitle from '../app/PageTitle.svelte';
   import Chip from '../ui/Chip.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
@@ -92,8 +92,7 @@
   }
 
   function onKeydown(event: KeyboardEvent): void {
-    const { key, ctrlKey, metaKey } = event;
-    if ((isMacOs() ? metaKey : ctrlKey) && key === 's') {
+    if (isSaveEvent(event)) {
       event.preventDefault();
       saveConstraint();
     }

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -8,7 +8,7 @@
   import { commandDictionaries } from '../../stores/sequencing';
   import type { ExpansionRule, ExpansionRuleInsertInput } from '../../types/expansion';
   import effects from '../../utilities/effects';
-  import { isMacOs } from '../../utilities/generic';
+  import { isSaveEvent } from '../../utilities/keyboardEvents';
   import PageTitle from '../app/PageTitle.svelte';
   import Chip from '../ui/Chip.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
@@ -66,8 +66,7 @@
   }
 
   function onKeydown(event: KeyboardEvent): void {
-    const { key, ctrlKey, metaKey } = event;
-    if ((isMacOs() ? metaKey : ctrlKey) && key === 's') {
+    if (isSaveEvent(event)) {
       event.preventDefault();
       saveRule();
     }

--- a/src/components/scheduling/conditions/SchedulingConditionForm.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditionForm.svelte
@@ -9,7 +9,7 @@
   import type { PlanSchedulingSpec } from '../../../types/plan';
   import type { SchedulingCondition, SchedulingSpecConditionInsertInput } from '../../../types/scheduling';
   import effects from '../../../utilities/effects';
-  import { isMacOs } from '../../../utilities/generic';
+  import { isSaveEvent } from '../../../utilities/keyboardEvents';
   import Chip from '../../ui/Chip.svelte';
   import CssGrid from '../../ui/CssGrid.svelte';
   import CssGridGutter from '../../ui/CssGridGutter.svelte';
@@ -77,8 +77,7 @@
   }
 
   function onKeydown(event: KeyboardEvent): void {
-    const { key, ctrlKey, metaKey } = event;
-    if ((isMacOs() ? metaKey : ctrlKey) && key === 's') {
+    if (isSaveEvent(event)) {
       event.preventDefault();
       saveCondition();
     }

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte
@@ -9,7 +9,7 @@
   import type { PlanSchedulingSpec } from '../../../types/plan';
   import type { SchedulingGoal, SchedulingSpecGoalInsertInput } from '../../../types/scheduling';
   import effects from '../../../utilities/effects';
-  import { isMacOs } from '../../../utilities/generic';
+  import { isSaveEvent } from '../../../utilities/keyboardEvents';
   import { showConfirmModal } from '../../../utilities/modal';
   import PageTitle from '../../app/PageTitle.svelte';
   import Chip from '../../ui/Chip.svelte';
@@ -79,8 +79,7 @@
   }
 
   function onKeydown(event: KeyboardEvent): void {
-    const { key, ctrlKey, metaKey } = event;
-    if ((isMacOs() ? metaKey : ctrlKey) && key === 's') {
+    if (isSaveEvent(event)) {
       event.preventDefault();
       saveGoal();
     }

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -8,7 +8,7 @@
   import { commandDictionaries, userSequencesColumns } from '../../stores/sequencing';
   import type { UserSequence, UserSequenceInsertInput } from '../../types/sequencing';
   import effects from '../../utilities/effects';
-  import { isMacOs } from '../../utilities/generic';
+  import { isSaveEvent } from '../../utilities/keyboardEvents';
   import PageTitle from '../app/PageTitle.svelte';
   import Chip from '../ui/Chip.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
@@ -71,8 +71,7 @@
   }
 
   function onKeydown(event: KeyboardEvent): void {
-    const { key, ctrlKey, metaKey } = event;
-    if ((isMacOs() ? metaKey : ctrlKey) && key === 's') {
+    if (isSaveEvent(event)) {
       event.preventDefault();
       saveSequence();
     }

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -63,7 +63,7 @@
   import type { GridChangeSizesEvent } from '../../../types/grid';
   import { createActivitiesMap } from '../../../utilities/activities';
   import effects from '../../../utilities/effects';
-  import { isMacOs } from '../../../utilities/generic';
+  import { isSaveEvent } from '../../../utilities/keyboardEvents';
   import { closeActiveModal, showPlanLockedModal } from '../../../utilities/modal';
   import { getUnixEpochTime } from '../../../utilities/time';
   import type { PageData } from './$types';
@@ -143,8 +143,7 @@
   }
 
   function onKeydown(event: KeyboardEvent): void {
-    const { key, ctrlKey, metaKey } = event;
-    if ((isMacOs() ? metaKey : ctrlKey) && key === 's') {
+    if (isSaveEvent(event)) {
       event.preventDefault();
       effects.simulate();
     }


### PR DESCRIPTION
This is just a followup refactoring to utilize the `isSaveEvent` util function that was previously added.