### PR TITLE
Toggle directive rendering on timeline

### DIFF
--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -127,6 +127,7 @@
     activityDirectives &&
     activityColor &&
     activityHeight &&
+    areDirectivesVisible !== undefined &&
     ctx &&
     drawHeight &&
     drawWidth &&
@@ -467,7 +468,7 @@
       let maxXPerY: Record<number, number> = {};
 
       const sortedActivityDirectives: ActivityDirective[] = activityDirectives.sort(sortActivityDirectivesOrSpans);
-      for (const activityDirective of sortedActivityDirectives) {
+      sortedActivityDirectives.forEach((activityDirective, activityIndex) => {
         const directiveBounds = getDirectiveBounds(activityDirective); // Directive element
         const directiveInView = directiveBounds.xCanvas <= xScaleViewRangeMax && directiveBounds.xEndCanvas >= 0;
 
@@ -494,7 +495,7 @@
           // Draw spans
           let constrainedSpanY = -1;
           if (span) {
-            const spanStartY = directiveStartY;
+            const spanStartY = directiveStartY + (areDirectivesVisible ? activityHeight * (activityIndex + 1) : 0);
             // Wrap spans if overflowing draw height
             constrainedSpanY =
               spanBounds.maxY > drawHeight ? (spanBounds.maxY % maxCanvasRowY) - rowHeight : spanStartY;
@@ -520,7 +521,7 @@
 
           totalMaxY = Math.max(totalMaxY, directiveStartY, directiveStartY, spanBounds?.maxY || 0);
         }
-      }
+      });
 
       const newHeight = totalMaxY + rowHeight;
       if (newHeight > 0 && drawHeight !== newHeight) {

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -41,7 +41,6 @@
   export let activitySelectedColor: string = '#a9eaff';
   export let activityUnfinishedSelectedColor: string = '#ff3b19';
   export let activityUnfinishedColor: string = '#fc674d';
-  export let showDirectives: boolean = true;
   export let blur: FocusEvent | undefined;
   export let contextmenu: MouseEvent | undefined;
   export let debugMode: boolean = false;
@@ -59,6 +58,7 @@
   export let planStartTimeYmd: string;
   export let selectedActivityDirectiveId: ActivityDirectiveId | null = null;
   export let selectedSpanId: SpanId | null = null;
+  export let showDirectives: boolean = true;
   export let simulationDataset: SimulationDataset | null = null;
   export let spanUtilityMaps: SpanUtilityMaps;
   export let spansMap: SpansMap = {};

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -366,7 +366,8 @@
     areDirectivesVisible: boolean = true,
   ) {
     // Place the elements where they will fit in packed waterfall
-    let i = areDirectivesVisible ? rowHeight : 0;
+    const directiveRowHeight = areDirectivesVisible ? rowHeight : 0;
+    let i = directiveRowHeight;
     let directiveStartY = 0;
     let foundY = false;
     while (!foundY) {
@@ -416,7 +417,7 @@
     let childrenYIterator = 0;
     let spanStartY = 0;
     if (initialSpanBounds) {
-      childrenYIterator = directiveStartY + rowHeight;
+      childrenYIterator = directiveStartY + directiveRowHeight;
       spanStartY = initialSpanBounds.maxY + childrenYIterator;
       while (childrenYIterator < spanStartY) {
         // TODO span bounds could provide a maxXForY instead of absolute corner bounds?

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -41,6 +41,7 @@
   export let activitySelectedColor: string = '#a9eaff';
   export let activityUnfinishedSelectedColor: string = '#ff3b19';
   export let activityUnfinishedColor: string = '#fc674d';
+  export let areDirectivesVisible: boolean = true;
   export let blur: FocusEvent | undefined;
   export let contextmenu: MouseEvent | undefined;
   export let debugMode: boolean = false;
@@ -513,7 +514,9 @@
                 ? (directiveStartY % maxCanvasRowY) + rowHeight
                 : directiveStartY;
           }
-          drawActivityDirective(activityDirective, directiveBounds.xCanvas, constrainedDirectiveY);
+          if (areDirectivesVisible) {
+            drawActivityDirective(activityDirective, directiveBounds.xCanvas, constrainedDirectiveY);
+          }
 
           totalMaxY = Math.max(totalMaxY, directiveStartY, directiveStartY, spanBounds?.maxY || 0);
         }

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -41,7 +41,7 @@
   export let activitySelectedColor: string = '#a9eaff';
   export let activityUnfinishedSelectedColor: string = '#ff3b19';
   export let activityUnfinishedColor: string = '#fc674d';
-  export let areDirectivesVisible: boolean = true;
+  export let showDirectives: boolean = true;
   export let blur: FocusEvent | undefined;
   export let contextmenu: MouseEvent | undefined;
   export let debugMode: boolean = false;
@@ -127,7 +127,7 @@
     activityDirectives &&
     activityColor &&
     activityHeight &&
-    areDirectivesVisible !== undefined &&
+    showDirectives !== undefined &&
     ctx &&
     drawHeight &&
     drawWidth &&
@@ -363,10 +363,10 @@
     maxXPerY: Record<number, number>,
     directiveBounds: PointBounds,
     initialSpanBounds: BoundingBox,
-    areDirectivesVisible: boolean = true,
+    showDirectives: boolean = true,
   ) {
     // Place the elements where they will fit in packed waterfall
-    const directiveRowHeight = areDirectivesVisible ? rowHeight : 0;
+    const directiveRowHeight = showDirectives ? rowHeight : 0;
     let i = directiveRowHeight;
     let directiveStartY = 0;
     let foundY = false;
@@ -487,7 +487,7 @@
             spanBounds,
             directiveStartY,
             maxXPerY: newMaxXPerY,
-          } = placeActivityDirective(maxXPerY, directiveBounds, initialSpanBounds, areDirectivesVisible);
+          } = placeActivityDirective(maxXPerY, directiveBounds, initialSpanBounds, showDirectives);
 
           // Update maxXPerY
           maxXPerY = newMaxXPerY;
