### PR TITLE
Show both data and trace in error console if both are present

### DIFF
--- a/src/components/console/ConsoleSection.svelte
+++ b/src/components/console/ConsoleSection.svelte
@@ -37,7 +37,7 @@
           </div>
           {#if error.data || error.trace}
             <div class="trace">
-              {#if error.data && JSON.stringify(error.data) != '{}'}
+              {#if error.data && JSON.stringify(error.data) !== '{}'}
                 <pre>{JSON.stringify(error.data)}</pre>
               {/if}
               {#if error.trace}

--- a/src/components/console/ConsoleSection.svelte
+++ b/src/components/console/ConsoleSection.svelte
@@ -37,7 +37,12 @@
           </div>
           {#if error.data || error.trace}
             <div class="trace">
-              <pre>{error.data && JSON.stringify(error.data) !== '{}' ? JSON.stringify(error.data) : error.trace}</pre>
+              {#if error.data && JSON.stringify(error.data) != '{}'}
+                <pre>{JSON.stringify(error.data)}</pre>
+              {/if}
+              {#if error.trace}
+                <pre>{error.trace}</pre>
+              {/if}
             </div>
           {/if}
         </div>


### PR DESCRIPTION
When working on https://github.com/NASA-AMMOS/aerie/pull/724 I ran into a case where an error could have both `data`, and a `trace` - in which case I think it would be nice to show both.

<img width="881" alt="Screenshot 2023-03-10 at 7 04 38 AM" src="https://user-images.githubusercontent.com/1189602/224350258-8a8c54a9-ea15-4a7c-934f-3262430e7ba1.png">
