### PR TITLE
Replace simulation subscriptions with queries

### DIFF
--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -21,8 +21,7 @@ export const load: PageLoad = async ({ parent, params, url }) => {
         throw redirect(302, `${base}/plans/${id}/merge`);
       }
       const initialActivityTypes = await effects.getActivityTypes(initialPlan.model_id);
-      const initialResourceTypes = await effects.getResourceTypes(initialPlan.model_id);
-      const initialView = await effects.getView(url.searchParams, initialResourceTypes);
+      const initialView = await effects.getView(url.searchParams);
 
       return {
         initialActivityTypes,

--- a/src/types/simulation.ts
+++ b/src/types/simulation.ts
@@ -2,18 +2,15 @@ import type { BaseError, SimulationDatasetError } from './errors';
 import type { ArgumentsMap } from './parameter';
 import type { ValueSchema } from './schema';
 
-export type Dataset = {
-  profiles: Profile[];
-  spans: Span[];
-};
-
-export type ProfilesExternalResponse = {
-  datasets: [{ dataset: Dataset; offset_from_plan_start: string }];
-  duration: string;
-  start_time: string;
+export type PlanDataset = {
+  dataset: { profiles: Profile[] };
+  offset_from_plan_start: string;
 };
 
 export type Profile = {
+  dataset_id: number;
+  duration: string;
+  id: number;
   name: string;
   profile_segments: ProfileSegment[];
   type: {
@@ -23,10 +20,16 @@ export type Profile = {
 };
 
 export type ProfileSegment = {
+  dataset_id: number;
   dynamics: any;
+  is_gap: boolean;
+  profile_id: number;
   start_offset: string;
 };
 
+/**
+ * Resources are just sampled Profiles.
+ */
 export type Resource = {
   name: string;
   schema: ValueSchema;
@@ -56,7 +59,7 @@ export type Simulation = {
 };
 
 export type SimulationDataset = {
-  dataset: Dataset;
+  dataset_id: number;
   id: number;
   plan_revision: number;
   reason: SimulationDatasetError | null;

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -564,6 +564,49 @@ const gql = {
     }
   `,
 
+  GET_PROFILES: `#graphql
+    query GetProfiles($datasetId: Int!) {
+      profile(where: { dataset_id: { _eq: $datasetId } }) {
+        dataset_id
+        duration
+        id
+        name
+        profile_segments(where: { dataset_id: { _eq: $datasetId } }, order_by: { start_offset: asc }) {
+          dataset_id
+          dynamics
+          is_gap
+          profile_id
+          start_offset
+        }
+        type
+      }
+    }
+  `,
+
+  GET_PROFILES_EXTERNAL: `#graphql
+    query GetProfilesExternal($planId: Int!) {
+      plan_dataset(where: { plan_id: { _eq: $planId } }) {
+        dataset {
+          profiles {
+            dataset_id
+            duration
+            id
+            name
+            profile_segments(order_by: { start_offset: asc }) {
+              dataset_id
+              dynamics
+              is_gap
+              profile_id
+              start_offset
+            }
+            type
+          }
+        }
+        offset_from_plan_start
+      }
+    }
+  `,
+
   GET_RESOURCE_TYPES: `#graphql
     query GetResourceTypes($missionModelId: ID!) {
       resourceTypes(missionModelId: $missionModelId) {
@@ -627,6 +670,20 @@ const gql = {
         goal_id
         priority
         specification_id
+      }
+    }
+  `,
+
+  GET_SPANS: `#graphql
+    query GetSpans($datasetId: Int!) {
+      span(where: { dataset_id: { _eq: $datasetId } }, order_by: { start_offset: asc }) {
+        attributes
+        dataset_id
+        duration
+        id
+        parent_id
+        start_offset
+        type
       }
     }
   `,
@@ -1085,28 +1142,6 @@ const gql = {
     }
   `,
 
-  SUB_PROFILES_EXTERNAL: `#graphql
-    subscription SubProfilesExternal($planId: Int!) {
-      plan: plan_by_pk(id: $planId) {
-        datasets {
-          dataset {
-            profiles {
-              name
-              profile_segments(order_by: { start_offset: asc }) {
-                dynamics
-                start_offset
-              }
-              type
-            }
-          }
-          offset_from_plan_start
-        }
-        duration
-        start_time
-      }
-    }
-  `,
-
   SUB_SCHEDULING_CONDITIONS: `#graphql
     subscription SubSchedulingConditions {
       conditions: scheduling_condition(order_by: { id: desc }) {
@@ -1219,33 +1254,13 @@ const gql = {
   `,
 
   SUB_SIMULATION_DATASET: `#graphql
-    subscription SubSimulationDataset($planId: Int!, $simulationDatasetId: Int!) {
-      simulation(where: { plan_id: { _eq: $planId } }, order_by: { id: desc }, limit: 1) {
-        simulation_datasets(where: { id: { _eq: $simulationDatasetId } }, limit: 1) {
-          dataset {
-            profiles {
-              name
-              profile_segments(order_by: { start_offset: asc }) {
-                dynamics
-                start_offset
-              }
-              type
-            }
-            spans(order_by: { start_offset: asc }) {
-              attributes
-              dataset_id
-              duration
-              id
-              parent_id
-              start_offset
-              type
-            }
-          }
-          id
-          plan_revision
-          reason
-          status
-        }
+    subscription SubSimulationDataset($simulationDatasetId: Int!) {
+      simulation_dataset_by_pk(id: $simulationDatasetId) {
+        dataset_id
+        id
+        plan_revision
+        reason
+        status
       }
     }
   `,

--- a/src/utilities/resources.test.ts
+++ b/src/utilities/resources.test.ts
@@ -6,18 +6,30 @@ describe('sampleProfiles', () => {
   test('calculate the correct y-value for real profile segment rate of change', () => {
     const profiles: Profile[] = [
       {
+        dataset_id: 1,
+        duration: '',
+        id: 1,
         name: '/simple_data/b/volume',
         profile_segments: [
           {
+            dataset_id: 1,
             dynamics: { initial: 0, rate: 0 },
+            is_gap: false,
+            profile_id: 1,
             start_offset: '00:00:00',
           },
           {
+            dataset_id: 1,
             dynamics: { initial: 0, rate: 5 },
+            is_gap: false,
+            profile_id: 1,
             start_offset: '2 days 19:40:54.345',
           },
           {
+            dataset_id: 1,
             dynamics: { initial: 566834.75, rate: 0 },
+            is_gap: false,
+            profile_id: 1,
             start_offset: '4 days 03:10:21.295',
           },
         ],

--- a/src/utilities/resources.ts
+++ b/src/utilities/resources.ts
@@ -5,52 +5,55 @@ import { getDurationInMs } from './time';
  * Samples a list of profiles at their change points. Converts the sampled profiles to Resources.
  */
 export function sampleProfiles(
-  profiles: Profile[],
-  planStartTimeYmd: string,
-  duration: string,
+  profiles: Profile[] | null,
+  planStartTimeYmd: string | null,
+  duration: string | null,
   offset?: string,
 ): Resource[] {
-  const planOffset = getDurationInMs(offset);
-  const planStart = new Date(planStartTimeYmd).getTime() + planOffset;
-  const planDuration = getDurationInMs(duration);
   const resources: Resource[] = [];
 
-  for (const profile of profiles) {
-    const { name, profile_segments, type: profileType } = profile;
-    const { schema, type } = profileType;
-    const values: ResourceValue[] = [];
+  if (profiles && planStartTimeYmd && duration) {
+    const planOffset = getDurationInMs(offset);
+    const planStart = new Date(planStartTimeYmd).getTime() + planOffset;
+    const planDuration = getDurationInMs(duration);
 
-    for (let i = 0; i < profile_segments.length; ++i) {
-      const segment = profile_segments[i];
-      const nextSegment = profile_segments[i + 1];
+    for (const profile of profiles) {
+      const { name, profile_segments, type: profileType } = profile;
+      const { schema, type } = profileType;
+      const values: ResourceValue[] = [];
 
-      const segmentOffset = getDurationInMs(segment.start_offset);
-      const nextSegmentOffset = nextSegment ? getDurationInMs(nextSegment.start_offset) : planDuration;
+      for (let i = 0; i < profile_segments.length; ++i) {
+        const segment = profile_segments[i];
+        const nextSegment = profile_segments[i + 1];
 
-      const { dynamics } = segment;
+        const segmentOffset = getDurationInMs(segment.start_offset);
+        const nextSegmentOffset = nextSegment ? getDurationInMs(nextSegment.start_offset) : planDuration;
 
-      if (type === 'discrete') {
-        values.push({
-          x: planStart + segmentOffset,
-          y: dynamics,
-        });
-        values.push({
-          x: planStart + nextSegmentOffset,
-          y: dynamics,
-        });
-      } else if (type === 'real') {
-        values.push({
-          x: planStart + segmentOffset,
-          y: dynamics.initial,
-        });
-        values.push({
-          x: planStart + nextSegmentOffset,
-          y: dynamics.initial + dynamics.rate * ((nextSegmentOffset - segmentOffset) / 1000),
-        });
+        const { dynamics } = segment;
+
+        if (type === 'discrete') {
+          values.push({
+            x: planStart + segmentOffset,
+            y: dynamics,
+          });
+          values.push({
+            x: planStart + nextSegmentOffset,
+            y: dynamics,
+          });
+        } else if (type === 'real') {
+          values.push({
+            x: planStart + segmentOffset,
+            y: dynamics.initial,
+          });
+          values.push({
+            x: planStart + nextSegmentOffset,
+            y: dynamics.initial + dynamics.rate * ((nextSegmentOffset - segmentOffset) / 1000),
+          });
+        }
       }
-    }
 
-    resources.push({ name, schema, values });
+      resources.push({ name, schema, values });
+    }
   }
 
   return resources;


### PR DESCRIPTION
* Fixes database errors related to subscriptions for simulation data
* Use top-level plan page reactive expressions to fetch simulation results with regular GQL queries
* Remove top-level `resourceTypes` query since it's slow
    - See: https://github.com/NASA-AMMOS/aerie/issues/605
* Workaround fix for:
    - https://github.com/NASA-AMMOS/aerie/issues/595
    - https://github.com/NASA-AMMOS/aerie/issues/574
    - Still unclear why the database is choking for these subscriptions, will require further investigation
 * Big thanks to @mattdailis for starting this effort!

To test:
1. Open a new plan
2. Run simulation
3. Make sure simulation results are still showing up
4. Test external profiles are still showing up