### PR TITLE
Extended metadata (excluding tags)

### DIFF
--- a/e2e-tests/fixtures/Constraints.ts
+++ b/e2e-tests/fixtures/Constraints.ts
@@ -98,7 +98,7 @@ export class Constraints {
     this.confirmModal = page.locator(`.modal:has-text("Delete Constraint")`);
     this.confirmModalDeleteButton = page.locator(`.modal:has-text("Delete Constraint") >> button:has-text("Delete")`);
     this.inputConstraintDefinition = page.locator('.monaco-editor >> textarea.inputarea');
-    this.inputConstraintDescription = page.locator('input[name="constraint-description"]');
+    this.inputConstraintDescription = page.locator('textarea[name="constraint-description"]');
     this.inputConstraintModel = page.locator(this.inputConstraintModelSelector);
     this.inputConstraintName = page.locator('input[name="constraint-name"]');
     this.page = page;

--- a/e2e-tests/fixtures/ExpansionRules.ts
+++ b/e2e-tests/fixtures/ExpansionRules.ts
@@ -129,6 +129,7 @@ export class ExpansionRules {
     this.inputCommandDictionary = page.locator(this.inputCommandDictionarySelector);
     this.inputEditor = page.locator('.panel >> textarea.inputarea');
     this.inputModel = page.locator(this.inputModelSelector);
+    this.inputName = page.locator(this.inputNameSelector);
     this.newButton = page.locator(`button:has-text("New")`);
     this.page = page;
     this.rulesNavButton = page.locator(`.nav-button:has-text("Rules")`);

--- a/e2e-tests/fixtures/ExpansionRules.ts
+++ b/e2e-tests/fixtures/ExpansionRules.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page } from '@playwright/test';
+import { adjectives, animals, colors, uniqueNamesGenerator } from 'unique-names-generator';
 import { getOptionValueFromText } from '../utilities/selectors.js';
 import { Dictionaries } from './Dictionaries.js';
 import { Models } from './Models.js';
@@ -15,6 +16,8 @@ export class ExpansionRules {
   inputEditor: Locator;
   inputModel: Locator;
   inputModelSelector: string = 'select[name="modelId"]';
+  inputName: Locator;
+  inputNameSelector: string = 'input[name="name"]';
   newButton: Locator;
   ruleActivityType = 'PeelBanana';
   ruleLogic: string = `export default function({ activityInstance: ActivityType }): ExpansionReturn { return [C.FSW_CMD_0({ boolean_arg_0: true, enum_arg_0: "OFF", float_arg_0: 0.0 })]; }`;
@@ -36,6 +39,7 @@ export class ExpansionRules {
     await this.selectCommandDictionary();
     await this.selectModel();
     await this.selectActivityType();
+    await this.fillInputName();
     await this.fillInputEditor();
     await expect(this.saveButton).not.toBeDisabled();
     await this.saveButton.click();
@@ -73,6 +77,13 @@ export class ExpansionRules {
     await this.inputEditor.focus();
     await this.inputEditor.fill(this.ruleLogic);
     await this.inputEditor.evaluate(e => e.blur());
+  }
+
+  async fillInputName() {
+    const expansionRuleName = uniqueNamesGenerator({ dictionaries: [adjectives, colors, animals] });
+    await this.inputName.focus();
+    await this.inputName.fill(expansionRuleName);
+    await this.inputName.evaluate(e => e.blur());
   }
 
   async goto() {

--- a/e2e-tests/fixtures/Plans.ts
+++ b/e2e-tests/fixtures/Plans.ts
@@ -107,7 +107,7 @@ export class Plans {
     this.alertError = page.locator('.alert-error');
     this.confirmModal = page.locator(`.modal:has-text("Delete Plan")`);
     this.confirmModalDeleteButton = page.locator(`.modal:has-text("Delete Plan") >> button:has-text("Delete")`);
-    this.createButton = page.locator('text=Create');
+    this.createButton = page.getByRole('button', { name: 'Create' });
     this.durationDisplay = page.locator('input[name="duration"]');
     this.inputEndTime = page.locator('input[name="end-time"]');
     this.inputModel = page.locator(this.inputModelSelector);

--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -100,10 +100,10 @@
       if (mode === 'create') {
         const newConstraintId = await effects.createConstraint(
           constraintDefinition,
-          constraintDescription,
           constraintModelId,
           constraintName,
           constraintPlanId,
+          constraintDescription,
           user,
         );
 
@@ -114,11 +114,11 @@
         await effects.updateConstraint(
           constraintId,
           constraintDefinition,
-          constraintDescription,
           constraintModelId,
           constraintName,
           constraintPlanId,
           user,
+          constraintDescription,
         );
 
         savedConstraint = {

--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -203,7 +203,7 @@
 
       <fieldset>
         <label for="constraint-description">Description</label>
-        <input
+        <textarea
           bind:value={constraintDescription}
           autocomplete="off"
           class="st-input w-100"

--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import { constraintsColumns } from '../../stores/constraints';
+  import { constraintsFormColumns } from '../../stores/constraints';
   import type { User } from '../../types/app';
   import type { Constraint } from '../../types/constraint';
   import type { ModelSlim } from '../../types/model';
@@ -137,7 +137,7 @@
 
 <PageTitle subTitle={pageSubtitle} title={pageTitle} />
 
-<CssGrid bind:columns={$constraintsColumns}>
+<CssGrid bind:columns={$constraintsFormColumns}>
   <Panel overflowYBody="hidden" padBody={false}>
     <svelte:fragment slot="header">
       <SectionTitle>{mode === 'create' ? 'New Constraint' : 'Edit Constraint'}</SectionTitle>

--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -103,8 +103,8 @@
           constraintModelId,
           constraintName,
           constraintPlanId,
-          constraintDescription,
           user,
+          constraintDescription,
         );
 
         if (newConstraintId !== null) {

--- a/src/components/constraints/Constraints.svelte
+++ b/src/components/constraints/Constraints.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import type { ICellRendererParams } from 'ag-grid-community';
+  import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
   import { constraintsAll, constraintsColumns } from '../../stores/constraints';
   import type { User } from '../../types/app';
   import type { Constraint } from '../../types/constraint';
@@ -54,6 +54,54 @@
       field: 'plan_id',
       filter: 'number',
       headerName: 'Plan ID',
+      sortable: true,
+      suppressAutoSize: true,
+      suppressSizeToFit: true,
+      width: 80,
+    },
+    {
+      field: 'owner',
+      filter: 'string',
+      headerName: 'Owner',
+      sortable: true,
+      suppressAutoSize: true,
+      suppressSizeToFit: true,
+      width: 80,
+    },
+    {
+      field: 'created_at',
+      filter: 'string',
+      headerName: 'Date Created',
+      sortable: true,
+      suppressAutoSize: true,
+      suppressSizeToFit: true,
+      valueGetter: (params: ValueGetterParams<Constraint>) => {
+        if (params.data?.created_at) {
+          // TODO make this a util? Does vary a bit.
+          return new Date(params.data?.created_at).toISOString().slice(0, 19);
+        }
+      },
+      width: 200,
+    },
+    {
+      field: 'updated_at',
+      filter: 'string',
+      headerName: 'Updated At',
+      sortable: true,
+      suppressAutoSize: true,
+      suppressSizeToFit: true,
+      valueGetter: (params: ValueGetterParams<Constraint>) => {
+        if (params.data?.updated_at) {
+          // TODO make this a util? Does vary a bit.
+          return new Date(params.data?.updated_at).toISOString().slice(0, 19);
+        }
+      },
+      width: 200,
+    },
+    {
+      field: 'updated_by',
+      filter: 'string',
+      headerName: 'Updated By',
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,

--- a/src/components/constraints/Constraints.svelte
+++ b/src/components/constraints/Constraints.svelte
@@ -224,12 +224,7 @@
       <SectionTitle>Constraints</SectionTitle>
 
       <Input>
-        <input
-          bind:value={filterText}
-          class="st-input"
-          placeholder="Filter constraints"
-          style="max-width: 300px; width: 100%;"
-        />
+        <input bind:value={filterText} class="st-input" placeholder="Filter constraints" style="width: 100%;" />
       </Input>
 
       <div class="right">

--- a/src/components/constraints/Constraints.svelte
+++ b/src/components/constraints/Constraints.svelte
@@ -40,7 +40,7 @@
       suppressSizeToFit: true,
       width: 60,
     },
-    { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
+    { field: 'name', filter: 'text', headerName: 'Name', minWidth: 80, resizable: true, sortable: true },
     {
       field: 'model_id',
       filter: 'number',

--- a/src/components/constraints/Constraints.svelte
+++ b/src/components/constraints/Constraints.svelte
@@ -10,6 +10,7 @@
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { PlanSlim } from '../../types/plan';
   import effects from '../../utilities/effects';
+  import { getShortISOForDate } from '../../utilities/time';
   import Input from '../form/Input.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
@@ -77,8 +78,7 @@
       suppressSizeToFit: true,
       valueGetter: (params: ValueGetterParams<Constraint>) => {
         if (params.data?.created_at) {
-          // TODO make this a util? Does vary a bit.
-          return new Date(params.data?.created_at).toISOString().slice(0, 19);
+          return getShortISOForDate(new Date(params.data?.created_at));
         }
       },
       width: 200,

--- a/src/components/constraints/Constraints.svelte
+++ b/src/components/constraints/Constraints.svelte
@@ -105,7 +105,7 @@
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      width: 80,
+      width: 120,
     },
     {
       cellClass: 'action-cell-container',

--- a/src/components/constraints/Constraints.svelte
+++ b/src/components/constraints/Constraints.svelte
@@ -3,14 +3,13 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
+  import type { ICellRendererParams } from 'ag-grid-community';
   import { constraintsAll, constraintsColumns } from '../../stores/constraints';
   import type { User } from '../../types/app';
   import type { Constraint } from '../../types/constraint';
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { PlanSlim } from '../../types/plan';
   import effects from '../../utilities/effects';
-  import { getShortISOForDate } from '../../utilities/time';
   import Input from '../form/Input.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
@@ -68,35 +67,6 @@
       suppressAutoSize: true,
       suppressSizeToFit: true,
       width: 80,
-    },
-    {
-      field: 'created_at',
-      filter: 'string',
-      headerName: 'Date Created',
-      sortable: true,
-      suppressAutoSize: true,
-      suppressSizeToFit: true,
-      valueGetter: (params: ValueGetterParams<Constraint>) => {
-        if (params.data?.created_at) {
-          return getShortISOForDate(new Date(params.data?.created_at));
-        }
-      },
-      width: 200,
-    },
-    {
-      field: 'updated_at',
-      filter: 'string',
-      headerName: 'Updated At',
-      sortable: true,
-      suppressAutoSize: true,
-      suppressSizeToFit: true,
-      valueGetter: (params: ValueGetterParams<Constraint>) => {
-        if (params.data?.updated_at) {
-          // TODO make this a util? Does vary a bit.
-          return new Date(params.data?.updated_at).toISOString().slice(0, 19);
-        }
-      },
-      width: 200,
     },
     {
       field: 'updated_by',

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { base } from '$app/paths';
   import type { ICellRendererParams } from 'ag-grid-community';
   import {
     creatingExpansionSequence,
@@ -12,10 +13,11 @@
   import { simulationDatasetId } from '../../stores/simulation';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef, RowId } from '../../types/data-grid';
-  import type { ExpansionSequence } from '../../types/expansion';
+  import type { ExpansionSequence, ExpansionSet } from '../../types/expansion';
   import type { ViewGridSection } from '../../types/view';
   import effects from '../../utilities/effects';
   import { showExpansionSequenceModal } from '../../utilities/modal';
+  import { getShortISOForDate } from '../../utilities/time';
   import Collapse from '../Collapse.svelte';
   import Input from '../form/Input.svelte';
   import GridMenu from '../menus/GridMenu.svelte';
@@ -95,9 +97,11 @@
   let createButtonEnabled: boolean = false;
   let expandButtonEnabled: boolean = false;
   let seqIdInput: string = '';
+  let selectedExpansionSet: ExpansionSet | null;
 
   $: createButtonEnabled = seqIdInput !== '';
   $: expandButtonEnabled = $selectedExpansionSetId !== null;
+  $: selectedExpansionSet = $expansionSets.find(s => s.id === $selectedExpansionSetId);
 
   function deleteExpansionSequence(sequence: ExpansionSequence) {
     effects.deleteExpansionSequence(sequence, user);
@@ -135,9 +139,11 @@
 
   <svelte:fragment slot="body">
     <div class="expansion-panel-body">
-      <a href="">See all expansion sets</a>
       <fieldset>
-        <label for="expansionSet">Expansion Set</label>
+        <label for="expansionSet" class="expansion-set-selector">
+          Expansion Set
+          <a href={`${base}/expansion/rules`} target="_blank" rel="noopener noreferrer">View All Expansion Sets</a>
+        </label>
         <select
           bind:value={$selectedExpansionSetId}
           class="st-select w-100"
@@ -156,8 +162,44 @@
           {/if}
         </select>
       </fieldset>
-
-      <div>Expansion set metadata: - Owner: aplave</div>
+      <fieldset>
+        <Collapse className="details-container" title="Expansion Set Details" defaultExpanded={false}>
+          {#if !selectedExpansionSet}
+            <div class="st-typography-label">No Expansion Set Selected</div>
+          {:else}
+            <div class="expansion-set-details">
+              <div>
+                <span class="st-typography-label">Mission Modal ID:</span>
+                {selectedExpansionSet.mission_model_id}
+              </div>
+              <div>
+                <span class="st-typography-label">Command Dictionary ID:</span>
+                {selectedExpansionSet.command_dict_id}
+              </div>
+              <div>
+                <span class="st-typography-label">Created At:</span>
+                {getShortISOForDate(new Date(selectedExpansionSet.created_at))}
+              </div>
+              <div>
+                <span class="st-typography-label">Owner:</span>
+                {selectedExpansionSet.owner}
+              </div>
+              <div>
+                <span class="st-typography-label">Updated At:</span>
+                {getShortISOForDate(new Date(selectedExpansionSet.updated_at))}
+              </div>
+              <div>
+                <span class="st-typography-label">Updated By:</span>
+                {selectedExpansionSet.updated_by}
+              </div>
+              <div>
+                <span class="st-typography-label">Description:</span>
+                {selectedExpansionSet.description}
+              </div>
+            </div>
+          {/if}
+        </Collapse>
+      </fieldset>
 
       <fieldset>
         <Collapse className="details-container" title="Sequences">
@@ -213,6 +255,27 @@
     display: grid;
     grid-template-rows: min-content auto;
     height: 100%;
+  }
+
+  .expansion-set-selector {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .expansion-set-selector a:visited {
+    color: blue;
+  }
+
+  .expansion-set-details {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .expansion-set-details span {
+    display: inline-block;
+    width: 160px;
   }
 
   :global(.details-container) {

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -135,6 +135,7 @@
 
   <svelte:fragment slot="body">
     <div class="expansion-panel-body">
+      <a href="">See all expansion sets</a>
       <fieldset>
         <label for="expansionSet">Expansion Set</label>
         <select
@@ -155,6 +156,8 @@
           {/if}
         </select>
       </fieldset>
+
+      <div>Expansion set metadata: - Owner: aplave</div>
 
       <fieldset>
         <Collapse className="details-container" title="Sequences">

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -155,7 +155,7 @@
             <option value={null} />
             {#each $expansionSets as set}
               <option value={set.id}>
-                Expansion Set {set.id}
+                {set.name} ({set.id})
               </option>
             {/each}
           {/if}
@@ -174,6 +174,10 @@
               <div class="expansion-set-detail">
                 <span class="st-typography-label">Command Dictionary ID:</span>
                 <span>{selectedExpansionSet.command_dict_id}</span>
+              </div>
+              <div class="expansion-set-detail">
+                <span class="st-typography-label">Name:</span>
+                <span>{selectedExpansionSet.name}</span>
               </div>
               <div class="expansion-set-detail">
                 <span class="st-typography-label">Created At:</span>

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -55,7 +55,6 @@
       sortable: true,
     },
     { field: 'created_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
-    { field: 'updated_at', filter: 'text', headerName: 'Updated At', resizable: true, sortable: true },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: ExpansionSequenceCellRendererParams) => {

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -142,7 +142,7 @@
       <fieldset>
         <label for="expansionSet" class="expansion-set-selector">
           Expansion Set
-          <a href={`${base}/expansion/rules`} target="_blank" rel="noopener noreferrer">View All Expansion Sets</a>
+          <a href={`${base}/expansion/sets`} target="_blank" rel="noopener noreferrer">View All Expansion Sets</a>
         </label>
         <select
           bind:value={$selectedExpansionSetId}

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -168,33 +168,33 @@
             <div class="st-typography-label">No Expansion Set Selected</div>
           {:else}
             <div class="expansion-set-details">
-              <div>
+              <div class="expansion-set-detail">
                 <span class="st-typography-label">Mission Modal ID:</span>
-                {selectedExpansionSet.mission_model_id}
+                <span>{selectedExpansionSet.mission_model_id}</span>
               </div>
-              <div>
+              <div class="expansion-set-detail">
                 <span class="st-typography-label">Command Dictionary ID:</span>
-                {selectedExpansionSet.command_dict_id}
+                <span>{selectedExpansionSet.command_dict_id}</span>
               </div>
-              <div>
+              <div class="expansion-set-detail">
                 <span class="st-typography-label">Created At:</span>
-                {getShortISOForDate(new Date(selectedExpansionSet.created_at))}
+                <span>{getShortISOForDate(new Date(selectedExpansionSet.created_at))}</span>
               </div>
-              <div>
+              <div class="expansion-set-detail">
                 <span class="st-typography-label">Owner:</span>
-                {selectedExpansionSet.owner}
+                <span>{selectedExpansionSet.owner}</span>
               </div>
-              <div>
+              <div class="expansion-set-detail">
                 <span class="st-typography-label">Updated At:</span>
-                {getShortISOForDate(new Date(selectedExpansionSet.updated_at))}
+                <span>{getShortISOForDate(new Date(selectedExpansionSet.updated_at))}</span>
               </div>
-              <div>
+              <div class="expansion-set-detail">
                 <span class="st-typography-label">Updated By:</span>
-                {selectedExpansionSet.updated_by}
+                <span>{selectedExpansionSet.updated_by}</span>
               </div>
-              <div>
+              <div class="expansion-set-detail">
                 <span class="st-typography-label">Description:</span>
-                {selectedExpansionSet.description}
+                <span>{selectedExpansionSet.description}</span>
               </div>
             </div>
           {/if}
@@ -273,9 +273,18 @@
     gap: 8px;
   }
 
-  .expansion-set-details span {
-    display: inline-block;
-    width: 160px;
+  .expansion-set-detail {
+    display: flex;
+  }
+  .expansion-set-details span:first-child {
+    display: flex;
+    flex: 1;
+    max-width: 200px;
+  }
+
+  .expansion-set-details span:last-child {
+    display: flex;
+    flex: 1;
   }
 
   :global(.details-container) {

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import { expansionRulesFormColumns, savingExpansionRule } from '../../stores/expansion';
+  import { createExpansionRuleError, expansionRulesFormColumns, savingExpansionRule } from '../../stores/expansion';
   import { activityTypes, models } from '../../stores/plan';
   import { commandDictionaries } from '../../stores/sequencing';
   import type { User } from '../../types/app';
@@ -11,6 +11,7 @@
   import effects from '../../utilities/effects';
   import { isSaveEvent } from '../../utilities/keyboardEvents';
   import PageTitle from '../app/PageTitle.svelte';
+  import AlertError from '../ui/AlertError.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
   import Panel from '../ui/Panel.svelte';
@@ -137,6 +138,8 @@
     </svelte:fragment>
 
     <svelte:fragment slot="body">
+      <AlertError class="m-2" error={$createExpansionRuleError} />
+
       {#if mode === 'edit'}
         <fieldset>
           <label for="ruleId">Rule ID</label>

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import { expansionRulesColumns, savingExpansionRule } from '../../stores/expansion';
+  import { expansionRulesFormColumns, savingExpansionRule } from '../../stores/expansion';
   import { activityTypes, models } from '../../stores/plan';
   import { commandDictionaries } from '../../stores/sequencing';
   import type { User } from '../../types/app';
@@ -115,7 +115,7 @@
 
 <PageTitle title={pageTitle} />
 
-<CssGrid bind:columns={$expansionRulesColumns}>
+<CssGrid bind:columns={$expansionRulesFormColumns}>
   <Panel overflowYBody="hidden">
     <svelte:fragment slot="header">
       <SectionTitle>{mode === 'create' ? 'New Expansion Rule' : 'Edit Expansion Rule'}</SectionTitle>

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -18,6 +18,7 @@
   import ExpansionLogicEditor from './ExpansionLogicEditor.svelte';
 
   export let initialRuleActivityType: string | null = null;
+  export let initialRuleDescription: string | null = null;
   export let initialRuleCreatedAt: string | null = null;
   export let initialRuleDictionaryId: number | null = null;
   export let initialRuleId: number | null = null;
@@ -30,6 +31,7 @@
 
   let ruleActivityType: string | null = initialRuleActivityType;
   let ruleCreatedAt: string | null = initialRuleCreatedAt;
+  let ruleDescription: string | null = initialRuleDescription;
   let ruleDictionaryId: number | null = initialRuleDictionaryId;
   let ruleId: number | null = initialRuleId;
   let ruleLogic: string = initialRuleLogic;
@@ -40,6 +42,7 @@
     activity_type: ruleActivityType,
     authoring_command_dict_id: ruleDictionaryId,
     authoring_mission_model_id: ruleModelId,
+    description: ruleDescription,
     expansion_logic: ruleLogic,
   };
 
@@ -49,6 +52,7 @@
     activity_type: ruleActivityType,
     authoring_command_dict_id: ruleDictionaryId,
     authoring_mission_model_id: ruleModelId,
+    description: ruleDescription,
     expansion_logic: ruleLogic,
   });
   $: saveButtonText = mode === 'edit' && !ruleModified ? 'Saved' : 'Save';
@@ -81,6 +85,7 @@
           activity_type: ruleActivityType,
           authoring_command_dict_id: ruleDictionaryId,
           authoring_mission_model_id: ruleModelId,
+          description: ruleDescription,
           expansion_logic: ruleLogic,
         };
         const newRuleId = await effects.createExpansionRule(newRule, user);
@@ -93,6 +98,7 @@
           activity_type: ruleActivityType,
           authoring_command_dict_id: ruleDictionaryId,
           authoring_mission_model_id: ruleModelId,
+          description: ruleDescription,
           expansion_logic: ruleLogic,
         };
         const updated_at = await effects.updateExpansionRule(ruleId, updatedRule, user);
@@ -182,6 +188,18 @@
             </option>
           {/each}
         </select>
+      </fieldset>
+
+      <fieldset>
+        <label for="description">Description</label>
+        <textarea
+          bind:value={ruleDescription}
+          autocomplete="off"
+          class="st-input w-100"
+          name="description"
+          placeholder="Enter a rule description (optional)"
+          required
+        />
       </fieldset>
     </svelte:fragment>
   </Panel>

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -25,6 +25,7 @@
   export let initialRuleLogic: string =
     'export default function MyExpansion(props: {\n  activityInstance: ActivityType\n}): ExpansionReturn {\n  const { activityInstance } = props;\n  return [];\n}\n';
   export let initialRuleModelId: number | null = null;
+  export let initialRuleName: string | null = null;
   export let initialRuleUpdatedAt: string | null = null;
   export let mode: 'create' | 'edit' = 'create';
   export let user: User | null;
@@ -36,6 +37,7 @@
   let ruleId: number | null = initialRuleId;
   let ruleLogic: string = initialRuleLogic;
   let ruleModelId: number | null = initialRuleModelId;
+  let ruleName: string | null = initialRuleName;
   let ruleUpdatedAt: string | null = initialRuleUpdatedAt;
   let saveButtonEnabled: boolean = false;
   let savedRule: Partial<ExpansionRule> = {
@@ -44,6 +46,7 @@
     authoring_mission_model_id: ruleModelId,
     description: ruleDescription,
     expansion_logic: ruleLogic,
+    name: ruleName,
   };
 
   $: activityTypes.setVariables({ modelId: ruleModelId ?? -1 });
@@ -54,6 +57,7 @@
     authoring_mission_model_id: ruleModelId,
     description: ruleDescription,
     expansion_logic: ruleLogic,
+    name: ruleName,
   });
   $: saveButtonText = mode === 'edit' && !ruleModified ? 'Saved' : 'Save';
   $: saveButtonClass = ruleModified && saveButtonEnabled ? 'primary' : 'secondary';
@@ -86,6 +90,7 @@
           authoring_command_dict_id: ruleDictionaryId,
           authoring_mission_model_id: ruleModelId,
           expansion_logic: ruleLogic,
+          name: ruleName,
           ...(ruleDescription && { description: ruleDescription }),
         };
         const newRuleId = await effects.createExpansionRule(newRule, user);
@@ -99,6 +104,7 @@
           authoring_command_dict_id: ruleDictionaryId,
           authoring_mission_model_id: ruleModelId,
           expansion_logic: ruleLogic,
+          name: ruleName,
           ...(ruleDescription && { description: ruleDescription }),
         };
         const updated_at = await effects.updateExpansionRule(ruleId, updatedRule, user);
@@ -188,6 +194,18 @@
             </option>
           {/each}
         </select>
+      </fieldset>
+
+      <fieldset>
+        <label for="name">Name</label>
+        <input
+          autocomplete="off"
+          bind:value={ruleName}
+          class="st-input w-100"
+          name="name"
+          placeholder="Enter a rule name (required)"
+          required
+        />
       </fieldset>
 
       <fieldset>

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -85,8 +85,8 @@
           activity_type: ruleActivityType,
           authoring_command_dict_id: ruleDictionaryId,
           authoring_mission_model_id: ruleModelId,
-          description: ruleDescription,
           expansion_logic: ruleLogic,
+          ...(ruleDescription && { description: ruleDescription }),
         };
         const newRuleId = await effects.createExpansionRule(newRule, user);
 
@@ -98,8 +98,8 @@
           activity_type: ruleActivityType,
           authoring_command_dict_id: ruleDictionaryId,
           authoring_mission_model_id: ruleModelId,
-          description: ruleDescription,
           expansion_logic: ruleLogic,
+          ...(ruleDescription && { description: ruleDescription }),
         };
         const updated_at = await effects.updateExpansionRule(ruleId, updatedRule, user);
         if (updated_at !== null) {

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -26,7 +26,7 @@
   export let initialRuleLogic: string =
     'export default function MyExpansion(props: {\n  activityInstance: ActivityType\n}): ExpansionReturn {\n  const { activityInstance } = props;\n  return [];\n}\n';
   export let initialRuleModelId: number | null = null;
-  export let initialRuleName: string | null = null;
+  export let initialRuleName: string = '';
   export let initialRuleUpdatedAt: string | null = null;
   export let mode: 'create' | 'edit' = 'create';
   export let user: User | null;
@@ -38,7 +38,7 @@
   let ruleId: number | null = initialRuleId;
   let ruleLogic: string = initialRuleLogic;
   let ruleModelId: number | null = initialRuleModelId;
-  let ruleName: string | null = initialRuleName;
+  let ruleName: string = initialRuleName;
   let ruleUpdatedAt: string | null = initialRuleUpdatedAt;
   let saveButtonEnabled: boolean = false;
   let savedRule: Partial<ExpansionRule> = {
@@ -51,7 +51,7 @@
   };
 
   $: activityTypes.setVariables({ modelId: ruleModelId ?? -1 });
-  $: saveButtonEnabled = ruleActivityType !== null && ruleLogic !== '';
+  $: saveButtonEnabled = ruleActivityType !== null && ruleLogic !== '' && ruleName !== '';
   $: ruleModified = diffRule(savedRule, {
     activity_type: ruleActivityType,
     authoring_command_dict_id: ruleDictionaryId,

--- a/src/components/expansion/ExpansionRules.svelte
+++ b/src/components/expansion/ExpansionRules.svelte
@@ -6,7 +6,6 @@
   import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
   import { expansionRules, expansionRulesColumns } from '../../stores/expansion';
   import type { User } from '../../types/app';
-  import type { Constraint } from '../../types/constraint';
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { ExpansionRule } from '../../types/expansion';
   import effects from '../../utilities/effects';
@@ -53,7 +52,7 @@
       headerName: 'Created At',
       resizable: true,
       sortable: true,
-      valueGetter: (params: ValueGetterParams<Constraint>) => {
+      valueGetter: (params: ValueGetterParams<ExpansionRule>) => {
         if (params.data?.created_at) {
           // TODO make this a util? Does vary a bit.
           return new Date(params.data?.created_at).toISOString().slice(0, 19);
@@ -67,7 +66,7 @@
       headerName: 'Updated At',
       resizable: true,
       sortable: true,
-      valueGetter: (params: ValueGetterParams<Constraint>) => {
+      valueGetter: (params: ValueGetterParams<ExpansionRule>) => {
         if (params.data?.updated_at) {
           // TODO make this a util? Does vary a bit.
           return new Date(params.data?.updated_at).toISOString().slice(0, 19);

--- a/src/components/expansion/ExpansionRules.svelte
+++ b/src/components/expansion/ExpansionRules.svelte
@@ -9,6 +9,7 @@
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { ExpansionRule } from '../../types/expansion';
   import effects from '../../utilities/effects';
+  import { getShortISOForDate } from '../../utilities/time';
   import Input from '../form/Input.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
@@ -61,8 +62,7 @@
       sortable: true,
       valueGetter: (params: ValueGetterParams<ExpansionRule>) => {
         if (params.data?.created_at) {
-          // TODO make this a util? Does vary a bit.
-          return new Date(params.data?.created_at).toISOString().slice(0, 19);
+          return getShortISOForDate(new Date(params.data?.created_at));
         }
       },
     },
@@ -75,8 +75,7 @@
       sortable: true,
       valueGetter: (params: ValueGetterParams<ExpansionRule>) => {
         if (params.data?.updated_at) {
-          // TODO make this a util? Does vary a bit.
-          return new Date(params.data?.updated_at).toISOString().slice(0, 19);
+          return getShortISOForDate(new Date(params.data?.updated_at));
         }
       },
     },

--- a/src/components/expansion/ExpansionRules.svelte
+++ b/src/components/expansion/ExpansionRules.svelte
@@ -37,7 +37,14 @@
       suppressSizeToFit: true,
       width: 60,
     },
-    { field: 'activity_type', filter: 'text', headerName: 'Activity Type', resizable: true, sortable: true },
+    {
+      field: 'activity_type',
+      filter: 'text',
+      headerName: 'Activity Type',
+      minWidth: 200,
+      resizable: true,
+      sortable: true,
+    },
     {
       field: 'authoring_command_dict_id',
       filter: 'number',

--- a/src/components/expansion/ExpansionRules.svelte
+++ b/src/components/expansion/ExpansionRules.svelte
@@ -3,9 +3,10 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import type { ICellRendererParams } from 'ag-grid-community';
+  import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
   import { expansionRules, expansionRulesColumns } from '../../stores/expansion';
   import type { User } from '../../types/app';
+  import type { Constraint } from '../../types/constraint';
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { ExpansionRule } from '../../types/expansion';
   import effects from '../../utilities/effects';

--- a/src/components/expansion/ExpansionRules.svelte
+++ b/src/components/expansion/ExpansionRules.svelte
@@ -47,7 +47,10 @@
     },
     { field: 'authoring_mission_model_id', filter: 'number', headerName: 'Model ID', sortable: true },
     { field: 'created_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
+    { field: 'owner', filter: 'text', headerName: 'Owner', resizable: true, sortable: true },
     { field: 'updated_at', filter: 'text', headerName: 'Updated At', resizable: true, sortable: true },
+    { field: 'updated_by', filter: 'text', headerName: 'Updated By', resizable: true, sortable: true },
+    { field: 'description', filter: 'text', headerName: 'Description', resizable: true, sortable: true },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: ExpansionRuleCellRendererParams) => {
@@ -140,12 +143,7 @@
       <SectionTitle>Expansion Rules</SectionTitle>
 
       <Input>
-        <input
-          bind:value={filterText}
-          class="st-input"
-          placeholder="Filter rules"
-          style="max-width: 300px; width: 100%;"
-        />
+        <input bind:value={filterText} class="st-input" placeholder="Filter rules" style="width: 100%;" />
       </Input>
 
       <div class="right">

--- a/src/components/expansion/ExpansionRules.svelte
+++ b/src/components/expansion/ExpansionRules.svelte
@@ -3,13 +3,12 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
+  import type { ICellRendererParams } from 'ag-grid-community';
   import { expansionRules, expansionRulesColumns } from '../../stores/expansion';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { ExpansionRule } from '../../types/expansion';
   import effects from '../../utilities/effects';
-  import { getShortISOForDate } from '../../utilities/time';
   import Input from '../form/Input.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
@@ -39,6 +38,14 @@
       width: 60,
     },
     {
+      field: 'name',
+      filter: 'text',
+      headerName: 'Name',
+      minWidth: 120,
+      resizable: true,
+      sortable: true,
+    },
+    {
       field: 'activity_type',
       filter: 'text',
       headerName: 'Activity Type',
@@ -54,31 +61,7 @@
       sortable: true,
     },
     { field: 'authoring_mission_model_id', filter: 'number', headerName: 'Model ID', sortable: true },
-    {
-      field: 'created_at',
-      filter: 'text',
-      headerName: 'Created At',
-      resizable: true,
-      sortable: true,
-      valueGetter: (params: ValueGetterParams<ExpansionRule>) => {
-        if (params.data?.created_at) {
-          return getShortISOForDate(new Date(params.data?.created_at));
-        }
-      },
-    },
     { field: 'owner', filter: 'text', headerName: 'Owner', resizable: true, sortable: true },
-    {
-      field: 'updated_at',
-      filter: 'text',
-      headerName: 'Updated At',
-      resizable: true,
-      sortable: true,
-      valueGetter: (params: ValueGetterParams<ExpansionRule>) => {
-        if (params.data?.updated_at) {
-          return getShortISOForDate(new Date(params.data?.updated_at));
-        }
-      },
-    },
     { field: 'updated_by', filter: 'text', headerName: 'Updated By', resizable: true, sortable: true },
     { field: 'description', filter: 'text', headerName: 'Description', resizable: true, sortable: true },
     {

--- a/src/components/expansion/ExpansionRules.svelte
+++ b/src/components/expansion/ExpansionRules.svelte
@@ -46,9 +46,33 @@
       sortable: true,
     },
     { field: 'authoring_mission_model_id', filter: 'number', headerName: 'Model ID', sortable: true },
-    { field: 'created_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
+    {
+      field: 'created_at',
+      filter: 'text',
+      headerName: 'Created At',
+      resizable: true,
+      sortable: true,
+      valueGetter: (params: ValueGetterParams<Constraint>) => {
+        if (params.data?.created_at) {
+          // TODO make this a util? Does vary a bit.
+          return new Date(params.data?.created_at).toISOString().slice(0, 19);
+        }
+      },
+    },
     { field: 'owner', filter: 'text', headerName: 'Owner', resizable: true, sortable: true },
-    { field: 'updated_at', filter: 'text', headerName: 'Updated At', resizable: true, sortable: true },
+    {
+      field: 'updated_at',
+      filter: 'text',
+      headerName: 'Updated At',
+      resizable: true,
+      sortable: true,
+      valueGetter: (params: ValueGetterParams<Constraint>) => {
+        if (params.data?.updated_at) {
+          // TODO make this a util? Does vary a bit.
+          return new Date(params.data?.updated_at).toISOString().slice(0, 19);
+        }
+      },
+    },
     { field: 'updated_by', filter: 'text', headerName: 'Updated By', resizable: true, sortable: true },
     { field: 'description', filter: 'text', headerName: 'Description', resizable: true, sortable: true },
     {

--- a/src/components/expansion/ExpansionSetForm.svelte
+++ b/src/components/expansion/ExpansionSetForm.svelte
@@ -4,7 +4,7 @@
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
-  import { expansionSetsColumns, savingExpansionSet } from '../../stores/expansion';
+  import { expansionSetsFormColumns, savingExpansionSet } from '../../stores/expansion';
   import { models } from '../../stores/plan';
   import { commandDictionaries } from '../../stores/sequencing';
   import type { ActivityTypeExpansionRules } from '../../types/activity';
@@ -39,6 +39,7 @@
   let setExpansionRuleIds: number[] = [];
   let setDictionaryId: number | null = null;
   let setModelId: number | null = null;
+  let setDescription: string = '';
 
   $: effects
     .getActivityTypesExpansionRules(setModelId, user)
@@ -54,7 +55,13 @@
 
   async function saveSet() {
     if (mode === 'create' && setDictionaryId && setModelId) {
-      const newSetId = await effects.createExpansionSet(setDictionaryId, setModelId, setExpansionRuleIds, user);
+      const newSetId = await effects.createExpansionSet(
+        setDictionaryId,
+        setModelId,
+        setExpansionRuleIds,
+        setDescription,
+        user,
+      );
 
       if (newSetId !== null) {
         goto(`${base}/expansion/sets`);
@@ -111,7 +118,7 @@
   };
 </script>
 
-<CssGrid bind:columns={$expansionSetsColumns}>
+<CssGrid bind:columns={$expansionSetsFormColumns}>
   <Panel>
     <svelte:fragment slot="header">
       <SectionTitle>New Expansion Set</SectionTitle>
@@ -155,6 +162,17 @@
             </option>
           {/each}
         </select>
+      </fieldset>
+
+      <fieldset>
+        <label for="description">Description</label>
+        <textarea
+          bind:value={setDescription}
+          autocomplete="off"
+          class="st-input w-100"
+          name="description"
+          placeholder="Enter Expansion Set Description (optional)"
+        />
       </fieldset>
 
       <fieldset class="expansion-rules-table">

--- a/src/components/expansion/ExpansionSetForm.svelte
+++ b/src/components/expansion/ExpansionSetForm.svelte
@@ -39,6 +39,7 @@
   let setExpansionRuleIds: number[] = [];
   let setDictionaryId: number | null = null;
   let setModelId: number | null = null;
+  let setName: string = '';
   let setDescription: string = '';
 
   $: effects
@@ -51,7 +52,8 @@
     ? `Expansion Rule - Logic Editor - ${lastSelectedExpansionRule.activity_type} - Rule ${lastSelectedExpansionRule.id} (Read-only)`
     : 'Expansion Rule - Logic Editor (Read-only)';
   $: setExpansionRuleIds = Object.values(selectedExpansionRules) ?? [];
-  $: saveButtonEnabled = setDictionaryId !== null && setModelId !== null && setExpansionRuleIds.length > 0;
+  $: saveButtonEnabled =
+    setDictionaryId !== null && setModelId !== null && setName !== '' && setExpansionRuleIds.length > 0;
 
   async function saveSet() {
     if (mode === 'create' && setDictionaryId && setModelId) {
@@ -59,6 +61,7 @@
         setDictionaryId,
         setModelId,
         setExpansionRuleIds,
+        setName,
         user,
         setDescription,
       );
@@ -162,6 +165,16 @@
             </option>
           {/each}
         </select>
+      </fieldset>
+
+      <fieldset>
+        <label for="name">Name</label>
+        <input
+          bind:value={setName}
+          class="st-input w-100"
+          name="description"
+          placeholder="Enter Expansion Set Name (required)"
+        />
       </fieldset>
 
       <fieldset>

--- a/src/components/expansion/ExpansionSetForm.svelte
+++ b/src/components/expansion/ExpansionSetForm.svelte
@@ -39,7 +39,6 @@
   let setExpansionRuleIds: number[] = [];
   let setDictionaryId: number | null = null;
   let setModelId: number | null = null;
-  let setName: string = '';
   let setDescription: string = '';
 
   $: effects
@@ -52,8 +51,7 @@
     ? `Expansion Rule - Logic Editor - ${lastSelectedExpansionRule.activity_type} - Rule ${lastSelectedExpansionRule.id} (Read-only)`
     : 'Expansion Rule - Logic Editor (Read-only)';
   $: setExpansionRuleIds = Object.values(selectedExpansionRules) ?? [];
-  $: saveButtonEnabled =
-    setDictionaryId !== null && setModelId !== null && setName !== '' && setExpansionRuleIds.length > 0;
+  $: saveButtonEnabled = setDictionaryId !== null && setModelId !== null && setExpansionRuleIds.length > 0;
 
   async function saveSet() {
     if (mode === 'create' && setDictionaryId && setModelId) {
@@ -61,7 +59,6 @@
         setDictionaryId,
         setModelId,
         setExpansionRuleIds,
-        setName,
         user,
         setDescription,
       );
@@ -165,17 +162,6 @@
             </option>
           {/each}
         </select>
-      </fieldset>
-
-      <fieldset>
-        <label for="name">Name</label>
-        <input
-          bind:value={setName}
-          autocomplete="off"
-          class="st-input w-100"
-          name="description"
-          placeholder="Enter Expansion Set Name (required)"
-        />
       </fieldset>
 
       <fieldset>

--- a/src/components/expansion/ExpansionSetForm.svelte
+++ b/src/components/expansion/ExpansionSetForm.svelte
@@ -59,8 +59,8 @@
         setDictionaryId,
         setModelId,
         setExpansionRuleIds,
-        setDescription,
         user,
+        setDescription,
       );
 
       if (newSetId !== null) {

--- a/src/components/expansion/ExpansionSetForm.svelte
+++ b/src/components/expansion/ExpansionSetForm.svelte
@@ -171,6 +171,7 @@
         <label for="name">Name</label>
         <input
           bind:value={setName}
+          autocomplete="off"
           class="st-input w-100"
           name="description"
           placeholder="Enter Expansion Set Name (required)"

--- a/src/components/expansion/ExpansionSetRuleSelection.svelte
+++ b/src/components/expansion/ExpansionSetRuleSelection.svelte
@@ -18,6 +18,7 @@
 
 <style>
   .expansion-rule-selection {
+    align-items: center;
     display: flex;
     gap: 4px;
   }

--- a/src/components/expansion/ExpansionSetRuleSelection.svelte
+++ b/src/components/expansion/ExpansionSetRuleSelection.svelte
@@ -19,5 +19,6 @@
 <style>
   .expansion-rule-selection {
     display: flex;
+    gap: 4px;
   }
 </style>

--- a/src/components/expansion/ExpansionSets.svelte
+++ b/src/components/expansion/ExpansionSets.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import type { ICellRendererParams } from 'ag-grid-community';
+  import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
   import { expansionSets, expansionSetsColumns } from '../../stores/expansion';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
@@ -44,7 +44,35 @@
       sortable: true,
     },
     { field: 'mission_model_id', filter: 'number', headerName: 'Model ID', resizable: true, sortable: true },
-    { field: 'created_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
+    {
+      field: 'created_at',
+      filter: 'text',
+      headerName: 'Created At',
+      resizable: true,
+      sortable: true,
+      valueGetter: (params: ValueGetterParams<ExpansionSet>) => {
+        if (params.data?.created_at) {
+          // TODO make this a util? Does vary a bit.
+          return new Date(params.data?.created_at).toISOString().slice(0, 19);
+        }
+      },
+    },
+    { field: 'owner', filter: 'text', headerName: 'Owner', resizable: true, sortable: true },
+    {
+      field: 'updated_at',
+      filter: 'text',
+      headerName: 'Updated At',
+      resizable: true,
+      sortable: true,
+      valueGetter: (params: ValueGetterParams<ExpansionSet>) => {
+        if (params.data?.updated_at) {
+          // TODO make this a util? Does vary a bit.
+          return new Date(params.data?.updated_at).toISOString().slice(0, 19);
+        }
+      },
+    },
+    { field: 'updated_by', filter: 'text', headerName: 'Updated By', resizable: true, sortable: true },
+    { field: 'description', filter: 'text', headerName: 'Description', resizable: true, sortable: true },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: ExpansionSetCellRendererParams) => {
@@ -98,6 +126,10 @@
 
   function deleteSetContext(event: CustomEvent<RowId[]>) {
     deleteSet({ id: event.detail[0] as number });
+  }
+
+  function editRule({ id }: Pick<ExpansionRule, 'id'>) {
+    goto(`${base}/expansion/rules/edit/${id}`);
   }
 
   function toggleRule(event: CustomEvent<DataGridRowSelection<ExpansionRule>>) {
@@ -178,6 +210,41 @@
                 width: 60,
               },
               { field: 'activity_type', filter: 'text', headerName: 'Activity Type', sortable: true },
+              {
+                cellClass: 'action-cell-container',
+                cellRenderer: params => {
+                  const actionsDiv = document.createElement('div');
+                  actionsDiv.className = 'actions-cell';
+                  new DataGridActions({
+                    props: {
+                      deleteCallback: params.deleteRule,
+                      deleteTooltip: {
+                        content: 'Delete Rule',
+                        placement: 'bottom',
+                      },
+                      editCallback: params.editRule,
+                      editTooltip: {
+                        content: 'Edit Rule',
+                        placement: 'bottom',
+                      },
+                      rowData: params.data,
+                    },
+                    target: actionsDiv,
+                  });
+
+                  return actionsDiv;
+                },
+                cellRendererParams: {
+                  editRule,
+                },
+                field: 'actions',
+                headerName: '',
+                resizable: false,
+                sortable: false,
+                suppressAutoSize: true,
+                suppressSizeToFit: true,
+                width: 55,
+              },
             ]}
             rowData={selectedExpansionSet?.expansion_rules}
             rowSelection="single"

--- a/src/components/expansion/ExpansionSets.svelte
+++ b/src/components/expansion/ExpansionSets.svelte
@@ -3,13 +3,12 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
+  import type { ICellRendererParams } from 'ag-grid-community';
   import { expansionSets, expansionSetsColumns } from '../../stores/expansion';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { ExpansionRule, ExpansionSet } from '../../types/expansion';
   import effects from '../../utilities/effects';
-  import { getShortISOForDate } from '../../utilities/time';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
   import DataGrid from '../ui/DataGrid/DataGrid.svelte';
@@ -46,31 +45,7 @@
       sortable: true,
     },
     { field: 'mission_model_id', filter: 'number', headerName: 'Model ID', resizable: true, sortable: true },
-    {
-      field: 'created_at',
-      filter: 'text',
-      headerName: 'Created At',
-      resizable: true,
-      sortable: true,
-      valueGetter: (params: ValueGetterParams<ExpansionSet>) => {
-        if (params.data?.created_at) {
-          return getShortISOForDate(new Date(params.data?.created_at));
-        }
-      },
-    },
     { field: 'owner', filter: 'text', headerName: 'Owner', resizable: true, sortable: true },
-    {
-      field: 'updated_at',
-      filter: 'text',
-      headerName: 'Updated At',
-      resizable: true,
-      sortable: true,
-      valueGetter: (params: ValueGetterParams<ExpansionSet>) => {
-        if (params.data?.updated_at) {
-          return getShortISOForDate(new Date(params.data?.updated_at));
-        }
-      },
-    },
     { field: 'updated_by', filter: 'text', headerName: 'Updated By', resizable: true, sortable: true },
     { field: 'description', filter: 'text', headerName: 'Description', resizable: true, sortable: true },
     {

--- a/src/components/expansion/ExpansionSets.svelte
+++ b/src/components/expansion/ExpansionSets.svelte
@@ -9,6 +9,7 @@
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { ExpansionRule, ExpansionSet } from '../../types/expansion';
   import effects from '../../utilities/effects';
+  import { getShortISOForDate } from '../../utilities/time';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
   import DataGrid from '../ui/DataGrid/DataGrid.svelte';
@@ -52,8 +53,7 @@
       sortable: true,
       valueGetter: (params: ValueGetterParams<ExpansionSet>) => {
         if (params.data?.created_at) {
-          // TODO make this a util? Does vary a bit.
-          return new Date(params.data?.created_at).toISOString().slice(0, 19);
+          return getShortISOForDate(new Date(params.data?.created_at));
         }
       },
     },
@@ -66,8 +66,7 @@
       sortable: true,
       valueGetter: (params: ValueGetterParams<ExpansionSet>) => {
         if (params.data?.updated_at) {
-          // TODO make this a util? Does vary a bit.
-          return new Date(params.data?.updated_at).toISOString().slice(0, 19);
+          return getShortISOForDate(new Date(params.data?.updated_at));
         }
       },
     },

--- a/src/components/expansion/ExpansionSets.svelte
+++ b/src/components/expansion/ExpansionSets.svelte
@@ -37,6 +37,7 @@
       suppressSizeToFit: true,
       width: 60,
     },
+    { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
     {
       field: 'command_dict_id',
       filter: 'number',

--- a/src/components/plan/PlanMergeReview.test.ts
+++ b/src/components/plan/PlanMergeReview.test.ts
@@ -34,6 +34,7 @@ const mockMergeRequest: PlanMergeRequestSchema = {
 const mockInitialPlan: Plan = {
   child_plans: [{ id: 2, name: 'Branch 1' }],
   collaborators: [{ collaborator: 'tester 2' }],
+  created_at: '2023-02-16T00:00:00',
   duration: '168:00:00',
   end_time_doy: '2023-054T00:00:00',
   id: 1,
@@ -53,13 +54,15 @@ const mockInitialPlan: Plan = {
   },
   model_id: 1,
   name: 'Demo Plan',
-  owner: 'tester 1',
+  owner: 'spacecaptain',
   parent_plan: null,
   revision: 3,
   scheduling_specifications: [{ id: 1 }],
   simulations: [{ simulation_datasets: [{ id: 1 }] }],
   start_time: '2023-02-16T00:00:00',
   start_time_doy: '2023-047T00:00:00',
+  updated_at: '2023-02-16T00:00:00',
+  updated_by: 'redshirt',
 };
 
 const user: User = { allowedRoles: ['admin'], defaultRole: 'admin', id: 'foo', permissibleQueries: {}, token: '' };

--- a/src/components/plan/PlanMergeReview.test.ts
+++ b/src/components/plan/PlanMergeReview.test.ts
@@ -39,10 +39,12 @@ const mockInitialPlan: Plan = {
   id: 1,
   is_locked: true,
   model: {
+    created_at: '2023-02-16T00:00:00',
     id: 1,
     jar_id: 1,
     mission: '',
     name: 'Demo Model',
+    owner: 'spacecaptain',
     parameters: {
       parameters: {},
     },

--- a/src/components/scheduling/conditions/SchedulingConditionForm.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditionForm.svelte
@@ -93,10 +93,10 @@
       if (mode === 'create') {
         const newCondition = await effects.createSchedulingCondition(
           conditionDefinition,
-          conditionDescription,
           conditionName,
           conditionModelId,
           user,
+          conditionDescription,
         );
 
         if (newCondition !== null) {

--- a/src/components/scheduling/conditions/SchedulingConditionForm.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditionForm.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import { schedulingColumns } from '../../../stores/scheduling';
+  import { schedulingConditionsFormColumns } from '../../../stores/scheduling';
   import type { User } from '../../../types/app';
   import type { ModelSlim } from '../../../types/model';
   import type { PlanSchedulingSpec } from '../../../types/plan';
@@ -135,7 +135,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<CssGrid bind:columns={$schedulingColumns}>
+<CssGrid bind:columns={$schedulingConditionsFormColumns}>
   <Panel overflowYBody="hidden" padBody={false}>
     <svelte:fragment slot="header">
       <SectionTitle>{mode === 'create' ? 'New Scheduling Condition' : 'Edit Scheduling Condition'}</SectionTitle>

--- a/src/components/scheduling/conditions/SchedulingConditions.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditions.svelte
@@ -8,6 +8,7 @@
   import type { User } from '../../../types/app';
   import type { DataGridColumnDef, RowId } from '../../../types/data-grid';
   import type { SchedulingCondition } from '../../../types/scheduling';
+  import { getShortISOForDate } from '../../../utilities/time';
   import Input from '../../form/Input.svelte';
   import DataGridActions from '../../ui/DataGrid/DataGridActions.svelte';
   import SingleActionDataGrid from '../../ui/DataGrid/SingleActionDataGrid.svelte';
@@ -49,8 +50,7 @@
       suppressSizeToFit: true,
       valueGetter: (params: ValueGetterParams<SchedulingCondition>) => {
         if (params.data?.created_date) {
-          // TODO make this a util? Does vary a bit.
-          return new Date(params.data?.created_date).toISOString().slice(0, 19);
+          return getShortISOForDate(new Date(params.data?.created_date));
         }
       },
       width: 160,
@@ -64,8 +64,7 @@
       suppressSizeToFit: true,
       valueGetter: (params: ValueGetterParams<SchedulingCondition>) => {
         if (params.data?.modified_date) {
-          // TODO make this a util? Does vary a bit.
-          return new Date(params.data?.modified_date).toISOString().slice(0, 19);
+          return getShortISOForDate(new Date(params.data?.modified_date));
         }
       },
       width: 160,

--- a/src/components/scheduling/conditions/SchedulingConditions.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditions.svelte
@@ -37,6 +37,39 @@
     },
     { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
     { field: 'model_id', filter: 'number', headerName: 'Model ID', sortable: true, width: 120 },
+    { field: 'author', filter: 'string', headerName: 'Author', sortable: true, width: 100 },
+    { field: 'last_modified_by', filter: 'string', headerName: 'Last Modified By', sortable: true, width: 100 },
+    { field: 'description', filter: 'string', headerName: 'Description', sortable: true, width: 120 },
+    {
+      field: 'created_date',
+      filter: 'string',
+      headerName: 'Created Date',
+      sortable: true,
+      suppressAutoSize: true,
+      suppressSizeToFit: true,
+      valueGetter: (params: ValueGetterParams<SchedulingGoal>) => {
+        if (params.data?.created_date) {
+          // TODO make this a util? Does vary a bit.
+          return new Date(params.data?.created_date).toISOString().slice(0, 19);
+        }
+      },
+      width: 160,
+    },
+    {
+      field: 'modified_date',
+      filter: 'string',
+      headerName: 'Modified Date',
+      sortable: true,
+      suppressAutoSize: true,
+      suppressSizeToFit: true,
+      valueGetter: (params: ValueGetterParams<SchedulingGoal>) => {
+        if (params.data?.modified_date) {
+          // TODO make this a util? Does vary a bit.
+          return new Date(params.data?.modified_date).toISOString().slice(0, 19);
+        }
+      },
+      width: 160,
+    },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: SchedulingConditionsCellRendererParams) => {

--- a/src/components/scheduling/conditions/SchedulingConditions.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditions.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import type { ICellRendererParams } from 'ag-grid-community';
+  import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
   import { createEventDispatcher } from 'svelte';
   import type { User } from '../../../types/app';
   import type { DataGridColumnDef, RowId } from '../../../types/data-grid';
@@ -47,7 +47,7 @@
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      valueGetter: (params: ValueGetterParams<SchedulingGoal>) => {
+      valueGetter: (params: ValueGetterParams<SchedulingCondition>) => {
         if (params.data?.created_date) {
           // TODO make this a util? Does vary a bit.
           return new Date(params.data?.created_date).toISOString().slice(0, 19);
@@ -62,7 +62,7 @@
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      valueGetter: (params: ValueGetterParams<SchedulingGoal>) => {
+      valueGetter: (params: ValueGetterParams<SchedulingCondition>) => {
         if (params.data?.modified_date) {
           // TODO make this a util? Does vary a bit.
           return new Date(params.data?.modified_date).toISOString().slice(0, 19);
@@ -148,12 +148,7 @@
     <SectionTitle>Scheduling Conditions</SectionTitle>
 
     <Input>
-      <input
-        bind:value={filterText}
-        class="st-input"
-        placeholder="Filter conditions"
-        style="max-width: 300px; width: 100%;"
-      />
+      <input bind:value={filterText} class="st-input" placeholder="Filter conditions" style="width: 100%;" />
     </Input>
 
     <div class="right">

--- a/src/components/scheduling/conditions/SchedulingConditions.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditions.svelte
@@ -3,12 +3,11 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
+  import type { ICellRendererParams } from 'ag-grid-community';
   import { createEventDispatcher } from 'svelte';
   import type { User } from '../../../types/app';
   import type { DataGridColumnDef, RowId } from '../../../types/data-grid';
   import type { SchedulingCondition } from '../../../types/scheduling';
-  import { getShortISOForDate } from '../../../utilities/time';
   import Input from '../../form/Input.svelte';
   import DataGridActions from '../../ui/DataGrid/DataGridActions.svelte';
   import SingleActionDataGrid from '../../ui/DataGrid/SingleActionDataGrid.svelte';
@@ -41,34 +40,6 @@
     { field: 'author', filter: 'string', headerName: 'Author', sortable: true, width: 100 },
     { field: 'last_modified_by', filter: 'string', headerName: 'Last Modified By', sortable: true, width: 100 },
     { field: 'description', filter: 'string', headerName: 'Description', sortable: true, width: 120 },
-    {
-      field: 'created_date',
-      filter: 'string',
-      headerName: 'Created Date',
-      sortable: true,
-      suppressAutoSize: true,
-      suppressSizeToFit: true,
-      valueGetter: (params: ValueGetterParams<SchedulingCondition>) => {
-        if (params.data?.created_date) {
-          return getShortISOForDate(new Date(params.data?.created_date));
-        }
-      },
-      width: 160,
-    },
-    {
-      field: 'modified_date',
-      filter: 'string',
-      headerName: 'Modified Date',
-      sortable: true,
-      suppressAutoSize: true,
-      suppressSizeToFit: true,
-      valueGetter: (params: ValueGetterParams<SchedulingCondition>) => {
-        if (params.data?.modified_date) {
-          return getShortISOForDate(new Date(params.data?.modified_date));
-        }
-      },
-      width: 160,
-    },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: SchedulingConditionsCellRendererParams) => {

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte
@@ -96,9 +96,9 @@
       if (mode === 'create') {
         const newGoal = await effects.createSchedulingGoal(
           goalDefinition,
-          goalDescription,
           goalName,
           goalModelId,
+          goalDescription,
           user,
         );
 

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte
@@ -98,8 +98,8 @@
           goalDefinition,
           goalName,
           goalModelId,
-          goalDescription,
           user,
+          goalDescription,
         );
 
         if (newGoal !== null) {

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte.test.ts
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte.test.ts
@@ -27,9 +27,11 @@ const plans: PlanSchedulingSpec[] = [
 
 const models: ModelSlim[] = [
   {
+    created_at: '2023-02-16T00:00:00',
     id: 1,
     jar_id: 1,
     name: 'BananaNation',
+    owner: 'bananafarmer',
     plans: [],
     version: '1.0.0',
   },

--- a/src/components/scheduling/goals/SchedulingGoals.svelte
+++ b/src/components/scheduling/goals/SchedulingGoals.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import type { ICellRendererParams } from 'ag-grid-community';
+  import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
   import { createEventDispatcher } from 'svelte';
   import type { User } from '../../../types/app';
   import type { DataGridColumnDef, RowId } from '../../../types/data-grid';
@@ -36,7 +36,40 @@
       width: 60,
     },
     { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
-    { field: 'model_id', filter: 'number', headerName: 'Model ID', sortable: true, width: 120 },
+    { field: 'model_id', filter: 'number', headerName: 'Model ID', sortable: true, width: 90 },
+    { field: 'author', filter: 'string', headerName: 'Author', sortable: true, width: 100 },
+    { field: 'last_modified_by', filter: 'string', headerName: 'Last Modified By', sortable: true, width: 100 },
+    { field: 'description', filter: 'string', headerName: 'Description', sortable: true, width: 120 },
+    {
+      field: 'created_date',
+      filter: 'string',
+      headerName: 'Created Date',
+      sortable: true,
+      suppressAutoSize: true,
+      suppressSizeToFit: true,
+      valueGetter: (params: ValueGetterParams<SchedulingGoal>) => {
+        if (params.data?.created_date) {
+          // TODO make this a util? Does vary a bit.
+          return new Date(params.data?.created_date).toISOString().slice(0, 19);
+        }
+      },
+      width: 160,
+    },
+    {
+      field: 'modified_date',
+      filter: 'string',
+      headerName: 'Modified Date',
+      sortable: true,
+      suppressAutoSize: true,
+      suppressSizeToFit: true,
+      valueGetter: (params: ValueGetterParams<SchedulingGoal>) => {
+        if (params.data?.modified_date) {
+          // TODO make this a util? Does vary a bit.
+          return new Date(params.data?.modified_date).toISOString().slice(0, 19);
+        }
+      },
+      width: 160,
+    },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: SchedulingGoalsCellRendererParams) => {

--- a/src/components/scheduling/goals/SchedulingGoals.svelte
+++ b/src/components/scheduling/goals/SchedulingGoals.svelte
@@ -8,6 +8,7 @@
   import type { User } from '../../../types/app';
   import type { DataGridColumnDef, RowId } from '../../../types/data-grid';
   import type { SchedulingGoal } from '../../../types/scheduling';
+  import { getShortISOForDate } from '../../../utilities/time';
   import Input from '../../form/Input.svelte';
   import DataGridActions from '../../ui/DataGrid/DataGridActions.svelte';
   import SingleActionDataGrid from '../../ui/DataGrid/SingleActionDataGrid.svelte';
@@ -49,8 +50,7 @@
       suppressSizeToFit: true,
       valueGetter: (params: ValueGetterParams<SchedulingGoal>) => {
         if (params.data?.created_date) {
-          // TODO make this a util? Does vary a bit.
-          return new Date(params.data?.created_date).toISOString().slice(0, 19);
+          return getShortISOForDate(new Date(params.data?.created_date));
         }
       },
       width: 160,
@@ -64,8 +64,7 @@
       suppressSizeToFit: true,
       valueGetter: (params: ValueGetterParams<SchedulingGoal>) => {
         if (params.data?.modified_date) {
-          // TODO make this a util? Does vary a bit.
-          return new Date(params.data?.modified_date).toISOString().slice(0, 19);
+          return getShortISOForDate(new Date(params.data?.modified_date));
         }
       },
       width: 160,

--- a/src/components/scheduling/goals/SchedulingGoals.svelte
+++ b/src/components/scheduling/goals/SchedulingGoals.svelte
@@ -148,12 +148,7 @@
     <SectionTitle>Scheduling Goals</SectionTitle>
 
     <Input>
-      <input
-        bind:value={filterText}
-        class="st-input"
-        placeholder="Filter goals"
-        style="max-width: 300px; width: 100%;"
-      />
+      <input bind:value={filterText} class="st-input" placeholder="Filter goals" style="width: 100%;" />
     </Input>
 
     <div class="right">

--- a/src/components/scheduling/goals/SchedulingGoals.svelte
+++ b/src/components/scheduling/goals/SchedulingGoals.svelte
@@ -3,12 +3,11 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
+  import type { ICellRendererParams } from 'ag-grid-community';
   import { createEventDispatcher } from 'svelte';
   import type { User } from '../../../types/app';
   import type { DataGridColumnDef, RowId } from '../../../types/data-grid';
   import type { SchedulingGoal } from '../../../types/scheduling';
-  import { getShortISOForDate } from '../../../utilities/time';
   import Input from '../../form/Input.svelte';
   import DataGridActions from '../../ui/DataGrid/DataGridActions.svelte';
   import SingleActionDataGrid from '../../ui/DataGrid/SingleActionDataGrid.svelte';
@@ -41,34 +40,6 @@
     { field: 'author', filter: 'string', headerName: 'Author', sortable: true, width: 100 },
     { field: 'last_modified_by', filter: 'string', headerName: 'Last Modified By', sortable: true, width: 100 },
     { field: 'description', filter: 'string', headerName: 'Description', sortable: true, width: 120 },
-    {
-      field: 'created_date',
-      filter: 'string',
-      headerName: 'Created Date',
-      sortable: true,
-      suppressAutoSize: true,
-      suppressSizeToFit: true,
-      valueGetter: (params: ValueGetterParams<SchedulingGoal>) => {
-        if (params.data?.created_date) {
-          return getShortISOForDate(new Date(params.data?.created_date));
-        }
-      },
-      width: 160,
-    },
-    {
-      field: 'modified_date',
-      filter: 'string',
-      headerName: 'Modified Date',
-      sortable: true,
-      suppressAutoSize: true,
-      suppressSizeToFit: true,
-      valueGetter: (params: ValueGetterParams<SchedulingGoal>) => {
-        if (params.data?.modified_date) {
-          return getShortISOForDate(new Date(params.data?.modified_date));
-        }
-      },
-      width: 160,
-    },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: SchedulingGoalsCellRendererParams) => {

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -4,7 +4,7 @@
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import { onMount } from 'svelte';
-  import { commandDictionaries, userSequencesColumns } from '../../stores/sequencing';
+  import { commandDictionaries, userSequenceFormColumns } from '../../stores/sequencing';
   import type { User } from '../../types/app';
   import type { UserSequence, UserSequenceInsertInput } from '../../types/sequencing';
   import effects from '../../utilities/effects';
@@ -116,7 +116,7 @@
 
 <PageTitle subTitle={pageSubtitle} title={pageTitle} />
 
-<CssGrid bind:columns={$userSequencesColumns}>
+<CssGrid bind:columns={$userSequenceFormColumns}>
   <Panel overflowYBody="hidden" padBody={false}>
     <svelte:fragment slot="header">
       <SectionTitle>{mode === 'create' ? 'New Sequence' : 'Edit Sequence'}</SectionTitle>

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -193,12 +193,7 @@
       <SectionTitle>Sequences</SectionTitle>
 
       <Input>
-        <input
-          bind:value={filterText}
-          class="st-input"
-          placeholder="Filter sequences"
-          style="max-width: 300px; width: 100%;"
-        />
+        <input bind:value={filterText} class="st-input" placeholder="Filter sequences" style="width: 100%;" />
       </Input>
 
       <div class="right">

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -9,6 +9,7 @@
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { UserSequence } from '../../types/sequencing';
   import effects from '../../utilities/effects';
+  import { getShortISOForDate } from '../../utilities/time';
   import Input from '../form/Input.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
@@ -53,8 +54,7 @@
       sortable: true,
       valueGetter: (params: ValueGetterParams<UserSequence>) => {
         if (params.data?.created_at) {
-          // TODO make this a util? Does vary a bit.
-          return new Date(params.data?.updated_at).toISOString().slice(0, 19);
+          return getShortISOForDate(new Date(params.data?.created_at));
         }
       },
     },
@@ -67,8 +67,7 @@
       sortable: true,
       valueGetter: (params: ValueGetterParams<UserSequence>) => {
         if (params.data?.updated_at) {
-          // TODO make this a util? Does vary a bit.
-          return new Date(params.data?.updated_at).toISOString().slice(0, 19);
+          return getShortISOForDate(new Date(params.data?.updated_at));
         }
       },
     },

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import type { ICellRendererParams } from 'ag-grid-community';
+  import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
   import { userSequences, userSequencesColumns } from '../../stores/sequencing';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
@@ -45,8 +45,33 @@
       resizable: true,
       sortable: true,
     },
-    { field: 'created_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
-    { field: 'updated_at', filter: 'text', headerName: 'Updated At', resizable: true, sortable: true },
+    {
+      field: 'created_at',
+      filter: 'text',
+      headerName: 'Created At',
+      resizable: true,
+      sortable: true,
+      valueGetter: (params: ValueGetterParams<UserSequence>) => {
+        if (params.data?.created_at) {
+          // TODO make this a util? Does vary a bit.
+          return new Date(params.data?.updated_at).toISOString().slice(0, 19);
+        }
+      },
+    },
+    { field: 'requested_by', filter: 'text', headerName: 'Requested By', resizable: true, sortable: true },
+    {
+      field: 'updated_at',
+      filter: 'text',
+      headerName: 'Updated At',
+      resizable: true,
+      sortable: true,
+      valueGetter: (params: ValueGetterParams<UserSequence>) => {
+        if (params.data?.updated_at) {
+          // TODO make this a util? Does vary a bit.
+          return new Date(params.data?.updated_at).toISOString().slice(0, 19);
+        }
+      },
+    },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: SequencesCellRendererParams) => {

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -3,13 +3,12 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
+  import type { ICellRendererParams } from 'ag-grid-community';
   import { userSequences, userSequencesColumns } from '../../stores/sequencing';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { UserSequence } from '../../types/sequencing';
   import effects from '../../utilities/effects';
-  import { getShortISOForDate } from '../../utilities/time';
   import Input from '../form/Input.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
@@ -45,30 +44,6 @@
       headerName: 'Command Dictionary ID',
       resizable: true,
       sortable: true,
-    },
-    {
-      field: 'created_at',
-      filter: 'text',
-      headerName: 'Created At',
-      resizable: true,
-      sortable: true,
-      valueGetter: (params: ValueGetterParams<UserSequence>) => {
-        if (params.data?.created_at) {
-          return getShortISOForDate(new Date(params.data?.created_at));
-        }
-      },
-    },
-    {
-      field: 'updated_at',
-      filter: 'text',
-      headerName: 'Updated At',
-      resizable: true,
-      sortable: true,
-      valueGetter: (params: ValueGetterParams<UserSequence>) => {
-        if (params.data?.updated_at) {
-          return getShortISOForDate(new Date(params.data?.updated_at));
-        }
-      },
     },
     {
       cellClass: 'action-cell-container',

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -46,7 +46,7 @@
       sortable: true,
     },
     { field: 'created_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
-    { field: 'updated_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
+    { field: 'updated_at', filter: 'text', headerName: 'Updated At', resizable: true, sortable: true },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: SequencesCellRendererParams) => {

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -58,7 +58,6 @@
         }
       },
     },
-    { field: 'requested_by', filter: 'text', headerName: 'Requested By', resizable: true, sortable: true },
     {
       field: 'updated_at',
       filter: 'text',

--- a/src/components/simulation/SimulationHistoryDataset.svelte
+++ b/src/components/simulation/SimulationHistoryDataset.svelte
@@ -54,7 +54,7 @@
       <Input class="simulation-dataset-input">
         <input {checked} type="checkbox" tabIndex={-1} />
       </Input>
-      Simulation ID: {simulationDataset.id}
+      ID: {simulationDataset.id}
     </div>
     <div class="simulation-dataset-metadata">
       <div class="simulation-dataset-metadata-time-ago">

--- a/src/components/simulation/SimulationHistoryDataset.svelte
+++ b/src/components/simulation/SimulationHistoryDataset.svelte
@@ -5,7 +5,7 @@
   import PinPlayIcon from '@nasa-jpl/stellar/icons/pin_play.svg?component';
   import { createEventDispatcher } from 'svelte';
   import type { SimulationDataset } from '../../types/simulation';
-  import { timeAgo } from '../../utilities/time';
+  import { getDoyTime, timeAgo } from '../../utilities/time';
   import Input from '../form/Input.svelte';
 
   export let checked: boolean = false;
@@ -17,9 +17,11 @@
   const planDuration = planEndTimeMs - planStartTimeMs;
 
   let timeVizRangeLeft = 0;
-  let timeVizRangeWidth = 100;
+  let timeVizRangeWidth = 0;
   let startTimeText = '';
   let endTimeText = '';
+
+  $: timeVizRangeWidthStyle = timeVizRangeWidth < 1 ? '4px' : `${timeVizRangeWidth}%`;
 
   $: {
     // Compute time range left and width
@@ -30,18 +32,17 @@
       if (simulationStartTimeMS === planStartTimeMs) {
         startTimeText = 'Plan Start';
       } else {
-        startTimeText = simulationDataset.simulation_start_time.split('+')[0];
+        startTimeText = getDoyTime(new Date(simulationDataset.simulation_start_time)).split('+')[0];
       }
 
       if (simulationDataset.simulation_end_time) {
         const simulationEndTimeMS = new Date(simulationDataset.simulation_end_time).getTime();
-        timeVizRangeWidth = ((simulationEndTimeMS - simulationStartTimeMS) / planDuration) * 100 || 100;
-        endTimeText = simulationDataset.simulation_start_time.split('+')[0];
+        timeVizRangeWidth = ((simulationEndTimeMS - simulationStartTimeMS) / planDuration) * 100 || 0;
 
         if (simulationEndTimeMS === planEndTimeMs) {
           endTimeText = 'Plan End';
         } else {
-          endTimeText = simulationDataset.simulation_end_time.split('+')[0];
+          endTimeText = getDoyTime(new Date(simulationDataset.simulation_end_time)).split('+')[0];
         }
       }
     }
@@ -73,7 +74,10 @@
 
   <div class="simulation-range-visualiztion">
     <div class="simulation-range-background">
-      <div class="simulation-range-fill" style={`margin-left: ${timeVizRangeLeft}%; width: ${timeVizRangeWidth}%`} />
+      <div
+        class="simulation-range-fill"
+        style={`margin-left: ${timeVizRangeLeft}%; width: ${timeVizRangeWidthStyle}`}
+      />
     </div>
   </div>
 </button>

--- a/src/components/simulation/SimulationHistoryDataset.svelte
+++ b/src/components/simulation/SimulationHistoryDataset.svelte
@@ -5,7 +5,7 @@
   import PinPlayIcon from '@nasa-jpl/stellar/icons/pin_play.svg?component';
   import { createEventDispatcher } from 'svelte';
   import type { SimulationDataset } from '../../types/simulation';
-  import { getDoyTime, timeAgo } from '../../utilities/time';
+  import { getDoyTime, getTimeAgo } from '../../utilities/time';
   import Input from '../form/Input.svelte';
 
   export let checked: boolean = false;
@@ -59,7 +59,7 @@
     </div>
     <div class="simulation-dataset-metadata">
       <div class="simulation-dataset-metadata-time-ago">
-        {timeAgo(new Date(simulationDataset.requested_at))}
+        {getTimeAgo(new Date(simulationDataset.requested_at))}
       </div>
       <div class="simulation-dataset-metadata-user">
         @{simulationDataset.requested_by || 'Unknown User'}

--- a/src/components/simulation/SimulationHistoryDataset.svelte
+++ b/src/components/simulation/SimulationHistoryDataset.svelte
@@ -5,6 +5,7 @@
   import PinPlayIcon from '@nasa-jpl/stellar/icons/pin_play.svg?component';
   import { createEventDispatcher } from 'svelte';
   import type { SimulationDataset } from '../../types/simulation';
+  import { timeAgo } from '../../utilities/time';
   import Input from '../form/Input.svelte';
 
   export let checked: boolean = false;
@@ -47,14 +48,21 @@
   }
 </script>
 
-<button class="simulation-dataset st-typography-label" on:click={() => dispatch('click')}>
+<button class="simulation-dataset st-typography-label" class:active={checked} on:click={() => dispatch('click')}>
   <div class="simulation-dataset-top-row">
-    <Input class="simulation-dataset-input">
-      <input {checked} type="checkbox" tabIndex={-1} />
-    </Input>
-
-    <div>
+    <div class="simulation-dataset-input-container">
+      <Input class="simulation-dataset-input">
+        <input {checked} type="checkbox" tabIndex={-1} />
+      </Input>
       Simulation ID: {simulationDataset.id}
+    </div>
+    <div class="simulation-dataset-metadata">
+      <div class="simulation-dataset-metadata-time-ago">
+        {timeAgo(new Date(simulationDataset.requested_at))}
+      </div>
+      <div class="simulation-dataset-metadata-user">
+        @{simulationDataset.requested_by || 'Unknown User'}
+      </div>
     </div>
   </div>
 
@@ -80,7 +88,16 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
+    opacity: 0.8;
     padding: 8px;
+  }
+
+  .simulation-dataset.active {
+    opacity: 1;
+  }
+
+  .simulation-dataset.active {
+    opacity: 1;
   }
 
   .simulation-dataset:hover {
@@ -92,6 +109,32 @@
     display: flex;
     gap: 8px;
     height: 24px;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .simulation-dataset-input-container {
+    display: flex;
+    gap: 8px;
+  }
+
+  .simulation-dataset-metadata {
+    display: flex;
+    gap: 8px;
+  }
+
+  .simulation-dataset-metadata {
+    color: var(--st-gray-50) dataset-metadata-time-ago;
+    display: flex;
+    gap: 8px;
+  }
+
+  .simulation-dataset-metadata-user {
+    color: var(--st-gray-70);
+  }
+
+  .simulation-dataset-metadata-time-ago {
+    color: var(--st-gray-50);
   }
 
   .simulation-dataset-top-row :global(.input.simulation-dataset-input) {
@@ -117,8 +160,13 @@
   }
 
   .simulation-range-label :global(svg) {
+    color: var(--st-gray-40);
     flex-shrink: 0;
     z-index: 0;
+  }
+
+  .simulation-dataset.active .simulation-range-label :global(svg) {
+    color: var(--st-gray-60);
   }
 
   .simulation-range-label.start {
@@ -149,7 +197,7 @@
     content: ' ';
     height: 16px;
     left: 8px;
-    opacity: 0.3;
+    opacity: 0.15;
     position: absolute;
     top: 0;
     width: 12px;
@@ -173,12 +221,17 @@
     background: linear-gradient(270deg, #717171 45.83%, rgba(188, 188, 188, 0) 95.83%);
     content: ' ';
     height: 16px;
-    opacity: 0.3;
+    opacity: 0.15;
     position: absolute;
     right: 8px;
     top: 0px;
     width: 12px;
     z-index: -1;
+  }
+
+  .simulation-dataset.active .simulation-range-label.start:after,
+  .simulation-dataset.active .simulation-range-label.end:after {
+    opacity: 0.3;
   }
 
   .simulation-range-visualiztion {
@@ -198,6 +251,5 @@
     background: var(--st-gray-90);
     border-radius: 2px;
     height: 2px;
-    width: 50px; /* temporary */
   }
 </style>

--- a/src/css/ag-grid-stellar.css
+++ b/src/css/ag-grid-stellar.css
@@ -479,3 +479,22 @@
 .ag-theme-stellar .ag-cell-value {
   letter-spacing: var(--st-table-th-letter-spacing);
 }
+
+.ag-picker-field-display {
+  color: var(--st-typography-medium-color);
+  font-family: var(--st-typography-medium-font-family);
+  font-size: var(--st-typography-medium-font-size);
+  font-weight: var(--st-typography-medium-font-weight);
+  letter-spacing: var(--st-typography-medium-letter-spacing);
+  line-height: var(--st-typography-medium-line-height);
+}
+
+.ag-filter-condition,
+.ag-text-field-input {
+  color: var(--st-typography-body-color);
+  font-family: var(--st-typography-body-font-family);
+  font-size: var(--st-typography-body-font-size);
+  font-weight: var(--st-typography-body-font-weight);
+  letter-spacing: var(--st-typography-body-letter-spacing);
+  line-height: var(--st-typography-body-line-height);
+}

--- a/src/routes/expansion/rules/edit/[id]/+page.svelte
+++ b/src/routes/expansion/rules/edit/[id]/+page.svelte
@@ -15,6 +15,7 @@
   initialRuleId={data.initialRule.id}
   initialRuleLogic={data.initialRule.expansion_logic}
   initialRuleModelId={data.initialRule.authoring_mission_model_id}
+  initialRuleName={data.initialRule.name}
   initialRuleUpdatedAt={data.initialRule.updated_at}
   mode="edit"
   user={data.user}

--- a/src/routes/expansion/rules/edit/[id]/+page.svelte
+++ b/src/routes/expansion/rules/edit/[id]/+page.svelte
@@ -9,6 +9,7 @@
 
 <ExpansionRuleForm
   initialRuleActivityType={data.initialRule.activity_type}
+  initialRuleDescription={data.initialRule.description}
   initialRuleCreatedAt={data.initialRule.created_at}
   initialRuleDictionaryId={data.initialRule.authoring_command_dict_id}
   initialRuleId={data.initialRule.id}

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -68,6 +68,7 @@
   let name = '';
   let user: User | null = null;
   let version = '';
+  let description = '';
 
   $: createButtonDisabled = !files || name === '' || version === '' || $creatingModel === true;
   $: {
@@ -131,7 +132,7 @@
   }
 
   async function submitForm(e: SubmitEvent) {
-    await effects.createModel(name, version, files, user);
+    await effects.createModel(name, version, description, files, data.user);
     if ($createModelError === null && e.target instanceof HTMLFormElement) {
       e.target.reset();
     }
@@ -183,6 +184,17 @@
                 hasPermission: hasCreatePermission,
                 permissionError: creationPermissionError,
               }}
+            />
+          </fieldset>
+
+          <fieldset>
+            <label for="description">Description</label>
+            <textarea
+              bind:value={description}
+              autocomplete="off"
+              class="st-input w-100"
+              name="description"
+              placeholder="Enter Model Description (optional)"
             />
           </fieldset>
 

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -132,7 +132,7 @@
   }
 
   async function submitForm(e: SubmitEvent) {
-    await effects.createModel(name, version, description, files, data.user);
+    await effects.createModel(name, version, files, data.user, description);
     if ($createModelError === null && e.target instanceof HTMLFormElement) {
       e.target.reset();
     }

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import type { ICellRendererParams } from 'ag-grid-community';
+  import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
   import BarChartIcon from 'bootstrap-icons/icons/bar-chart.svg?component';
   import { onMount } from 'svelte';
   import Nav from '../../components/app/Nav.svelte';
@@ -43,6 +43,20 @@
       width: 60,
     },
     { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
+    { field: 'owner', filter: 'text', headerName: 'Owner', resizable: true, sortable: true },
+    {
+      field: 'created_at',
+      filter: 'text',
+      headerName: 'Date Created',
+      resizable: true,
+      sortable: true,
+      valueGetter: (params: ValueGetterParams<ModelSlim>) => {
+        if (params.data?.created_at) {
+          return new Date(params.data?.created_at).toISOString().slice(0, 19);
+        }
+      },
+    },
+    { field: 'description', filter: 'text', headerName: 'Description', resizable: true, sortable: true },
     { field: 'version', filter: 'number', headerName: 'Version', sortable: true, width: 120 },
   ];
 

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -28,7 +28,7 @@
   import { removeQueryParam } from '../../utilities/generic';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
-  import { convertUsToDurationString, getUnixEpochTime } from '../../utilities/time';
+  import { convertUsToDurationString, getShortISOForDate, getUnixEpochTime } from '../../utilities/time';
   import { min, required, timestamp } from '../../utilities/validators';
   import type { PageData } from './$types';
 
@@ -84,8 +84,7 @@
       sortable: true,
       valueGetter: (params: ValueGetterParams<Plan>) => {
         if (params.data?.created_at) {
-          // TODO make this a util? Does vary a bit.
-          return new Date(params.data?.created_at).toISOString().slice(0, 19);
+          return getShortISOForDate(new Date(params.data?.created_at));
         }
       },
     },

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -96,7 +96,7 @@
       sortable: true,
       valueGetter: (params: ValueGetterParams<Plan>) => {
         if (params.data?.updated_at) {
-          return new Date(params.data?.updated_at).toISOString().slice(0, 19);
+          return getShortISOForDate(new Date(params.data?.updated_at));
         }
       },
     },

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -58,7 +58,7 @@
       headerName: 'Start Time',
       resizable: true,
       sortable: true,
-      valueGetter: (params: ValueGetterParams<PlanSlim>) => {
+      valueGetter: (params: ValueGetterParams<Plan>) => {
         if (params.data?.start_time_doy) {
           return params.data?.start_time_doy.split('T')[0];
         }
@@ -70,7 +70,7 @@
       headerName: 'End Time',
       resizable: true,
       sortable: true,
-      valueGetter: (params: ValueGetterParams<PlanSlim>) => {
+      valueGetter: (params: ValueGetterParams<Plan>) => {
         if (params.data?.end_time_doy) {
           return params.data?.end_time_doy.split('T')[0];
         }
@@ -82,7 +82,7 @@
       headerName: 'Date Created',
       resizable: true,
       sortable: true,
-      valueGetter: (params: ValueGetterParams<PlanSlim>) => {
+      valueGetter: (params: ValueGetterParams<Plan>) => {
         if (params.data?.created_at) {
           // TODO make this a util? Does vary a bit.
           return new Date(params.data?.created_at).toISOString().slice(0, 19);
@@ -95,7 +95,7 @@
       headerName: 'Updated At',
       resizable: true,
       sortable: true,
-      valueGetter: (params: ValueGetterParams<PlanSlim>) => {
+      valueGetter: (params: ValueGetterParams<Plan>) => {
         if (params.data?.updated_at) {
           return new Date(params.data?.updated_at).toISOString().slice(0, 19);
         }

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -100,7 +100,7 @@
         }
       },
     },
-    { field: 'updated_by', filter: 'text', headerName: 'Created By', resizable: true, sortable: true },
+    { field: 'updated_by', filter: 'text', headerName: 'Updated By', resizable: true, sortable: true },
     { field: 'owner', filter: 'text', headerName: 'Owner', resizable: true, sortable: true },
     {
       cellClass: 'action-cell-container',

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -5,7 +5,7 @@
   import { base } from '$app/paths';
   import { page } from '$app/stores';
   import PlanIcon from '@nasa-jpl/stellar/icons/plan.svg?component';
-  import type { ICellRendererParams } from 'ag-grid-community';
+  import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
   import { onMount } from 'svelte';
   import Nav from '../../components/app/Nav.svelte';
   import PageTitle from '../../components/app/PageTitle.svelte';
@@ -52,8 +52,57 @@
     },
     { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
     { field: 'model_id', filter: 'number', headerName: 'Model ID', sortable: true, suppressAutoSize: true, width: 120 },
-    { field: 'start_time_doy', filter: 'text', headerName: 'Start Time', resizable: true, sortable: true },
-    { field: 'end_time_doy', filter: 'text', headerName: 'End Time', resizable: true, sortable: true },
+    {
+      field: 'start_time_doy',
+      filter: 'text',
+      headerName: 'Start Time',
+      resizable: true,
+      sortable: true,
+      valueGetter: (params: ValueGetterParams<PlanSlim>) => {
+        if (params.data?.start_time_doy) {
+          return params.data?.start_time_doy.split('T')[0];
+        }
+      },
+    },
+    {
+      field: 'end_time_doy',
+      filter: 'text',
+      headerName: 'Start Time',
+      resizable: true,
+      sortable: true,
+      valueGetter: (params: ValueGetterParams<PlanSlim>) => {
+        if (params.data?.end_time_doy) {
+          return params.data?.end_time_doy.split('T')[0];
+        }
+      },
+    },
+    {
+      field: 'created_at',
+      filter: 'text',
+      headerName: 'Date Created',
+      resizable: true,
+      sortable: true,
+      valueGetter: (params: ValueGetterParams<PlanSlim>) => {
+        if (params.data?.created_at) {
+          // TODO make this a util? Does vary a bit.
+          return new Date(params.data?.created_at).toISOString().slice(0, 19);
+        }
+      },
+    },
+    {
+      field: 'updated_at',
+      filter: 'text',
+      headerName: 'Updated At',
+      resizable: true,
+      sortable: true,
+      valueGetter: (params: ValueGetterParams<PlanSlim>) => {
+        if (params.data?.updated_at) {
+          return new Date(params.data?.updated_at).toISOString().slice(0, 19);
+        }
+      },
+    },
+    { field: 'updated_by', filter: 'text', headerName: 'Created By', resizable: true, sortable: true },
+    { field: 'owner', filter: 'text', headerName: 'Owner', resizable: true, sortable: true },
     {
       cellClass: 'action-cell-container',
       cellRenderer: (params: PlanCellRendererParams) => {

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -67,7 +67,7 @@
     {
       field: 'end_time_doy',
       filter: 'text',
-      headerName: 'Start Time',
+      headerName: 'End Time',
       resizable: true,
       sortable: true,
       valueGetter: (params: ValueGetterParams<PlanSlim>) => {

--- a/src/stores/constraints.ts
+++ b/src/stores/constraints.ts
@@ -36,7 +36,7 @@ export const checkConstraintsStatus: Writable<Status | null> = writable(null);
 
 export const constraintViolationsResponse: Writable<ConstraintViolation[]> = writable([]);
 
-export const constraintsColumns: Writable<string> = writable('1fr 3px 1fr');
+export const constraintsColumns: Writable<string> = writable('2fr 3px 1fr');
 export const constraintsFormColumns: Writable<string> = writable('1fr 3px 2fr');
 
 /* Derived. */

--- a/src/stores/constraints.ts
+++ b/src/stores/constraints.ts
@@ -36,7 +36,7 @@ export const checkConstraintsStatus: Writable<Status | null> = writable(null);
 
 export const constraintViolationsResponse: Writable<ConstraintViolation[]> = writable([]);
 
-export const constraintsColumns: Writable<string> = writable('1fr 3px 2fr');
+export const constraintsColumns: Writable<string> = writable('1fr 3px 1fr');
 
 /* Derived. */
 

--- a/src/stores/constraints.ts
+++ b/src/stores/constraints.ts
@@ -37,6 +37,7 @@ export const checkConstraintsStatus: Writable<Status | null> = writable(null);
 export const constraintViolationsResponse: Writable<ConstraintViolation[]> = writable([]);
 
 export const constraintsColumns: Writable<string> = writable('1fr 3px 1fr');
+export const constraintsFormColumns: Writable<string> = writable('1fr 3px 2fr');
 
 /* Derived. */
 

--- a/src/stores/expansion.ts
+++ b/src/stores/expansion.ts
@@ -17,6 +17,8 @@ export const expansionSets = gqlSubscribable<ExpansionSet[]>(gql.SUB_EXPANSION_S
 
 export const creatingExpansionSequence: Writable<boolean> = writable(false);
 
+export const createExpansionRuleError: Writable<string | null> = writable(null);
+
 export const expansionRulesColumns: Writable<string> = writable('2fr 3px 1fr');
 
 export const expansionRulesFormColumns: Writable<string> = writable('1fr 3px 2fr');
@@ -44,6 +46,7 @@ export const filteredExpansionSequences: Readable<ExpansionSequence[]> = derived
 );
 
 export function resetExpansionStores(): void {
+  createExpansionRuleError.set(null);
   creatingExpansionSequence.set(false);
   savingExpansionRule.set(false);
   savingExpansionSet.set(false);

--- a/src/stores/expansion.ts
+++ b/src/stores/expansion.ts
@@ -17,7 +17,7 @@ export const expansionSets = gqlSubscribable<ExpansionSet[]>(gql.SUB_EXPANSION_S
 
 export const creatingExpansionSequence: Writable<boolean> = writable(false);
 
-export const expansionRulesColumns: Writable<string> = writable('1fr 3px 2fr');
+export const expansionRulesColumns: Writable<string> = writable('2.5fr 3px 1.5fr');
 
 export const expansionSetsColumns: Writable<string> = writable('1fr 3px 2fr');
 

--- a/src/stores/expansion.ts
+++ b/src/stores/expansion.ts
@@ -17,9 +17,13 @@ export const expansionSets = gqlSubscribable<ExpansionSet[]>(gql.SUB_EXPANSION_S
 
 export const creatingExpansionSequence: Writable<boolean> = writable(false);
 
-export const expansionRulesColumns: Writable<string> = writable('2.5fr 3px 1.5fr');
+export const expansionRulesColumns: Writable<string> = writable('2fr 3px 1fr');
 
-export const expansionSetsColumns: Writable<string> = writable('1fr 3px 2fr');
+export const expansionRulesFormColumns: Writable<string> = writable('1fr 3px 2fr');
+
+export const expansionSetsColumns: Writable<string> = writable('2fr 3px 1fr');
+
+export const expansionSetsFormColumns: Writable<string> = writable('1fr 3px 2fr');
 
 export const expansionRunsColumns: Writable<string> = writable('1fr 3px 2fr');
 

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -15,7 +15,7 @@ import { gqlSubscribable } from './subscribable';
 
 export const schedulingColumns: Writable<string> = writable('2fr 3px 1fr');
 export const schedulingFormColumns: Writable<string> = writable('1fr 3px 2fr');
-export const schedulingConditionsColumns: Writable<string> = writable('1fr 3px 2fr');
+export const schedulingConditionsFormColumns: Writable<string> = writable('1fr 3px 2fr');
 export const schedulingGoalsColumns: Writable<string> = writable('1fr 3px 2fr');
 export const schedulingStatus: Writable<Status | null> = writable(null);
 

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -13,7 +13,8 @@ import { gqlSubscribable } from './subscribable';
 
 /* Writeable. */
 
-export const schedulingColumns: Writable<string> = writable('1fr 3px 2fr');
+export const schedulingColumns: Writable<string> = writable('2fr 3px 1fr');
+export const schedulingFormColumns: Writable<string> = writable('1fr 3px 2fr');
 export const schedulingConditionsColumns: Writable<string> = writable('1fr 3px 2fr');
 export const schedulingGoalsColumns: Writable<string> = writable('1fr 3px 2fr');
 export const schedulingStatus: Writable<Status | null> = writable(null);

--- a/src/stores/sequencing.ts
+++ b/src/stores/sequencing.ts
@@ -11,6 +11,8 @@ export const userSequences = gqlSubscribable<UserSequence[]>(gql.SUB_USER_SEQUEN
 
 /* Writeable. */
 
-export const userSequencesColumns: Writable<string> = writable('1fr 3px 2fr');
+export const userSequencesColumns: Writable<string> = writable('1.5fr 3px 1fr');
+
+export const userSequenceFormColumns: Writable<string> = writable('1fr 3px 2fr');
 
 export const userSequencesRows: Writable<string> = writable('1fr 3px 1fr');

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -10,6 +10,7 @@ export type Constraint = {
   name: string;
   owner: string;
   plan_id: number | null;
+  updated_at: string;
   updated_by: string;
 };
 

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -2,7 +2,6 @@ import type { TimeRange } from './timeline';
 
 export type Constraint = {
   created_at: string;
-  created_by: string;
   definition: string;
   description: string;
   id: number;

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -13,7 +13,7 @@ export type Constraint = {
   updated_by: string;
 };
 
-export type ConstraintInsertInput = Omit<Constraint, 'id'>;
+export type ConstraintInsertInput = Omit<Constraint, 'id' | 'created_at' | 'updated_at' | 'owner' | 'updated_by'>;
 
 export type ConstraintType = 'model' | 'plan';
 

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -1,12 +1,16 @@
 import type { TimeRange } from './timeline';
 
 export type Constraint = {
+  created_at: string;
+  created_by: string;
   definition: string;
   description: string;
   id: number;
   model_id: number | null;
   name: string;
+  owner: string;
   plan_id: number | null;
+  updated_by: string;
 };
 
 export type ConstraintInsertInput = Omit<Constraint, 'id'>;

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -6,9 +6,12 @@ export type ExpansionRule = {
   authoring_command_dict_id: number;
   authoring_mission_model_id: number;
   created_at: string;
+  description: string;
   expansion_logic: string;
   id: number;
+  owner: string;
   updated_at: string;
+  updated_by: string;
 };
 
 export type ExpansionRuleInsertInput = Omit<ExpansionRule, 'created_at' | 'id' | 'updated_at'>;

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -14,7 +14,7 @@ export type ExpansionRule = {
   updated_by: string;
 };
 
-export type ExpansionRuleInsertInput = Omit<ExpansionRule, 'created_at' | 'id' | 'updated_at'>;
+export type ExpansionRuleInsertInput = Omit<ExpansionRule, 'created_at' | 'id' | 'updated_at' | 'updated_by' | 'owner'>;
 
 export type ExpansionSequenceToActivityInsertInput = {
   seq_id: string;

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -27,7 +27,6 @@ export type ExpansionSequence = {
   metadata: any;
   seq_id: string;
   simulation_dataset_id: number;
-  updated_at: string;
 };
 
 export type ExpansionSequenceInsertInput = Omit<ExpansionSequence, 'created_at' | 'updated_at'>;

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -38,6 +38,7 @@ export type ExpansionSet = {
   expansion_rules: ExpansionRule[];
   id: number;
   mission_model_id: number;
+  name: string;
   owner: string;
   updated_at: string;
   updated_by: string;

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -9,6 +9,7 @@ export type ExpansionRule = {
   description: string;
   expansion_logic: string;
   id: number;
+  name: string;
   owner: string;
   updated_at: string;
   updated_by: string;

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -35,9 +35,13 @@ export type ExpansionSequenceInsertInput = Omit<ExpansionSequence, 'created_at' 
 export type ExpansionSet = {
   command_dict_id: number;
   created_at: string;
+  description: string;
   expansion_rules: ExpansionRule[];
   id: number;
   mission_model_id: number;
+  owner: string;
+  updated_at: string;
+  updated_by: string;
 };
 
 export type SeqId = Pick<ExpansionSequence, 'seq_id'>;

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -2,7 +2,7 @@ import type { ParametersMap } from './parameter';
 
 export type Model = ModelSchema;
 
-export type ModelInsertInput = Pick<Model, 'jar_id' | 'mission' | 'name' | 'version'>;
+export type ModelInsertInput = Pick<Model, 'description' | 'jar_id' | 'mission' | 'name' | 'version'>;
 
 export type ModelSchema = {
   created_at: string;

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -6,7 +6,7 @@ export type ModelInsertInput = Pick<Model, 'description' | 'jar_id' | 'mission' 
 
 export type ModelSchema = {
   created_at: string;
-  description: string;
+  description?: string;
   id: number;
   jar_id: number;
   mission: string;

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -5,13 +5,19 @@ export type Model = ModelSchema;
 export type ModelInsertInput = Pick<Model, 'jar_id' | 'mission' | 'name' | 'version'>;
 
 export type ModelSchema = {
+  created_at: string;
+  description: string;
   id: number;
   jar_id: number;
   mission: string;
   name: string;
+  owner: string;
   parameters: { parameters: ParametersMap };
   plans: { id: number }[];
   version: string;
 };
 
-export type ModelSlim = Pick<Model, 'id' | 'jar_id' | 'name' | 'plans' | 'version'>;
+export type ModelSlim = Pick<
+  Model,
+  'created_at' | 'description' | 'id' | 'jar_id' | 'name' | 'plans' | 'owner' | 'version'
+>;

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -69,6 +69,7 @@ export type PlanMergeResolution = 'none' | 'source' | 'target';
 export type PlanSchema = {
   child_plans: Pick<PlanSchema, 'id' | 'name'>[];
   collaborators: PlanCollaborator[];
+  created_at: string;
   duration: string;
   id: number;
   is_locked: boolean;
@@ -81,11 +82,24 @@ export type PlanSchema = {
   scheduling_specifications: Pick<SchedulingSpec, 'id'>[];
   simulations: [{ simulation_datasets: [{ id: number }] }];
   start_time: string;
+  updated_at: string;
+  updated_by: string;
 };
 
 export type PlanSlim = Pick<
   Plan,
-  'collaborators' | 'end_time_doy' | 'id' | 'model_id' | 'name' | 'owner' | 'revision' | 'start_time' | 'start_time_doy'
+  | 'created_at'
+  | 'collaborators'
+  | 'end_time_doy'
+  | 'id'
+  | 'model_id'
+  | 'name'
+  | 'owner'
+  | 'revision'
+  | 'start_time'
+  | 'start_time_doy'
+  | 'updated_at'
+  | 'updated_by'
 >;
 
 export type PlanSlimmer = Pick<PlanSlim, 'id' | 'start_time' | 'end_time_doy'>;

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -90,6 +90,7 @@ export type PlanSlim = Pick<
   Plan,
   | 'created_at'
   | 'collaborators'
+  | 'duration'
   | 'end_time_doy'
   | 'id'
   | 'model_id'

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -6,7 +6,7 @@ export type SchedulingGoal = {
   author: string | null;
   created_date: string;
   definition: string;
-  description: string | null;
+  description?: string;
   id: number;
   last_modified_by: string | null;
   model_id: number;
@@ -19,7 +19,7 @@ export type SchedulingCondition = {
   author: string | null;
   created_date: string;
   definition: string;
-  description: string | null;
+  description?: string;
   id: number;
   last_modified_by: string | null;
   model_id: number;

--- a/src/types/sequencing.ts
+++ b/src/types/sequencing.ts
@@ -30,8 +30,7 @@ export type UserSequence = {
   id: number;
   name: string;
   owner: string;
-  requested_by: string;
   updated_at: string;
 };
 
-export type UserSequenceInsertInput = Omit<UserSequence, 'created_at' | 'id' | 'requested_by' | 'updated_at'>;
+export type UserSequenceInsertInput = Omit<UserSequence, 'created_at' | 'id' | 'updated_at'>;

--- a/src/types/sequencing.ts
+++ b/src/types/sequencing.ts
@@ -30,7 +30,8 @@ export type UserSequence = {
   id: number;
   name: string;
   owner: string;
+  requested_by: string;
   updated_at: string;
 };
 
-export type UserSequenceInsertInput = Omit<UserSequence, 'created_at' | 'id' | 'updated_at'>;
+export type UserSequenceInsertInput = Omit<UserSequence, 'created_at' | 'id' | 'requested_by' | 'updated_at'>;

--- a/src/types/simulation.ts
+++ b/src/types/simulation.ts
@@ -68,6 +68,8 @@ export type SimulationDataset = {
   id: number;
   plan_revision: number;
   reason: SimulationDatasetError | null;
+  requested_at: string;
+  requested_by: string;
   simulation_end_time: string | null;
   simulation_revision: number;
   simulation_start_time: string | null;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -413,6 +413,7 @@ const effects = {
     dictionaryId: number,
     modelId: number,
     expansionRuleIds: number[],
+    description: string,
     user: User | null,
   ): Promise<number | null> {
     try {
@@ -421,7 +422,11 @@ const effects = {
       }
 
       savingExpansionSet.set(true);
-      const data = await reqHasura(gql.CREATE_EXPANSION_SET, { dictionaryId, expansionRuleIds, modelId }, user);
+      const data = await reqHasura(
+        gql.CREATE_EXPANSION_SET,
+        { description, dictionaryId, expansionRuleIds, modelId },
+        user,
+      );
       const { createExpansionSet } = data;
       const { id } = createExpansionSet;
       showSuccessToast('Expansion Set Created Successfully');

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -338,8 +338,8 @@ const effects = {
     model_id: number | null,
     name: string,
     plan_id: number | null,
-    description?: string,
     user: User | null,
+    description?: string,
   ): Promise<number | null> {
     try {
       if (!queryPermissions.CREATE_CONSTRAINT(user)) {
@@ -413,8 +413,8 @@ const effects = {
     dictionaryId: number,
     modelId: number,
     expansionRuleIds: number[],
-    description?: string,
     user: User | null,
+    description?: string,
   ): Promise<number | null> {
     try {
       if (!queryPermissions.CREATE_EXPANSION_SET(user)) {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -435,7 +435,13 @@ const effects = {
     }
   },
 
-  async createModel(name: string, version: string, files: FileList, user: User | null): Promise<void> {
+  async createModel(
+    name: string,
+    version: string,
+    description: string,
+    files: FileList,
+    user: User | null,
+  ): Promise<void> {
     try {
       createModelError.set(null);
 
@@ -450,6 +456,7 @@ const effects = {
 
       if (jar_id !== null) {
         const modelInsertInput: ModelInsertInput = {
+          description,
           jar_id,
           mission: '',
           name,
@@ -457,8 +464,8 @@ const effects = {
         };
         const data = await reqHasura(gql.CREATE_MODEL, { model: modelInsertInput }, user);
         const { createModel } = data;
-        const { id } = createModel;
-        const model: ModelSlim = { id, jar_id, name, plans: [], version };
+        const { id, created_at, owner } = createModel;
+        const model: ModelSlim = { created_at, description, id, jar_id, name, owner, plans: [], version };
 
         showSuccessToast('Model Created Successfully');
         createModelError.set(null);

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -413,7 +413,6 @@ const effects = {
     dictionaryId: number,
     modelId: number,
     expansionRuleIds: number[],
-    name: string,
     user: User | null,
     description?: string,
   ): Promise<number | null> {
@@ -429,7 +428,6 @@ const effects = {
           dictionaryId,
           expansionRuleIds,
           modelId,
-          name,
           ...(description && { description }),
         },
         user,

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -5,6 +5,7 @@ import { activityDirectivesMap, selectedActivityDirectiveId } from '../stores/ac
 import { checkConstraintsStatus, constraintViolationsResponse } from '../stores/constraints';
 import { catchError, catchSchedulingError } from '../stores/errors';
 import {
+  createExpansionRuleError,
   creatingExpansionSequence,
   planExpansionStatus,
   savingExpansionRule,
@@ -368,6 +369,8 @@ const effects = {
 
   async createExpansionRule(rule: ExpansionRuleInsertInput, user: User | null): Promise<number | null> {
     try {
+      createExpansionRuleError.set(null);
+
       if (!queryPermissions.CREATE_EXPANSION_RULE(user)) {
         throwPermissionError('create an expansion rule');
       }
@@ -383,6 +386,7 @@ const effects = {
       catchError('Expansion Rule Create Failed', e as Error);
       showFailureToast('Expansion Rule Create Failed');
       savingExpansionRule.set(false);
+      createExpansionRuleError.set((e as Error).message);
       return null;
     }
   },
@@ -2535,6 +2539,7 @@ const effects = {
   async updateExpansionRule(id: number, rule: Partial<ExpansionRule>, user: User | null): Promise<string | null> {
     try {
       savingExpansionRule.set(true);
+      createExpansionRuleError.set(null);
 
       if (!queryPermissions.UPDATE_EXPANSION_RULE(user)) {
         throwPermissionError('update this expansion rule');
@@ -2550,6 +2555,7 @@ const effects = {
       catchError('Expansion Rule Update Failed', e as Error);
       showFailureToast('Expansion Rule Update Failed');
       savingExpansionRule.set(false);
+      createExpansionRuleError.set((e as Error).message);
       return null;
     }
   },

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -522,7 +522,7 @@ const effects = {
         name,
         start_time: start_time_doy, // Postgres accepts DOY dates for it's 'timestamptz' type.
       };
-      const data = await reqHasura<Pick<PlanSchema, 'collaborators' | 'id' | 'owner' | 'revision' | 'start_time'>>(
+      const data = await reqHasura<PlanSlim>(
         gql.CREATE_PLAN,
         {
           plan: planInsertInput,
@@ -530,7 +530,8 @@ const effects = {
         user,
       );
       const { createPlan } = data;
-      const { collaborators, id, owner, revision, start_time } = createPlan;
+      const { collaborators, created_at, duration, id, owner, revision, start_time, updated_at, updated_by } =
+        createPlan;
 
       if (!(await effects.initialSimulationUpdate(id, simulation_template_id, start_time_doy, end_time_doy, user))) {
         throw Error('Failed to update simulation.');
@@ -554,6 +555,8 @@ const effects = {
 
       const plan: PlanSlim = {
         collaborators,
+        created_at,
+        duration,
         end_time_doy,
         id,
         model_id,
@@ -562,6 +565,8 @@ const effects = {
         revision,
         start_time,
         start_time_doy,
+        updated_at,
+        updated_by,
       };
 
       showSuccessToast('Plan Created Successfully');
@@ -1687,10 +1692,7 @@ const effects = {
     try {
       const data = (await reqHasura(gql.GET_PLANS_AND_MODELS, {}, user)) as {
         models: ModelSlim[];
-        plans: Pick<
-          Plan,
-          'collaborators' | 'duration' | 'id' | 'model_id' | 'name' | 'owner' | 'revision' | 'start_time'
-        >[];
+        plans: PlanSlim[];
       };
       const { models, plans } = data;
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -413,6 +413,7 @@ const effects = {
     dictionaryId: number,
     modelId: number,
     expansionRuleIds: number[],
+    name: string,
     user: User | null,
     description?: string,
   ): Promise<number | null> {
@@ -428,6 +429,7 @@ const effects = {
           dictionaryId,
           expansionRuleIds,
           modelId,
+          name,
           ...(description && { description }),
         },
         user,

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -335,10 +335,10 @@ const effects = {
 
   async createConstraint(
     definition: string,
-    description: string,
     model_id: number | null,
     name: string,
     plan_id: number | null,
+    description?: string,
     user: User | null,
   ): Promise<number | null> {
     try {
@@ -348,10 +348,10 @@ const effects = {
 
       const constraintInsertInput: ConstraintInsertInput = {
         definition,
-        description,
         model_id: plan_id !== null ? null : model_id,
         name,
         plan_id,
+        ...(description && { description }),
       };
       const data = await reqHasura(gql.CREATE_CONSTRAINT, { constraint: constraintInsertInput }, user);
       const { createConstraint } = data;
@@ -413,7 +413,7 @@ const effects = {
     dictionaryId: number,
     modelId: number,
     expansionRuleIds: number[],
-    description: string,
+    description?: string,
     user: User | null,
   ): Promise<number | null> {
     try {
@@ -424,7 +424,12 @@ const effects = {
       savingExpansionSet.set(true);
       const data = await reqHasura(
         gql.CREATE_EXPANSION_SET,
-        { description, dictionaryId, expansionRuleIds, modelId },
+        {
+          dictionaryId,
+          expansionRuleIds,
+          modelId,
+          ...(description && { description }),
+        },
         user,
       );
       const { createExpansionSet } = data;
@@ -443,9 +448,9 @@ const effects = {
   async createModel(
     name: string,
     version: string,
-    description: string,
     files: FileList,
     user: User | null,
+    description?: string,
   ): Promise<void> {
     try {
       createModelError.set(null);
@@ -470,7 +475,16 @@ const effects = {
         const data = await reqHasura(gql.CREATE_MODEL, { model: modelInsertInput }, user);
         const { createModel } = data;
         const { id, created_at, owner } = createModel;
-        const model: ModelSlim = { created_at, description, id, jar_id, name, owner, plans: [], version };
+        const model: ModelSlim = {
+          created_at,
+          id,
+          jar_id,
+          name,
+          owner,
+          plans: [],
+          version,
+          ...(description && { description }),
+        };
 
         showSuccessToast('Model Created Successfully');
         createModelError.set(null);
@@ -648,10 +662,10 @@ const effects = {
 
   async createSchedulingCondition(
     definition: string,
-    description: string,
     name: string,
     modelId: number,
     user: User | null,
+    description?: string,
   ): Promise<SchedulingCondition | null> {
     try {
       if (!queryPermissions.CREATE_SCHEDULING_CONDITION(user)) {
@@ -661,10 +675,10 @@ const effects = {
       const conditionInsertInput: SchedulingConditionInsertInput = {
         author: user?.id ?? 'unknown',
         definition,
-        description,
         last_modified_by: user?.id ?? 'unknown',
         model_id: modelId,
         name,
+        ...(description && { description }),
       };
       const data = await reqHasura<SchedulingCondition>(
         gql.CREATE_SCHEDULING_CONDITION,
@@ -684,10 +698,10 @@ const effects = {
 
   async createSchedulingGoal(
     definition: string,
-    description: string,
     name: string,
     modelId: number,
     user: User | null,
+    description?: string,
   ): Promise<SchedulingGoal | null> {
     try {
       if (!queryPermissions.CREATE_SCHEDULING_GOAL(user)) {
@@ -697,10 +711,10 @@ const effects = {
       const goalInsertInput: SchedulingGoalInsertInput = {
         author: user?.id ?? 'unknown',
         definition,
-        description,
         last_modified_by: user?.id ?? 'unknown',
         model_id: modelId,
         name,
+        ...(description && { description }),
       };
       const data = await reqHasura<SchedulingGoal>(gql.CREATE_SCHEDULING_GOAL, { goal: goalInsertInput }, user);
       const { createSchedulingGoal: newGoal } = data;
@@ -2490,11 +2504,11 @@ const effects = {
   async updateConstraint(
     id: number,
     definition: string,
-    description: string,
     model_id: number,
     name: string,
     plan_id: number,
     user: User | null,
+    description?: string,
   ): Promise<void> {
     try {
       if (!queryPermissions.UPDATE_CONSTRAINT(user)) {
@@ -2503,10 +2517,10 @@ const effects = {
 
       const constraint: Partial<Constraint> = {
         definition,
-        description,
         model_id: plan_id !== null ? null : model_id,
         name,
         plan_id,
+        ...(description && { description }),
       };
       await reqHasura(gql.UPDATE_CONSTRAINT, { constraint, id }, user);
       showSuccessToast('Constraint Updated Successfully');
@@ -2696,17 +2710,11 @@ const effects = {
         throwPermissionError('update this simulation template');
       }
 
-      const simulationTemplateSetInput: SimulationTemplateSetInput = {};
-
-      if (partialSimulationTemplate.arguments) {
-        simulationTemplateSetInput.arguments = partialSimulationTemplate.arguments;
-      }
-      if (partialSimulationTemplate.description) {
-        simulationTemplateSetInput.description = partialSimulationTemplate.description;
-      }
-      if (partialSimulationTemplate.model_id) {
-        simulationTemplateSetInput.model_id = partialSimulationTemplate.model_id;
-      }
+      const simulationTemplateSetInput: SimulationTemplateSetInput = {
+        ...(partialSimulationTemplate.arguments && { arguments: partialSimulationTemplate.arguments }),
+        ...(partialSimulationTemplate.description && { description: partialSimulationTemplate.description }),
+        ...(partialSimulationTemplate.model_id && { model_id: partialSimulationTemplate.model_id }),
+      };
 
       const {
         update_simulation_template_by_pk: { description: templateDescription },

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -620,6 +620,7 @@ const gql = {
         collaborators {
           collaborator
         }
+        created_at
         duration
         id
         is_locked
@@ -649,6 +650,8 @@ const gql = {
           }
         }
         start_time
+        updated_at
+        updated_by
       }
     }
   `,
@@ -668,6 +671,7 @@ const gql = {
         collaborators {
           collaborator
         }
+        created_at
         duration
         id
         model_id
@@ -675,6 +679,8 @@ const gql = {
         owner
         revision
         start_time
+        updated_at
+        updated_by
       }
     }
   `,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1185,6 +1185,9 @@ const gql = {
         expansion_logic
         id
         updated_at
+        owner
+        updated_by
+        description
       }
     }
   `,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -575,12 +575,15 @@ const gql = {
   GET_MODELS: `#graphql
     query GetModels {
       models: mission_model {
+        created_at
+        description
         id
-        jar_id,
+        jar_id
         name
         plans {
           id
         }
+        owner
         version
       }
     }
@@ -1218,12 +1221,15 @@ const gql = {
   SUB_MODELS: `#graphql
     subscription SubModels {
       models: mission_model(order_by: { name: asc }) {
+        created_at
+        description
         id
-        jar_id,
+        jar_id
         name
         plans {
           id
         }
+        owner
         version
       }
     }

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1227,7 +1227,6 @@ const gql = {
         metadata
         seq_id
         simulation_dataset_id
-        requested_by
         updated_at
       }
     }

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -455,12 +455,15 @@ const gql = {
   GET_CONSTRAINT: `#graphql
     query GetConstraint($id: Int!) {
       constraint: constraint_by_pk(id: $id) {
+        created_at
         definition
         description
         id
         model_id
         name
+        owner
         plan_id
+        updated_by
       }
     }
   `,
@@ -1152,12 +1155,15 @@ const gql = {
           { plan_id: { _eq: $planId } }
         ]
       }, order_by: { name: asc }) {
+        created_at
         definition
         description
         id
         model_id
         name
+        owner
         plan_id
+        updated_by
       }
     }
   `,
@@ -1165,12 +1171,15 @@ const gql = {
   SUB_CONSTRAINTS_ALL: `#graphql
     subscription SubConstraintsAll {
       constraints: constraint(order_by: { name: asc }) {
+        created_at
         definition
         description
         id
         model_id
         name
+        owner
         plan_id
+        updated_by
       }
     }
   `,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1214,6 +1214,7 @@ const gql = {
         description
         expansion_logic
         id
+        name
         owner
         updated_at
         updated_by

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -506,9 +506,12 @@ const gql = {
         authoring_command_dict_id
         authoring_mission_model_id
         created_at
+        description
         expansion_logic
         id
+        owner
         updated_at
+        updated_by
       }
     }
   `,
@@ -1220,6 +1223,8 @@ const gql = {
         metadata
         seq_id
         simulation_dataset_id
+        requested_by
+        updated_at
       }
     }
   `,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -93,11 +93,12 @@ const gql = {
   `,
 
   CREATE_EXPANSION_SET: `#graphql
-    mutation CreateExpansionSet($dictionaryId: Int!, $modelId: Int!, $expansionRuleIds: [Int!]!) {
+    mutation CreateExpansionSet($dictionaryId: Int!, $modelId: Int!, $expansionRuleIds: [Int!]!, $description: String) {
       createExpansionSet(
         commandDictionaryId: $dictionaryId,
         missionModelId: $modelId,
-        expansionIds: $expansionRuleIds
+        expansionIds: $expansionRuleIds,
+        description: $description
       ) {
         id
       }
@@ -1202,12 +1203,12 @@ const gql = {
         authoring_command_dict_id
         authoring_mission_model_id
         created_at
+        description
         expansion_logic
         id
-        updated_at
         owner
+        updated_at
         updated_by
-        description
       }
     }
   `,
@@ -1228,6 +1229,7 @@ const gql = {
       expansionSets: expansion_set(order_by: { id: desc }) {
         command_dict_id
         created_at
+        description
         expansion_rules {
           activity_type
           authoring_command_dict_id
@@ -1237,6 +1239,9 @@ const gql = {
         }
         id
         mission_model_id
+        owner
+        updated_at
+        updated_by
       }
     }
   `,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -108,6 +108,8 @@ const gql = {
     mutation CreateModel($model: mission_model_insert_input!) {
       createModel: insert_mission_model_one(object: $model) {
         id
+        created_at
+        owner
       }
     }
   `,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -93,11 +93,12 @@ const gql = {
   `,
 
   CREATE_EXPANSION_SET: `#graphql
-    mutation CreateExpansionSet($dictionaryId: Int!, $modelId: Int!, $expansionRuleIds: [Int!]!, $description: String) {
+    mutation CreateExpansionSet($dictionaryId: Int!, $modelId: Int!, $expansionRuleIds: [Int!]!, $name: String!, $description: String) {
       createExpansionSet(
         commandDictionaryId: $dictionaryId,
         missionModelId: $modelId,
         expansionIds: $expansionRuleIds,
+        name: $name
         description: $description
       ) {
         id
@@ -1246,6 +1247,7 @@ const gql = {
         }
         id
         mission_model_id
+        name
         owner
         updated_at
         updated_by

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1227,7 +1227,6 @@ const gql = {
         metadata
         seq_id
         simulation_dataset_id
-        updated_at
       }
     }
   `,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -463,6 +463,7 @@ const gql = {
         name
         owner
         plan_id
+        updated_at
         updated_by
       }
     }
@@ -1163,6 +1164,7 @@ const gql = {
         name
         owner
         plan_id
+        updated_at
         updated_by
       }
     }
@@ -1179,6 +1181,7 @@ const gql = {
         name
         owner
         plan_id
+        updated_at
         updated_by
       }
     }

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -118,13 +118,17 @@ const gql = {
   CREATE_PLAN: `#graphql
     mutation CreatePlan($plan: plan_insert_input!) {
       createPlan: insert_plan_one(object: $plan) {
+        created_at
         collaborators {
           collaborator
         }
+        duration
         id
         owner
         revision
         start_time
+        updated_at
+        updated_by
       }
     }
   `,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -513,6 +513,7 @@ const gql = {
         description
         expansion_logic
         id
+        name
         owner
         updated_at
         updated_by

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1470,6 +1470,8 @@ const gql = {
         id
         plan_revision
         reason
+        requested_at
+        requested_by
         simulation_end_time
         simulation_revision
         simulation_start_time
@@ -1483,6 +1485,8 @@ const gql = {
       simulation(where: { plan_id: { _eq: $planId } }, order_by: { id: desc }) {
         simulation_datasets(order_by: { id: desc }) {
           id
+          requested_at
+          requested_by
           simulation_end_time
           simulation_start_time
         }

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -93,12 +93,11 @@ const gql = {
   `,
 
   CREATE_EXPANSION_SET: `#graphql
-    mutation CreateExpansionSet($dictionaryId: Int!, $modelId: Int!, $expansionRuleIds: [Int!]!, $name: String!, $description: String) {
+    mutation CreateExpansionSet($dictionaryId: Int!, $modelId: Int!, $expansionRuleIds: [Int!]!, $description: String) {
       createExpansionSet(
         commandDictionaryId: $dictionaryId,
         missionModelId: $modelId,
         expansionIds: $expansionRuleIds,
-        name: $name
         description: $description
       ) {
         id

--- a/src/utilities/time.test.ts
+++ b/src/utilities/time.test.ts
@@ -9,6 +9,7 @@ import {
   getDoy,
   getDoyTime,
   getDoyTimeComponents,
+  getShortISOForDate,
   getTimeAgo,
   getUnixEpochTime,
   parseDoyOrYmdTime,
@@ -145,5 +146,5 @@ test('getTimeAgo', () => {
 });
 
 test('getShortISOForDate', () => {
-  expect(getTimeAgo(new Date('2023-05-23T00:00:00.000Z'))).toEqual('2023-05-23T00:00');
+  expect(getShortISOForDate(new Date('2023-05-23T00:00:00.000Z'))).toEqual('2023-05-23T00:00:00');
 });

--- a/src/utilities/time.test.ts
+++ b/src/utilities/time.test.ts
@@ -9,9 +9,9 @@ import {
   getDoy,
   getDoyTime,
   getDoyTimeComponents,
+  getTimeAgo,
   getUnixEpochTime,
   parseDoyOrYmdTime,
-  timeAgo,
 } from '../../src/utilities/time';
 
 test('convertDurationStringToUs', () => {
@@ -129,17 +129,21 @@ test('parseDoyOrYmdTime', () => {
   expect(parseDoyOrYmdTime('2022-20-2T00:00:00')).toEqual(null);
 });
 
-test('timeAgo', () => {
+test('getTimeAgo', () => {
   const time = new Date('2023-05-23T00:00:00.000Z');
-  expect(timeAgo(new Date())).toEqual('Now');
-  expect(timeAgo(new Date(time.getTime() - 100), time)).toEqual('Now');
-  expect(timeAgo(new Date(time.getTime() - 1000), time)).toEqual('1s ago');
-  expect(timeAgo(new Date(time.getTime() - 1000 * 60), time)).toEqual('1m ago');
-  expect(timeAgo(new Date(time.getTime() - 1000 * 60 * 60), time)).toEqual('1h ago');
-  expect(timeAgo(new Date(time.getTime() - 1000 * 60 * 60 * 23), time)).toEqual('23h ago');
-  expect(timeAgo(new Date(time.getTime() - 1000 * 60 * 60 * 24), time)).toEqual('2023-05-22');
-  expect(timeAgo(new Date(time.getTime() - 1000 * 60 * 60 * 24), time, 1000 * 60 * 60 * 24)).toEqual('1d ago');
-  expect(timeAgo(new Date(time.getTime() - 1000 * 60 * 60 * 24 * 366), time, 1000 * 60 * 60 * 24 * 366)).toEqual(
+  expect(getTimeAgo(new Date())).toEqual('Now');
+  expect(getTimeAgo(new Date(time.getTime() - 100), time)).toEqual('Now');
+  expect(getTimeAgo(new Date(time.getTime() - 1000), time)).toEqual('1s ago');
+  expect(getTimeAgo(new Date(time.getTime() - 1000 * 60), time)).toEqual('1m ago');
+  expect(getTimeAgo(new Date(time.getTime() - 1000 * 60 * 60), time)).toEqual('1h ago');
+  expect(getTimeAgo(new Date(time.getTime() - 1000 * 60 * 60 * 23), time)).toEqual('23h ago');
+  expect(getTimeAgo(new Date(time.getTime() - 1000 * 60 * 60 * 24), time)).toEqual('2023-05-22');
+  expect(getTimeAgo(new Date(time.getTime() - 1000 * 60 * 60 * 24), time, 1000 * 60 * 60 * 24)).toEqual('1d ago');
+  expect(getTimeAgo(new Date(time.getTime() - 1000 * 60 * 60 * 24 * 366), time, 1000 * 60 * 60 * 24 * 366)).toEqual(
     '1y ago',
   );
+});
+
+test('getShortISOForDate', () => {
+  expect(getTimeAgo(new Date('2023-05-23T00:00:00.000Z'))).toEqual('2023-05-23T00:00');
 });

--- a/src/utilities/time.test.ts
+++ b/src/utilities/time.test.ts
@@ -11,6 +11,7 @@ import {
   getDoyTimeComponents,
   getUnixEpochTime,
   parseDoyOrYmdTime,
+  timeAgo,
 } from '../../src/utilities/time';
 
 test('convertDurationStringToUs', () => {
@@ -126,4 +127,19 @@ test('parseDoyOrYmdTime', () => {
 
   expect(parseDoyOrYmdTime('2019-365T08:80:00.1234')).toEqual(null);
   expect(parseDoyOrYmdTime('2022-20-2T00:00:00')).toEqual(null);
+});
+
+test('timeAgo', () => {
+  const time = new Date('2023-05-23T00:00:00.000Z');
+  expect(timeAgo(new Date())).toEqual('Now');
+  expect(timeAgo(new Date(time.getTime() - 100), time)).toEqual('Now');
+  expect(timeAgo(new Date(time.getTime() - 1000), time)).toEqual('1s ago');
+  expect(timeAgo(new Date(time.getTime() - 1000 * 60), time)).toEqual('1m ago');
+  expect(timeAgo(new Date(time.getTime() - 1000 * 60 * 60), time)).toEqual('1h ago');
+  expect(timeAgo(new Date(time.getTime() - 1000 * 60 * 60 * 23), time)).toEqual('23h ago');
+  expect(timeAgo(new Date(time.getTime() - 1000 * 60 * 60 * 24), time)).toEqual('2023-05-22');
+  expect(timeAgo(new Date(time.getTime() - 1000 * 60 * 60 * 24), time, 1000 * 60 * 60 * 24)).toEqual('1d ago');
+  expect(timeAgo(new Date(time.getTime() - 1000 * 60 * 60 * 24 * 366), time, 1000 * 60 * 60 * 24 * 366)).toEqual(
+    '1y ago',
+  );
 });

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -495,13 +495,19 @@ export function parseDoyOrYmdTime(dateString: string, numDecimals = 6): null | P
 }
 
 /**
- * Returns a string indicating how long ago a date was compared to now.
+ * Returns a string indicating how long ago a date was compared to the given date.
  * Optionally pass in formatAsDateAfterMS to override the default 1 day cut off in MS
  * after which the date will be formatted in a more conventional form.
  * @example timeAgo(new Date()) -> 0s
+ * @example timeAgo(new Date(new Date().getTime() - 1000), new Date(new Date().getTime())) -> 0s
  */
-export function timeAgo(date: Date, formatAsDateAfterMS: number = 1000 * 60 * 60 * 23) {
-  const diff = new Date().getTime() - date.getTime();
+export function timeAgo(
+  date: Date,
+  comparisonDate: Date = new Date(),
+  formatAsDateAfterMS: number = 1000 * 60 * 60 * 23,
+) {
+  const comparisonDateTime = comparisonDate.getTime();
+  const diff = comparisonDateTime - date.getTime();
   if (diff < 1000) {
     return 'Now';
   }
@@ -509,5 +515,5 @@ export function timeAgo(date: Date, formatAsDateAfterMS: number = 1000 * 60 * 60
   if (diff > formatAsDateAfterMS) {
     return date.toISOString().slice(0, 10);
   }
-  return `${convertUsToDurationString((new Date().getTime() - date.getTime()) * 1000).split(' ')[0]} ago`;
+  return `${convertUsToDurationString((comparisonDateTime - date.getTime()) * 1000).split(' ')[0]} ago`;
 }

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -493,3 +493,21 @@ export function parseDoyOrYmdTime(dateString: string, numDecimals = 6): null | P
 
   return null;
 }
+
+/**
+ * Returns a string indicating how long ago a date was compared to now.
+ * Optionally pass in formatAsDateAfterMS to override the default 1 day cut off in MS
+ * after which the date will be formatted in a more conventional form.
+ * @example timeAgo(new Date()) -> 0s
+ */
+export function timeAgo(date: Date, formatAsDateAfterMS: number = 1000 * 60 * 60 * 23) {
+  const diff = new Date().getTime() - date.getTime();
+  if (diff < 1000) {
+    return 'Now';
+  }
+  // Format as mm-dd-YYYY if over limit
+  if (diff > formatAsDateAfterMS) {
+    return date.toISOString().slice(0, 10);
+  }
+  return `${convertUsToDurationString((new Date().getTime() - date.getTime()) * 1000).split(' ')[0]} ago`;
+}

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -519,7 +519,7 @@ export function getTimeAgo(
 }
 
 /**
- * Returns a date formatted in ISO string without seconds, milliseconds, and timezone identifier
+ * Returns a date formatted in ISO string without milliseconds and timezone identifier
  * @example getShortISOForDate(new Date("2023-05-23T00:30:09.597Z")) -> '2023-05-23T00:30:09'
  */
 export function getShortISOForDate(date: Date) {

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -498,10 +498,10 @@ export function parseDoyOrYmdTime(dateString: string, numDecimals = 6): null | P
  * Returns a string indicating how long ago a date was compared to the given date.
  * Optionally pass in formatAsDateAfterMS to override the default 1 day cut off in MS
  * after which the date will be formatted in a more conventional form.
- * @example timeAgo(new Date()) -> 0s
- * @example timeAgo(new Date(new Date().getTime() - 1000), new Date(new Date().getTime())) -> 0s
+ * @example getTimeAgo(new Date()) -> 0s
+ * @example getTimeAgo(new Date(new Date().getTime() - 1000), new Date(new Date().getTime())) -> 0s
  */
-export function timeAgo(
+export function getTimeAgo(
   date: Date,
   comparisonDate: Date = new Date(),
   formatAsDateAfterMS: number = 1000 * 60 * 60 * 23,
@@ -516,4 +516,12 @@ export function timeAgo(
     return date.toISOString().slice(0, 10);
   }
   return `${convertUsToDurationString((comparisonDateTime - date.getTime()) * 1000).split(' ')[0]} ago`;
+}
+
+/**
+ * Returns a date formatted in ISO string without seconds, milliseconds, and timezone identifier
+ * @example getShortISOForDate(new Date("2023-05-23T00:30:09.597Z")) -> '2023-05-23T00:30:09'
+ */
+export function getShortISOForDate(date: Date) {
+  return date.toISOString().slice(0, 19);
 }


### PR DESCRIPTION
Adds new metadata to the UI where appropriate. Closes #574.

Blockers:
- [ ] ~~https://github.com/NASA-AMMOS/aerie/issues/977~~

Changes:
- Models:
  - Update Models table, schema, and queries
  - Add description field to Model upload form
- Expansion Rules:
  - Update Expansion Rules table, schema, and queries
  - Add description field to Expansion Rule form
  - Tweak Expansion Rules CSS Grid sizing
- Expansion Sets:
  - Update Expansion Sets table, schema, and queries
  - Add description field to Expansion Set form
  - Tweak Expansion Sets CSS Grid sizing
- Constraints:
  - Update Constraints table, schema, and queries
  - Add description field to Constraint form
  - Tweak Constraints CSS Grid sizing
- Plans:
  - Update Plans table, schema, and queries
- Simulation Dataset Display:
  - Update Simulation Dataset schema, and queries
  - Style tweaks to SimulationDataset card.
  - Show the `requested_by` user and the `requested_at` time in SimulationDataset card. Format `requested_at` date using "time ago" where dates that are less than a day old show as "1m ago", "5h ago", etc. Dates older than a day will be rendered as `mm-dd-YYYY`. 
- Sequences:
  - Update Sequences table, schema, and queries
  - Add description field to Sequence form
  - Tweak Sequences CSS Grid sizing
- Scheduling Goals and Conditions:
  - Update Scheduling Goals and Conditions tables
  - Tweak Scheduling Goals and Conditions CSS Grid sizing
- Plan Expansion
  - Figure out what to do design wise
- DataGrid
  - Update a few grid library override styles to align with Stellar


TODO:
- [x] Fix tests
- [x] Iterate on and discuss table controls rework
- [x] Make a util for formatting dates in YMD without seconds and ms