### PR TITLE
Set Sim Bounds to Plan Bounds on Plan Creation

### DIFF
--- a/src/types/simulation.ts
+++ b/src/types/simulation.ts
@@ -57,6 +57,8 @@ export type Simulation = {
   arguments: ArgumentsMap;
   id: number;
   revision: number;
+  simulation_end_time: string | null;
+  simulation_start_time: string | null;
   template: SimulationTemplate | null;
 };
 
@@ -69,9 +71,10 @@ export type SimulationDataset = {
   status: 'failed' | 'incomplete' | 'pending' | 'success';
 };
 
-export type SimulationInsertInput = {
+export type SimulationInitialUpdateInput = {
   arguments: ArgumentsMap;
-  plan_id: number;
+  simulation_end_time: string | null;
+  simulation_start_time: string | null;
   simulation_template_id: number | null;
 };
 

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -169,14 +169,6 @@ const gql = {
     }
   `,
 
-  CREATE_SIMULATION: `#graphql
-    mutation CreateSimulation($simulation: simulation_insert_input!) {
-      createSimulation: insert_simulation_one(object: $simulation) {
-        id
-      }
-    }
-  `,
-
   CREATE_USER_SEQUENCE: `#graphql
     mutation CreateUserSequence($sequence: user_sequence_insert_input!) {
       createUserSequence: insert_user_sequence_one(object: $sequence) {
@@ -787,6 +779,16 @@ const gql = {
     }
   `,
 
+  INITIAL_SIMULATION_UPDATE: `#graphql
+    mutation initialSimulationUpdate($plan_id: Int!, $simulation: simulation_set_input!) {
+      update_simulation(where: {plan_id: {_eq: $plan_id}}, _set: $simulation) {
+        returning {
+          id
+        }
+      }
+    }
+  `,
+
   INSERT_EXPANSION_SEQUENCE_TO_ACTIVITY: `#graphql
     mutation InsertSequenceToActivity($input: sequence_to_simulated_activity_insert_input!) {
       sequence: insert_sequence_to_simulated_activity_one(
@@ -1250,6 +1252,8 @@ const gql = {
         arguments
         id
         revision
+        simulation_start_time
+        simulation_end_time
         template: simulation_template {
           arguments
           description


### PR DESCRIPTION
This is meant to be a quick fix to continue to allow plans created via the UI to be simulated without having to manually update the database until the UI for Temporal Subset Sim is finished.
