### PR TITLE
Navbar status and action menus

### DIFF
--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -46,6 +46,7 @@ export class Plan {
   schedulingConditionEnabledCheckbox: Locator;
   schedulingConditionListItemSelector: string;
   schedulingConditionNewButton: Locator;
+  schedulingGoal: Locator;
   schedulingGoalDifferenceBadge: Locator;
   schedulingGoalEnabledCheckbox: Locator;
   schedulingGoalExpand: Locator;
@@ -64,7 +65,7 @@ export class Plan {
     this.constraintListItemSelector = `.constraint-list-item:has-text("${constraints.constraintName}")`;
     this.schedulingConditionListItemSelector = `.scheduling-condition:has-text("${schedulingConditions.conditionName}")`;
     this.schedulingGoalListItemSelector = `.scheduling-goal:has-text("${schedulingGoals.goalName}")`;
-    this.schedulingStatusSelector = (status: string) => `.status-badge.${status}`;
+    this.schedulingStatusSelector = (status: string) => `.header-actions > .status-badge.${status}`;
     this.updatePage(page);
   }
 
@@ -181,22 +182,19 @@ export class Plan {
   }
 
   async showSchedulingLayout() {
-    await this.navButtonScheduling.click();
+    await this.showPanel('Scheduling Goals');
+    await this.showPanel('Scheduling Conditions', true);
     await this.panelSchedulingGoals.waitFor({ state: 'attached' });
     await this.panelSchedulingGoals.waitFor({ state: 'visible' });
     await this.panelSchedulingConditions.waitFor({ state: 'attached' });
     await this.panelSchedulingConditions.waitFor({ state: 'visible' });
-    await this.panelActivityForm.waitFor({ state: 'attached' });
-    await this.panelActivityForm.waitFor({ state: 'visible' });
     await this.panelActivityTable.waitFor({ state: 'attached' });
     await this.panelActivityTable.waitFor({ state: 'visible' });
     await this.panelTimeline.waitFor({ state: 'attached' });
     await this.panelTimeline.waitFor({ state: 'visible' });
     await expect(this.panelSchedulingGoals).toBeVisible();
-    await expect(this.panelActivityForm).toBeVisible();
     await expect(this.panelActivityTable).toBeVisible();
     await expect(this.panelTimeline).toBeVisible();
-    await expect(this.navButtonScheduling).toHaveClass(/selected/);
   }
 
   updatePage(page: Page): void {
@@ -238,16 +236,17 @@ export class Plan {
     this.panelTimelineEditor = page.locator('[data-component-name="TimelineEditorPanel"]');
     this.panelViewEditor = page.locator('[data-component-name="ViewEditorPanel"]');
     this.planTitle = page.locator(`.plan-title:has-text("${this.plans.planName}")`);
-    this.scheduleButton = page.locator('.header-actions > button[aria-label="Schedule"]');
-    this.analyzeButton = page.locator('.header-actions > button[aria-label="Analyze"]');
-    this.schedulingGoalDifferenceBadge = page.locator('.difference-badge');
-    this.schedulingGoalEnabledCheckbox = page.locator(
-      `.scheduling-goal:has-text("${this.schedulingGoals.goalName}") >> input[type="checkbox"]`,
-    );
-    this.schedulingConditionEnabledCheckbox = page.locator(
-      `.scheduling-condition:has-text("${this.schedulingConditions.conditionName}") >> input[type="checkbox"]`,
-    );
-    this.schedulingGoalExpand = page.locator('span[aria-label="scheduling-goal-expand"]');
+    this.scheduleButton = page.locator('.header-actions button[aria-label="Schedule"]');
+    this.analyzeButton = page.locator('.header-actions button[aria-label="Analyze"]');
+    this.schedulingGoal = page.locator('.scheduling-goal').first();
+    this.schedulingGoalDifferenceBadge = this.schedulingGoal.locator('.difference-badge');
+    this.schedulingGoalEnabledCheckbox = page
+      .locator(`.scheduling-goal:has-text("${this.schedulingGoals.goalName}") >> input[type="checkbox"]`)
+      .first();
+    this.schedulingConditionEnabledCheckbox = page
+      .locator(`.scheduling-condition:has-text("${this.schedulingConditions.conditionName}") >> input[type="checkbox"]`)
+      .first();
+    this.schedulingGoalExpand = page.locator('span[aria-label="scheduling-goal-expand"]').first();
     this.schedulingGoalNewButton = page.locator(`button[name="new-scheduling-goal"]`);
     this.schedulingConditionNewButton = page.locator(`button[name="new-scheduling-condition"]`);
     this.schedulingSatisfiedActivity = page.locator('li > .satisfied-activity');

--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -152,11 +152,10 @@ export class Plan {
   }
 
   async showConstraintsLayout() {
-    await this.navButtonConstraints.click();
+    await this.showPanel('Constraints');
+    await this.showPanel('Constraint Violations', true);
     await this.panelConstraints.waitFor({ state: 'attached' });
     await this.panelConstraints.waitFor({ state: 'visible' });
-    await this.panelActivityForm.waitFor({ state: 'attached' });
-    await this.panelActivityForm.waitFor({ state: 'visible' });
     await this.panelActivityTable.waitFor({ state: 'attached' });
     await this.panelActivityTable.waitFor({ state: 'visible' });
     await this.panelConstraintViolations.waitFor({ state: 'attached' });
@@ -164,16 +163,18 @@ export class Plan {
     await this.panelTimeline.waitFor({ state: 'attached' });
     await this.panelTimeline.waitFor({ state: 'visible' });
     await expect(this.panelConstraints).toBeVisible();
-    await expect(this.panelActivityForm).toBeVisible();
     await expect(this.panelActivityTable).toBeVisible();
     await expect(this.panelConstraintViolations).toBeVisible();
     await expect(this.panelTimeline).toBeVisible();
-    await expect(this.navButtonConstraints).toHaveClass(/selected/);
   }
 
-  async showPanel(name: string) {
+  async showPanel(name: string, pickLastMenu: boolean = false) {
     await expect(this.gridMenu).not.toBeVisible();
-    await this.gridMenuButton.first().click();
+    if (pickLastMenu) {
+      await this.gridMenuButton.last().click();
+    } else {
+      await this.gridMenuButton.first().click();
+    }
     await this.gridMenu.waitFor({ state: 'attached' });
     await this.gridMenu.waitFor({ state: 'visible' });
     await this.gridMenuItem(name).click();

--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -213,12 +213,10 @@ export class Plan {
     this.navButtonConstraints = page.locator(`.nav-button:has-text("Constraints")`);
     this.navButtonScheduling = page.locator(`.nav-button:has-text("Scheduling")`);
     this.navButtonSimulation = page.locator(`.nav-button:has-text("Simulation")`);
-    this.navButtonView = page.locator(`.nav-button:has-text("View")`);
-    this.navButtonViewMenu = page.locator(`.view-menu > .menu`);
-    this.navButtonViewSaveAsMenuButton = page.locator(`.view-menu > .menu .menu-item:has-text("Save as")`);
-    this.navButtonViewSavedViewsMenuButton = page.locator(
-      `.view-menu > .menu .menu-item:has-text("Browse saved views")`,
-    );
+    this.navButtonView = page.locator('.view-menu');
+    this.navButtonViewMenu = page.locator(`.view-menu .menu`);
+    this.navButtonViewSaveAsMenuButton = page.locator(`.view-menu .menu .menu-item:has-text("Save as")`);
+    this.navButtonViewSavedViewsMenuButton = page.locator(`.view-menu .menu .menu-item:has-text("Browse saved views")`);
     this.page = page;
     this.panelActivityForm = page.locator('[data-component-name="ActivityFormPanel"]');
     this.panelActivityTable = page.locator('[data-component-name="ActivityTablePanel"]');

--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -17,10 +17,14 @@ export class Plan {
   gridMenu: Locator;
   gridMenuButton: Locator;
   gridMenuItem: (name: string) => Locator;
-  navButtonActivities: Locator;
   navButtonConstraints: Locator;
+  navButtonConstraintsMenu: Locator;
+  navButtonExpansion: Locator;
+  navButtonExpansionMenu: Locator;
   navButtonScheduling: Locator;
+  navButtonSchedulingMenu: Locator;
   navButtonSimulation: Locator;
+  navButtonSimulationMenu: Locator;
   navButtonView: Locator;
   navButtonViewMenu: Locator;
   navButtonViewSaveAsMenuButton: Locator;
@@ -101,8 +105,6 @@ export class Plan {
   }
 
   async deleteAllActivities() {
-    await this.navButtonActivities.click();
-    await this.activitiesTable.waitFor({ state: 'attached' });
     await expect(this.confirmModal).not.toBeVisible();
 
     await this.activitiesTableFirstRow.click({ button: 'right' });
@@ -209,10 +211,14 @@ export class Plan {
     this.gridMenuButton = page.locator('.grid-menu');
     this.gridMenuItem = (name: string) =>
       page.locator(`.grid-menu > .menu > .menu-slot > .menu-item:has-text("${name}")`);
-    this.navButtonActivities = page.locator(`.nav-button:has-text("Activities")`);
+    this.navButtonExpansion = page.locator(`.nav-button:has-text("Expansion")`);
+    this.navButtonExpansionMenu = page.locator(`.nav-button:has-text("Expansion") .menu`);
     this.navButtonConstraints = page.locator(`.nav-button:has-text("Constraints")`);
+    this.navButtonConstraintsMenu = page.locator(`.nav-button:has-text("Constraints") .menu`);
     this.navButtonScheduling = page.locator(`.nav-button:has-text("Scheduling")`);
+    this.navButtonSchedulingMenu = page.locator(`.nav-button:has-text("Scheduling") .menu`);
     this.navButtonSimulation = page.locator(`.nav-button:has-text("Simulation")`);
+    this.navButtonSimulationMenu = page.locator(`.nav-button:has-text("Simulation") .menu`);
     this.navButtonView = page.locator('.view-menu');
     this.navButtonViewMenu = page.locator(`.view-menu .menu`);
     this.navButtonViewSaveAsMenuButton = page.locator(`.view-menu .menu .menu-item:has-text("Save as")`);

--- a/e2e-tests/tests/plan-merge.test.ts
+++ b/e2e-tests/tests/plan-merge.test.ts
@@ -66,6 +66,7 @@ test.describe.serial('Plan Merge', () => {
     await page.locator('input[name="start-time"]').click();
     await page.locator('input[name="start-time"]').fill(newActivityStartTime);
     await page.locator('input[name="start-time"]').press('Enter');
+    await page.waitForTimeout(250);
   });
 
   test('Create a merge request from branch to parent plan', async () => {
@@ -82,11 +83,13 @@ test.describe.serial('Plan Merge', () => {
     await page.getByRole('button', { name: '1 incoming, 0 outgoing' }).click();
     await page.getByRole('button', { name: 'Review' }).click();
     await page.waitForURL(`${baseURL}/plans/*/merge`);
+    await page.waitForTimeout(250);
   });
 
   test('Complete the merge review', async ({ baseURL }) => {
     await page.getByRole('button', { name: 'Approve Changes' }).click();
     await page.waitForURL(`${baseURL}/plans/${plans.planId}/merge`);
+    await page.waitForTimeout(250);
   });
 
   test('Make sure the start time of the activity in the parent plan now equals the start time of the activity in branch', async () => {

--- a/e2e-tests/tests/plan.test.ts
+++ b/e2e-tests/tests/plan.test.ts
@@ -103,17 +103,17 @@ test.describe.serial('Plan', () => {
     await expect(plan.panelViewEditor).toBeVisible();
   });
 
-  test(`Clicking on 'Default View' in the top navigation bar should toggle the view menu`, async () => {
+  test(`Hovering on 'Default View' in the top navigation bar should show the view menu`, async () => {
     await expect(plan.navButtonViewMenu).not.toBeVisible();
-    plan.navButtonView.click();
+    plan.navButtonView.hover();
     await expect(plan.navButtonViewMenu).toBeVisible();
-    plan.navButtonView.click();
+    plan.planTitle.hover();
     await expect(plan.navButtonViewMenu).not.toBeVisible();
   });
 
   test(`Clicking on 'Saved Views' in the view menu should pop up a SavedViewsModal`, async () => {
     await expect(plan.navButtonViewMenu).not.toBeVisible();
-    plan.navButtonView.click();
+    plan.navButtonView.hover();
     await expect(plan.navButtonViewMenu).toBeVisible();
     await expect(plan.navButtonViewSavedViewsMenuButton).toBeVisible();
     await plan.navButtonViewSavedViewsMenuButton.click();

--- a/e2e-tests/tests/plan.test.ts
+++ b/e2e-tests/tests/plan.test.ts
@@ -103,6 +103,38 @@ test.describe.serial('Plan', () => {
     await expect(plan.panelViewEditor).toBeVisible();
   });
 
+  test(`Hovering on 'Constraints' in the top navigation bar should show the constraints menu`, async () => {
+    await expect(plan.navButtonConstraintsMenu).not.toBeVisible();
+    plan.navButtonConstraints.hover();
+    await expect(plan.navButtonConstraintsMenu).toBeVisible();
+    plan.planTitle.hover();
+    await expect(plan.navButtonConstraintsMenu).not.toBeVisible();
+  });
+
+  test(`Hovering on 'Simulation' in the top navigation bar should show the simulation menu`, async () => {
+    await expect(plan.navButtonSimulationMenu).not.toBeVisible();
+    plan.navButtonSimulation.hover();
+    await expect(plan.navButtonSimulationMenu).toBeVisible();
+    plan.planTitle.hover();
+    await expect(plan.navButtonSimulationMenu).not.toBeVisible();
+  });
+
+  test(`Hovering on 'Expansion' in the top navigation bar should show the expansion menu`, async () => {
+    await expect(plan.navButtonExpansionMenu).not.toBeVisible();
+    plan.navButtonExpansion.hover();
+    await expect(plan.navButtonExpansionMenu).toBeVisible();
+    plan.planTitle.hover();
+    await expect(plan.navButtonExpansionMenu).not.toBeVisible();
+  });
+
+  test(`Hovering on 'Scheduling' in the top navigation bar should show the scheduling menu`, async () => {
+    await expect(plan.navButtonSchedulingMenu).not.toBeVisible();
+    plan.navButtonScheduling.hover();
+    await expect(plan.navButtonSchedulingMenu).toBeVisible();
+    plan.planTitle.hover();
+    await expect(plan.navButtonSchedulingMenu).not.toBeVisible();
+  });
+
   test(`Hovering on 'Default View' in the top navigation bar should show the view menu`, async () => {
     await expect(plan.navButtonViewMenu).not.toBeVisible();
     plan.navButtonView.hover();

--- a/e2e-tests/tests/scheduling.test.ts
+++ b/e2e-tests/tests/scheduling.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, type BrowserContext, type Page } from '@playwright/test';
+import { adjectives, animals, colors, uniqueNamesGenerator } from 'unique-names-generator';
 import { Constraints } from '../fixtures/Constraints.js';
 import { Models } from '../fixtures/Models.js';
 import { Plan } from '../fixtures/Plan.js';
@@ -14,6 +15,8 @@ let plan: Plan;
 let plans: Plans;
 let schedulingConditions: SchedulingConditions;
 let schedulingGoals: SchedulingGoals;
+const goalName1: string = uniqueNamesGenerator({ dictionaries: [adjectives, colors, animals] });
+const goalName2: string = uniqueNamesGenerator({ dictionaries: [adjectives, colors, animals] });
 
 test.beforeAll(async ({ browser }) => {
   context = await browser.newContext();
@@ -48,7 +51,7 @@ test.describe.serial('Scheduling', () => {
   });
 
   test('Create scheduling goal from the plan page', async ({ baseURL }) => {
-    await plan.createSchedulingGoal(baseURL);
+    await plan.createSchedulingGoal(baseURL, goalName1);
   });
 
   test('Create scheduling condition from the plan page', async ({ baseURL }) => {
@@ -57,15 +60,15 @@ test.describe.serial('Scheduling', () => {
 
   test('Disabling a scheduling goal should not include that goal in a scheduling run ', async ({ baseURL }) => {
     // Create a second scheduling goal so that when the first goal is disabled, analysis and scheduling buttons are still enabled
-    await plan.createSchedulingGoal(baseURL);
+    await plan.createSchedulingGoal(baseURL, goalName2);
     await expect(plan.schedulingGoalDifferenceBadge).not.toBeVisible();
-    await expect(plan.schedulingGoalEnabledCheckbox).toBeChecked();
-    await plan.schedulingGoalEnabledCheckbox.uncheck();
-    await expect(plan.schedulingGoalEnabledCheckbox).not.toBeChecked();
+    await expect(plan.schedulingGoalEnabledCheckboxSelector(goalName1)).toBeChecked();
+    await plan.schedulingGoalEnabledCheckboxSelector(goalName1).uncheck();
+    await expect(plan.schedulingGoalEnabledCheckboxSelector(goalName1)).not.toBeChecked();
     await plan.runScheduling();
     await expect(plan.schedulingGoalDifferenceBadge).not.toBeVisible();
-    await plan.schedulingGoalEnabledCheckbox.check();
-    await expect(plan.schedulingGoalEnabledCheckbox).toBeChecked();
+    await plan.schedulingGoalEnabledCheckboxSelector(goalName1).check();
+    await expect(plan.schedulingGoalEnabledCheckboxSelector(goalName1)).toBeChecked();
   });
 
   test('The condition should prevent showing +10 in the goals badge', async () => {
@@ -84,7 +87,7 @@ test.describe.serial('Scheduling', () => {
   });
 
   test('Running the same scheduling goal twice in a row should show +0 in that goals badge', async () => {
-    await expect(plan.schedulingGoalEnabledCheckbox).toBeChecked();
+    await expect(plan.schedulingGoalEnabledCheckboxSelector(goalName1)).toBeChecked();
     await plan.runScheduling();
     await expect(plan.schedulingGoalDifferenceBadge).toHaveText('+10');
     await plan.runScheduling();
@@ -98,7 +101,7 @@ test.describe.serial('Scheduling', () => {
   });
 
   test('Running analyze-only should show +0 in that goals badge', async () => {
-    await expect(plan.schedulingGoalEnabledCheckbox).toBeChecked();
+    await expect(plan.schedulingGoalEnabledCheckboxSelector(goalName1)).toBeChecked();
     await plan.runAnalysis();
     await expect(plan.schedulingGoalDifferenceBadge).toHaveText('+0');
     await plan.runAnalysis();
@@ -106,6 +109,6 @@ test.describe.serial('Scheduling', () => {
   });
 
   test('Delete scheduling goal', async () => {
-    await schedulingGoals.deleteSchedulingGoal();
+    await schedulingGoals.deleteSchedulingGoal(goalName1);
   });
 });

--- a/e2e-tests/tests/scheduling.test.ts
+++ b/e2e-tests/tests/scheduling.test.ts
@@ -55,7 +55,9 @@ test.describe.serial('Scheduling', () => {
     await plan.createSchedulingCondition(baseURL);
   });
 
-  test('Disabling a scheduling goal should not include that goal in a scheduling run ', async () => {
+  test('Disabling a scheduling goal should not include that goal in a scheduling run ', async ({ baseURL }) => {
+    // Create a second scheduling goal so that when the first goal is disabled, analysis and scheduling buttons are still enabled
+    await plan.createSchedulingGoal(baseURL);
     await expect(plan.schedulingGoalDifferenceBadge).not.toBeVisible();
     await expect(plan.schedulingGoalEnabledCheckbox).toBeChecked();
     await plan.schedulingGoalEnabledCheckbox.uncheck();

--- a/src/components/app/Nav.svelte
+++ b/src/components/app/Nav.svelte
@@ -22,7 +22,7 @@
   }
   .nav {
     align-items: center;
-    background: var(--st-primary);
+    background: #110d3e;
     color: var(--st-primary-background-color);
     display: flex;
     height: var(--nav-header-height);

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -4,9 +4,10 @@
   import type { ICellRendererParams } from 'ag-grid-community';
   import {
     creatingExpansionSequence,
-    expandingPlan,
     expansionSets,
     filteredExpansionSequences,
+    planExpansionStatus,
+    selectedExpansionSetId,
   } from '../../stores/expansion';
   import { simulationDatasetId } from '../../stores/simulation';
   import type { DataGridColumnDef } from '../../types/data-grid';
@@ -19,6 +20,8 @@
   import DataGridActions from '../ui/DataGrid/DataGridActions.svelte';
   import SingleActionDataGrid from '../ui/DataGrid/SingleActionDataGrid.svelte';
   import Panel from '../ui/Panel.svelte';
+  import PanelHeaderActionButton from '../ui/PanelHeaderActionButton.svelte';
+  import PanelHeaderActions from '../ui/PanelHeaderActions.svelte';
 
   export let gridId: number;
 
@@ -87,11 +90,10 @@
 
   let createButtonEnabled: boolean = false;
   let expandButtonEnabled: boolean = false;
-  let selectedExpansionSetId: number | null = null;
   let seqIdInput: string = '';
 
   $: createButtonEnabled = seqIdInput !== '';
-  $: expandButtonEnabled = selectedExpansionSetId !== null;
+  $: expandButtonEnabled = $selectedExpansionSetId !== null;
 
   function deleteExpansionSequence(sequence: ExpansionSequence) {
     effects.deleteExpansionSequence(sequence);
@@ -113,15 +115,14 @@
 <Panel padBody={false}>
   <svelte:fragment slot="header">
     <GridMenu {gridId} title="Expansion" />
-    <div class="right">
-      <button
-        class="st-button secondary ellipsis"
-        disabled={!expandButtonEnabled}
-        on:click|stopPropagation={() => effects.expand(selectedExpansionSetId, $simulationDatasetId)}
-      >
-        {$expandingPlan ? 'Expanding... ' : 'Expand'}
-      </button>
-    </div>
+    <PanelHeaderActions status={$planExpansionStatus}>
+      <PanelHeaderActionButton
+        title="Expand"
+        showLabel
+        disabled={$selectedExpansionSetId === null}
+        on:click={() => effects.expand($selectedExpansionSetId, $simulationDatasetId)}
+      />
+    </PanelHeaderActions>
   </svelte:fragment>
 
   <svelte:fragment slot="body">
@@ -129,7 +130,7 @@
       <fieldset>
         <label for="expansionSet">Expansion Set</label>
         <select
-          bind:value={selectedExpansionSetId}
+          bind:value={$selectedExpansionSetId}
           class="st-select w-100"
           disabled={!$expansionSets.length}
           name="expansionSet"

--- a/src/components/menus/ViewMenu.svelte
+++ b/src/components/menus/ViewMenu.svelte
@@ -1,24 +1,22 @@
 <svelte:options accessors={true} immutable={true} />
 
 <script lang="ts">
-  import ChevronDownIcon from '@nasa-jpl/stellar/icons/chevron_down.svg?component';
   import ViewGridIcon from '@nasa-jpl/stellar/icons/view_grid_filled.svg?component';
   import { createEventDispatcher } from 'svelte';
   import { user as userStore } from '../../stores/app';
   import { view, viewIsModified } from '../../stores/views';
   import { showSavedViewsModal } from '../../utilities/modal';
   import { Status } from '../../utilities/status';
-  import NavButton from '../app/NavButton.svelte';
-  import Menu from './Menu.svelte';
+  import PlanNavButton from '../plan/PlanNavButton.svelte';
   import MenuItem from './MenuItem.svelte';
 
   const defaultViewName = 'Default View';
   const dispatch = createEventDispatcher();
 
   let saveViewDisabled: boolean = true;
-  let viewMenu: Menu;
 
   $: saveViewDisabled = $view?.name === '' || $view?.owner !== $userStore?.id || !$viewIsModified;
+  $: console.log('$viewIsModified :>> ', $viewIsModified);
 
   function saveAsView() {
     if ($view) {
@@ -46,16 +44,10 @@
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
-<NavButton
-  status={$viewIsModified ? Status.Modified : null}
-  title={$view?.name ?? defaultViewName}
-  on:click={() => viewMenu.toggle()}
->
-  <div class="view-menu-icon"><ViewGridIcon /></div>
-  <div class="view-menu st-typography-body" slot="menu">
-    <ChevronDownIcon />
-
-    <Menu bind:this={viewMenu} offset={[-120, -5]}>
+<div class="view-menu">
+  <PlanNavButton status={$viewIsModified ? Status.Modified : null} title={$view?.name ?? defaultViewName} menuTitle="">
+    <ViewGridIcon />
+    <div class="view-menu st-typography-medium" slot="menu">
       <MenuItem disabled={saveViewDisabled} on:click={saveView}>Save</MenuItem>
       <MenuItem on:click={saveAsView}>Save as</MenuItem>
       <MenuItem disabled={!$viewIsModified} on:click={resetView}>Reset to default</MenuItem>
@@ -64,31 +56,30 @@
         <hr />
         <MenuItem on:click={editView}>Rename view</MenuItem>
       {/if}
-    </Menu>
-  </div>
-</NavButton>
+    </div>
+  </PlanNavButton>
+</div>
 
 <style>
   .view-menu {
     --aerie-menu-item-template-columns: auto;
     align-items: center;
-    color: white;
     cursor: pointer;
-    display: flex;
+    display: grid;
     height: inherit;
     justify-content: center;
     position: relative;
   }
 
   .view-menu hr {
-    background-color: var(--st-gray-30);
+    background-color: var(--st-gray-20);
     border: 0;
     height: 1px;
     margin: 0 4px;
   }
 
-  .view-menu-icon > :global(svg) {
-    display: block;
-    height: 16px;
+  .view-menu :global(.header),
+  .view-menu :global(.nav-button .menu-body) {
+    display: none;
   }
 </style>

--- a/src/components/menus/ViewMenu.svelte
+++ b/src/components/menus/ViewMenu.svelte
@@ -16,7 +16,6 @@
   let saveViewDisabled: boolean = true;
 
   $: saveViewDisabled = $view?.name === '' || $view?.owner !== $userStore?.id || !$viewIsModified;
-  $: console.log('$viewIsModified :>> ', $viewIsModified);
 
   function saveAsView() {
     if ($view) {

--- a/src/components/plan/PlanNavButton.svelte
+++ b/src/components/plan/PlanNavButton.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+  import PlayIcon from '@nasa-jpl/stellar/icons/play.svg?component';
+  import type { Status } from '../../utilities/status';
+  import { tooltip } from '../../utilities/tooltip';
+  import Menu from '../menus/Menu.svelte';
+
+  import MenuHeader from '../menus/MenuHeader.svelte';
+  import StatusBadge from '../ui/StatusBadge.svelte';
+
+  export let buttonText: string = '';
+  export let buttonTooltipContent: string = '';
+  export let disabled: boolean = false;
+  export let menuTitle: string = '';
+  export let status: Status | null = null;
+  export let statusText: string = '';
+  export let title: string;
+
+  let showMenu = false;
+</script>
+
+<div
+  class="nav-button st-typography-medium"
+  on:mouseenter={() => (showMenu = true)}
+  on:mouseleave={() => (showMenu = false)}
+>
+  <div class="nav-button-icon-container">
+    <slot />
+    <span class="nav-button-status">
+      {#if status}
+        <StatusBadge {status} showTooltip={false} />
+      {/if}
+    </span>
+  </div>
+  {title}
+  <Menu hideAfterClick={false} placement="bottom-start" shown={showMenu} offset={[0, 0]}>
+    <MenuHeader title={menuTitle} showBorder={false} />
+    <div class="menu-body">
+      {#if status}
+        <div class="status-row st-typography-body">
+          <StatusBadge {status} showTooltip={false} />
+          {statusText || status}
+        </div>
+      {/if}
+      <div class="menu-metadata st-typography-body">
+        <slot name="metadata" />
+      </div>
+
+      {#if buttonText}
+        <div use:tooltip={{ content: buttonTooltipContent, placement: 'bottom' }}>
+          <button class="st-button secondary" {disabled} on:click><PlayIcon /> {buttonText}</button>
+        </div>
+      {/if}
+    </div>
+  </Menu>
+</div>
+
+<style>
+  .nav-button {
+    align-items: center;
+    color: var(--st-gray-20);
+    cursor: pointer;
+    display: inline-flex;
+    font-size: 14px;
+    gap: 12px;
+    height: var(--nav-header-height);
+    letter-spacing: 0.14px;
+    line-height: 14px;
+    padding: 16px;
+    position: relative;
+    user-select: none;
+  }
+
+  .nav-button:hover {
+    background: #2c2850;
+  }
+
+  .nav-button:hover :global(.nav-button-status .status-badge.Failed) {
+    filter: drop-shadow(3px 0px 0px #2c2850);
+  }
+
+  .nav-button-icon-container {
+    position: relative;
+  }
+
+  .nav-button-icon-container :global(.st-icon) {
+    height: 20px;
+    width: 20px;
+  }
+
+  .nav-button .nav-button-status {
+    position: absolute;
+    right: -8px;
+    top: -8px;
+  }
+
+  .nav-button :global(.header) {
+    padding-bottom: 0;
+  }
+
+  .nav-button :global(.nav-button-status .status-badge.Failed) {
+    filter: drop-shadow(3px 0px 0px #110d3e);
+  }
+
+  .menu-body {
+    cursor: auto;
+    display: grid;
+    gap: 8px;
+    max-height: 376px;
+    overflow: auto;
+    padding: 8px;
+    text-align: left;
+  }
+
+  .menu-body button {
+    gap: 4px;
+    width: 100%;
+  }
+
+  .status-row {
+    align-items: center;
+    display: flex;
+    gap: 8px;
+  }
+
+  .menu-metadata {
+    color: var(--st-gray-50);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+</style>

--- a/src/components/plan/PlanNavButton.svelte
+++ b/src/components/plan/PlanNavButton.svelte
@@ -31,9 +31,15 @@
       {/if}
     </span>
   </div>
-  {title}
+  {#if title}
+    <div class="nav-button-title">
+      {title}
+    </div>
+  {/if}
   <Menu hideAfterClick={false} placement="bottom-start" shown={showMenu} offset={[0, 0]}>
-    <MenuHeader title={menuTitle} showBorder={false} />
+    {#if menuTitle}
+      <MenuHeader title={menuTitle} showBorder={false} />
+    {/if}
     <div class="menu-body">
       {#if status}
         <div class="status-row st-typography-body">
@@ -51,6 +57,7 @@
         </div>
       {/if}
     </div>
+    <slot name="menu" />
   </Menu>
 </div>
 
@@ -61,13 +68,13 @@
     cursor: pointer;
     display: inline-flex;
     font-size: 14px;
-    gap: 12px;
     height: var(--nav-header-height);
     letter-spacing: 0.14px;
     line-height: 14px;
     padding: 16px;
     position: relative;
     user-select: none;
+    white-space: nowrap;
   }
 
   .nav-button:hover {
@@ -76,6 +83,10 @@
 
   .nav-button:hover :global(.nav-button-status .status-badge.Failed) {
     filter: drop-shadow(3px 0px 0px #2c2850);
+  }
+
+  .nav-button-title {
+    margin-left: 12px;
   }
 
   .nav-button-icon-container {

--- a/src/components/plan/PlanNavButton.svelte
+++ b/src/components/plan/PlanNavButton.svelte
@@ -3,7 +3,6 @@
   import type { Status } from '../../utilities/status';
   import { tooltip } from '../../utilities/tooltip';
   import Menu from '../menus/Menu.svelte';
-
   import MenuHeader from '../menus/MenuHeader.svelte';
   import StatusBadge from '../ui/StatusBadge.svelte';
 

--- a/src/components/scheduling/SchedulingGoalsPanel.svelte
+++ b/src/components/scheduling/SchedulingGoalsPanel.svelte
@@ -5,7 +5,7 @@
   import ChecklistIcon from '@nasa-jpl/stellar/icons/checklist.svg?component';
   import { afterUpdate, beforeUpdate } from 'svelte';
   import { plan } from '../../stores/plan';
-  import { schedulingSpecGoals, schedulingStatus, selectedSpecId } from '../../stores/scheduling';
+  import { enableScheduling, schedulingSpecGoals, schedulingStatus, selectedSpecId } from '../../stores/scheduling';
   import type { SchedulingSpecGoal } from '../../types/scheduling';
   import effects from '../../utilities/effects';
   import GridMenu from '../menus/GridMenu.svelte';
@@ -45,10 +45,10 @@
   <svelte:fragment slot="header">
     <GridMenu {gridId} title="Scheduling Goals" />
     <PanelHeaderActions status={$schedulingStatus}>
-      <PanelHeaderActionButton title="Analyze" on:click={() => effects.schedule(true)}>
+      <PanelHeaderActionButton title="Analyze" on:click={() => effects.schedule(true)} disabled={!$enableScheduling}>
         <ChecklistIcon />
       </PanelHeaderActionButton>
-      <PanelHeaderActionButton title="Schedule" on:click={() => effects.schedule()} />
+      <PanelHeaderActionButton title="Schedule" on:click={() => effects.schedule()} disabled={!$enableScheduling} />
     </PanelHeaderActions>
   </svelte:fragment>
 

--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -3,6 +3,7 @@
 <script lang="ts">
   import { plan } from '../../stores/plan';
   import {
+    enableSimulation,
     simulation,
     simulationDatasetId,
     simulationDatasetIds,
@@ -14,6 +15,7 @@
   import effects from '../../utilities/effects';
   import { getTarget } from '../../utilities/generic';
   import { getArguments, getFormParameters } from '../../utilities/parameters';
+  import { Status } from '../../utilities/status';
   import GridMenu from '../menus/GridMenu.svelte';
   import Parameters from '../parameters/Parameters.svelte';
   import Panel from '../ui/Panel.svelte';
@@ -68,7 +70,15 @@
   <svelte:fragment slot="header">
     <GridMenu {gridId} title="Simulation" />
     <PanelHeaderActions status={$simulationStatus}>
-      <PanelHeaderActionButton title="Simulate" showLabel on:click={() => effects.simulate()} />
+      <PanelHeaderActionButton
+        disabled={!$enableSimulation}
+        tooltipContent={$simulationStatus === Status.Complete || $simulationStatus === Status.Failed
+          ? 'Simluation up-to-date'
+          : ''}
+        title="Simulate"
+        showLabel
+        on:click={() => effects.simulate()}
+      />
     </PanelHeaderActions>
   </svelte:fragment>
 

--- a/src/components/ui/PanelHeaderActionButton.svelte
+++ b/src/components/ui/PanelHeaderActionButton.svelte
@@ -6,28 +6,33 @@
   export let disabled: boolean = false;
   export let showLabel: boolean = false;
   export let title: string = '';
+  export let tooltipContent: string = '';
 
   const dispatch = createEventDispatcher();
 </script>
 
 {#if showLabel}
-  <button class="st-button icon has-label" {disabled} on:click={() => dispatch('click')}>
-    <slot>
-      <PlayIcon />
-    </slot>
-    {title}
-  </button>
+  <span use:tooltip={{ content: tooltipContent, placement: 'top' }}>
+    <button class="st-button icon has-label" {disabled} on:click={() => dispatch('click')}>
+      <slot>
+        <PlayIcon />
+      </slot>
+      {title}
+    </button>
+  </span>
 {:else}
-  <button
-    class="st-button icon"
-    {disabled}
-    on:click={() => dispatch('click')}
-    use:tooltip={{ content: title, placement: 'bottom' }}
+  <span use:tooltip={{ content: tooltipContent, placement: 'top' }}>
+    <button
+      class="st-button icon"
+      {disabled}
+      on:click={() => dispatch('click')}
+      use:tooltip={{ content: title, placement: 'bottom' }}
+    >
+      <slot>
+        <PlayIcon />
+      </slot>
+    </button></span
   >
-    <slot>
-      <PlayIcon />
-    </slot>
-  </button>
 {/if}
 
 <style>

--- a/src/components/ui/StatusBadge.svelte
+++ b/src/components/ui/StatusBadge.svelte
@@ -33,7 +33,7 @@
       <EditingIcon />
     {:else if status === Status.Pending}
       <ThreeDotsIcon />
-    {:else if status === Status.Indeterminate}
+    {:else if status === Status.PartialSuccess}
       <MinusIcon />
     {/if}
   </span>

--- a/src/components/ui/StatusBadge.svelte
+++ b/src/components/ui/StatusBadge.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import CheckIcon from '@nasa-jpl/stellar/icons/check.svg?component';
   import EditingIcon from '@nasa-jpl/stellar/icons/editing.svg?component';
+  import MinusIcon from '@nasa-jpl/stellar/icons/minus.svg?component';
   import SpinnerIcon from '@nasa-jpl/stellar/icons/spinner.svg?component';
   import ThreeDotsIcon from '@nasa-jpl/stellar/icons/three_dot_horizontal.svg?component';
   import WarningIcon from '@nasa-jpl/stellar/icons/warning.svg?component';
@@ -8,6 +9,7 @@
   import { tooltip } from '../../utilities/tooltip';
 
   export let status: Status | null = null;
+  export let showTooltip: boolean = true;
 
   let color: string = statusColors.gray;
 
@@ -19,7 +21,7 @@
     aria-label={status}
     class="status-badge {status}"
     style="background: {status === Status.Failed ? 'transparent' : color}"
-    use:tooltip={{ content: status, placement: 'bottom' }}
+    use:tooltip={{ content: showTooltip ? status : '', placement: 'bottom' }}
   >
     {#if status === Status.Complete}
       <CheckIcon />
@@ -31,6 +33,8 @@
       <EditingIcon />
     {:else if status === Status.Pending}
       <ThreeDotsIcon />
+    {:else if status === Status.Indeterminate}
+      <MinusIcon />
     {/if}
   </span>
 {/if}

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import ActivityIcon from '@nasa-jpl/stellar/icons/activity.svg?component';
   import CalendarIcon from '@nasa-jpl/stellar/icons/calendar.svg?component';
   import PlanIcon from '@nasa-jpl/stellar/icons/plan.svg?component';
   import PlayIcon from '@nasa-jpl/stellar/icons/play.svg?component';

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -2,17 +2,15 @@
 
 <script lang="ts">
   import CalendarIcon from '@nasa-jpl/stellar/icons/calendar.svg?component';
+  import PlanIcon from '@nasa-jpl/stellar/icons/plan.svg?component';
+  import PlayIcon from '@nasa-jpl/stellar/icons/play.svg?component';
+  import VerticalCollapseIcon from '@nasa-jpl/stellar/icons/vertical_collapse_with_center_line.svg?component';
   import GearWideConnectedIcon from 'bootstrap-icons/icons/gear-wide-connected.svg?component';
-  import PlanIcon from 'bootstrap-icons/icons/plan.svg?component';
-  import PlayIcon from 'bootstrap-icons/icons/play.svg?component';
-  import VerticalCollapseIcon from 'bootstrap-icons/icons/vertical_collapse.svg?component';
   import { onDestroy } from 'svelte';
-  import PlanNavButton from '../../../../components/plan/PlanNavButton.svelte';
   import ActivityFormPanel from '../../../components/activity/ActivityFormPanel.svelte';
   import ActivityTablePanel from '../../../components/activity/ActivityTablePanel.svelte';
   import ActivityTypesPanel from '../../../components/activity/ActivityTypesPanel.svelte';
   import Nav from '../../../components/app/Nav.svelte';
-  import NavButton from '../../../components/app/NavButton.svelte';
   import PageTitle from '../../../components/app/PageTitle.svelte';
   import Console from '../../../components/console/Console.svelte';
   import ConsoleSection from '../../../components/console/ConsoleSection.svelte';
@@ -23,6 +21,7 @@
   import PlanMenu from '../../../components/menus/PlanMenu.svelte';
   import ViewMenu from '../../../components/menus/ViewMenu.svelte';
   import PlanMergeRequestsStatusButton from '../../../components/plan/PlanMergeRequestsStatusButton.svelte';
+  import PlanNavButton from '../../../components/plan/PlanNavButton.svelte';
   import SchedulingConditionsPanel from '../../../components/scheduling/SchedulingConditionsPanel.svelte';
   import SchedulingGoalsPanel from '../../../components/scheduling/SchedulingGoalsPanel.svelte';
   import SimulationPanel from '../../../components/simulation/SimulationPanel.svelte';
@@ -65,14 +64,7 @@
     simulationStatus,
     spans,
   } from '../../../stores/simulation';
-  import {
-    initializeView,
-    resetOriginalView,
-    resetView,
-    view,
-    viewSetLayout,
-    viewUpdateLayout,
-  } from '../../../stores/views';
+  import { initializeView, resetOriginalView, resetView, view, viewUpdateLayout } from '../../../stores/views';
   import type { GridChangeSizesEvent } from '../../../types/grid';
   import type { ViewSaveEvent } from '../../../types/view';
   import { createActivitiesMap } from '../../../utilities/activities';
@@ -101,7 +93,12 @@
     ViewEditorPanel,
   };
 
+  let compactNavMode = false;
   let planHasBeenLocked = false;
+  let satisfiedSchedulingGoalCount = 0;
+  let schedulingGoalCount = 0;
+  let schedulingAnalysisStatus: Status | null;
+  let windowWidth = 0;
 
   $: if (data.initialPlan) {
     $plan = data.initialPlan;
@@ -149,10 +146,6 @@
     planHasBeenLocked = false;
   }
 
-  let schedulingGoalCount = 0;
-  let satisfiedSchedulingGoalCount = 0;
-  let schedulingAnalysisStatus: Status | null;
-
   $: schedulingAnalysisStatus = $schedulingStatus;
 
   $: if ($schedulingSpecGoals) {
@@ -178,6 +171,8 @@
       schedulingAnalysisStatus = Status.PartialSuccess;
     }
   }
+
+  $: compactNavMode = windowWidth < 1100;
 
   onDestroy(() => {
     resetActivityStores();
@@ -250,7 +245,7 @@
   }
 </script>
 
-<svelte:window on:keydown={onKeydown} />
+<svelte:window on:keydown={onKeydown} bind:innerWidth={windowWidth} />
 
 <PageTitle subTitle={data.initialPlan.name} title="Plans" />
 
@@ -264,7 +259,7 @@
     </svelte:fragment>
     <svelte:fragment slot="right">
       <PlanNavButton
-        title="Expansion"
+        title={!compactNavMode ? 'Expansion' : ''}
         buttonText="Expand Activities"
         menuTitle="Expansion Status"
         disabled={$selectedExpansionSetId === null}
@@ -277,7 +272,7 @@
         </svelte:fragment>
       </PlanNavButton>
       <PlanNavButton
-        title="Simulation"
+        title={!compactNavMode ? 'Simulation' : ''}
         menuTitle="Simulation Status"
         buttonText="Simulate"
         buttonTooltipContent={$simulationStatus === Status.Complete || $simulationStatus === Status.Failed
@@ -293,7 +288,7 @@
         </svelte:fragment>
       </PlanNavButton>
       <PlanNavButton
-        title="Constraints"
+        title={!compactNavMode ? 'Constraints' : ''}
         menuTitle="Constraint Status"
         buttonText="Check Constraints"
         status={$checkConstraintsStatus}
@@ -305,7 +300,7 @@
         </svelte:fragment>
       </PlanNavButton>
       <PlanNavButton
-        title="Scheduling"
+        title={!compactNavMode ? 'Scheduling' : ''}
         menuTitle="Scheduling Analysis Status"
         buttonText="Analyze Goal Satisfaction"
         status={schedulingAnalysisStatus}
@@ -318,14 +313,6 @@
       >
         <CalendarIcon />
       </PlanNavButton>
-      <NavButton
-        selected={$view.definition.plan.layout?.gridName === 'Simulation'}
-        status={$simulationStatus}
-        title="Simulation"
-        on:click={() => viewSetLayout('Simulation')}
-      >
-        <GearWideConnectedIcon />
-      </NavButton>
       <ViewMenu
         on:createView={onCreateView}
         on:editView={onEditView}

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -159,21 +159,23 @@
     schedulingGoalCount = 0;
     satisfiedSchedulingGoalCount = 0;
 
-    // TODO do we skip disabled goals?
+    // Derive the number of satisfied scheduling goals from the last analysis
     $schedulingSpecGoals.forEach(schedulingSpecGoal => {
+      // TODO how should we handle disabled goals? Enabling/disabling goals will trigger
+      // a refresh of this data and we don't know if the last analysis included a goal
+      // since it could have been disabled.
       schedulingGoalCount++;
-      schedulingSpecGoal.goal.analyses.forEach(analysis => {
-        if (analysis.satisfied) {
+      if (schedulingSpecGoal.goal.analyses.length > 0) {
+        const latestAnalysis = schedulingSpecGoal.goal.analyses[0];
+        if (latestAnalysis.satisfied) {
           satisfiedSchedulingGoalCount++;
         }
-      });
+      }
     });
 
     // Derive schedulingAnalysisStatus
-
-    /* TODO review this, kind of complicated and unclear how all of this behaves */
     if ($schedulingStatus === Status.Complete && schedulingGoalCount !== satisfiedSchedulingGoalCount) {
-      schedulingAnalysisStatus = Status.Indeterminate;
+      schedulingAnalysisStatus = Status.PartialSuccess;
     }
   }
 
@@ -307,7 +309,7 @@
         menuTitle="Scheduling Analysis Status"
         buttonText="Analyze Goal Satisfaction"
         status={schedulingAnalysisStatus}
-        statusText={schedulingAnalysisStatus === Status.Indeterminate || schedulingAnalysisStatus === Status.Complete
+        statusText={schedulingAnalysisStatus === Status.PartialSuccess || schedulingAnalysisStatus === Status.Complete
           ? `${satisfiedSchedulingGoalCount} satisfied, ${
               schedulingGoalCount - satisfiedSchedulingGoalCount
             } unsatisfied`

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -54,6 +54,7 @@
   } from '../../../stores/plan';
   import { resourceTypes } from '../../../stores/resource';
   import {
+    enableScheduling,
     latestAnalyses,
     resetSchedulingStores,
     satisfiedSchedulingGoalCount,
@@ -287,6 +288,7 @@
         title={!compactNavMode ? 'Scheduling' : ''}
         menuTitle="Scheduling Analysis Status"
         buttonText="Analyze Goal Satisfaction"
+        disabled={!$enableScheduling}
         status={schedulingAnalysisStatus}
         statusText={schedulingAnalysisStatus === Status.PartialSuccess || schedulingAnalysisStatus === Status.Complete
           ? `${$satisfiedSchedulingGoalCount} satisfied, ${

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -54,10 +54,10 @@
   } from '../../../stores/plan';
   import { resourceTypes } from '../../../stores/resource';
   import {
+    latestAnalyses,
     resetSchedulingStores,
     satisfiedSchedulingGoalCount,
     schedulingGoalCount,
-    schedulingSpecGoals,
     schedulingStatus,
   } from '../../../stores/scheduling';
   import {
@@ -150,16 +150,13 @@
     planHasBeenLocked = false;
   }
 
+  $: compactNavMode = windowWidth < 1100;
   $: schedulingAnalysisStatus = $schedulingStatus;
-
-  $: if ($schedulingSpecGoals) {
-    // Derive schedulingAnalysisStatus
-    if ($schedulingStatus === Status.Complete && $schedulingGoalCount !== $satisfiedSchedulingGoalCount) {
+  $: if ($latestAnalyses) {
+    if ($schedulingGoalCount !== $satisfiedSchedulingGoalCount) {
       schedulingAnalysisStatus = Status.PartialSuccess;
     }
   }
-
-  $: compactNavMode = windowWidth < 1100;
 
   onDestroy(() => {
     resetActivityStores();

--- a/src/stores/expansion.ts
+++ b/src/stores/expansion.ts
@@ -1,6 +1,7 @@
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
 import type { ExpansionRule, ExpansionSequence, ExpansionSet } from '../types/expansion';
 import gql from '../utilities/gql';
+import type { Status } from '../utilities/status';
 import { simulationDatasetId } from './simulation';
 import { gqlSubscribable } from './subscribable';
 
@@ -28,7 +29,11 @@ export const savingExpansionRule: Writable<boolean> = writable(false);
 
 export const savingExpansionSet: Writable<boolean> = writable(false);
 
-export const expandingPlan: Writable<boolean> = writable(false);
+// export const expandingPlan: Writable<boolean> = writable(false);
+
+export const planExpansionStatus: Writable<Status | null> = writable(null);
+
+export const selectedExpansionSetId: Writable<number | null> = writable(null);
 
 /* Derived. */
 

--- a/src/stores/expansion.ts
+++ b/src/stores/expansion.ts
@@ -29,8 +29,6 @@ export const savingExpansionRule: Writable<boolean> = writable(false);
 
 export const savingExpansionSet: Writable<boolean> = writable(false);
 
-// export const expandingPlan: Writable<boolean> = writable(false);
-
 export const planExpansionStatus: Writable<Status | null> = writable(null);
 
 export const selectedExpansionSetId: Writable<number | null> = writable(null);

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -1,4 +1,4 @@
-import { derived, writable, type Writable } from 'svelte/store';
+import { derived, writable, type Readable, type Writable } from 'svelte/store';
 import { plan } from '../stores/plan';
 import type {
   SchedulingCondition,
@@ -64,6 +64,10 @@ export const satisfiedSchedulingGoalCount = derived(
   latestAnalyses,
   $latestAnalyses => Object.values($latestAnalyses).filter(analysis => analysis.satisfied).length,
 );
+
+export const enableScheduling: Readable<boolean> = derived([schedulingSpecGoals], ([$schedulingSpecGoals]) => {
+  return $schedulingSpecGoals.filter(schedulingSpecGoal => schedulingSpecGoal.enabled).length > 0;
+});
 
 /* Helper Functions. */
 

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -39,6 +39,25 @@ export const schedulingSpecGoals = gqlSubscribable<SchedulingSpecGoal[]>(
   [],
 );
 
+export const schedulingGoalCount = derived(schedulingSpecGoals, $schedulingSpecGoals => $schedulingSpecGoals.length);
+export const satisfiedSchedulingGoalCount = derived(schedulingSpecGoals, $schedulingSpecGoals => {
+  let count = 0;
+
+  // Derive the number of satisfied scheduling goals from the last analysis
+  $schedulingSpecGoals.forEach(schedulingSpecGoal => {
+    // TODO how should we handle disabled goals? Enabling/disabling goals will trigger
+    // a refresh of this data and we don't know if the last analysis included a goal
+    // since it could have been disabled.
+    if (schedulingSpecGoal.goal.analyses.length > 0) {
+      const latestAnalysis = schedulingSpecGoal.goal.analyses[0];
+      if (latestAnalysis.satisfied) {
+        count++;
+      }
+    }
+  });
+  return count;
+});
+
 /* Helper Functions. */
 
 export function resetSchedulingStores() {

--- a/src/stores/simulation.ts
+++ b/src/stores/simulation.ts
@@ -114,6 +114,10 @@ export const simulationStatus: Readable<Status | null> = derived(
   null,
 );
 
+export const enableSimulation: Readable<boolean> = derived([simulationStatus], ([$simulationStatus]) => {
+  return $simulationStatus === Status.Modified || $simulationStatus === null;
+});
+
 /* Helper Functions. */
 
 export function resetSimulationStores() {

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -29,6 +29,7 @@ export type SchedulingCondition = {
 };
 
 export type SchedulingGoalAnalysis = {
+  analysis_id: number;
   satisfied: boolean;
   satisfying_activities: { activity_id: number }[];
 };

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -8,7 +8,7 @@ import {
   createDictionaryError,
   creatingDictionary,
   creatingExpansionSequence,
-  expandingPlan,
+  planExpansionStatus,
   savingExpansionRule,
   savingExpansionSet,
 } from '../stores/expansion';
@@ -944,14 +944,14 @@ const effects = {
 
   async expand(expansionSetId: number, simulationDatasetId: number): Promise<void> {
     try {
-      expandingPlan.set(true);
+      planExpansionStatus.set(Status.Incomplete);
       await reqHasura(gql.EXPAND, { expansionSetId, simulationDatasetId });
+      planExpansionStatus.set(Status.Complete);
       showSuccessToast('Plan Expanded Successfully');
-      expandingPlan.set(false);
     } catch (e) {
       catchError('Plan Expansion Failed', e);
+      planExpansionStatus.set(Status.Failed);
       showFailureToast('Plan Expansion Failed');
-      expandingPlan.set(false);
     }
   },
 

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1236,6 +1236,7 @@ const gql = {
         enabled
         goal {
           analyses(order_by: { request: { specification_revision: desc } }, limit: 2) {
+            analysis_id
             satisfied
             satisfying_activities {
               activity_id

--- a/src/utilities/status.ts
+++ b/src/utilities/status.ts
@@ -4,7 +4,7 @@ export enum Status {
   Incomplete = 'Incomplete',
   Modified = 'Modified',
   Pending = 'Pending',
-  Indeterminate = 'Indeterminate',
+  PartialSuccess = 'PartialSuccess',
 }
 
 export const statusColors: Record<string, string> = {
@@ -29,7 +29,7 @@ export function getColorForStatus(status: Status): string {
     return statusColors.yellow;
   } else if (status === Status.Pending) {
     return statusColors.gray;
-  } else if (status === Status.Indeterminate) {
+  } else if (status === Status.PartialSuccess) {
     return statusColors.orange;
   } else {
     return statusColors.gray;

--- a/src/utilities/status.ts
+++ b/src/utilities/status.ts
@@ -4,11 +4,13 @@ export enum Status {
   Incomplete = 'Incomplete',
   Modified = 'Modified',
   Pending = 'Pending',
+  Indeterminate = 'Indeterminate',
 }
 
 export const statusColors: Record<string, string> = {
   gray: '#bec0c2',
   green: '#0eaf0a',
+  orange: '#c58b00',
   red: '#db5139',
   yellow: '#e6b300',
 };
@@ -27,6 +29,8 @@ export function getColorForStatus(status: Status): string {
     return statusColors.yellow;
   } else if (status === Status.Pending) {
     return statusColors.gray;
+  } else if (status === Status.Indeterminate) {
+    return statusColors.orange;
   } else {
     return statusColors.gray;
   }


### PR DESCRIPTION
Closes #349 
Also adds basic responsive styling to the navbar.

One unresolved question - how do we handle enabling/disabling of scheduling goals with respect to the navbar scheduling analysis status? A scheduling analysis does not note which goals were included in the last run so we don't have an easy way to know whether or not to include each goal in the tally. Right now the tally just uses the latest analysis for all goals.

TODO:
- [x] Review Scheduling status and metadata logic