### PR TITLE
Make sure Monaco Editor setValue is not null

### DIFF
--- a/src/components/ui/MonacoEditor.svelte
+++ b/src/components/ui/MonacoEditor.svelte
@@ -35,7 +35,7 @@
     const currentValue = editor.getValue();
     if (value !== currentValue) {
       const scrollTop = editor.getScrollTop(); // setValue can nuke scroll position.
-      editor.getModel().setValue(value);
+      editor.getModel().setValue(value ?? ''); // Make sure value is not null or Monaco throws.
       editor.setScrollPosition({ scrollTop });
     }
   }


### PR DESCRIPTION
* Otherwise the editor crashes

To test:
- Open the expansion panel on the plan page
- Create a sequence
- Open the sequence modal to show the editor
- The editor should load and not crash