### PR TITLE
Firefox activity selection fix

### DIFF
--- a/src/utilities/activities.ts
+++ b/src/utilities/activities.ts
@@ -37,5 +37,8 @@ export function getSpanRootParent(spansMap: SpansMap, spanId: SpanId): Span | nu
 export function sortActivityDirectives(a: ActivityDirective, b: ActivityDirective): number {
   const aStartOffsetMs = getIntervalInMs(a.start_offset);
   const bStartOffsetMs = getIntervalInMs(b.start_offset);
+  if (aStartOffsetMs === bStartOffsetMs) {
+    return compare(a.id, b.id);
+  }
   return compare(aStartOffsetMs, bStartOffsetMs);
 }


### PR DESCRIPTION
Closes #514. Fix is to compare activity directives IDs if two directives have the same start offset to ensure deterministic sorting. Seems to only happen in Firefox oddly.