### PR TITLE
Support plans without scheduling specs

### DIFF
--- a/src/components/scheduling/conditions/SchedulingConditionForm.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditionForm.svelte
@@ -49,7 +49,11 @@
 
   $: planOptions = plans
     .filter(plan => plan.model_id === conditionModelId)
-    .map(({ id, name, scheduling_specifications }) => ({ id, name, specId: scheduling_specifications[0].id }));
+    .map(({ id, name, scheduling_specifications }) => ({
+      id,
+      name,
+      specId: (scheduling_specifications && scheduling_specifications[0]?.id) || null,
+    }));
   $: specId = planOptions.some(plan => plan.specId === specId) ? specId : null; // Null the specId value if the filtered plan list no longer includes the chosen spec
 
   $: saveButtonEnabled =
@@ -189,8 +193,8 @@
         <select bind:value={specId} class="st-select w-100" name="plan">
           <option value={null} />
           {#each planOptions as plan}
-            <option value={plan.specId}>
-              {plan.name} ({plan.id})
+            <option value={plan.specId} disabled={!plan.specId}>
+              {plan.name} ({plan.id}) {#if plan.specId === null} (Missing Scheduling Specification) {/if}
             </option>
           {/each}
         </select>

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte
@@ -51,7 +51,12 @@
 
   $: planOptions = plans
     .filter(plan => plan.model_id === goalModelId)
-    .map(({ id, name, scheduling_specifications }) => ({ id, name, specId: scheduling_specifications[0].id }));
+    .map(({ id, name, scheduling_specifications }) => ({
+      id,
+      name,
+      specId: (scheduling_specifications && scheduling_specifications[0]?.id) || null,
+    }));
+
   $: specId = planOptions.some(plan => plan.specId === specId) ? specId : null; // Null the specId value if the filtered plan list no longer includes the chosen spec
   $: saveButtonEnabled = goalDefinition !== '' && goalModelId !== null && goalName !== '' && specId !== null;
   $: goalModified =
@@ -211,8 +216,8 @@
         <select bind:value={specId} class="st-select w-100" name="plan">
           <option value={null} />
           {#each planOptions as plan}
-            <option value={plan.specId}>
-              {plan.name} ({plan.id})
+            <option value={plan.specId} disabled={plan.specId === null}>
+              {plan.name} ({plan.id}) {#if plan.specId === null} (Missing Scheduling Specification) {/if}
             </option>
           {/each}
         </select>

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte.test.ts
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte.test.ts
@@ -1,0 +1,55 @@
+import { cleanup, render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ModelSlim } from '../../../types/model';
+import type { PlanSchedulingSpec } from '../../../types/plan';
+import SchedulingGoalForm from './SchedulingGoalForm.svelte';
+
+const plans: PlanSchedulingSpec[] = [
+  {
+    id: 1,
+    model_id: 1,
+    name: 'Plan With Scheduling Spec',
+    scheduling_specifications: [
+      {
+        id: 1,
+      },
+    ],
+  },
+  {
+    id: 2,
+    model_id: 1,
+    name: 'Plan Without Scheduling Spec',
+    scheduling_specifications: undefined,
+  },
+];
+
+const models: ModelSlim[] = [
+  {
+    id: 1,
+    jar_id: 1,
+    name: 'BananaNation',
+    version: '1.0.0',
+  },
+];
+
+describe('Scheduling Goal Form component', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('Should not assume all plans have a scheduling spec', () => {
+    const { container } = render(SchedulingGoalForm, {
+      initialGoalModelId: models[0].id,
+      models,
+      plans,
+    });
+
+    const planDropdown: HTMLSelectElement = container.querySelector('.st-select[name="plan"]');
+
+    // Ensure the page and dropdown were rendered;
+    expect(planDropdown).to.exist;
+
+    // Ensure each plan is listed (plus one for empty option)
+    expect(planDropdown.options.length).toEqual(plans.length + 1);
+  });
+});

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -28,7 +28,7 @@ export const load: PageLoad = async ({ parent, params, url }) => {
           analysis_only: false,
           horizon_end: end_time_doy,
           horizon_start: start_time_doy,
-          plan_id: Number(id),
+          plan_id: planId,
           plan_revision: revision,
           simulation_arguments: {},
         });

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -14,12 +14,31 @@ export const load: PageLoad = async ({ parent, params, url }) => {
   const planId = parseFloat(id);
 
   if (!Number.isNaN(planId)) {
-    const initialPlan = await effects.getPlan(planId);
+    let initialPlan = await effects.getPlan(planId);
 
     if (initialPlan) {
       if (initialPlan.is_locked) {
         throw redirect(302, `${base}/plans/${id}/merge`);
       }
+
+      // if plan doesn't have a scheduling spec, create one at this point
+      if (!initialPlan.scheduling_specifications.length) {
+        const { start_time_doy, end_time_doy, revision } = initialPlan;
+        const schedulingSpec = await effects.createSchedulingSpec({
+          analysis_only: false,
+          horizon_end: end_time_doy,
+          horizon_start: start_time_doy,
+          plan_id: Number(id),
+          plan_revision: revision,
+          simulation_arguments: {},
+        });
+
+        initialPlan = {
+          ...initialPlan,
+          scheduling_specifications: [schedulingSpec],
+        };
+      }
+
       const initialActivityTypes = await effects.getActivityTypes(initialPlan.model_id);
       const initialView = await effects.getView(url.searchParams, initialActivityTypes, []);
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -513,9 +513,9 @@ const effects = {
     }
   },
 
-  async createSchedulingSpec(spec: SchedulingSpecInsertInput): Promise<Pick<SchedulingSpec, 'id'>> {
+  async createSchedulingSpec(spec: SchedulingSpecInsertInput): Promise<{ id: number }> {
     try {
-      const data = await reqHasura<Pick<SchedulingSpec, 'id'>>(gql.CREATE_SCHEDULING_SPEC, { spec });
+      const data = await reqHasura<{ id: number }>(gql.CREATE_SCHEDULING_SPEC, { spec });
       const { createSchedulingSpec: newSchedulingSpec } = data;
       return newSchedulingSpec;
     } catch (e) {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -513,9 +513,11 @@ const effects = {
     }
   },
 
-  async createSchedulingSpec(spec: SchedulingSpecInsertInput): Promise<void> {
+  async createSchedulingSpec(spec: SchedulingSpecInsertInput): Promise<Pick<SchedulingSpec, 'id'>> {
     try {
-      await reqHasura(gql.CREATE_SCHEDULING_SPEC, { spec });
+      const data = await reqHasura<Pick<SchedulingSpec, 'id'>>(gql.CREATE_SCHEDULING_SPEC, { spec });
+      const { createSchedulingSpec: newSchedulingSpec } = data;
+      return newSchedulingSpec;
     } catch (e) {
       catchError(e);
     }

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -513,9 +513,9 @@ const effects = {
     }
   },
 
-  async createSchedulingSpec(spec: SchedulingSpecInsertInput): Promise<{ id: number }> {
+  async createSchedulingSpec(spec: SchedulingSpecInsertInput): Promise<Pick<SchedulingSpec, 'id'>> {
     try {
-      const data = await reqHasura<{ id: number }>(gql.CREATE_SCHEDULING_SPEC, { spec });
+      const data = await reqHasura<Pick<SchedulingSpec, 'id'>>(gql.CREATE_SCHEDULING_SPEC, { spec });
       const { createSchedulingSpec: newSchedulingSpec } = data;
       return newSchedulingSpec;
     } catch (e) {


### PR DESCRIPTION
Closes #363 

Now that we're explicitly associating a scheduling goal with a plan, the SchedulingGoalForm was assuming that a plan always had a Scheduling Specification. This is true when a plan is created through the UI, but not necessarily true when created by an API. To support this possibility we're taking two approaches:

- When the user loads a plan, if the plan does not already have a scheduling spec, we create one at page load.
- If the user somehow still navigates to the goals page without creating a scheduling spec, we ensure the page doesn't break, and show a message in the dropdown that the plan can't be used for goals due to a "Missing Scheduling Specification".