### PR TITLE
Prevent plan creation invalid date

### DIFF
--- a/src/components/ui/DatePicker/DatePicker.svelte
+++ b/src/components/ui/DatePicker/DatePicker.svelte
@@ -133,12 +133,14 @@
     }
   }
 
-  function autoCompleteDate(event: Event) {
+  function attempAutoCompleteDate(event: Event) {
     const { value } = getTarget(event);
 
     const parsedDate = getDateFromString(`${value}`);
     if (parsedDate !== null) {
       setDateString(getDoyTime(parsedDate, parsedDate.getUTCMilliseconds() > 0));
+    } else {
+      setDateString(`${value}`);
     }
   }
 
@@ -210,7 +212,7 @@
     if (key === 'Enter') {
       event.preventDefault();
 
-      autoCompleteDate(event);
+      attempAutoCompleteDate(event);
       closeDatePicker();
     }
   }
@@ -252,7 +254,7 @@
     {name}
     bind:value={dateString}
     use:popperRef
-    on:change={autoCompleteDate}
+    on:change={attempAutoCompleteDate}
     on:click={openDatePicker}
     on:focus={openDatePicker}
     on:keydown={onInputKeydown}

--- a/src/components/ui/DatePicker/DatePicker.svelte
+++ b/src/components/ui/DatePicker/DatePicker.svelte
@@ -133,7 +133,7 @@
     }
   }
 
-  function attempAutoCompleteDate(event: Event) {
+  function attemptAutoCompleteDate(event: Event) {
     const { value } = getTarget(event);
 
     const parsedDate = getDateFromString(`${value}`);
@@ -212,7 +212,7 @@
     if (key === 'Enter') {
       event.preventDefault();
 
-      attempAutoCompleteDate(event);
+      attemptAutoCompleteDate(event);
       closeDatePicker();
     }
   }
@@ -254,7 +254,7 @@
     {name}
     bind:value={dateString}
     use:popperRef
-    on:change={attempAutoCompleteDate}
+    on:change={attemptAutoCompleteDate}
     on:click={openDatePicker}
     on:focus={openDatePicker}
     on:keydown={onInputKeydown}

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -162,7 +162,7 @@
   }
 
   function onStartTimeChanged() {
-    if ($startTimeDoyField.value && $endTimeDoyField.value === '') {
+    if ($startTimeDoyField.value && $startTimeDoyField.valid && $endTimeDoyField.value === '') {
       endTimeDoyField.set($startTimeDoyField);
     }
     updateDurationString();


### PR DESCRIPTION
resolves #358 

To test:
1. Fill in fields to create a plan
2. Fill in valid start/end times
3. Make one of the times an invalid time (e.g. add a letter in the time where it shouldn't belong)
4. Verify that a validation error is shown in the relevant time field
5. Verify that the "Create" button is disabled until you fix the time format