### PR TITLE
Account for null target activity in non-conflicting activity in plan merge

### DIFF
--- a/src/components/plan/PlanMergeReview.svelte
+++ b/src/components/plan/PlanMergeReview.svelte
@@ -111,7 +111,9 @@
         const { source, target } = conflictingActivity;
 
         return {
-          receivingPlanDirectives: [...previous.receivingPlanDirectives, target],
+          receivingPlanDirectives: target
+            ? [...previous.receivingPlanDirectives, target]
+            : previous.receivingPlanDirectives,
           supplyingPlanDirectives: [
             ...previous.supplyingPlanDirectives,
             {

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -28,7 +28,7 @@ export type PlanMergeNonConflictingActivity = {
   change_type: PlanMergeActivityOutcome;
   merge_request_id: number;
   source: PlanMergeActivityDirective;
-  target: PlanMergeActivityDirective;
+  target: PlanMergeActivityDirective | null;
 };
 
 export type PlanMergeRequestType = 'incoming' | 'outgoing';


### PR DESCRIPTION
Target activity in non-conflicting activities for plan merges can be null. This updates the type to reflect this and accounts for the nulls.