### PR TITLE
Allow unlocking plan while in the process of dragging activity

### DIFF
--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -43,8 +43,10 @@
   let canvas: HTMLCanvasElement;
   let ctx: CanvasRenderingContext2D;
   let dpr: number = 1;
+  let dragCurrentX: number | null = null;
   let dragOffsetX: number | null = null;
   let dragPoint: ActivityPoint | null = null;
+  let dragStartX: number | null = null;
   let maxActivityWidth: number;
   let quadtree: Quadtree<QuadtreeRect>;
   let visiblePointsByUniqueId: Record<ActivityUniqueId, ActivityPoint> = {};
@@ -155,42 +157,45 @@
   }
 
   /**
-   * @note We only allow dragging parent activities. Disable dragging all activities if timeline is "locked"
+   * @note We only allow dragging parent activities.
    */
   function dragActivityStart(points: ActivityPoint[], offsetX: number): void {
-    if (!timelineLocked && points.length) {
+    if (points.length) {
       const [point] = points;
       if (point.parent_id === null) {
         dragOffsetX = offsetX - xScaleView(point.x);
         dragPoint = point;
+        dragStartX = dragCurrentX = dragPoint.x;
       }
     }
   }
 
   function dragActivity(offsetX: number): void {
-    if (dragOffsetX && dragPoint) {
+    // Only update the x position if the timeline is unlocked
+    if (!timelineLocked && dragPoint) {
       const x = offsetX - dragOffsetX;
-      const unixEpochTime = xScaleView.invert(x).getTime();
-      const start_time_doy = getDoyTime(new Date(unixEpochTime));
-      if (unixEpochTime !== dragPoint.x) {
+      dragCurrentX = xScaleView.invert(x).getTime();
+      const start_time_doy = getDoyTime(new Date(dragCurrentX));
+      if (dragCurrentX !== dragPoint.x) {
         $activitiesMap[dragPoint.uniqueId].start_time_doy = start_time_doy;
         draw();
       }
     }
   }
 
-  function dragActivityEnd(offsetX: number): void {
-    if (dragOffsetX && dragPoint) {
-      const x = offsetX - dragOffsetX;
-      const unixEpochTime = xScaleView.invert(x).getTime();
-      const start_time_doy = getDoyTime(new Date(unixEpochTime));
-      const dragActivity = $activitiesMap[dragPoint.uniqueId];
-      if (unixEpochTime !== dragPoint.x) {
+  function dragActivityEnd(): void {
+    if (dragPoint && dragStartX !== null && dragCurrentX !== null) {
+      if (dragStartX !== dragCurrentX) {
+        const start_time_doy = getDoyTime(new Date(dragCurrentX));
+        const dragActivity = $activitiesMap[dragPoint.uniqueId];
         const { activityId, planId } = decomposeActivityDirectiveId(dragActivity.uniqueId);
         effects.updateActivityDirective(planId, activityId, { start_time_doy });
       }
+
       dragOffsetX = null;
       dragPoint = null;
+      dragStartX = null;
+      dragCurrentX = null;
     }
   }
 
@@ -273,8 +278,7 @@
 
   function onMouseup(e: MouseEvent | undefined): void {
     if (e) {
-      const { offsetX } = e;
-      dragActivityEnd(offsetX);
+      dragActivityEnd();
     }
   }
 

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -180,7 +180,7 @@
 
   function dragActivity(offsetX: number): void {
     // Only update the x position if the timeline is unlocked
-    if (!timelineLocked && dragPoint) {
+    if (!timelineLocked && dragPoint && $activitiesMap[dragPoint.uniqueId]) {
       const x = offsetX - dragOffsetX;
       dragCurrentX = xScaleView.invert(x).getTime();
       const start_time_doy = getDoyTime(new Date(dragCurrentX));
@@ -193,7 +193,7 @@
 
   function dragActivityEnd(): void {
     if (dragPoint && dragStartX !== null && dragCurrentX !== null) {
-      if (dragStartX !== dragCurrentX) {
+      if (dragStartX !== dragCurrentX && $activitiesMap[dragPoint.uniqueId]) {
         const start_time_doy = getDoyTime(new Date(dragCurrentX));
         const dragActivity = $activitiesMap[dragPoint.uniqueId];
         const { activityId, planId } = decomposeActivityDirectiveId(dragActivity.uniqueId);


### PR DESCRIPTION
Resolves #254 

This refactors the activity dragging functionality a bit in regards to how it interacts with the locked/unlocked state. Previously we would prevent the `dragActivityStart` event from running if the timeline was locked when initially mousing down on the activity. Now we always let the `dragActivityStart` event happen, but in the `dragActivity` event only update the position if the timeline is unlocked. Then ultimately in `dragActivityEnd` we only commit the update if the moved position differs from the start position. This allows for a bit more flexible dragging behavior like being able to first click the event and start dragging, and then pressing shift to unlock afterwards.

![2023-01-18 15 41 45](https://user-images.githubusercontent.com/888818/213319336-db946443-9463-43e0-8f52-70f2512da8b3.gif)