### PR TITLE
Add check for existing selected nodes when auto scrolling table

### DIFF
--- a/src/components/ui/DataGrid/DataGrid.svelte
+++ b/src/components/ui/DataGrid/DataGrid.svelte
@@ -220,7 +220,7 @@
 
         // only dispatch `rowSelected` or enforce visibility for single row selections
         if (selectedNodes.length <= 1 || suppressRowClickSelection) {
-          if (scrollToSelection) {
+          if (selectedNodes.length && scrollToSelection) {
             gridOptions?.api?.ensureIndexVisible(selectedNodes[0].rowIndex);
           }
 


### PR DESCRIPTION
This resolves #379 

To test:

1. Create a plan with a few activities
2. Open the browser dev console
3. Select an activity and delete it
4. Verify that the error no longer is thrown