### PR TITLE
Fix rendering issues with Data Grids

### DIFF
--- a/src/components/ui/DataGrid/DataGrid.svelte
+++ b/src/components/ui/DataGrid/DataGrid.svelte
@@ -102,18 +102,18 @@
   let resizeObserver: ResizeObserver | null = null;
 
   $: {
-    const seen_set = new Set<number>();
+    const seenSet = new Set<RowId>();
     rowData.forEach(rowDatum => {
-      if (!seen_set.has(rowDatum[idKey])) {
+      if (!seenSet.has(getRowId(rowDatum))) {
         // Non duplicate case
-        seen_set.add(rowDatum[idKey]);
+        seenSet.add(getRowId(rowDatum));
       } else {
         // Found duplicate, write error message
         console.error(
           `%c Grid Problems? Look Here!
 A DataGrid has had multiple rows keyed over the same ID - ensure no two rows have the same value for the \`${String(
             idKey,
-          )}\` property at the same time, even for a moment.
+          )}\` property at the same time, even for a moment. The offending ID is ${getRowId(rowDatum)}
 This has been seen to result in unintended and often glitchy behavior, which often requires a page reload to resolve.`,
           'font-weight:bold;',
         );

--- a/src/components/ui/DataGrid/DataGrid.svelte
+++ b/src/components/ui/DataGrid/DataGrid.svelte
@@ -103,19 +103,21 @@
 
   $: {
     const seen_set = new Set<number>();
-    gridOptions?.api?.setRowData(
-      // Deduplicate the row data by ID
-      // If this is not done, the ag-grid library can just explode! Duplicate IDs seem to be undefined behavior and
-      // result in the UI being messed up until the next reload, even if the duplicate data itself is later remvoed
-      rowData.filter(val => {
-        if (!seen_set.has(val.id)) {
-          seen_set.add(val.id);
-          return true;
-        } else {
-          return false;
-        }
-      }),
-    );
+    rowData.forEach(rowDatum => {
+      if (!seen_set.has(rowDatum[idKey])) {
+        // Non duplicate case
+        seen_set.add(rowDatum[idKey]);
+      } else {
+        // Found duplicate, write error message
+        console.error(
+          `%c Grid Problems? Look Here!
+A DataGrid has had multiple rows keyed over the same ID - ensure no two rows have the same value for the \`${idKey}\` property at the same time, even for a moment.
+This has been seen to result in unintended and often glitchy behavior, which often requires a page reload to resolve.`,
+          'font-weight:bold;',
+        );
+      }
+    });
+    gridOptions?.api?.setRowData(rowData);
 
     const previousSelectedRowIds: RowId[] = [];
     // get all currently selected nodes. we cannot use `getSelectedNodes` because that does not include filtered rows

--- a/src/components/ui/DataGrid/DataGrid.svelte
+++ b/src/components/ui/DataGrid/DataGrid.svelte
@@ -102,19 +102,19 @@
   let resizeObserver: ResizeObserver | null = null;
 
   $: {
-    const seen_set = new Set<number>()
+    const seen_set = new Set<number>();
     gridOptions?.api?.setRowData(
       // Deduplicate the row data by ID
       // If this is not done, the ag-grid library can just explode! Duplicate IDs seem to be undefined behavior and
       // result in the UI being messed up until the next reload, even if the duplicate data itself is later remvoed
-      rowData.filter((val) => {
+      rowData.filter(val => {
         if (!seen_set.has(val.id)) {
-          seen_set.add(val.id)
-          return true
+          seen_set.add(val.id);
+          return true;
         } else {
-          return false
+          return false;
         }
-      })
+      }),
     );
 
     const previousSelectedRowIds: RowId[] = [];

--- a/src/components/ui/DataGrid/DataGrid.svelte
+++ b/src/components/ui/DataGrid/DataGrid.svelte
@@ -102,7 +102,20 @@
   let resizeObserver: ResizeObserver | null = null;
 
   $: {
-    gridOptions?.api?.setRowData(rowData);
+    const seen_set = new Set<number>()
+    gridOptions?.api?.setRowData(
+      // Deduplicate the row data by ID
+      // If this is not done, the ag-grid library can just explode! Duplicate IDs seem to be undefined behavior and
+      // result in the UI being messed up until the next reload, even if the duplicate data itself is later remvoed
+      rowData.filter((val) => {
+        if (!seen_set.has(val.id)) {
+          seen_set.add(val.id)
+          return true
+        } else {
+          return false
+        }
+      })
+    );
 
     const previousSelectedRowIds: RowId[] = [];
     // get all currently selected nodes. we cannot use `getSelectedNodes` because that does not include filtered rows

--- a/src/components/ui/DataGrid/DataGrid.svelte
+++ b/src/components/ui/DataGrid/DataGrid.svelte
@@ -111,7 +111,9 @@
         // Found duplicate, write error message
         console.error(
           `%c Grid Problems? Look Here!
-A DataGrid has had multiple rows keyed over the same ID - ensure no two rows have the same value for the \`${idKey}\` property at the same time, even for a moment.
+A DataGrid has had multiple rows keyed over the same ID - ensure no two rows have the same value for the \`${String(
+            idKey,
+          )}\` property at the same time, even for a moment.
 This has been seen to result in unintended and often glitchy behavior, which often requires a page reload to resolve.`,
           'font-weight:bold;',
         );

--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -91,7 +91,18 @@
 
     try {
       const newCommandDictionary = await effects.createCommandDictionary(files, data.user);
-      commandDictionaries.updateValue((dictionaries: CommandDictionary[]) => [newCommandDictionary, ...dictionaries]);
+
+      const seenSet = new Set<number>();
+      commandDictionaries.updateValue((dictionaries: CommandDictionary[]) =>
+        [newCommandDictionary, ...dictionaries].filter(val => {
+          if (!seenSet.has(val.id)) {
+            seenSet.add(val.id);
+            return true;
+          } else {
+            return false;
+          }
+        }),
+      );
       showSuccessToast('Command Dictionary Created Successfully');
     } catch (e) {
       createDictionaryError = e.message;


### PR DESCRIPTION
The ag-grid library we depend on for the aerie-ui/src/components/ui/DataGrid/DataGrid.svelte compoment breaks if multiple rows with duplicate ID numbers ever exist!

To fix this, I deduplicate the inputs in the `DataGrid.svelte` file before they get passed to the inner library. 

Closes https://github.com/NASA-AMMOS/aerie-ui/issues/433