### PR TITLE
Simulation time range visualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@fontsource/jetbrains-mono": "^4.5.12",
-        "@nasa-jpl/stellar": "^1.1.3",
+        "@nasa-jpl/stellar": "^1.1.4",
         "@sveltejs/adapter-node": "1.2.1",
         "@sveltejs/kit": "1.10.0",
         "ag-grid-community": "^29.1.0",
@@ -669,9 +669,9 @@
       }
     },
     "node_modules/@nasa-jpl/stellar": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@nasa-jpl/stellar/-/stellar-1.1.3.tgz",
-      "integrity": "sha512-V1nobtCqJapa5fLTu+SNm2CO1cw1uBSjt5ABE+i6BSVM9tGu+n31ehJAMuj3fnmXtjzjWqPQ36lK0R7M9MryhA=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/stellar/-/stellar-1.1.4.tgz",
+      "integrity": "sha512-tWgawwlIHa211hEvHWY2yRHTUzW0DlK8HqZEcHjJMhtsrbjB7v9YMFZhTTE9XD1YL1AJ2oB3K1eKL/b7eiHgXw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -7089,9 +7089,9 @@
       }
     },
     "@nasa-jpl/stellar": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@nasa-jpl/stellar/-/stellar-1.1.3.tgz",
-      "integrity": "sha512-V1nobtCqJapa5fLTu+SNm2CO1cw1uBSjt5ABE+i6BSVM9tGu+n31ehJAMuj3fnmXtjzjWqPQ36lK0R7M9MryhA=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/stellar/-/stellar-1.1.4.tgz",
+      "integrity": "sha512-tWgawwlIHa211hEvHWY2yRHTUzW0DlK8HqZEcHjJMhtsrbjB7v9YMFZhTTE9XD1YL1AJ2oB3K1eKL/b7eiHgXw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@fontsource/jetbrains-mono": "^4.5.12",
-    "@nasa-jpl/stellar": "^1.1.3",
+    "@nasa-jpl/stellar": "^1.1.4",
     "@sveltejs/adapter-node": "1.2.1",
     "@sveltejs/kit": "1.10.0",
     "ag-grid-community": "^29.1.0",

--- a/src/components/context-menu/ContextMenuSeparator.svelte
+++ b/src/components/context-menu/ContextMenuSeparator.svelte
@@ -1,0 +1,10 @@
+<hr class="context-menu-separator" />
+
+<style>
+  hr {
+    background-color: var(--st-gray-20);
+    border: 0;
+    height: 1px;
+    margin: 4px;
+  }
+</style>

--- a/src/components/context-menu/ContextSubMenuItem.svelte
+++ b/src/components/context-menu/ContextSubMenuItem.svelte
@@ -52,6 +52,7 @@
     align-items: center;
     display: flex;
     gap: 4px;
