### PR TITLE
Fix menu overlapping

### DIFF
--- a/src/components/menus/Menu.svelte
+++ b/src/components/menus/Menu.svelte
@@ -18,9 +18,14 @@
 
   export let hideAfterClick: boolean = true;
   export let offset: number[] = [0, 1];
-  export let shown: boolean = false;
   export let isMounted: boolean = false;
   export let placement: Placement = 'bottom-start';
+
+  // The shown state is intentionally private.
+  // Use the accessor functions to change this state.
+  // This is so we can more easily control global state of all Menus on a page.
+  // See 'hideAllMenus' above.
+  let shown: boolean = false;
 
   $: if (isMounted) {
     if (shown) {
@@ -35,6 +40,10 @@
       dispatch('hide');
     }
     shown = false;
+  }
+
+  export function isShown(): boolean {
+    return shown;
   }
 
   export function show(): void {

--- a/src/components/plan/PlanNavButton.svelte
+++ b/src/components/plan/PlanNavButton.svelte
@@ -14,14 +14,10 @@
   export let statusText: string = '';
   export let title: string;
 
-  let showMenu = false;
+  let menu: Menu;
 </script>
 
-<div
-  class="nav-button st-typography-medium"
-  on:mouseenter={() => (showMenu = true)}
-  on:mouseleave={() => (showMenu = false)}
->
+<div class="nav-button st-typography-medium" on:mouseenter={() => menu.show()} on:mouseleave={() => menu.hide()}>
   <div class="nav-button-icon-container">
     <slot />
     <span class="nav-button-status">
@@ -35,7 +31,7 @@
       {title}
     </div>
   {/if}
-  <Menu hideAfterClick={false} placement="bottom-start" shown={showMenu} offset={[0, 0]}>
+  <Menu bind:this={menu} hideAfterClick={false} placement="bottom-start" offset={[0, 0]}>
     {#if menuTitle}
       <MenuHeader title={menuTitle} showBorder={false} />
     {/if}

--- a/src/components/timeline/form/TimelineEditorLayerFilter.svelte
+++ b/src/components/timeline/form/TimelineEditorLayerFilter.svelte
@@ -24,7 +24,7 @@
   $: if (layer) {
     selectedValuesMap = listToMap(values);
     if (layer.chartType === 'activity') {
-      menuTitle = 'Activty Dictionary';
+      menuTitle = 'Activity Dictionary';
     } else if (layer.chartType === 'line') {
       menuTitle = 'Resource Types';
     } else if (layer.chartType === 'x-range') {
@@ -77,7 +77,7 @@
       bind:this={input}
       bind:value={filterString}
       on:click|stopPropagation={() => {
-        if (!filterMenu.shown) {
+        if (!filterMenu.isShown()) {
           filterMenu.show();
           input.focus();
         }


### PR DESCRIPTION
Fixes https://github.com/NASA-AMMOS/aerie-ui/issues/414

* Use functions on `Menu` which handle hiding all menus so no overlaps occur
* Make `shown` prop from `Menu` private so it's not used easily
* Create `isShown` accessor for `Menu` for reading the internal `shown` value
* Fix spelling
* Future work:
    * Make the props on `Menu` work to handle hiding other menus
    * How to allow multiple `Menu` elements on the page? Do we even need this?