### PR TITLE
Improve simulated activity timeline rendering

### DIFF
--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -34,6 +34,12 @@ export type PointBounds = {
   xEndCanvas: number;
 };
 
+export type SpanTimeBounds = {
+  duration: number;
+  end: number;
+  start: number;
+};
+
 export type HorizontalGuide = {
   id: number;
   label: Label;


### PR DESCRIPTION
Closes #608 
- Render spans even if their directives are not in view. 
- Make span text sticky to the left. 
- Display an arrow to indicate partially out of view spans when needed.
<img width="809" alt="image" src="https://user-images.githubusercontent.com/4419607/236078198-513e421b-84ed-4013-96d5-3516d27bec98.png">
