### PR TITLE
Update GQL playground link to Gateway

### DIFF
--- a/e2e-tests/fixtures/AppNav.ts
+++ b/e2e-tests/fixtures/AppNav.ts
@@ -10,7 +10,7 @@ export class AppNav {
   appMenuItemDocumentation: Locator;
   appMenuItemExpansion: Locator;
   appMenuItemGateway: Locator;
-  appMenuItemGraphQLConsole: Locator;
+  appMenuItemGraphQLPlayground: Locator;
   appMenuItemLogout: Locator;
   appMenuItemModels: Locator;
   appMenuItemPlans: Locator;
@@ -37,8 +37,8 @@ export class AppNav {
     );
     this.appMenuItemExpansion = page.locator(`.app-menu > .menu > .menu-slot > .menu-item:has-text("Expansion")`);
     this.appMenuItemGateway = page.locator(`.app-menu > .menu > .menu-slot > .menu-item:has-text("Gateway")`);
-    this.appMenuItemGraphQLConsole = page.locator(
-      `.app-menu > .menu > .menu-slot > .menu-item:has-text("GraphQL Console")`,
+    this.appMenuItemGraphQLPlayground = page.locator(
+      `.app-menu > .menu > .menu-slot > .menu-item:has-text("GraphQL Playground")`,
     );
     this.appMenuItemLogout = page.locator(`.app-menu > .menu > .menu-slot > .menu-item:has-text("Logout")`);
     this.appMenuItemModels = page.locator(`.app-menu > .menu > .menu-slot > .menu-item:has-text("Models")`);

--- a/e2e-tests/tests/app-nav.test.ts
+++ b/e2e-tests/tests/app-nav.test.ts
@@ -95,13 +95,12 @@ test.describe.serial('App Nav', () => {
     await gatewayPage.close();
   });
 
-  test(`Clicking on the app menu 'GraphQL Console' option should open a new tab to the console page`, async () => {
+  test(`Clicking on the app menu 'GraphQL Playground' option should open a new tab to the playground page`, async () => {
     await appNav.appMenuButton.click();
     await appNav.appMenu.waitFor({ state: 'attached' });
     await appNav.appMenu.waitFor({ state: 'visible' });
-    const [consolePage] = await Promise.all([page.waitForEvent('popup'), appNav.appMenuItemGraphQLConsole.click()]);
-    await consolePage.waitForTimeout(3000);
-    expect(await consolePage.title()).toContain('Login | Hasura');
+    const [consolePage] = await Promise.all([page.waitForEvent('popup'), appNav.appMenuItemGraphQLPlayground.click()]);
+    expect(await consolePage.title()).toContain('Altair');
     await consolePage.close();
   });
 

--- a/src/components/menus/AppMenu.svelte
+++ b/src/components/menus/AppMenu.svelte
@@ -75,11 +75,9 @@
       <DiagramIcon />
       Gateway
     </MenuItem>
-    <MenuItem
-      on:click={() => window.open(`${env.PUBLIC_HASURA_CLIENT_URL.replace('v1/graphql', 'console')}`, '_newtab')}
-    >
+    <MenuItem on:click={() => window.open(`${env.PUBLIC_GATEWAY_CLIENT_URL}/api-playground`, '_newtab')}>
       <GraphQLIcon />
-      GraphQL Console
+      GraphQL Playground
     </MenuItem>
     <MenuItem on:click={() => window.open('https://nasa-ammos.github.io/aerie-docs/', '_newtab')}>
       <JournalsIcon />


### PR DESCRIPTION
The gateway exports a new playground to query the API. This just updates the link to that new playground.