### PR TITLE
Add view download button to ViewsTable

### DIFF
--- a/src/components/ui/DataGrid/DataGridActions.svelte
+++ b/src/components/ui/DataGrid/DataGridActions.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import DownloadIcon from '@nasa-jpl/stellar/icons/download.svg?component';
   import ExpandIcon from '@nasa-jpl/stellar/icons/expand.svg?component';
   import PenIcon from '@nasa-jpl/stellar/icons/pen.svg?component';
   import TrashIcon from '@nasa-jpl/stellar/icons/trash.svg?component';
@@ -16,10 +17,12 @@
   export let rowData: TRowData;
   export let editTooltip: Tooltip = undefined;
   export let deleteTooltip: Tooltip = undefined;
+  export let downloadTooltip: Tooltip = undefined;
   export let viewTooltip: Tooltip = undefined;
 
   export let editCallback: (data: TRowData) => void = undefined;
   export let deleteCallback: (data: TRowData) => void = undefined;
+  export let downloadCallback: (data: TRowData) => void = undefined;
   export let viewCallback: (data: TRowData) => void = undefined;
 </script>
 
@@ -32,6 +35,17 @@
     use:tooltip={viewTooltip}
   >
     <ExpandIcon />
+  </button>
+{/if}
+{#if downloadCallback}
+  <button
+    class="st-button icon"
+    on:click|stopPropagation={() => {
+      downloadCallback(rowData);
+    }}
+    use:tooltip={downloadTooltip}
+  >
+    <DownloadIcon />
   </button>
 {/if}
 {#if editCallback}

--- a/src/components/view/ViewsTable.svelte
+++ b/src/components/view/ViewsTable.svelte
@@ -12,6 +12,7 @@
 
   type CellRendererParams = {
     deleteView: (view: View) => void;
+    downloadView: (view: View) => void;
     openView: (view: View) => void;
   };
   type ViewCellRendererParams = ICellRendererParams<View> & CellRendererParams;
@@ -60,6 +61,11 @@
                   },
                 }
               : {}),
+            downloadCallback: params.downloadView,
+            downloadTooltip: {
+              content: 'Download View',
+              placement: 'bottom',
+            },
             rowData: params.data,
             viewCallback: params.openView,
             viewTooltip: {
@@ -74,6 +80,7 @@
       },
       cellRendererParams: {
         deleteView,
+        downloadView,
         openView,
       } as CellRendererParams,
       field: 'actions',
@@ -82,7 +89,7 @@
       sortable: false,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      width: 55,
+      width: 81,
     },
   ];
 
@@ -93,6 +100,13 @@
   function deleteViews({ detail: views }: CustomEvent<View[]>) {
     const viewIds = views.map(({ id }) => id);
     dispatch('deleteViews', viewIds);
+  }
+
+  function downloadView(view: View) {
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(new Blob([JSON.stringify(view.definition, null, 2)], { type: 'application/json' }));
+    a.download = view.name;
+    a.click();
   }
 
   function openView({ id: viewId }: View) {


### PR DESCRIPTION
To test:
1. Create some views
2. Open Views Table
![Screenshot 2023-03-01 at 5 28 39 PM](https://user-images.githubusercontent.com/5290214/222307435-71429a43-994a-4039-8a17-a526d2b18e26.png)
3. Hover over the row of the view you want to download
4. Confirm that a new download icon is displayed at the right
![Screenshot 2023-03-01 at 5 31 23 PM](https://user-images.githubusercontent.com/5290214/222307694-79ab7de0-65bd-45a0-97b4-b11e363e0dee.png)
5. Confirm that clicking the button downloads a JSON file
