### PR TITLE
ActionDataGrid deleteItem event fix

### DIFF
--- a/src/components/ui/DataGrid/SingleActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/SingleActionDataGrid.svelte
@@ -78,7 +78,7 @@
   }
 
   function onKeyDown(event: KeyboardEvent) {
-    if (isDeleteEvent(event)) {
+    if (selectedItemId !== null && isDeleteEvent(event)) {
       deleteItem();
     }
   }


### PR DESCRIPTION
Only fire deleteItem event in SingleActionDataGrid when there is a selected item. Closes #400 