### PR TITLE
Mark Simulation as Dirty when Simulation Revision Changes

### DIFF
--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -74,7 +74,7 @@
       <PanelHeaderActionButton
         disabled={!$enableSimulation}
         tooltipContent={$simulationStatus === Status.Complete || $simulationStatus === Status.Failed
-          ? 'Simluation up-to-date'
+          ? 'Simulation up-to-date'
           : ''}
         title="Simulate"
         showLabel

--- a/src/stores/simulation.ts
+++ b/src/stores/simulation.ts
@@ -89,12 +89,15 @@ export const resourcesByViewLayerId: Readable<Record<number, Resource[]>> = deri
 );
 
 export const simulationStatus: Readable<Status | null> = derived(
-  [planRevision, simulationDataset],
-  ([$planRevision, $simulationDataset]) => {
-    if ($simulationDataset) {
+  [planRevision, simulationDataset, simulation],
+  ([$planRevision, $simulationDataset, $simulation]) => {
+    if ($simulationDataset && $simulation) {
       const { status } = $simulationDataset;
 
-      if ($planRevision !== $simulationDataset.plan_revision) {
+      if (
+        $planRevision !== $simulationDataset.plan_revision ||
+        $simulation.revision !== $simulationDataset.simulation_revision
+      ) {
         return Status.Modified;
       }
 

--- a/src/types/simulation.ts
+++ b/src/types/simulation.ts
@@ -55,6 +55,7 @@ export type SimulateResponse = {
 export type Simulation = {
   arguments: ArgumentsMap;
   id: number;
+  revision: number;
   template: SimulationTemplate | null;
 };
 
@@ -63,6 +64,7 @@ export type SimulationDataset = {
   id: number;
   plan_revision: number;
   reason: SimulationDatasetError | null;
+  simulation_revision: number;
   status: 'failed' | 'incomplete' | 'pending' | 'success';
 };
 

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1239,6 +1239,7 @@ const gql = {
       simulation(where: { plan_id: { _eq: $planId } }, order_by: { id: desc }, limit: 1) {
         arguments
         id
+        revision
         template: simulation_template {
           arguments
           description
@@ -1255,6 +1256,7 @@ const gql = {
         id
         plan_revision
         reason
+        simulation_revision
         status
       }
     }


### PR DESCRIPTION
Closes #434.

In addition to comparing the plan revision, also track and compare the Simulation Revision.