### PR TITLE
For ground block and events return the name field

### DIFF
--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -776,6 +776,7 @@ const gql = {
           metadata
           steps {
             args
+            name
             description
             models
             metadata


### PR DESCRIPTION
This should allow for the name field to be shown when you are in the Sequence Editor. 