### PR TITLE
Fix sim time for spans

### DIFF
--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -675,10 +675,7 @@
 
       for (const span of spans) {
         // Use simulation start YMD time if available, otherwise use the plan start YMD
-        let startYmd = planStartTimeYmd;
-        if (simulationDataset && simulationDataset.simulation_start_time) {
-          startYmd = simulationDataset.simulation_start_time;
-        }
+        let startYmd = simulationDataset?.simulation_start_time ?? planStartTimeYmd;
         const startTime = getUnixEpochTimeFromInterval(startYmd, span.start_offset);
         const duration = getIntervalInMs(span.duration);
         const x = xScaleView(startTime);

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -49,6 +49,7 @@
   export let planStartTimeYmd: string;
   export let selectedActivityDirectiveId: ActivityDirectiveId | null = null;
   export let selectedSpanId: SpanId | null = null;
+  export let simulationDataset: simulationDataset | null = null;
   export let spanUtilityMaps: SpanUtilityMaps;
   export let spansMap: SpansMap = {};
   export let timelineLockStatus: TimelineLockStatus;
@@ -673,7 +674,12 @@
       let y = parentY + rowHeight;
 
       for (const span of spans) {
-        const startTime = getUnixEpochTimeFromInterval(planStartTimeYmd, span.start_offset);
+        // Use simulation start YMD time if available, otherwise use the plan start YMD
+        let startYmd = planStartTimeYmd;
+        if (simulationDataset && simulationDataset.simulation_start_time) {
+          startYmd = simulationDataset.simulation_start_time;
+        }
+        const startTime = getUnixEpochTimeFromInterval(startYmd, span.start_offset);
         const duration = getIntervalInMs(span.duration);
         const x = xScaleView(startTime);
         const end = xScaleView(startTime + duration);

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -9,7 +9,7 @@
   import { createEventDispatcher, onDestroy, onMount, tick } from 'svelte';
   import SpanHashMarksSVG from '../../assets/span-hash-marks.svg?raw';
   import type { ActivityDirective, ActivityDirectiveId, ActivityDirectivesMap } from '../../types/activity';
-  import type { Span, SpanId, SpansMap, SpanUtilityMaps } from '../../types/simulation';
+  import type { SimulationDataset, Span, SpanId, SpansMap, SpanUtilityMaps } from '../../types/simulation';
   import type { ActivityLayerFilter, BoundingBox, PointBounds, QuadtreeRect, TimeRange } from '../../types/timeline';
   import { getSpanRootParent, sortActivityDirectives } from '../../utilities/activities';
   import { hexToRgba, shadeColor } from '../../utilities/color';
@@ -49,7 +49,7 @@
   export let planStartTimeYmd: string;
   export let selectedActivityDirectiveId: ActivityDirectiveId | null = null;
   export let selectedSpanId: SpanId | null = null;
-  export let simulationDataset: simulationDataset | null = null;
+  export let simulationDataset: SimulationDataset | null = null;
   export let spanUtilityMaps: SpanUtilityMaps;
   export let spansMap: SpansMap = {};
   export let timelineLockStatus: TimelineLockStatus;

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -675,7 +675,7 @@
 
       for (const span of spans) {
         // Use simulation start YMD time if available, otherwise use the plan start YMD
-        let startYmd = simulationDataset?.simulation_start_time ?? planStartTimeYmd;
+        const startYmd = simulationDataset?.simulation_start_time ?? planStartTimeYmd;
         const startTime = getUnixEpochTimeFromInterval(startYmd, span.start_offset);
         const duration = getIntervalInMs(span.duration);
         const x = xScaleView(startTime);

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -14,7 +14,7 @@
     ActivityDirectivesMap,
   } from '../../types/activity';
   import type { ConstraintViolation } from '../../types/constraint';
-  import type { Resource, Span, SpanId, SpansMap, SpanUtilityMaps } from '../../types/simulation';
+  import type { Resource, SimulationDataset, Span, SpanId, SpansMap, SpanUtilityMaps } from '../../types/simulation';
   import type {
     Axis,
     HorizontalGuide,
@@ -59,6 +59,7 @@
   export let rowDragMoveDisabled = true;
   export let selectedActivityDirectiveId: ActivityDirectiveId | null = null;
   export let selectedSpanId: SpanId | null = null;
+  export let simulationDataset: SimulationDataset | null = null;
   export let spanUtilityMaps: SpanUtilityMaps;
   export let spansMap: SpansMap = {};
   export let timelineLockStatus: TimelineLockStatus;
@@ -273,6 +274,7 @@
             {planStartTimeYmd}
             {selectedActivityDirectiveId}
             {selectedSpanId}
+            {simulationDataset}
             {spanUtilityMaps}
             {spansMap}
             {timelineLockStatus}

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -5,7 +5,7 @@
   import { dndzone, SOURCES, TRIGGERS } from 'svelte-dnd-action';
   import type { ActivityDirectiveId, ActivityDirectivesByView, ActivityDirectivesMap } from '../../types/activity';
   import type { ConstraintViolation } from '../../types/constraint';
-  import type { Resource, Span, SpanId, SpansMap, SpanUtilityMaps } from '../../types/simulation';
+  import type { Resource, SimulationDataset, Span, SpanId, SpansMap, SpanUtilityMaps } from '../../types/simulation';
   import type { MouseDown, MouseOver, Row, Timeline, TimeRange, XAxisTick } from '../../types/timeline';
   import { clamp } from '../../utilities/generic';
   import { getDoy, getDoyTime } from '../../utilities/time';
@@ -35,6 +35,7 @@
   export let resourcesByViewLayerId: Record<number, Resource[]> = {};
   export let selectedActivityDirectiveId: ActivityDirectiveId | null = null;
   export let selectedSpanId: SpanId | null = null;
+  export let simulationDataset: SimulationDataset | null = null;
   export let spanUtilityMaps: SpanUtilityMaps;
   export let spansMap: SpansMap = {};
   export let spans: Span[] = [];
@@ -264,6 +265,7 @@
         {rowDragMoveDisabled}
         {selectedActivityDirectiveId}
         {selectedSpanId}
+        {simulationDataset}
         {spanUtilityMaps}
         {spansMap}
         {timelineLockStatus}

--- a/src/components/timeline/TimelinePanel.svelte
+++ b/src/components/timeline/TimelinePanel.svelte
@@ -9,7 +9,14 @@
   } from '../../stores/activities';
   import { constraintViolations } from '../../stores/constraints';
   import { maxTimeRange, plan, planId, viewTimeRange } from '../../stores/plan';
-  import { resourcesByViewLayerId, selectedSpanId, spans, spansMap, spanUtilityMaps } from '../../stores/simulation';
+  import {
+    resourcesByViewLayerId,
+    selectedSpanId,
+    simulationDataset,
+    spans,
+    spansMap,
+    spanUtilityMaps,
+  } from '../../stores/simulation';
   import { timelineLockStatus, view, viewUpdateRow, viewUpdateTimeline } from '../../stores/views';
   import type { ActivityDirectiveId } from '../../types/activity';
   import type { MouseDown } from '../../types/timeline';
@@ -83,6 +90,7 @@
       resourcesByViewLayerId={$resourcesByViewLayerId}
       selectedActivityDirectiveId={$selectedActivityDirectiveId}
       selectedSpanId={$selectedSpanId}
+      simulationDataset={$simulationDataset}
       spanUtilityMaps={$spanUtilityMaps}
       spansMap={$spansMap}
       spans={$spans}

--- a/src/types/simulation.ts
+++ b/src/types/simulation.ts
@@ -67,7 +67,9 @@ export type SimulationDataset = {
   id: number;
   plan_revision: number;
   reason: SimulationDatasetError | null;
+  simulation_end_time: string | null;
   simulation_revision: number;
+  simulation_start_time: string | null;
   status: 'failed' | 'incomplete' | 'pending' | 'success';
 };
 

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1332,7 +1332,9 @@ const gql = {
         id
         plan_revision
         reason
+        simulation_end_time
         simulation_revision
+        simulation_start_time
         status
       }
     }


### PR DESCRIPTION
Closes #527. Use simulation time for computing span start time when available to ensure that spans render at the correct time position in the timeline.