+    justify-content: space-between;
   }
   .context-sub-menu-item :global(svg) {
     height: 12px;

--- a/src/components/simulation/SimulationHistoryDataset.svelte
+++ b/src/components/simulation/SimulationHistoryDataset.svelte
@@ -147,11 +147,11 @@
   .simulation-range-label.start:after {
     background: linear-gradient(90deg, #717171 54.17%, rgba(188, 188, 188, 0) 104.17%);
     content: ' ';
-    height: 13px;
+    height: 16px;
     left: 8px;
     opacity: 0.3;
     position: absolute;
-    top: 1.5px;
+    top: 0;
     width: 12px;
     z-index: -1;
   }
@@ -172,11 +172,11 @@
   .simulation-range-label.end:after {
     background: linear-gradient(270deg, #717171 45.83%, rgba(188, 188, 188, 0) 95.83%);
     content: ' ';
-    height: 12px;
+    height: 16px;
     opacity: 0.3;
     position: absolute;
     right: 8px;
-    top: 1.5px;
+    top: 0px;
     width: 12px;
     z-index: -1;
   }

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -5,7 +5,15 @@
   import { dndzone, SOURCES, TRIGGERS } from 'svelte-dnd-action';
   import type { ActivityDirectiveId, ActivityDirectivesByView, ActivityDirectivesMap } from '../../types/activity';
   import type { ConstraintViolation } from '../../types/constraint';
-  import type { Resource, SimulationDataset, Span, SpanId, SpansMap, SpanUtilityMaps } from '../../types/simulation';
+  import type {
+    Resource,
+    Simulation,
+    SimulationDataset,
+    Span,
+    SpanId,
+    SpansMap,
+    SpanUtilityMaps,
+  } from '../../types/simulation';
   import type { MouseDown, MouseOver, Row, Timeline, TimeRange, XAxisTick } from '../../types/timeline';
   import { clamp } from '../../utilities/generic';
   import { getDoy, getDoyTime } from '../../utilities/time';
@@ -37,6 +45,7 @@
   export let resourcesByViewLayerId: Record<number, Resource[]> = {};
   export let selectedActivityDirectiveId: ActivityDirectiveId | null = null;
   export let selectedSpanId: SpanId | null = null;
+  export let simulation: Simulation | null = null;
   export let simulationDataset: SimulationDataset | null = null;
   export let spanUtilityMaps: SpanUtilityMaps;
   export let spansMap: SpansMap = {};
@@ -313,6 +322,8 @@
     on:jumpToSpan
     on:hide={() => (contextMenu = null)}
     on:updateVerticalGuides
+    {simulation}
+    {simulationDataset}
     {spansMap}
     {spanUtilityMaps}
     {planStartTimeYmd}

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -23,6 +23,7 @@
   import TimelineContextMenu from './TimelineContextMenu.svelte';
   import TimelineCursors from './TimelineCursors.svelte';
   import TimelineHistogram from './TimelineHistogram.svelte';
+  import TimelineSimulationRange from './TimelineSimulationRange.svelte';
   import Tooltip from './Tooltip.svelte';
   import TimelineXAxis from './XAxis.svelte';
 
@@ -231,6 +232,13 @@
       on:viewTimeRangeChanged
     />
   </div>
+  <TimelineSimulationRange
+    {cursorHeaderHeight}
+    {drawWidth}
+    marginLeft={timeline?.marginLeft}
+    {simulationDataset}
+    {xScaleView}
+  />
   <TimelineCursors
     {cursorHeaderHeight}
     {cursorEnabled}

--- a/src/components/timeline/TimelineContextMenu.svelte
+++ b/src/components/timeline/TimelineContextMenu.svelte
@@ -3,9 +3,9 @@
 <script lang="ts">
   import type { ScaleTime } from 'd3-scale';
   import { createEventDispatcher } from 'svelte';
-  import { view } from '../../stores/views';
+  import { view, viewUpdateGrid } from '../../stores/views';
   import type { ActivityDirective, ActivityDirectivesMap } from '../../types/activity';
-  import type { Simulation, SimulationDataset, Span, SpansMap, SpanUtilityMaps } from '../../types/simulation';
+  import type { Simulation, SimulationDataset, Span, SpanUtilityMaps, SpansMap } from '../../types/simulation';
   import type { MouseOver, VerticalGuide } from '../../types/timeline';
   import { getAllSpansForActivityDirective, getSpanRootParent } from '../../utilities/activities';
   import effects from '../../utilities/effects';
@@ -73,16 +73,22 @@
     dispatch('updateVerticalGuides', [...verticalGuides, newVerticalGuide]);
   }
 
+  function switchToSimulation() {
+    viewUpdateGrid({ leftComponentTop: 'SimulationPanel' });
+  }
+
   function updateSimulationStartTime(date: Date) {
     const doyString = getDoyTime(date, false);
     const newSimulation: Simulation = { ...simulation, simulation_start_time: doyString };
     effects.updateSimulation(newSimulation);
+    switchToSimulation();
   }
 
   function updateSimulationEndTime(date: Date) {
     const doyString = getDoyTime(date, false);
     const newSimulation: Simulation = { ...simulation, simulation_end_time: doyString };
     effects.updateSimulation(newSimulation);
+    switchToSimulation();
   }
 
   function getSpanDate(span: Span, includeDuration: boolean = false) {

--- a/src/components/timeline/TimelineContextMenu.svelte
+++ b/src/components/timeline/TimelineContextMenu.svelte
@@ -5,16 +5,20 @@
   import { createEventDispatcher } from 'svelte';
   import { view } from '../../stores/views';
   import type { ActivityDirective, ActivityDirectivesMap } from '../../types/activity';
-  import type { Span, SpansMap, SpanUtilityMaps } from '../../types/simulation';
+  import type { Simulation, SimulationDataset, Span, SpansMap, SpanUtilityMaps } from '../../types/simulation';
   import type { MouseOver, VerticalGuide } from '../../types/timeline';
   import { getAllSpansForActivityDirective, getSpanRootParent } from '../../utilities/activities';
+  import effects from '../../utilities/effects';
   import { getDoyTime, getIntervalInMs, getUnixEpochTimeFromInterval } from '../../utilities/time';
   import { createVerticalGuide } from '../../utilities/timeline';
   import ContextMenu from '../context-menu/ContextMenu.svelte';
   import ContextMenuItem from '../context-menu/ContextMenuItem.svelte';
+  import ContextMenuSeparator from '../context-menu/ContextMenuSeparator.svelte';
   import ContextSubMenuItem from '../context-menu/ContextSubMenuItem.svelte';
 
   export let activityDirectivesMap: ActivityDirectivesMap;
+  export let simulation: Simulation;
+  export let simulationDataset: SimulationDataset | null = null;
   export let spansMap: SpansMap;
   export let spanUtilityMaps: SpanUtilityMaps;
   export let planStartTimeYmd: string;
@@ -50,6 +54,11 @@
     activityDirectiveSpans = null;
   }
 
+  $: startYmd = simulationDataset?.simulation_start_time ?? planStartTimeYmd;
+  $: activityDirectiveStartDate = activityDirective
+    ? new Date(getUnixEpochTimeFromInterval(planStartTimeYmd, activityDirective.start_offset))
+    : null;
+
   function jumpToActivityDirective() {
     const rootSpan = getSpanRootParent(spansMap, span.id);
     if (rootSpan) {
@@ -63,13 +72,27 @@
     const newVerticalGuide = createVerticalGuide(timelines, cursorDOY);
     dispatch('updateVerticalGuides', [...verticalGuides, newVerticalGuide]);
   }
+
+  function updateSimulationStartTime(date: Date) {
+    const doyString = getDoyTime(date, false);
+    const newSimulation: Simulation = { ...simulation, simulation_start_time: doyString };
+    effects.updateSimulation(newSimulation);
+  }
+
+  function updateSimulationEndTime(date: Date) {
+    const doyString = getDoyTime(date, false);
+    const newSimulation: Simulation = { ...simulation, simulation_end_time: doyString };
+    effects.updateSimulation(newSimulation);
+  }
+
+  function getSpanDate(span: Span, includeDuration: boolean = false) {
+    const duration = includeDuration ? getIntervalInMs(span.duration) : 0;
+    return new Date(getUnixEpochTimeFromInterval(startYmd, span.start_offset) + duration);
+  }
 </script>
 
 <ContextMenu hideAfterClick on:hide bind:this={contextMenuComponent}>
   {#if activityDirective}
-    <ContextMenuItem on:click={() => dispatch('deleteActivityDirective', activityDirective.id)}>
-      Delete Directive
-    </ContextMenuItem>
     {#if activityDirectiveSpans && activityDirectiveSpans.length}
       <ContextSubMenuItem text="Jump to Simulated Activities" parentMenu={contextMenuComponent}>
         {#each activityDirectiveSpans as activityDirectiveSpan}
@@ -78,6 +101,7 @@
           </ContextMenuItem>
         {/each}
       </ContextSubMenuItem>
+      <ContextMenuSeparator />
     {/if}
 
     {#if activityDirective.anchor_id !== null}
@@ -87,31 +111,60 @@
     {/if}
     <ContextMenuItem
       on:click={() => {
-        addVerticalGuide(new Date(getUnixEpochTimeFromInterval(planStartTimeYmd, activityDirective.start_offset)));
+        addVerticalGuide(activityDirectiveStartDate);
       }}
     >
       Place Guide at Directive Start
     </ContextMenuItem>
+    <ContextMenuSeparator />
+    <ContextMenuItem on:click={() => updateSimulationStartTime(activityDirectiveStartDate)}>
+      Set Simulation Start at Directive Start
+    </ContextMenuItem>
+    <ContextMenuItem on:click={() => updateSimulationEndTime(activityDirectiveStartDate)}>
+      Set Simulation End at Directive Start
+    </ContextMenuItem>
+    <ContextMenuSeparator />
+    <ContextMenuItem on:click={() => dispatch('deleteActivityDirective', activityDirective.id)}>
+      Delete Directive
+    </ContextMenuItem>
   {:else if span}
     <ContextMenuItem on:click={jumpToActivityDirective}>Jump to Activity Directive</ContextMenuItem>
-    <ContextMenuItem
-      on:click={() => {
-        addVerticalGuide(new Date(getUnixEpochTimeFromInterval(planStartTimeYmd, span.start_offset)));
-      }}
-    >
-      Place Guide at Simulated Activity Start
-    </ContextMenuItem>
-    <ContextMenuItem
-      on:click={() => {
-        const duration = getIntervalInMs(span.duration);
-        addVerticalGuide(new Date(getUnixEpochTimeFromInterval(planStartTimeYmd, span.start_offset) + duration));
-      }}
-    >
-      Place Guide at Simulated Activity End
-    </ContextMenuItem>
+    <ContextMenuSeparator />
+    <ContextSubMenuItem text="Place Guide" parentMenu={contextMenuComponent}>
+      <ContextMenuItem on:click={() => addVerticalGuide(getSpanDate(span))}>
+        At Simulated Activity Start
+      </ContextMenuItem>
+      <ContextMenuItem on:click={() => addVerticalGuide(getSpanDate(span, true))}>
+        At Simulated Activity End
+      </ContextMenuItem>
+    </ContextSubMenuItem>
+    <ContextMenuSeparator />
+    <ContextSubMenuItem text="Set Simulation Start" parentMenu={contextMenuComponent}>
+      <ContextMenuItem on:click={() => updateSimulationStartTime(getSpanDate(span))}>
+        At Simulated Activity Start
+      </ContextMenuItem>
+      <ContextMenuItem on:click={() => updateSimulationStartTime(getSpanDate(span, true))}>
+        At Simulated Activity End
+      </ContextMenuItem>
+    </ContextSubMenuItem>
+    <ContextSubMenuItem text="Set Simulation End" parentMenu={contextMenuComponent}>
+      <ContextMenuItem on:click={() => updateSimulationEndTime(getSpanDate(span))}>
+        At Simulated Activity Start
+      </ContextMenuItem>
+      <ContextMenuItem on:click={() => updateSimulationEndTime(getSpanDate(span, true))}>
+        At Simulated Activity End
+      </ContextMenuItem>
+    </ContextSubMenuItem>
   {:else}
     <ContextMenuItem on:click={() => addVerticalGuide(xScaleView.invert(contextMenu.e.offsetX))}>
       Place Guide
+    </ContextMenuItem>
+    <ContextMenuSeparator />
+    <ContextMenuItem on:click={() => updateSimulationStartTime(xScaleView.invert(contextMenu.e.offsetX))}>
+      Set Simulation Start
+    </ContextMenuItem>
+    <ContextMenuItem on:click={() => updateSimulationEndTime(xScaleView.invert(contextMenu.e.offsetX))}>
+      Set Simulation End
     </ContextMenuItem>
   {/if}
 </ContextMenu>

--- a/src/components/timeline/TimelinePanel.svelte
+++ b/src/components/timeline/TimelinePanel.svelte
@@ -12,6 +12,7 @@
   import {
     resourcesByViewLayerId,
     selectedSpanId,
+    simulation,
     simulationDataset,
     spans,
     spansMap,
@@ -100,6 +101,7 @@
       resourcesByViewLayerId={$resourcesByViewLayerId}
       selectedActivityDirectiveId={$selectedActivityDirectiveId}
       selectedSpanId={$selectedSpanId}
+      simulation={$simulation}
       simulationDataset={$simulationDataset}
       spanUtilityMaps={$spanUtilityMaps}
       spansMap={$spansMap}

--- a/src/components/timeline/TimelineSimulationRange.svelte
+++ b/src/components/timeline/TimelineSimulationRange.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+  import PinPauseIcon from '@nasa-jpl/stellar/icons/pin_pause.svg?component';
+  import PinPlayIcon from '@nasa-jpl/stellar/icons/pin_play.svg?component';
+  import type { ScaleTime } from 'd3-scale';
+  import type { SimulationDataset } from '../../types/simulation';
+  import TimelineSimulationRangeCursor from './TimelineSimulationRangeCursor.svelte';
+
+  export let cursorHeaderHeight: number = 20;
+  export let drawWidth: number = 0;
+  export let marginLeft: number = 50;
+  export let xScaleView: ScaleTime<number, number> | null = null;
+  export let simulationDataset: SimulationDataset | null = null;
+
+  $: onSimulationDatasetChange(simulationDataset, xScaleView);
+
+  let simStartX: number = 0;
+  let simEndX: number = 0;
+  let simRangeWidth: number = 0;
+  let simCursorStartX = -1;
+  let simCursorEndX = -1;
+  let simRangeStartX = -1;
+  let simRangeEndX = -1;
+
+  function onSimulationDatasetChange(
+    simulationDataset: SimulationDataset,
+    xScaleView: ScaleTime<number, number> | null,
+  ) {
+    let simStartUnixEpochTime = new Date(simulationDataset?.simulation_start_time).getTime();
+    let simEndUnixEpochTime = new Date(simulationDataset?.simulation_end_time).getTime();
+    simStartX = xScaleView(simStartUnixEpochTime);
+    simEndX = xScaleView(simEndUnixEpochTime);
+
+    if (simStartX < 0 || simStartX > drawWidth) {
+      simCursorStartX = -1;
+    } else {
+      simCursorStartX = simStartX + marginLeft;
+    }
+    if (simEndX < 0 || simEndX > drawWidth) {
+      simCursorEndX = -1;
+    } else {
+      simCursorEndX = simEndX + marginLeft;
+    }
+
+    simRangeStartX = Math.max(0, simStartX);
+    simRangeEndX = Math.min(xScaleView(xScaleView.domain()[1].getTime()), simEndX);
+    simRangeWidth = simRangeEndX - simRangeStartX;
+  }
+</script>
+
+{#if simulationDataset}
+  <div class="timeline-simulation-range-margin" style="height: {cursorHeaderHeight}px" />
+  <div class="timeline-simulation-range-container">
+    <div class="timeline-simulation-range-header" />
+    {#if simRangeWidth > 0}
+      <div
+        class="timeline-simulation-range-bar"
+        style={`transform: translateX(${simRangeStartX}px); width: ${simRangeWidth}px; margin-left: ${marginLeft}px`}
+      />
+    {/if}
+    {#if simCursorStartX >= 0}
+      <TimelineSimulationRangeCursor color={''} x={simCursorStartX}>
+        <div class="play-icon">
+          <PinPlayIcon />
+        </div>
+      </TimelineSimulationRangeCursor>
+    {/if}
+    {#if simCursorEndX >= 0}
+      <TimelineSimulationRangeCursor color={''} x={simCursorEndX}>
+        <div class="pause-icon">
+          <PinPauseIcon />
+        </div>
+      </TimelineSimulationRangeCursor>
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .timeline-simulation-range-margin {
+    position: relative;
+  }
+
+  .timeline-simulation-range-container {
+    height: 100%;
+    pointer-events: none;
+    position: absolute;
+    width: 100%;
+  }
+
+  .timeline-simulation-range-header {
+    height: 1rem;
+    position: relative;
+  }
+
+  .timeline-simulation-range-bar {
+    background: #fdde8f;
+    height: 13px;
+    left: 0;
+    opacity: 0.3;
+    pointer-events: none;
+    position: absolute;
+    top: -13px;
+    transform: translateX(0);
+  }
+
+  .play-icon:before {
+    background: white;
+    content: ' ';
+    height: 5px;
+    left: 6px;
+    position: absolute;
+    top: 4px;
+    width: 5px;
+    z-index: -1;
+  }
+
+  .pause-icon:before {
+    background: white;
+    content: ' ';
+    height: 6px;
+    position: absolute;
+    right: 6px;
+    top: 3px;
+    width: 5px;
+    z-index: -1;
+  }
+</style>

--- a/src/components/timeline/TimelineSimulationRange.svelte
+++ b/src/components/timeline/TimelineSimulationRange.svelte
@@ -58,14 +58,14 @@
       />
     {/if}
     {#if simCursorStartX >= 0}
-      <TimelineSimulationRangeCursor color={''} x={simCursorStartX}>
+      <TimelineSimulationRangeCursor x={simCursorStartX}>
         <div class="play-icon">
           <PinPlayIcon />
         </div>
       </TimelineSimulationRangeCursor>
     {/if}
     {#if simCursorEndX >= 0}
-      <TimelineSimulationRangeCursor color={''} x={simCursorEndX}>
+      <TimelineSimulationRangeCursor x={simCursorEndX}>
         <div class="pause-icon">
           <PinPauseIcon />
         </div>

--- a/src/components/timeline/TimelineSimulationRange.svelte
+++ b/src/components/timeline/TimelineSimulationRange.svelte
@@ -13,8 +13,6 @@
 
   $: onSimulationDatasetChange(simulationDataset, xScaleView);
 
-  let simStartX: number = 0;
-  let simEndX: number = 0;
   let simRangeWidth: number = 0;
   let simCursorStartX = -1;
   let simCursorEndX = -1;
@@ -27,20 +25,11 @@
   ) {
     let simStartUnixEpochTime = new Date(simulationDataset?.simulation_start_time).getTime();
     let simEndUnixEpochTime = new Date(simulationDataset?.simulation_end_time).getTime();
-    simStartX = xScaleView(simStartUnixEpochTime);
-    simEndX = xScaleView(simEndUnixEpochTime);
+    const simStartX = xScaleView(simStartUnixEpochTime);
+    const simEndX = xScaleView(simEndUnixEpochTime);
 
-    if (simStartX < 0 || simStartX > drawWidth) {
-      simCursorStartX = -1;
-    } else {
-      simCursorStartX = simStartX + marginLeft;
-    }
-    if (simEndX < 0 || simEndX > drawWidth) {
-      simCursorEndX = -1;
-    } else {
-      simCursorEndX = simEndX + marginLeft;
-    }
-
+    simCursorStartX = simStartX < 0 || simStartX > drawWidth ? -1 : simStartX + marginLeft;
+    simCursorEndX = simEndX < 0 || simEndX > drawWidth ? -1 : simEndX + marginLeft;
     simRangeStartX = Math.max(0, simStartX);
     simRangeEndX = Math.min(xScaleView(xScaleView.domain()[1].getTime()), simEndX);
     simRangeWidth = simRangeEndX - simRangeStartX;

--- a/src/components/timeline/TimelineSimulationRange.svelte
+++ b/src/components/timeline/TimelineSimulationRange.svelte
@@ -8,16 +8,16 @@
   export let cursorHeaderHeight: number = 20;
   export let drawWidth: number = 0;
   export let marginLeft: number = 50;
-  export let xScaleView: ScaleTime<number, number> | null = null;
   export let simulationDataset: SimulationDataset | null = null;
+  export let xScaleView: ScaleTime<number, number> | null = null;
 
   $: onSimulationDatasetChange(simulationDataset, xScaleView);
 
   let simRangeWidth: number = 0;
-  let simCursorStartX = -1;
-  let simCursorEndX = -1;
-  let simRangeStartX = -1;
-  let simRangeEndX = -1;
+  let simCursorStartX: number = -1;
+  let simCursorEndX: number = -1;
+  let simRangeStartX: number = -1;
+  let simRangeEndX: number = -1;
 
   function onSimulationDatasetChange(
     simulationDataset: SimulationDataset,

--- a/src/components/timeline/TimelineSimulationRange.svelte
+++ b/src/components/timeline/TimelineSimulationRange.svelte
@@ -23,8 +23,8 @@
     simulationDataset: SimulationDataset,
     xScaleView: ScaleTime<number, number> | null,
   ) {
-    let simStartUnixEpochTime = new Date(simulationDataset?.simulation_start_time).getTime();
-    let simEndUnixEpochTime = new Date(simulationDataset?.simulation_end_time).getTime();
+    const simStartUnixEpochTime = new Date(simulationDataset?.simulation_start_time).getTime();
+    const simEndUnixEpochTime = new Date(simulationDataset?.simulation_end_time).getTime();
     const simStartX = xScaleView(simStartUnixEpochTime);
     const simEndX = xScaleView(simEndUnixEpochTime);
 

--- a/src/components/timeline/TimelineSimulationRange.svelte
+++ b/src/components/timeline/TimelineSimulationRange.svelte
@@ -47,14 +47,14 @@
       />
     {/if}
     {#if simCursorStartX >= 0}
-      <TimelineSimulationRangeCursor x={simCursorStartX}>
+      <TimelineSimulationRangeCursor tooltipContent="Simulation Start" x={simCursorStartX}>
         <div class="play-icon">
           <PinPlayIcon />
         </div>
       </TimelineSimulationRangeCursor>
     {/if}
     {#if simCursorEndX >= 0}
-      <TimelineSimulationRangeCursor x={simCursorEndX}>
+      <TimelineSimulationRangeCursor tooltipContent="Simulation End" x={simCursorEndX}>
         <div class="pause-icon">
           <PinPauseIcon />
         </div>

--- a/src/components/timeline/TimelineSimulationRangeCursor.svelte
+++ b/src/components/timeline/TimelineSimulationRangeCursor.svelte
@@ -1,15 +1,12 @@
 <script lang="ts">
   export let x = 0;
-  export let label = '';
-  export let color = '';
 </script>
 
 <div class="timeline-simulation-range-cursor" style="transform: translateX({x}px)">
-  <div class="timeline-simulation-range-cursor-line" style="background: {color}" />
-  <button class="timeline-simulation-range-cursor-icon" style="color: {color}" on:click>
+  <div class="timeline-simulation-range-cursor-line" />
+  <button class="timeline-simulation-range-cursor-icon" on:click>
     <slot />
   </button>
-  <div class="timeline-simulation-range-cursor-label">{label}</div>
 </div>
 
 <style>
@@ -49,23 +46,5 @@
     position: absolute;
     top: 0;
     width: 1px;
-  }
-
-  .timeline-simulation-range-cursor-label {
-    background-color: var(--st-gray-15);
-    border-radius: 16px;
-    box-shadow: 0 0.5px 1px rgba(0, 0, 0, 0.25);
-    font-size: 12px;
-    left: 10px;
-    letter-spacing: 0.04em;
-    line-height: 16px;
-    overflow: hidden;
-    padding: 0 5px;
-    pointer-events: all;
-    position: relative;
-    text-overflow: ellipsis;
-    top: -11px;
-    white-space: nowrap;
-    z-index: 0;
   }
 </style>

--- a/src/components/timeline/TimelineSimulationRangeCursor.svelte
+++ b/src/components/timeline/TimelineSimulationRangeCursor.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  export let x = 0;
+  export let label = '';
+  export let color = '';
+</script>
+
+<div class="timeline-simulation-range-cursor" style="transform: translateX({x}px)">
+  <div class="timeline-simulation-range-cursor-line" style="background: {color}" />
+  <button class="timeline-simulation-range-cursor-icon" style="color: {color}" on:click>
+    <slot />
+  </button>
+  <div class="timeline-simulation-range-cursor-label">{label}</div>
+</div>
+
+<style>
+  .timeline-simulation-range-cursor {
+    height: 100%;
+    left: 0;
+    opacity: 1;
+    pointer-events: all;
+    position: absolute;
+    top: -10px;
+    transform: translateX(0);
+  }
+
+  .timeline-simulation-range-cursor-icon {
+    background-color: transparent;
+    border: none;
+    color: var(--st-gray-60);
+    cursor: pointer;
+    display: block;
+    height: 16px;
+    left: 0;
+    left: -8px;
+    margin: 0;
+    padding: 0;
+    pointer-events: all;
+    position: absolute;
+    top: -9px;
+    width: 15px;
+  }
+
+  .timeline-simulation-range-cursor-line {
+    background-color: var(--st-gray-70);
+    display: block;
+    height: 100%;
+    left: -0.5px;
+    opacity: 0.3;
+    position: absolute;
+    top: 0;
+    width: 1px;
+  }
+
+  .timeline-simulation-range-cursor-label {
+    background-color: var(--st-gray-15);
+    border-radius: 16px;
+    box-shadow: 0 0.5px 1px rgba(0, 0, 0, 0.25);
+    font-size: 12px;
+    left: 10px;
+    letter-spacing: 0.04em;
+    line-height: 16px;
+    overflow: hidden;
+    padding: 0 5px;
+    pointer-events: all;
+    position: relative;
+    text-overflow: ellipsis;
+    top: -11px;
+    white-space: nowrap;
+    z-index: 0;
+  }
+</style>

--- a/src/components/timeline/TimelineSimulationRangeCursor.svelte
+++ b/src/components/timeline/TimelineSimulationRangeCursor.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
-  export let x = 0;
+  import { tooltip } from '../../utilities/tooltip';
+
+  export let tooltipContent: string = '';
+  export let x: number = 0;
 </script>
 
 <div class="timeline-simulation-range-cursor" style="transform: translateX({x}px)">
   <div class="timeline-simulation-range-cursor-line" />
-  <button class="timeline-simulation-range-cursor-icon" on:click>
+  <div class="timeline-simulation-range-cursor-icon" use:tooltip={{ content: tooltipContent, placement: 'top' }}>
     <slot />
-  </button>
+  </div>
 </div>
 
 <style>
@@ -24,7 +27,6 @@
     background-color: transparent;
     border: none;
     color: var(--st-gray-60);
-    cursor: pointer;
     display: block;
     height: 16px;
     left: 0;


### PR DESCRIPTION
Closes #545 

TODO:
- [x] Add context menu items with simulation time setting utilities
- [x] Hover states on sim time pins?
- [x] Open simulation panel when setting simulation start/end time from timeline to help indicate that the time has changed.
- [ ] Design question: What color do we use for the sim indicator bar. Could use the first activity layer color but what if you have multiple activity layers with different colors? Could also use some solid gray.
- [ ] Design question: Decide if it's acceptable to have the sim time pins render underneath the TimelineCursors. Right now they are independent and don't truncate themselves / react to other guides since they have no labels.

<img width="751" alt="image" src="https://user-images.githubusercontent.com/4419607/229582900-34167948-e859-4e2f-bed6-763df5a2cf65.png">
