### PR TITLE
Add option to scroll to table items when selected

### DIFF
--- a/src/components/activity/ActivityTable.svelte
+++ b/src/components/activity/ActivityTable.svelte
@@ -89,6 +89,7 @@
   {getRowId}
   items={activities}
   pluralItemDisplayText="Activities"
+  scrollToSelection={true}
   singleItemDisplayText="Activity"
   suppressDragLeaveHidesColumns={false}
   on:bulkDeleteItems={deleteActivityDirectives}

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -19,6 +19,7 @@
   export let idKey: keyof TRowData = 'id';
   export let items: TRowData[];
   export let pluralItemDisplayText: string = '';
+  export let scrollToSelection: boolean = false;
   export let selectedItemId: RowId | null = null;
   export let showContextMenu: boolean = true;
   export let singleItemDisplayText: string = '';
@@ -117,6 +118,7 @@
   preventDefaultOnContextMenu={showContextMenu}
   rowData={items}
   rowSelection="multiple"
+  {scrollToSelection}
   {suppressDragLeaveHidesColumns}
   {suppressRowClickSelection}
   on:blur={onBlur}

--- a/src/components/ui/DataGrid/DataGrid.svelte
+++ b/src/components/ui/DataGrid/DataGrid.svelte
@@ -56,6 +56,7 @@
   export let preventDefaultOnContextMenu: boolean | undefined = undefined;
   export let rowData: TRowData[] = [];
   export let rowSelection: 'single' | 'multiple' | undefined = undefined;
+  export let scrollToSelection: boolean = false;
   export let selectedRowIds: RowId[] = [];
   export let shouldAutoGenerateId: boolean = false;
   export let suppressCellFocus: boolean = true;
@@ -217,8 +218,12 @@
       onRowSelected(event: RowSelectedEvent<TRowData>) {
         const selectedNodes = gridOptions?.api?.getSelectedNodes();
 
-        // only dispatch `rowSelected` for single row selections
+        // only dispatch `rowSelected` or enforce visibility for single row selections
         if (selectedNodes.length <= 1 || suppressRowClickSelection) {
+          if (scrollToSelection) {
+            gridOptions?.api?.ensureIndexVisible(selectedNodes[0].rowIndex);
+          }
+
           dispatch('rowSelected', {
             data: event.data,
             isSelected: event.node.isSelected(),

--- a/src/components/ui/DataGrid/SingleActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/SingleActionDataGrid.svelte
@@ -20,6 +20,7 @@
   export let items: TRowData[];
   export let itemDisplayText: string;
   export let selectedItemId: number | null = null;
+  export let scrollToSelection: boolean = false;
 
   export let getRowId: (data: TRowData) => number = (data: TRowData): number => {
     return parseInt(data[idKey]);
@@ -94,6 +95,7 @@
   preventDefaultOnContextMenu
   rowData={items}
   rowSelection="single"
+  {scrollToSelection}
   on:blur={onBlur}
   on:cellContextMenu={onCellContextMenu}
   on:cellMouseOver


### PR DESCRIPTION
Closes #332.

ag-grid provides it's own method for ensuring a row is visible. I exposed a prop to use this on selection change, and for now turned that on only for the Activity Table. 

![2023-01-31 17 16 50](https://user-images.githubusercontent.com/888818/215921874-6d1314c5-ab41-4347-b798-b5c8d3990e6a.gif)