### PR TITLE
Add ellipsis to list item

### DIFF
--- a/src/components/ui/ListItem.svelte
+++ b/src/components/ui/ListItem.svelte
@@ -20,7 +20,7 @@
   on:dragend={e => dispatch('dragend', e)}
   on:dragstart={e => dispatch('dragstart', e)}
 >
-  <div>
+  <div class="list-item-content">
     <slot />
   </div>
   <div class="suffix">
@@ -37,6 +37,12 @@
     font-size: 0.8rem;
     justify-content: space-between;
     padding: 0.2rem;
+  }
+
+  .list-item-content {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .list-item:not(:last-child) {


### PR DESCRIPTION
* Fixes long names content overflow

To test:
- Open a plan and view the activity types panel
- Open the browser console and edit the text content to be very long so the ellipsis appears

<img width="350" alt="Screen Shot 2023-01-19 at 4 22 21 PM" src="https://user-images.githubusercontent.com/683355/213591053-9261be4b-17b5-49d3-a68f-8fb3a1df85ff.png">
