### PR TITLE
Fix for context menu assuming spans exist for a directive

### DIFF
--- a/src/components/timeline/TimelineContextMenu.svelte
+++ b/src/components/timeline/TimelineContextMenu.svelte
@@ -70,7 +70,7 @@
     <ContextMenuItem on:click={() => dispatch('deleteActivityDirective', activityDirective.id)}>
       Delete Directive
     </ContextMenuItem>
-    {#if activityDirectiveSpans}
+    {#if activityDirectiveSpans && activityDirectiveSpans.length}
       <ContextSubMenuItem text="Jump to Simulated Activities" parentMenu={contextMenuComponent}>
         {#each activityDirectiveSpans as activityDirectiveSpan}
           <ContextMenuItem on:click={() => dispatch('jumpToSpan', activityDirectiveSpan.id)}>

--- a/src/types/simulation.ts
+++ b/src/types/simulation.ts
@@ -110,7 +110,7 @@ export type DirectiveIdToSpanIdMap = Record<ActivityDirectiveId, SpanId>;
 export type SpanIdToChildIdsMap = Record<SpanId, SpanId[]>;
 
 export type SpanUtilityMaps = {
-  directiveIdToSpanIdMap: SpanIdToDirectiveIdMap;
+  directiveIdToSpanIdMap: DirectiveIdToSpanIdMap;
   spanIdToChildIdsMap: SpanIdToChildIdsMap;
   spanIdToDirectiveIdMap: SpanIdToDirectiveIdMap;
 };

--- a/src/utilities/activities.test.ts
+++ b/src/utilities/activities.test.ts
@@ -226,6 +226,9 @@ describe('getAllSpansForActivityDirective', () => {
         .sort(),
     ).to.deep.equal(resultingSpanIds);
   });
+  test('Should return empty array when primary span does not exist for an activity directive', () => {
+    expect(getAllSpansForActivityDirective(99, testSpansMap, testSpansUtilityMap)).to.be.empty;
+  });
 });
 
 describe('getAllSpanChildrenIds', () => {

--- a/src/utilities/activities.ts
+++ b/src/utilities/activities.ts
@@ -69,6 +69,9 @@ export function getAllSpansForActivityDirective(
   spanUtilityMaps: SpanUtilityMaps,
 ): Span[] {
   const primarySpanId = spanUtilityMaps.directiveIdToSpanIdMap[activityDirectiveId];
+  if (primarySpanId === undefined) {
+    return [];
+  }
   const childSpanIds = getAllSpanChildrenIds(primarySpanId, spanUtilityMaps);
   const allSpanIds = [primarySpanId, ...childSpanIds];
   return allSpanIds.map(spanId => spansMap[spanId]).sort(sortActivityDirectivesOrSpans);


### PR DESCRIPTION
Closes #542. Modifies getAllSpansForActivityDirective to return an empty list if the primary span id for an activity directive id is undefined. Ensures that a directive has at least 1 span to show before showing the "Jump to Simulated Activities" context menu item.