### PR TITLE
Add disableable default resize behavior to tables

### DIFF
--- a/src/components/activity/ActivityDirectivesTable.svelte
+++ b/src/components/activity/ActivityDirectivesTable.svelte
@@ -80,6 +80,7 @@
 <BulkActionDataGrid
   bind:dataGrid
   bind:selectedItemId={selectedActivityDirectiveId}
+  autoSizeColumnsToFit={false}
   columnDefs={[...(columnDefs ?? []), activityActionColumnDef]}
   {columnStates}
   {getRowId}

--- a/src/components/activity/ActivitySpansTable.svelte
+++ b/src/components/activity/ActivitySpansTable.svelte
@@ -29,6 +29,7 @@
   bind:this={dataGrid}
   bind:currentSelectedRowId={selectedSpanId}
   bind:selectedRowIds={selectedItemIds}
+  autoSizeColumnsToFit={false}
   columnDefs={[...(columnDefs ?? [])]}
   {columnStates}
   {getRowId}

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -16,6 +16,7 @@
   import ContextMenuItem from '../../context-menu/ContextMenuItem.svelte';
   import DataGrid from '../../ui/DataGrid/DataGrid.svelte';
 
+  export let autoSizeColumnsToFit: boolean = true;
   export let columnDefs: ColDef[];
   export let columnStates: ColumnState[] = [];
   export let dataGrid: DataGrid<RowData> | undefined = undefined;
@@ -92,6 +93,7 @@
   bind:this={dataGrid}
   bind:currentSelectedRowId={selectedItemId}
   bind:selectedRowIds={selectedItemIds}
+  {autoSizeColumnsToFit}
   {columnDefs}
   {columnStates}
   {getRowId}

--- a/src/components/ui/DataGrid/DataGrid.svelte
+++ b/src/components/ui/DataGrid/DataGrid.svelte
@@ -69,6 +69,7 @@
     gridOptions?.api?.sizeColumnsToFit(params);
   }
 
+  export let autoSizeColumnsToFit: boolean = true;
   export let columnDefs: ColDef[];
   export let columnStates: ColumnState[] = [];
   export let columnShiftResize: boolean = false;
@@ -97,6 +98,7 @@
   let gridDiv: HTMLDivElement;
   let onColumnStateChangeDebounced = debounce(onColumnStateChange, 500);
   let previousSelectedRowId: RowId | null = null;
+  let resizeObserver: ResizeObserver | null = null;
 
   $: {
     gridOptions?.api?.setRowData(rowData);
@@ -317,6 +319,13 @@
       suppressRowClickSelection,
     };
     new Grid(gridDiv, gridOptions);
+
+    if (autoSizeColumnsToFit) {
+      resizeObserver = new ResizeObserver(() => {
+        sizeColumnsToFit();
+      });
+      resizeObserver.observe(gridDiv);
+    }
   });
 </script>
 

--- a/src/components/ui/DataGrid/DataGrid.svelte
+++ b/src/components/ui/DataGrid/DataGrid.svelte
@@ -97,6 +97,7 @@
   let gridOptions: GridOptions<RowData>;
   let gridDiv: HTMLDivElement;
   let onColumnStateChangeDebounced = debounce(onColumnStateChange, 500);
+  let onWindowResizedDebounced = debounce(sizeColumnsToFit, 50);
   let previousSelectedRowId: RowId | null = null;
   let resizeObserver: ResizeObserver | null = null;
 
@@ -322,7 +323,7 @@
 
     if (autoSizeColumnsToFit) {
       resizeObserver = new ResizeObserver(() => {
-        sizeColumnsToFit();
+        onWindowResizedDebounced();
       });
       resizeObserver.observe(gridDiv);
     }

--- a/src/components/ui/DataGrid/DataGrid.test.ts
+++ b/src/components/ui/DataGrid/DataGrid.test.ts
@@ -1,9 +1,18 @@
 import { cleanup, fireEvent, render } from '@testing-library/svelte';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import DataGrid from './DataGrid.svelte';
 
 const numOfRows = 10;
 const testRowData = [...new Array(numOfRows)].map((_, i) => ({ id: i, name: `test ${i}` }));
+
+vi.stubGlobal(
+  'ResizeObserver',
+  vi.fn(() => ({
+    disconnect: vi.fn(),
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+  })),
+);
 
 describe('DataGrid Component', () => {
   afterEach(() => {

--- a/src/components/ui/DataGrid/SingleActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/SingleActionDataGrid.svelte
@@ -16,6 +16,7 @@
   import ContextMenuItem from '../../context-menu/ContextMenuItem.svelte';
   import DataGrid from '../../ui/DataGrid/DataGrid.svelte';
 
+  export let autoSizeColumnsToFit: boolean = true;
   export let columnDefs: ColDef[];
   export let columnStates: ColumnState[] = [];
   export let dataGrid: DataGrid<RowData> | undefined = undefined;
@@ -70,6 +71,7 @@
   bind:this={dataGrid}
   bind:currentSelectedRowId={selectedItemId}
   bind:selectedRowIds={selectedItemIds}
+  {autoSizeColumnsToFit}
   {columnDefs}
   {columnStates}
   {getRowId}


### PR DESCRIPTION
This adds a flag to the `DataGrid` component that's defaulted to true that enables table column resize on window resize.

Partially does #346 since column resize will happen automatically now. However, some thought still needs to be put into how to handle resizing for tables in a view where the tables' configuration is being saved.