### PR TITLE
Anchored activity dragging fixes

### DIFF
--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -177,7 +177,8 @@
   function dragActivityDirective(offsetX: number): void {
     if (!timelineLocked && dragActivityDirectiveActive) {
       const x = offsetX - dragOffsetX;
-      dragCurrentX = Math.max(xScaleView.invert(x).getTime(), planStartTimeMs);
+      const xMs = xScaleView.invert(x).getTime();
+      dragCurrentX = typeof dragActivityDirectiveActive.anchor_id === 'number' ? xMs : Math.max(xMs, planStartTimeMs);
       if (dragCurrentX !== dragPreviousX) {
         const start_offset = getIntervalUnixEpochTime(planStartTimeMs, dragCurrentX);
         dragActivityDirectiveActive.start_offset = start_offset; // Update activity in memory.
@@ -305,8 +306,14 @@
   }
 
   function getXForDirective(activityDirective: ActivityDirective) {
-    const start_offset = activityDirective.start_offset;
-    return getUnixEpochTimeFromInterval(planStartTimeYmd, start_offset);
+    return getActivityDirectiveStartTimeMs(
+      activityDirective.id,
+      planStartTimeYmd,
+      planEndTimeDoy,
+      activityDirectivesMap,
+      spansMap,
+      spanUtilityMaps,
+    );
   }
 
   function getSpanForActivityDirective(activityDirective: ActivityDirective) {
@@ -455,14 +462,7 @@
 
       const sortedActivityDirectives: ActivityDirective[] = activityDirectives.sort(sortActivityDirectivesOrSpans);
       for (const activityDirective of sortedActivityDirectives) {
-        const activityDirectiveX = getActivityDirectiveStartTimeMs(
-          activityDirective.id,
-          planStartTimeYmd,
-          planEndTimeDoy,
-          activityDirectivesMap,
-          spansMap,
-          spanUtilityMaps,
-        );
+        const activityDirectiveX = getXForDirective(activityDirective);
 
         if (activityDirectiveX >= viewTimeRange.start && activityDirectiveX <= viewTimeRange.end) {
           const {

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -373,18 +373,22 @@ export function getIntervalFromDoyRange(startTime: string, endTime: string): str
 export function getIntervalUnixEpochTime(startTimeMs: number, endTimeMs: number): string {
   const differenceMs = endTimeMs - startTimeMs;
 
-  const seconds = Math.floor(differenceMs / 1000);
+  const isNegative = differenceMs < 0;
+  const absoluteDifferenceMs = Math.abs(differenceMs);
+
+  const seconds = Math.floor(absoluteDifferenceMs / 1000);
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
   const remainingSeconds = seconds % 60;
-  const remainingMilliseconds = differenceMs % 1000;
+  const remainingMilliseconds = absoluteDifferenceMs % 1000;
 
   const paddedHours = hours.toString().padStart(2, '0');
   const paddedMinutes = minutes.toString().padStart(2, '0');
   const paddedSeconds = remainingSeconds.toString().padStart(2, '0');
   const paddedMilliseconds = remainingMilliseconds.toString().padStart(3, '0');
 
-  return `${paddedHours}:${paddedMinutes}:${paddedSeconds}.${paddedMilliseconds}`;
+  const sign = isNegative ? '-' : '';
+  return `${sign}${paddedHours}:${paddedMinutes}:${paddedSeconds}.${paddedMilliseconds}`;
 }
 
 /**

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -233,9 +233,9 @@ export function getActivityDirectiveStartTimeMs(
       const anchoredSpan = spansMap[anchoredSpanId];
 
       const anchoredStartTimeMs = getUnixEpochTimeFromInterval(
-        `${new Date(
+        new Date(
           getUnixEpochTimeFromInterval(
-            `${new Date(
+            new Date(
               getActivityDirectiveStartTimeMs(
                 anchor_id,
                 planStartTimeYmd,
@@ -246,10 +246,10 @@ export function getActivityDirectiveStartTimeMs(
                 cachedStartTimes,
                 { ...traversalMap, [anchor_id]: true },
               ),
-            )}`,
+            ).toISOString(),
             anchored_to_start ? '0' : anchoredSpan?.duration ?? '0',
           ),
-        )}`,
+        ).toISOString(),
         activityDirective.start_offset,
       );
 


### PR DESCRIPTION
Closes #518 

Fixes: 
- Anchored directives are now dragged with their anchor directive
- time.getActivityDirectiveStartTimeMs utility function now uses Date.toISOString instead of Date.toString in order to preserve milliseconds when computing an anchored activity directive start time.

Caveat: This PR does not implement plan start drag bounds checking for anchored directives due to the complexity of that task.