### PR TITLE
Disallow duplicate model creation

### DIFF
--- a/e2e-tests/fixtures/Models.ts
+++ b/e2e-tests/fixtures/Models.ts
@@ -7,6 +7,7 @@ export class Models {
   confirmModal: Locator;
   confirmModalDeleteButton: Locator;
   createButton: Locator;
+  creatingButton: Locator;
   inputFile: Locator;
   inputName: Locator;
   inputVersion: Locator;
@@ -81,7 +82,8 @@ export class Models {
     this.alertError = page.locator('.alert-error');
     this.confirmModal = page.locator(`.modal:has-text("Delete Model")`);
     this.confirmModalDeleteButton = page.locator(`.modal:has-text("Delete Model") >> button:has-text("Delete")`);
-    this.createButton = page.locator('text=Create');
+    this.createButton = page.getByRole('button', { name: 'Create' });
+    this.creatingButton = page.getByRole('button', { name: 'Creating...' });
     this.inputFile = page.locator('input[name="file"]');
     this.inputName = page.locator('input[name="name"]');
     this.inputVersion = page.locator('input[name="version"]');

--- a/e2e-tests/tests/models.test.ts
+++ b/e2e-tests/tests/models.test.ts
@@ -43,7 +43,27 @@ test.describe.serial('Models', () => {
   test('Create button should be enabled after entering a name, version, and file', async () => {
     await models.fillInputName();
     await models.fillInputVersion();
+    await models.fillInputFile();
     await expect(models.createButton).not.toBeDisabled();
+  });
+
+  test('Create button should be disabled after submitting once', async () => {
+    // Setup the test
+    await expect(models.tableRow).not.toBeVisible();
+    await models.fillInputName();
+    await models.fillInputVersion();
+    await models.fillInputFile();
+    await models.createButton.click();
+    // The create button shouldn't be there
+    await expect(models.createButton).not.toBeVisible();
+    // Instead, the creating button should be present and disabled
+    await expect(models.creatingButton).toBeVisible();
+    await expect(models.creatingButton).toBeDisabled();
+    await expect(models.createButton).toBeVisible();
+
+    await expect(models.inputFile).toBeEmpty();
+    await expect(models.inputVersion).toBeEmpty();
+    await expect(models.inputName).toBeEmpty();
   });
 
   test('Create model', async () => {

--- a/e2e-tests/tests/models.test.ts
+++ b/e2e-tests/tests/models.test.ts
@@ -47,6 +47,14 @@ test.describe.serial('Models', () => {
     await expect(models.createButton).not.toBeDisabled();
   });
 
+  test('Create model', async () => {
+    await models.createModel();
+  });
+
+  test('Delete model', async () => {
+    await models.deleteModel();
+  });
+
   test('Create button should be disabled after submitting once', async () => {
     // Setup the test
     await expect(models.tableRow).not.toBeVisible();
@@ -64,13 +72,5 @@ test.describe.serial('Models', () => {
     await expect(models.inputFile).toBeEmpty();
     await expect(models.inputVersion).toBeEmpty();
     await expect(models.inputName).toBeEmpty();
-  });
-
-  test('Create model', async () => {
-    await models.createModel();
-  });
-
-  test('Delete model', async () => {
-    await models.deleteModel();
   });
 });

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -77,7 +77,7 @@
   let name = '';
   let version = '';
 
-  $: createButtonDisabled = !files || name === '' || version === '';
+  $: createButtonDisabled = !files || name === '' || version === '' || $creatingModel === true;
 
   onMount(() => {
     models.updateValue(() => data.initialModels);
@@ -98,6 +98,13 @@
   function showModel(model: ModelSlim) {
     goto(`${base}/plans?modelId=${model.id}`);
   }
+
+  async function submitForm(e: SubmitEvent) {
+    await effects.createModel(name, version, files);
+    if ($createModelError === null && e.target instanceof HTMLFormElement) {
+      e.target.reset();
+    }
+  }
 </script>
 
 <PageTitle title="Models" />
@@ -114,7 +121,7 @@
       </svelte:fragment>
 
       <svelte:fragment slot="body">
-        <form on:submit|preventDefault={() => effects.createModel(name, version, files)}>
+        <form on:submit|preventDefault={submitForm}>
           <AlertError class="m-2" error={$createModelError} />
 
           <fieldset>


### PR DESCRIPTION
Closes #374 

It used to be possible to submit two attempts to create a model, resulting in a very unclear error message. This commit fixes that by disabling the button while the creation request is pending, as discussed in the issue. It also resets the form if the submission finishes successfully.

This commit also includes a test to avoid regression!