### PR TITLE
Pre-populate end time with start time during plan creation

### DIFF
--- a/e2e-tests/tests/plans.test.ts
+++ b/e2e-tests/tests/plans.test.ts
@@ -80,6 +80,21 @@ test.describe.serial('Plans', () => {
     await expect(plans.durationDisplay).toHaveValue('5d');
   });
 
+  test('Entering a valid start should prepopulate the end time correctly', async () => {
+    await plans.fillInputStartTime();
+
+    const endTime = await plans.inputEndTime.inputValue();
+    expect(endTime).toEqual(plans.startTime);
+  });
+
+  test('Entering an invalid start should not prepopulate the end time', async () => {
+    await plans.inputStartTime.fill('2022-');
+    await page.keyboard.press('Tab');
+
+    const endTime = await plans.inputEndTime.inputValue();
+    expect(endTime).toEqual('');
+  });
+
   test('Entering an invalid start time should display "None" in the duration text', async () => {
     await plans.inputStartTime.fill('2022-');
     await page.keyboard.press('Tab');

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -161,6 +161,13 @@
     goto(`${base}/plans/${plan.id}`);
   }
 
+  function onStartTimeChanged() {
+    if ($startTimeDoyField.value && $endTimeDoyField.value === '') {
+      endTimeDoyField.set($startTimeDoyField);
+    }
+    updateDurationString();
+  }
+
   function updateDurationString() {
     if ($startTimeDoyField.valid && $endTimeDoyField.valid) {
       durationString = convertUsToDurationString(
@@ -215,7 +222,7 @@
               field={startTimeDoyField}
               label="Start Time - YYYY-DDDThh:mm:ss"
               name="start-time"
-              on:change={updateDurationString}
+              on:change={onStartTimeChanged}
               on:keydown={updateDurationString}
             />
           </fieldset>


### PR DESCRIPTION
Resolves #347 

To test:

1. Go to plan creation page
2. Enter valid start time
3. Verify that end time is now the same as the start time
4. Clear out both inputs
5. Enter an invalid start time
6. Verify that the end time does not get updated until a valid start time is provided