### PR TITLE
Add context menu item to toggle simulation of scheduling goals

### DIFF
--- a/src/components/scheduling/SchedulingGoalsPanel.svelte
+++ b/src/components/scheduling/SchedulingGoalsPanel.svelte
@@ -73,6 +73,7 @@
           enabled={specGoal.enabled}
           goal={specGoal.goal}
           priority={specGoal.priority}
+          simulateAfter={specGoal.simulate_after}
           specificationId={specGoal.specification_id}
         />
       {/each}

--- a/src/components/scheduling/goals/SchedulingGoal.svelte
+++ b/src/components/scheduling/goals/SchedulingGoal.svelte
@@ -20,8 +20,10 @@
   export let goal: SchedulingGoal;
   export let priority: number;
   export let specificationId: number;
+  export let simulateAfter: boolean = true;
 
   $: upButtonClass = priority <= 0 ? 'hidden' : '';
+  $: simulateGoal = simulateAfter; // Copied to local var to reflect changed values immediately in the UI
 
   let contextMenu: ContextMenu;
   let expanded = false;
@@ -121,6 +123,18 @@
   </ContextMenuItem>
   <ContextMenuHeader>Modify</ContextMenuHeader>
   <ContextMenuItem on:click={() => effects.deleteSchedulingGoal(goal.id)}>Delete Goal</ContextMenuItem>
+  <ContextMenuItem>
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
+    <div
+      class="scheduling-goal-simulate-toggle"
+      on:click|stopPropagation={() => {
+        simulateGoal = !simulateGoal;
+        effects.updateSchedulingSpecGoal(goal.id, specificationId, { simulate_after: simulateGoal });
+      }}
+    >
+      <input bind:checked={simulateGoal} style:cursor="pointer" type="checkbox" /> Enable Simulation
+    </div>
+  </ContextMenuItem>
 </ContextMenu>
 
 <style>
@@ -147,6 +161,15 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .scheduling-goal-simulate-toggle {
+    align-items: center;
+    display: flex;
+  }
+
+  .scheduling-goal-simulate-toggle input {
+    margin-left: 0;
   }
 
   .left {

--- a/src/components/scheduling/goals/SchedulingGoal.svelte
+++ b/src/components/scheduling/goals/SchedulingGoal.svelte
@@ -132,7 +132,7 @@
         effects.updateSchedulingSpecGoal(goal.id, specificationId, { simulate_after: simulateGoal });
       }}
     >
-      <input bind:checked={simulateGoal} style:cursor="pointer" type="checkbox" /> Enable Simulation
+      <input bind:checked={simulateGoal} style:cursor="pointer" type="checkbox" /> Simulate After
     </div>
   </ContextMenuItem>
 </ContextMenu>

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -73,6 +73,7 @@ export type SchedulingSpecGoal = {
   enabled: boolean;
   goal: SchedulingGoal;
   priority: number;
+  simulate_after: boolean;
   specification_id: number;
 };
 

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1330,6 +1330,7 @@ const gql = {
           revision
         }
         priority
+        simulate_after
         specification_id
       }
     }


### PR DESCRIPTION
Resolves #419 
This is the UI component to add a toggle to control optional simulation of scheduling goals, as provided by https://github.com/NASA-AMMOS/aerie/pull/708

I tested this out by following similar steps to @JoelCourtney's test cases. Added a scheduling goal that peels bananas, and a second goal that takes a nap if it finds peeled bananas. If you toggle simulating off for the first goal, no naps are scheduled, but with simulation toggled on, one is scheduled.

![2023-04-12 16 25 25](https://user-images.githubusercontent.com/888818/231607979-c5fdc432-e874-44fc-a8b4-dbb0a5a954ea.gif)