@@ -517,7 +517,7 @@
                 ? (directiveStartY % maxCanvasRowY) + rowHeight
                 : directiveStartY;
           }
-          if (areDirectivesVisible) {
+          if (showDirectives) {
             drawActivityDirective(activityDirective, directiveBounds.xCanvas, constrainedDirectiveY);
           }
 

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -363,9 +363,10 @@
     maxXPerY: Record<number, number>,
     directiveBounds: PointBounds,
     initialSpanBounds: BoundingBox,
+    areDirectivesVisible: boolean = true,
   ) {
     // Place the elements where they will fit in packed waterfall
-    let i = rowHeight;
+    let i = areDirectivesVisible ? rowHeight : 0;
     let directiveStartY = 0;
     let foundY = false;
     while (!foundY) {
@@ -468,7 +469,7 @@
       let maxXPerY: Record<number, number> = {};
 
       const sortedActivityDirectives: ActivityDirective[] = activityDirectives.sort(sortActivityDirectivesOrSpans);
-      sortedActivityDirectives.forEach((activityDirective, activityIndex) => {
+      for (const activityDirective of sortedActivityDirectives) {
         const directiveBounds = getDirectiveBounds(activityDirective); // Directive element
         const directiveInView = directiveBounds.xCanvas <= xScaleViewRangeMax && directiveBounds.xEndCanvas >= 0;
 
@@ -485,7 +486,7 @@
             spanBounds,
             directiveStartY,
             maxXPerY: newMaxXPerY,
-          } = placeActivityDirective(maxXPerY, directiveBounds, initialSpanBounds);
+          } = placeActivityDirective(maxXPerY, directiveBounds, initialSpanBounds, areDirectivesVisible);
 
           // Update maxXPerY
           maxXPerY = newMaxXPerY;
@@ -495,7 +496,7 @@
           // Draw spans
           let constrainedSpanY = -1;
           if (span) {
-            const spanStartY = directiveStartY + (areDirectivesVisible ? activityHeight * (activityIndex + 1) : 0);
+            const spanStartY = directiveStartY;
             // Wrap spans if overflowing draw height
             constrainedSpanY =
               spanBounds.maxY > drawHeight ? (spanBounds.maxY % maxCanvasRowY) - rowHeight : spanStartY;
@@ -521,7 +522,7 @@
 
           totalMaxY = Math.max(totalMaxY, directiveStartY, directiveStartY, spanBounds?.maxY || 0);
         }
-      });
+      }
 
       const newHeight = totalMaxY + rowHeight;
       if (newHeight > 0 && drawHeight !== newHeight) {

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -44,7 +44,6 @@
 
   export let activityDirectivesByView: ActivityDirectivesByView = { byLayerId: {}, byTimelineId: {} };
   export let activityDirectivesMap: ActivityDirectivesMap = {};
-  export let showDirectives: boolean = true;
   export let autoAdjustHeight: boolean = false;
   export let constraintViolations: ConstraintViolation[] = [];
   export let drawHeight: number = 0;
@@ -62,6 +61,7 @@
   export let rowDragMoveDisabled = true;
   export let selectedActivityDirectiveId: ActivityDirectiveId | null = null;
   export let selectedSpanId: SpanId | null = null;
+  export let showDirectives: boolean = true;
   export let simulationDataset: SimulationDataset | null = null;
   export let spanUtilityMaps: SpanUtilityMaps;
   export let spansMap: SpansMap = {};
@@ -210,13 +210,15 @@
   <!-- Row Header. -->
   <RowHeader {expanded} rowId={id} title={name} {rowDragMoveDisabled} on:mouseDownRowMove on:toggleRowExpansion>
     <div slot="right" class="row-controls">
-      <TimelineViewDirectiveControls
-        directivesVisible={showDirectives}
-        offTooltipContent="Show Directives on this Timeline Row"
-        onTooltipContent="Hide Directives on this Timeline Row"
-        useBorder={false}
-        on:toggleDirectiveVisibility
-      />
+      {#if hasActivityLayer}
+        <TimelineViewDirectiveControls
+          directivesVisible={showDirectives}
+          offTooltipContent="Show Directives on this Timeline Row"
+          onTooltipContent="Hide Directives on this Timeline Row"
+          useBorder={false}
+          on:toggleDirectiveVisibility
+        />
+      {/if}
       <button
         use:tooltip={{ content: 'Edit Row', placement: 'top' }}
         class="st-button icon row-edit-button"

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -40,9 +40,11 @@
   import RowHorizontalGuides from './RowHorizontalGuides.svelte';
   import RowXAxisTicks from './RowXAxisTicks.svelte';
   import RowYAxes from './RowYAxes.svelte';
+  import TimelineViewDirectiveControls from './TimelineViewDirectiveControls.svelte';
 
   export let activityDirectivesByView: ActivityDirectivesByView = { byLayerId: {}, byTimelineId: {} };
   export let activityDirectivesMap: ActivityDirectivesMap = {};
+  export let areDirectivesVisible: boolean = true;
   export let autoAdjustHeight: boolean = false;
   export let constraintViolations: ConstraintViolation[] = [];
   export let drawHeight: number = 0;
@@ -207,7 +209,14 @@
 <div class="row-root" class:active-row={$selectedRow ? $selectedRow.id === id : false}>
   <!-- Row Header. -->
   <RowHeader {expanded} rowId={id} title={name} {rowDragMoveDisabled} on:mouseDownRowMove on:toggleRowExpansion>
-    <div slot="right">
+    <div slot="right" class="row-controls">
+      <TimelineViewDirectiveControls
+        directivesVisible={areDirectivesVisible}
+        offTooltipContent="Show Directives on this Timeline Row"
+        onTooltipContent="Hide Directives on this Timeline Row"
+        useBorder={false}
+        on:toggleDirectiveVisibility
+      />
       <button
         use:tooltip={{ content: 'Edit Row', placement: 'top' }}
         class="st-button icon row-edit-button"
@@ -266,6 +275,7 @@
             {...layer}
             activityDirectives={activityDirectivesByView?.byLayerId[layer.id] ?? []}
             {activityDirectivesMap}
+            {areDirectivesVisible}
             {blur}
             {contextmenu}
             {drawHeight}
@@ -380,6 +390,10 @@
     opacity: 1;
   }
 
+  .row-root .row-controls {
+    display: flex;
+  }
+
   .row.row-collapsed {
     display: none;
   }
@@ -390,6 +404,14 @@
 
   .row-edit-button {
     display: flex;
+  }
+
+  :global(.row-controls .st-button.icon svg) {
+    color: var(--st-gray-60);
+  }
+
+  :global(.row-controls .st-button.icon:hover svg) {
+    color: var(--st-gray-80);
   }
 
   :global(.row-edit-button.st-button.icon svg) {

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -44,7 +44,7 @@
 
   export let activityDirectivesByView: ActivityDirectivesByView = { byLayerId: {}, byTimelineId: {} };
   export let activityDirectivesMap: ActivityDirectivesMap = {};
-  export let areDirectivesVisible: boolean = true;
+  export let showDirectives: boolean = true;
   export let autoAdjustHeight: boolean = false;
   export let constraintViolations: ConstraintViolation[] = [];
   export let drawHeight: number = 0;
@@ -211,9 +211,10 @@
   <RowHeader {expanded} rowId={id} title={name} {rowDragMoveDisabled} on:mouseDownRowMove on:toggleRowExpansion>
     <div slot="right" class="row-controls">
       <TimelineViewDirectiveControls
-        directivesVisible={areDirectivesVisible}
+        directivesVisible={showDirectives}
         offTooltipContent="Show Directives on this Timeline Row"
         onTooltipContent="Hide Directives on this Timeline Row"
+        useBorder={false}
         on:toggleDirectiveVisibility
       />
       <button
@@ -274,7 +275,7 @@
             {...layer}
             activityDirectives={activityDirectivesByView?.byLayerId[layer.id] ?? []}
             {activityDirectivesMap}
-            {areDirectivesVisible}
+            {showDirectives}
             {blur}
             {contextmenu}
             {drawHeight}

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -214,7 +214,6 @@
         directivesVisible={areDirectivesVisible}
         offTooltipContent="Show Directives on this Timeline Row"
         onTooltipContent="Hide Directives on this Timeline Row"
-        useBorder={false}
         on:toggleDirectiveVisibility
       />
       <button
@@ -404,14 +403,6 @@
 
   .row-edit-button {
     display: flex;
-  }
-
-  :global(.row-controls .st-button.icon svg) {
-    color: var(--st-gray-60);
-  }
-
-  :global(.row-controls .st-button.icon:hover svg) {
-    color: var(--st-gray-80);
   }
 
   :global(.row-edit-button.st-button.icon svg) {

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -225,8 +225,8 @@
 <div bind:this={timelineDiv} bind:clientWidth class="timeline" id={`timeline-${timeline?.id}`}>
   <div bind:this={timelineHistogramDiv} style="padding-top: 12px">
     <TimelineHistogram
-      activityDirectives={activityDirectivesByView && timeline
-        ? activityDirectivesByView?.byTimelineId[timeline.id]
+      activityDirectives={timeline && activityDirectivesByView?.byTimelineId[timeline.id]
+        ? activityDirectivesByView.byTimelineId[timeline.id]
         : []}
       {constraintViolations}
       {cursorEnabled}

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -285,7 +285,7 @@
       <TimelineRow
         {activityDirectivesByView}
         {activityDirectivesMap}
-        areDirectivesVisible={timelineDirectiveVisibilityToggles[row.id]}
+        showDirectives={timelineDirectiveVisibilityToggles[row.id]}
         autoAdjustHeight={row.autoAdjustHeight}
         {constraintViolations}
         drawHeight={row.height}

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -51,20 +51,21 @@
   export let spansMap: SpansMap = {};
   export let spans: Span[] = [];
   export let timeline: Timeline | null = null;
+  export let timelineDirectiveVisibilityToggles: DirectiveVisibilityToggleMap = {};
   export let timelineLockStatus: TimelineLockStatus;
   export let viewTimeRange: TimeRange = { end: 0, start: 0 };
 
   const dispatch = createEventDispatcher();
 
   let clientWidth: number = 0;
-  let contextMenu: MouseOver;
+  let contextMenu: MouseOver | null;
   let contextMenuComponent: TimelineContextMenu;
   let tooltip: Tooltip;
   let cursorEnabled: boolean = true;
   let cursorHeaderHeight: number = 0;
   let estimatedLabelWidthPx: number = 74; // Width of MS time which is the largest display format
   let histogramCursorTime: Date | null = null;
-  let mouseOver: MouseOver;
+  let mouseOver: MouseOver | null;
   let rowDragMoveDisabled = true;
   let rowsMaxHeight: number = 600;
   let rows: Row[] = [];
@@ -77,7 +78,7 @@
   let xTicksView: XAxisTick[] = [];
 
   $: rows = timeline?.rows || [];
-  $: drawWidth = clientWidth > 0 ? clientWidth - timeline?.marginLeft - timeline?.marginRight : 0;
+  $: drawWidth = clientWidth > 0 ? clientWidth - (timeline?.marginLeft ?? 0) - (timeline?.marginRight ?? 0) : 0;
 
   // Compute number of ticks based off draw width
   $: if (drawWidth) {
@@ -163,7 +164,7 @@
   }
 
   function onMouseDown(event: CustomEvent<MouseDown>) {
-    dispatch('mouseDown', { ...event.detail, timelineId: timeline.id });
+    dispatch('mouseDown', { ...event.detail, timelineId: timeline?.id });
   }
 
   function onMouseDownRowMove(event: Event) {
@@ -174,6 +175,10 @@
   function onToggleRowExpansion(event: CustomEvent<{ expanded: boolean; rowId: number }>) {
     const { rowId, expanded } = event.detail;
     dispatch('toggleRowExpansion', { expanded, rowId });
+  }
+
+  function onToggleDirectiveVisibility(rowId: number, visible: boolean) {
+    dispatch('toggleDirectiveVisibility', { rowId, visible });
   }
 
   function onUpdateRowHeight(event: CustomEvent<{ newHeight: number; rowId: number; wasAutoAdjusted?: boolean }>) {
@@ -212,7 +217,9 @@
 <div bind:this={timelineDiv} bind:clientWidth class="timeline" id={`timeline-${timeline?.id}`}>
   <div bind:this={timelineHistogramDiv} style="padding-top: 12px">
     <TimelineHistogram
-      activityDirectives={activityDirectivesByView?.byTimelineId[timeline.id] ?? []}
+      activityDirectives={activityDirectivesByView && timeline
+        ? activityDirectivesByView?.byTimelineId[timeline.id]
+        : []}
       {constraintViolations}
       {cursorEnabled}
       drawHeight={timelineHistogramDrawHeight}
@@ -270,6 +277,7 @@
       <TimelineRow
         {activityDirectivesByView}
         {activityDirectivesMap}
+        areDirectivesVisible={timelineDirectiveVisibilityToggles[row.id]}
         autoAdjustHeight={row.autoAdjustHeight}
         {constraintViolations}
         drawHeight={row.height}
@@ -304,6 +312,7 @@
         on:mouseDownRowMove={onMouseDownRowMove}
         on:mouseOver={e => (mouseOver = e.detail)}
         on:toggleRowExpansion={onToggleRowExpansion}
+        on:toggleDirectiveVisibility={e => onToggleDirectiveVisibility(row.id, e.detail)}
         on:updateRowHeight={onUpdateRowHeight}
       />
     {/each}

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -285,7 +285,6 @@
       <TimelineRow
         {activityDirectivesByView}
         {activityDirectivesMap}
-        showDirectives={timelineDirectiveVisibilityToggles[row.id]}
         autoAdjustHeight={row.autoAdjustHeight}
         {constraintViolations}
         drawHeight={row.height}
@@ -303,6 +302,7 @@
         {rowDragMoveDisabled}
         {selectedActivityDirectiveId}
         {selectedSpanId}
+        showDirectives={timelineDirectiveVisibilityToggles[row.id]}
         {simulationDataset}
         {spanUtilityMaps}
         {spansMap}

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -14,7 +14,15 @@
     SpanUtilityMaps,
     SpansMap,
   } from '../../types/simulation';
-  import type { MouseDown, MouseOver, Row, TimeRange, Timeline, XAxisTick } from '../../types/timeline';
+  import type {
+    DirectiveVisibilityToggleMap,
+    MouseDown,
+    MouseOver,
+    Row,
+    TimeRange,
+    Timeline,
+    XAxisTick,
+  } from '../../types/timeline';
   import { clamp } from '../../utilities/generic';
   import { getDoy, getDoyTime } from '../../utilities/time';
   import {

--- a/src/components/timeline/TimelineViewControls.svelte
+++ b/src/components/timeline/TimelineViewControls.svelte
@@ -150,16 +150,13 @@
 >
   <RotateCounterClockwiseIcon />
 </button>
-<button
-  class="st-button icon"
-  on:click={onToggleDirectiveVisibility}
-  use:tooltip={{
-    content: `${allDirectivesVisible ? 'Hide' : 'Show'} Directives on all Timeline Rows`,
-    placement: 'bottom',
-  }}
->
-  <TimelineViewDirectiveControls directivesVisible={allDirectivesVisible} />
-</button>
+<TimelineViewDirectiveControls
+  directivesVisible={allDirectivesVisible}
+  offTooltipContent="Show Directives on all Timeline Rows"
+  onTooltipContent="Hide Directives on all Timeline Rows"
+  tooltipPlacement="bottom"
+  on:toggleDirectiveVisibility={onToggleDirectiveVisibility}
+/>
 
 <style>
   .st-button {
@@ -167,7 +164,7 @@
     color: var(--st-gray-70);
   }
 
-  :global(.st-button:hover svg) {
+  .st-button:hover :global(svg) {
     color: var(--st-gray-80);
   }
 </style>

--- a/src/components/timeline/TimelineViewControls.svelte
+++ b/src/components/timeline/TimelineViewControls.svelte
@@ -5,13 +5,17 @@
   import PlusIcon from '@nasa-jpl/stellar/icons/plus.svg?component';
   import RotateCounterClockwiseIcon from '@nasa-jpl/stellar/icons/rotate_counter_clockwise.svg?component';
   import { createEventDispatcher } from 'svelte';
-  import type { TimeRange } from '../../types/timeline';
+  import type { DirectiveVisibilityToggleMap, TimeRange } from '../../types/timeline';
   import { tooltip } from '../../utilities/tooltip';
+  import TimelineViewDirectiveControls from './TimelineViewDirectiveControls.svelte';
 
   export let maxTimeRange: TimeRange = { end: 0, start: 0 };
   export let minZoomMS = 100; // Min zoom of one minute
   export let nudgePercent = 0.05;
+  export let timelineDirectiveVisibilityToggles: DirectiveVisibilityToggleMap;
   export let viewTimeRange: TimeRange = { end: 0, start: 0 };
+
+  let allDirectivesVisible: boolean = true;
 
   const dispatch = createEventDispatcher();
 
@@ -22,6 +26,13 @@
   // TODO implement a more sophisticated zooming step that based off time instead of percentage for the high zoom
   // cases or even the whole range
   $: zoomActionPercent = viewTimeRangePercentZoom < 0.1 ? 0.005 : 0.05;
+  $: {
+    const rowVisibilities = Object.values(timelineDirectiveVisibilityToggles);
+    const allSame = rowVisibilities.every(val => val === rowVisibilities[0]);
+    if (allSame) {
+      allDirectivesVisible = rowVisibilities[0];
+    }
+  }
 
   function onKeydown(e: KeyboardEvent & { currentTarget: EventTarget & Window; target: HTMLElement }) {
     // If user holds shift while not focused on an input then activate the temporary unlock.
@@ -135,6 +146,12 @@
 >
   <RotateCounterClockwiseIcon />
 </button>
+<TimelineViewDirectiveControls
+  directivesVisible={allDirectivesVisible}
+  offTooltipContent="Show Directives on all Timeline Rows"
+  onTooltipContent="Hide Directives on all Timeline Rows"
+  on:toggleDirectiveVisibility
+/>
 
 <style>
   .st-button {

--- a/src/components/timeline/TimelineViewControls.svelte
+++ b/src/components/timeline/TimelineViewControls.svelte
@@ -102,6 +102,10 @@
   function onResetViewTimeRange() {
     dispatch('viewTimeRangeChanged', maxTimeRange);
   }
+
+  function onToggleDirectiveVisibility() {
+    dispatch('toggleDirectiveVisibility', !allDirectivesVisible);
+  }
 </script>
 
 <svelte:window on:keydown={onKeydown} />
@@ -146,16 +150,24 @@
 >
   <RotateCounterClockwiseIcon />
 </button>
-<TimelineViewDirectiveControls
-  directivesVisible={allDirectivesVisible}
-  offTooltipContent="Show Directives on all Timeline Rows"
-  onTooltipContent="Hide Directives on all Timeline Rows"
-  on:toggleDirectiveVisibility
-/>
+<button
+  class="st-button icon"
+  on:click={onToggleDirectiveVisibility}
+  use:tooltip={{
+    content: `${allDirectivesVisible ? 'Hide' : 'Show'} Directives on all Timeline Rows`,
+    placement: 'bottom',
+  }}
+>
+  <TimelineViewDirectiveControls directivesVisible={allDirectivesVisible} />
+</button>
 
 <style>
   .st-button {
     border: 1px solid var(--st-gray-30);
     color: var(--st-gray-70);
+  }
+
+  :global(.st-button:hover svg) {
+    color: var(--st-gray-80);
   }
 </style>

--- a/src/components/timeline/TimelineViewControls.svelte
+++ b/src/components/timeline/TimelineViewControls.svelte
@@ -150,13 +150,15 @@
 >
   <RotateCounterClockwiseIcon />
 </button>
-<TimelineViewDirectiveControls
-  directivesVisible={allDirectivesVisible}
-  offTooltipContent="Show Directives on all Timeline Rows"
-  onTooltipContent="Hide Directives on all Timeline Rows"
-  tooltipPlacement="bottom"
-  on:toggleDirectiveVisibility={onToggleDirectiveVisibility}
-/>
+{#if Object.keys(timelineDirectiveVisibilityToggles).length > 0}
+  <TimelineViewDirectiveControls
+    directivesVisible={allDirectivesVisible}
+    offTooltipContent="Show Directives on all Timeline Rows"
+    onTooltipContent="Hide Directives on all Timeline Rows"
+    tooltipPlacement="bottom"
+    on:toggleDirectiveVisibility={onToggleDirectiveVisibility}
+  />
+{/if}
 
 <style>
   .st-button {

--- a/src/components/timeline/TimelineViewDirectiveControls.svelte
+++ b/src/components/timeline/TimelineViewDirectiveControls.svelte
@@ -6,7 +6,6 @@
   export let directivesVisible: boolean = true;
   export let onTooltipContent: string = '';
   export let offTooltipContent: string = '';
-  export let useBorder: boolean = true;
 
   const dispatch = createEventDispatcher();
 
@@ -17,11 +16,10 @@
 </script>
 
 <ToggleableIconButton
-  class="toggle-icon-button"
+  class="timeline-view-directive-control"
   isOn={directivesVisible}
   {offTooltipContent}
   {onTooltipContent}
-  {useBorder}
   on:toggle={onToggleDirectiveVisibility}
 >
   <ActivityDirectiveIcon backgroundColor="#ccc" size="12px" />
@@ -49,7 +47,14 @@
     width: 20px;
   }
 
-  :global(.toggle-icon-button svg g) {
+  :global(.timeline-view-directive-control svg g) {
     opacity: 1;
+  }
+
+  :global(.timeline-view-directive-control svg) {
+    color: var(--st-gray-60);
+  }
+  :global(.timeline-view-directive-control:hover svg) {
+    color: var(--st-gray-80);
   }
 </style>

--- a/src/components/timeline/TimelineViewDirectiveControls.svelte
+++ b/src/components/timeline/TimelineViewDirectiveControls.svelte
@@ -6,6 +6,8 @@
   export let directivesVisible: boolean = true;
   export let onTooltipContent: string = '';
   export let offTooltipContent: string = '';
+  export let tooltipPlacement: string = 'top';
+  export let useBorder: boolean = true;
 
   const dispatch = createEventDispatcher();
 
@@ -15,19 +17,22 @@
   }
 </script>
 
-<ToggleableIconButton
-  class="timeline-view-directive-control"
-  isOn={directivesVisible}
-  {offTooltipContent}
-  {onTooltipContent}
-  on:toggle={onToggleDirectiveVisibility}
->
-  <ActivityDirectiveIcon backgroundColor="#ccc" size="12px" />
-  <div slot="offIcon" class="off-icon">
+<div class="timeline-view-directive-control">
+  <ToggleableIconButton
+    isOn={directivesVisible}
+    {offTooltipContent}
+    {onTooltipContent}
+    {tooltipPlacement}
+    {useBorder}
+    on:toggle={onToggleDirectiveVisibility}
+  >
     <ActivityDirectiveIcon backgroundColor="#ccc" size="12px" />
-    <div class="toggle-slash" />
-  </div>
-</ToggleableIconButton>
+    <div slot="offIcon" class="off-icon">
+      <ActivityDirectiveIcon backgroundColor="#ccc" size="12px" />
+      <div class="toggle-slash" />
+    </div>
+  </ToggleableIconButton>
+</div>
 
 <style>
   .off-icon {
@@ -47,14 +52,14 @@
     width: 20px;
   }
 
-  :global(.timeline-view-directive-control svg g) {
+  .timeline-view-directive-control :global(.st-button svg g) {
     opacity: 1;
   }
 
-  :global(.timeline-view-directive-control svg) {
+  .timeline-view-directive-control :global(.st-button svg) {
     color: var(--st-gray-60);
   }
-  :global(.timeline-view-directive-control:hover svg) {
+  .timeline-view-directive-control:hover :global(.st-button svg) {
     color: var(--st-gray-80);
   }
 </style>

--- a/src/components/timeline/TimelineViewDirectiveControls.svelte
+++ b/src/components/timeline/TimelineViewDirectiveControls.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import ActivityDirectiveIcon from '../ui/ActivityDirectiveIcon.svelte';
+  import ToggleableIconButton from '../ui/ToggleableIconButton.svelte';
+
+  export let directivesVisible: boolean = true;
+  export let onTooltipContent: string = '';
+  export let offTooltipContent: string = '';
+  export let useBorder: boolean = true;
+
+  const dispatch = createEventDispatcher();
+
+  function onToggleDirectiveVisibility(event: CustomEvent<boolean>) {
+    const { detail } = event;
+    dispatch('toggleDirectiveVisibility', detail);
+  }
+</script>
+
+<ToggleableIconButton
+  class="toggle-icon-button"
+  isOn={directivesVisible}
+  {offTooltipContent}
+  {onTooltipContent}
+  {useBorder}
+  on:toggle={onToggleDirectiveVisibility}
+>
+  <ActivityDirectiveIcon backgroundColor="#ccc" size="12px" />
+  <div slot="offIcon" class="off-icon">
+    <ActivityDirectiveIcon backgroundColor="#ccc" size="12px" />
+    <div class="toggle-slash" />
+  </div>
+</ToggleableIconButton>
+
+<style>
+  .off-icon {
+    align-items: center;
+    display: inline-flex;
+    position: relative;
+  }
+
+  .toggle-slash {
+    background-color: var(--st-gray-70);
+    bottom: 6px;
+    height: 2px;
+    left: -3px;
+    outline: 2px solid #fff;
+    position: absolute;
+    transform: rotate(-35deg);
+    width: 20px;
+  }
+
+  :global(.toggle-icon-button svg g) {
+    opacity: 1;
+  }
+</style>

--- a/src/components/ui/ActivityDirectiveIcon.svelte
+++ b/src/components/ui/ActivityDirectiveIcon.svelte
@@ -3,15 +3,21 @@
 <script lang="ts">
   import ActivityDirectiveIconSVG from '@nasa-jpl/stellar/icons/activity_directive.svg?component';
 
-  export let label: string = undefined;
-  export let backgroundColor: string = '#fcbd21';
-  export let color: string = '#000000';
+  export let backgroundColor: string | undefined = undefined;
+  export let color: string | undefined = undefined;
+  export let label: string | undefined = undefined;
+  export let opacity: number = 1;
+  export let size: string | undefined = '16px';
 </script>
 
 <div class="container">
   <div class="directive-icon-container">
-    <div class="directive-background" style="background-color: {backgroundColor};" />
-    <div class="directive-icon" style="color: {color};"><ActivityDirectiveIconSVG /></div>
+    <div
+      class="directive-icon"
+      style="background-color: {backgroundColor ?? '#fcbd21'};color: {color ?? '#000000'};opacity: {opacity}"
+    >
+      <ActivityDirectiveIconSVG width={size} height={size} />
+    </div>
   </div>
   {#if label}
     <span class="icon-label">{label}</span>

--- a/src/components/ui/ToggleableIconButton.svelte
+++ b/src/components/ui/ToggleableIconButton.svelte
@@ -11,6 +11,8 @@
   export let isOn: boolean = true;
   export let onTooltipContent: string = '';
   export let offTooltipContent: string = '';
+  export let tooltipPlacement: string = 'top';
+  export let useBorder: boolean = true;
   export { className as class };
 
   let className: string = '';
@@ -23,11 +25,12 @@
 </script>
 
 <button
-  class={classNames('toggleable-icon-button ', {
+  class={classNames('toggleable-icon-button st-button icon', {
+    'border-button': useBorder,
     [className]: !!className,
   })}
   on:click={onClick}
-  use:tooltip={{ content: isOn ? onTooltipContent : offTooltipContent, placement: 'bottom' }}
+  use:tooltip={{ content: isOn ? onTooltipContent : offTooltipContent, placement: tooltipPlacement }}
 >
   <ToggleableIcon {isOn} on:click={onClick}>
     <slot />
@@ -41,6 +44,9 @@
     background: none;
     border: 0;
     display: inline-flex;
+  }
+  .st-button.border-button {
+    border: 1px solid var(--st-gray-30);
   }
 
   .toggleable-icon-button:hover {

--- a/src/components/ui/ToggleableIconButton.svelte
+++ b/src/components/ui/ToggleableIconButton.svelte
@@ -11,7 +11,6 @@
   export let isOn: boolean = true;
   export let onTooltipContent: string = '';
   export let offTooltipContent: string = '';
-  export let useBorder: boolean = true;
   export { className as class };
 
   let className: string = '';
@@ -24,32 +23,27 @@
 </script>
 
 <button
-  class={classNames('st-button icon', {
-    'border-button': useBorder,
+  class={classNames('toggleable-icon-button ', {
     [className]: !!className,
   })}
   on:click={onClick}
   use:tooltip={{ content: isOn ? onTooltipContent : offTooltipContent, placement: 'bottom' }}
 >
-  <div class="icon-container">
-    <ToggleableIcon {isOn}>
-      <slot />
-      <slot name="offIcon" slot="offIcon" />
-    </ToggleableIcon>
-  </div>
+  <ToggleableIcon {isOn} on:click={onClick}>
+    <slot />
+    <slot name="offIcon" slot="offIcon" />
+  </ToggleableIcon>
 </button>
 
 <style>
-  .st-button {
-    color: var(--st-gray-70);
-  }
-
-  .st-button.border-button {
-    border: 1px solid var(--st-gray-30);
-  }
-
-  .icon-container {
+  .toggleable-icon-button {
     align-items: center;
+    background: none;
+    border: 0;
     display: inline-flex;
+  }
+
+  .toggleable-icon-button:hover {
+    cursor: pointer;
   }
 </style>

--- a/src/components/ui/ToggleableIconButton.svelte
+++ b/src/components/ui/ToggleableIconButton.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  interface $$Events {
+    toggle: CustomEvent<boolean>;
+  }
+
+  import { createEventDispatcher } from 'svelte';
+  import { classNames } from '../../utilities/generic';
+  import { tooltip } from '../../utilities/tooltip';
+  import ToggleableIcon from './ToggleableIcon.svelte';
+
+  export let isOn: boolean = true;
+  export let onTooltipContent: string = '';
+  export let offTooltipContent: string = '';
+  export let useBorder: boolean = true;
+  export { className as class };
+
+  let className: string = '';
+
+  const dispatch = createEventDispatcher();
+
+  function onClick() {
+    dispatch('toggle', !isOn);
+  }
+</script>
+
+<button
+  class={classNames('st-button icon', {
+    'border-button': useBorder,
+    [className]: !!className,
+  })}
+  on:click={onClick}
+  use:tooltip={{ content: isOn ? onTooltipContent : offTooltipContent, placement: 'bottom' }}
+>
+  <div class="icon-container">
+    <ToggleableIcon {isOn}>
+      <slot />
+      <slot name="offIcon" slot="offIcon" />
+    </ToggleableIcon>
+  </div>
+</button>
+
+<style>
+  .st-button {
+    color: var(--st-gray-70);
+  }
+
+  .st-button.border-button {
+    border: 1px solid var(--st-gray-30);
+  }
+
+  .icon-container {
+    align-items: center;
+    display: inline-flex;
+  }
+</style>

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -194,8 +194,3 @@ export interface XRangePoint extends Point {
 }
 
 export type DirectiveVisibilityToggleMap = Record<string, boolean>;
-
-export interface ToggleTimelineDirectiveVisibility {
-  rowId: number;
-  visible: boolean;
-}

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -192,3 +192,10 @@ export interface XRangePoint extends Point {
   is_gap?: boolean;
   label: Label;
 }
+
+export type DirectiveVisibilityToggleMap = Record<string, boolean>;
+
+export interface ToggleTimelineDirectiveVisibility {
+  rowId: number;
+  visible: boolean;
+}


### PR DESCRIPTION
Resolves #536 

To test:

1. Open a plan with directives and spans present in the timeline (ideally multiple rows that show activities)
2. Click on the directive icon at the top where the timeline controls are to disable drawing directives across all rows that have activities being rendered
![Screenshot 2023-05-08 at 12 22 59 PM](https://user-images.githubusercontent.com/5290214/236914933-e3bfccda-0b2a-49c0-80ff-c8311a690855.png)
3. Verify that all rows stop showing directive icons
4. Click on individual row directive icons to disable drawing directives just for that row
![Screenshot 2023-05-08 at 12 26 05 PM](https://user-images.githubusercontent.com/5290214/236915113-d72872ab-cb04-4ed9-a6af-90292899f77f.png)
5. Verify that only that row's directives are not drawn