### PR TITLE
Refactor generateDefaultView and view validation

### DIFF
--- a/src/routes/view/validate/+server.ts
+++ b/src/routes/view/validate/+server.ts
@@ -1,17 +1,12 @@
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
-import Ajv from 'ajv';
-import jsonSchema from '../../../schemas/ui-view-schema.json';
+import { validateViewJSONAgainstSchema } from '../../../utilities/view';
 
 export const POST: RequestHandler = async event => {
   try {
     const body = await event.request.json();
-    const ajv = new Ajv();
-    const validate = ajv.compile(jsonSchema);
-    const valid = validate(body);
-
+    const { errors, valid } = validateViewJSONAgainstSchema(body);
     if (!valid) {
-      const errors = validate.errors;
       return json({ errors, valid });
     } else {
       return json({ valid });

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -1,6 +1,5 @@
 import { goto } from '$app/navigation';
 import { base } from '$app/paths';
-import type { ErrorObject } from 'ajv';
 import { get } from 'svelte/store';
 import { activityDirectivesMap, selectedActivityDirectiveId } from '../stores/activities';
 import { checkConstraintsStatus, constraintViolationsMap } from '../stores/constraints';
@@ -105,7 +104,7 @@ import { sampleProfiles } from './resources';
 import { Status } from './status';
 import { getDoyTime, getDoyTimeFromInterval, getIntervalFromDoyRange } from './time';
 import { showFailureToast, showSuccessToast } from './toast';
-import { generateDefaultView } from './view';
+import { generateDefaultView, validateViewJSONAgainstSchema } from './view';
 
 /**
  * Functions that have side-effects (e.g. HTTP requests, toasts, popovers, store updates, etc.).
@@ -2170,12 +2169,7 @@ const effects = {
 
   async validateViewJSON(unValidatedView: unknown): Promise<{ errors?: string[]; valid: boolean }> {
     try {
-      const response = await fetch(`${base}/view/validate`, {
-        body: JSON.stringify(unValidatedView),
-        headers: { 'Content-Type': 'application/json' },
-        method: 'POST',
-      });
-      const { errors = [], valid } = (await response.json()) as { errors?: ErrorObject[]; valid: boolean };
+      const { errors, valid } = validateViewJSONAgainstSchema(unValidatedView);
       return {
         errors: errors.map(({ message }) => message),
         valid,

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -289,7 +289,11 @@ export function getNextTimelineID(timelines: Timeline[]): number {
 /**
  * Returns a new vertical guide
  */
-export function createVerticalGuide(timelines: Timeline[], doyTimestamp: string): VerticalGuide {
+export function createVerticalGuide(
+  timelines: Timeline[],
+  doyTimestamp: string,
+  args: Partial<VerticalGuide> = {},
+): VerticalGuide {
   const id = getNextVerticalGuideID(timelines);
   const defaultLabel = `Guide ${id}`;
 
@@ -297,13 +301,18 @@ export function createVerticalGuide(timelines: Timeline[], doyTimestamp: string)
     id,
     label: { color: '#969696', text: defaultLabel },
     timestamp: doyTimestamp,
+    ...args,
   };
 }
 
 /**
  * Returns a new horizontal guide
  */
-export function createHorizontalGuide(timelines: Timeline[], yAxes: Axis[]): HorizontalGuide {
+export function createHorizontalGuide(
+  timelines: Timeline[],
+  yAxes: Axis[],
+  args: Partial<HorizontalGuide> = {},
+): HorizontalGuide {
   const id = getNextHorizontalGuideID(timelines);
   const defaultLabel = `Guide ${id}`;
 
@@ -324,13 +333,14 @@ export function createHorizontalGuide(timelines: Timeline[], yAxes: Axis[]): Hor
     label: { color: '#969696', text: defaultLabel },
     y,
     yAxisId,
+    ...args,
   };
 }
 
 /**
  * Returns a new row
  */
-export function createRow(timelines: Timeline[]): Row {
+export function createRow(timelines: Timeline[], args: Partial<Row> = {}): Row {
   const id = getNextRowID(timelines);
 
   return {
@@ -342,17 +352,18 @@ export function createRow(timelines: Timeline[]): Row {
     layers: [],
     name: 'Row',
     yAxes: [],
+    ...args,
   };
 }
 
 /**
  * Returns a new y axis
  */
-export function createYAxis(timelines: Timeline[]): Axis {
+export function createYAxis(timelines: Timeline[], args: Partial<Axis> = {}): Axis {
   const id = getNextYAxisID(timelines);
 
   return {
-    color: '',
+    color: '#000000',
     id,
     label: { text: 'Label' },
 
@@ -360,13 +371,14 @@ export function createYAxis(timelines: Timeline[]): Axis {
     // no associated layers for a new y axis?
     scaleDomain: [0, 10],
     tickCount: 4,
+    ...args,
   };
 }
 
 /**
  * Returns a new timeline
  */
-export function createTimeline(timelines: Timeline[]): Timeline {
+export function createTimeline(timelines: Timeline[], args: Partial<Timeline> = {}): Timeline {
   const id = getNextTimelineID(timelines);
 
   return {
@@ -375,13 +387,14 @@ export function createTimeline(timelines: Timeline[]): Timeline {
     marginRight: 0,
     rows: [],
     verticalGuides: [],
+    ...args,
   };
 }
 
 /**
  * Returns a new activity layer
  */
-export function createTimelineActivityLayer(timelines: Timeline[]): ActivityLayer {
+export function createTimelineActivityLayer(timelines: Timeline[], args: Partial<ActivityLayer> = {}): ActivityLayer {
   const id = getNextLayerID(timelines);
 
   return {
@@ -395,13 +408,18 @@ export function createTimelineActivityLayer(timelines: Timeline[]): ActivityLaye
     },
     id,
     yAxisId: null,
+    ...args,
   };
 }
 
 /**
- * Returns a new line layer
+ * Returns a new line layer. Note that the yAxes should be those from the row the layer will be a member of.
  */
-export function createTimelineLineLayer(timelines: Timeline[], yAxes: Axis[]): LineLayer {
+export function createTimelineLineLayer(
+  timelines: Timeline[],
+  yAxes: Axis[],
+  args: Partial<LineLayer> = {},
+): LineLayer {
   const id = getNextLayerID(timelines);
   const yAxisId = yAxes.length > 0 ? yAxes[0].id : 0;
 
@@ -413,23 +431,28 @@ export function createTimelineLineLayer(timelines: Timeline[], yAxes: Axis[]): L
       },
     },
     id,
-    lineColor: 'ff0000',
+    lineColor: '#283593',
     lineWidth: 1,
     pointRadius: 2,
     yAxisId,
+    ...args,
   };
 }
 
 /**
- * Returns a new x-range layer
+ * Returns a new x-range layer. Note that the yAxes should be those from the row the layer will be a member of.
  */
-export function createTimelineXRangeLayer(timelines: Timeline[], yAxes: Axis[]): XRangeLayer {
+export function createTimelineXRangeLayer(
+  timelines: Timeline[],
+  yAxes: Axis[],
+  args: Partial<XRangeLayer> = {},
+): XRangeLayer {
   const id = getNextLayerID(timelines);
   const yAxisId = yAxes.length > 0 ? yAxes[0].id : 0;
 
   return {
     chartType: 'x-range',
-    colorScheme: 'schemeAccent',
+    colorScheme: 'schemeTableau10',
     filter: {
       resource: {
         names: [],
@@ -438,6 +461,7 @@ export function createTimelineXRangeLayer(timelines: Timeline[], yAxes: Axis[]):
     id,
     opacity: 0.8,
     yAxisId,
+    ...args,
   };
 }
 

--- a/src/utilities/view.test.ts
+++ b/src/utilities/view.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest';
+import { generateDefaultView, validateViewJSONAgainstSchema } from './view';
+
+describe('generateDefaultView', () => {
+  test('Should generate a valid view', async () => {
+    const view = generateDefaultView(
+      [],
+      [
+        { name: 'resource1', schema: { type: 'boolean' } },
+        { name: 'resource2', schema: { type: 'int' } },
+        { name: 'resource2', schema: { items: { type: 'boolean' }, type: 'series' } },
+      ],
+    );
+    const { valid, errors } = validateViewJSONAgainstSchema(view.definition);
+    expect(errors).to.deep.equal([]);
+    expect(valid).toBe(true);
+  });
+});

--- a/src/utilities/view.ts
+++ b/src/utilities/view.ts
@@ -1,7 +1,17 @@
+import Ajv from 'ajv';
+import jsonSchema from '../schemas/ui-view-schema.json';
 import type { ActivityType } from '../types/activity';
 import type { ResourceType } from '../types/simulation';
-import type { ActivityLayer, Axis, LineLayer, Row, XRangeLayer } from '../types/timeline';
+import type { Layer } from '../types/timeline';
 import type { View, ViewGridColumns, ViewGridRows } from '../types/view';
+import {
+  createRow,
+  createTimeline,
+  createTimelineActivityLayer,
+  createTimelineLineLayer,
+  createTimelineXRangeLayer,
+  createYAxis,
+} from './timeline';
 
 /**
  * Generates a default generic UI view.
@@ -9,9 +19,57 @@ import type { View, ViewGridColumns, ViewGridRows } from '../types/view';
 export function generateDefaultView(activityTypes: ActivityType[] = [], resourceTypes: ResourceType[] = []): View {
   const now = new Date().toISOString();
   const types: string[] = activityTypes.map(({ name }) => name);
-  let rowIds = 0;
-  let layerIds = 0;
-  let yAxisIds = 0;
+
+  const timeline = createTimeline([], { marginLeft: 110, marginRight: 30 });
+  const timelines = [timeline];
+
+  const activityLayer = createTimelineActivityLayer(timelines, {
+    filter: { activity: { types } },
+  });
+  const activityRow = createRow(timelines, {
+    autoAdjustHeight: false,
+    expanded: true,
+    height: 400,
+    layers: [activityLayer],
+    name: 'Activities',
+  });
+  timeline.rows.push(activityRow);
+
+  // Generate a row for every resource
+  resourceTypes.map(resourceType => {
+    const { name, schema } = resourceType;
+    const { type: schemaType } = schema;
+    const isDiscreteSchema = schemaType === 'boolean' || schemaType === 'string' || schemaType === 'variant';
+    const isNumericSchema =
+      schemaType === 'int' ||
+      schemaType === 'real' ||
+      (schemaType === 'struct' && schema?.items?.rate?.type === 'real' && schema?.items?.initial?.type === 'real');
+
+    const yAxis = createYAxis(timelines, {
+      label: { text: name },
+      scaleDomain: isNumericSchema ? [-6, 6] : [],
+      tickCount: isNumericSchema ? 5 : 0,
+    });
+
+    const resourceLayers = isDiscreteSchema
+      ? ([createTimelineXRangeLayer(timelines, [yAxis], { filter: { resource: { names: [name] } } })] as Layer[])
+      : isNumericSchema
+      ? ([createTimelineLineLayer(timelines, [yAxis], { filter: { resource: { names: [name] } } })] as Layer[])
+      : ([] as Layer[]);
+
+    const resourceRow = createRow(timelines, {
+      autoAdjustHeight: false,
+      expanded: true,
+      height: 100,
+      layers: resourceLayers,
+      name,
+      yAxes: [yAxis],
+    });
+
+    timeline.rows.push(resourceRow);
+  });
+
+  console.log(timeline.rows);
 
   return {
     created_at: now,
@@ -296,91 +354,7 @@ export function generateDefaultView(activityTypes: ActivityType[] = [], resource
             title: 'Mars-2020-EDL',
           },
         ],
-        timelines: [
-          {
-            id: 0,
-            marginLeft: 110,
-            marginRight: 30,
-            rows: [
-              {
-                autoAdjustHeight: false,
-                expanded: true,
-                height: 200,
-                horizontalGuides: [],
-                id: rowIds++,
-                layers: [
-                  {
-                    activityColor: '#fcdd8f',
-                    activityHeight: 16,
-                    chartType: 'activity',
-                    filter: { activity: { types } },
-                    id: layerIds++,
-                    yAxisId: null,
-                  } as ActivityLayer,
-                ],
-                name: 'Activities',
-                yAxes: [],
-              },
-              ...resourceTypes.map(resourceType => {
-                const { name, schema } = resourceType;
-                const { type: schemaType } = schema;
-                const isDiscreteSchema =
-                  schemaType === 'boolean' || schemaType === 'string' || schemaType === 'variant';
-                const isNumericSchema =
-                  schemaType === 'int' ||
-                  schemaType === 'real' ||
-                  (schemaType === 'struct' &&
-                    schema?.items?.rate?.type === 'real' &&
-                    schema?.items?.initial?.type === 'real');
-
-                const yAxis: Axis = {
-                  color: '#000000',
-                  id: yAxisIds++,
-                  label: { text: name },
-                  scaleDomain: isNumericSchema ? [-6, 6] : [],
-                  tickCount: isNumericSchema ? 5 : 0,
-                };
-
-                const row: Row = {
-                  autoAdjustHeight: false,
-                  expanded: true,
-                  height: 100,
-                  horizontalGuides: [],
-                  id: rowIds++,
-                  layers: isDiscreteSchema
-                    ? [
-                        {
-                          chartType: 'x-range',
-                          colorScheme: 'schemeTableau10',
-                          filter: { resource: { names: [name] } },
-                          id: layerIds++,
-                          opacity: 0.8,
-                          yAxisId: yAxis.id,
-                        } as XRangeLayer,
-                      ]
-                    : isNumericSchema
-                    ? [
-                        {
-                          chartType: 'line',
-                          filter: { resource: { names: [name] } },
-                          id: layerIds++,
-                          lineColor: '#283593',
-                          lineWidth: 1,
-                          pointRadius: 2,
-                          yAxisId: yAxis.id,
-                        } as LineLayer,
-                      ]
-                    : [],
-                  name,
-                  yAxes: [yAxis],
-                };
-
-                return row;
-              }),
-            ],
-            verticalGuides: [],
-          },
-        ],
+        timelines,
       },
     },
     id: 0,
@@ -467,4 +441,18 @@ export function createRowSizes({ row1 = '1fr', row2 = '1fr' }: ViewGridRows, col
   }
 
   return '1fr';
+}
+
+/* TODO better name but validateViewJSON already taken in effects */
+export function validateViewJSONAgainstSchema(json: any) {
+  try {
+    const ajv = new Ajv();
+    const validate = ajv.compile(jsonSchema);
+    const valid = validate(json);
+    const errors = valid ? [] : validate.errors;
+    return { errors, valid };
+  } catch (e) {
+    const { message } = e;
+    return { errors: [message], valid: false };
+  }
 }

--- a/src/utilities/view.ts
+++ b/src/utilities/view.ts
@@ -69,8 +69,6 @@ export function generateDefaultView(activityTypes: ActivityType[] = [], resource
     timeline.rows.push(resourceRow);
   });
 
-  console.log(timeline.rows);
-
   return {
     created_at: now,
     definition: {

--- a/src/utilities/view.ts
+++ b/src/utilities/view.ts
@@ -29,7 +29,7 @@ export function generateDefaultView(activityTypes: ActivityType[] = [], resource
   const activityRow = createRow(timelines, {
     autoAdjustHeight: false,
     expanded: true,
-    height: 400,
+    height: 200,
     layers: [activityLayer],
     name: 'Activities',
   });
@@ -441,7 +441,6 @@ export function createRowSizes({ row1 = '1fr', row2 = '1fr' }: ViewGridRows, col
   return '1fr';
 }
 
-/* TODO better name but validateViewJSON already taken in effects */
 export function validateViewJSONAgainstSchema(json: any) {
   try {
     const ajv = new Ajv();


### PR DESCRIPTION
Closes #559 
- Refactors generateDefaultView to use the utility functions that the timeline layer editor uses to generate new timeline components. 
- Moves view validation into a utility. Client and server now use this utility and client no longer interacts with the server for view validation.
- Adds unit test for generateDefaultView to ensure it generates a valid view.