### PR TITLE
Fix sim panel default args

### DIFF
--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -65,7 +65,7 @@
           ...defaultArguments,
           ...($simulation?.template?.arguments ?? {}),
         };
-        formParameters = getFormParameters(modelParametersMap, $simulation.arguments, [], defaultArgumentsMap);
+        formParameters = getFormParameters(modelParametersMap, $simulation.arguments, [], {}, defaultArgumentsMap);
       });
   }
 


### PR DESCRIPTION
* Make sure empty presets are passed to getFormParameters in sim panel
* https://github.com/NASA-AMMOS/aerie-ui/pull/507 added new param to `getFormParameters`
* Fixes https://github.com/NASA-AMMOS/aerie-ui/issues/525