### PR TITLE
Expansion Runs UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "d3-shape": "^3.2.0",
         "d3-time": "^3.1.0",
         "graphql-ws": "^5.12.1",
+        "jszip": "^3.10.1",
         "lodash-es": "^4.17.21",
         "modern-css-reset": "^1.4.0",
         "monaco-editor": "^0.37.1",
@@ -2062,6 +2063,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "node_modules/cosmiconfig": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
@@ -3677,6 +3683,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4224,6 +4235,17 @@
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -4258,6 +4280,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lines-and-columns": {
@@ -4771,6 +4801,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5079,6 +5114,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -5262,6 +5302,25 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -5451,6 +5510,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5529,6 +5593,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
       "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5714,6 +5783,14 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-width": {
@@ -6348,8 +6425,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
@@ -8127,6 +8203,11 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
     },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "cosmiconfig": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
@@ -9324,6 +9405,11 @@
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -9721,6 +9807,17 @@
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
+    "jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -9746,6 +9843,14 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "requires": {
+        "immediate": "~3.0.5"
       }
     },
     "lines-and-columns": {
@@ -10119,6 +10224,11 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10331,6 +10441,11 @@
         }
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -10466,6 +10581,27 @@
         }
       }
     },
+    "readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+        }
+      }
+    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -10593,6 +10729,11 @@
         "mri": "^1.1.0"
       }
     },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -10655,6 +10796,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
       "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -10805,6 +10951,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "string-width": {
       "version": "4.2.3",
@@ -11248,8 +11402,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "d3-shape": "^3.2.0",
     "d3-time": "^3.1.0",
     "graphql-ws": "^5.12.1",
+    "jszip": "^3.10.1",
     "lodash-es": "^4.17.21",
     "modern-css-reset": "^1.4.0",
     "monaco-editor": "^0.37.1",

--- a/src/components/expansion/ExpandedSequencesDownloadButton.svelte
+++ b/src/components/expansion/ExpandedSequencesDownloadButton.svelte
@@ -24,4 +24,4 @@
   }
 </script>
 
-<button class="st-button secondary ellipsis" on:click={downloadAllSeqJson}> Download All </button>
+<button class="st-button secondary ellipsis" on:click={downloadAllSeqJson}>Download All</button>

--- a/src/components/expansion/ExpandedSequencesDownloadButton.svelte
+++ b/src/components/expansion/ExpandedSequencesDownloadButton.svelte
@@ -1,0 +1,27 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import JSZip from 'jszip';
+  import type { ExpandedSequence } from '../../types/expansion';
+
+  export let expandedSequences: ExpandedSequence[] = [];
+  export let filename: string = 'expanded_sequences';
+
+  async function downloadAllSeqJson() {
+    const zip = new JSZip();
+
+    expandedSequences.forEach(sequence => {
+      const seqJson = JSON.stringify(sequence.expanded_sequence, null, 2);
+      zip.file(`${sequence.seq_id}.json`, seqJson);
+    });
+
+    const zippedSeqJson = await zip.generateAsync({ type: 'blob' });
+
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(zippedSeqJson);
+    a.download = filename;
+    a.click();
+  }
+</script>
+
+<button class="st-button secondary ellipsis" on:click={downloadAllSeqJson}> Download All </button>

--- a/src/components/expansion/ExpansionRuns.svelte
+++ b/src/components/expansion/ExpansionRuns.svelte
@@ -40,16 +40,6 @@
 
   const sequenceColumnDefs: DataGridColumnDef[] = [
     {
-      field: 'id',
-      filter: 'number',
-      headerName: 'ID',
-      resizable: true,
-      sortable: true,
-      suppressAutoSize: true,
-      suppressSizeToFit: true,
-      width: 60,
-    },
-    {
       field: 'seq_id',
       filter: 'text',
       headerName: 'Sequence ID',

--- a/src/components/expansion/ExpansionRuns.svelte
+++ b/src/components/expansion/ExpansionRuns.svelte
@@ -24,8 +24,46 @@
       suppressSizeToFit: true,
       width: 60,
     },
+    {
+      field: 'simulation_dataset.simulation.plan.name',
+      filter: 'text',
+      headerName: 'Plan Name',
+      resizable: true,
+      sortable: true,
+    },
     { field: 'expansion_set.name', filter: 'text', headerName: 'Expansion Set', resizable: true, sortable: true },
     { field: 'created_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
+  ];
+
+  const sequenceColumnDefs: DataGridColumnDef[] = [
+    {
+      field: 'id',
+      filter: 'number',
+      headerName: 'ID',
+      resizable: true,
+      sortable: true,
+      suppressAutoSize: true,
+      suppressSizeToFit: true,
+      width: 60,
+    },
+    {
+      field: 'seq_id',
+      filter: 'text',
+      headerName: 'Sequence ID',
+      resizable: true,
+      sortable: true,
+    },
+    // {
+    //   cellRenderer: (params: ICellRendererParams<ExpandedSequence>) => {
+    //   },
+    //   field: 'actions',
+    //   headerName: '',
+    //   resizable: false,
+    //   sortable: false,
+    //   suppressAutoSize: true,
+    //   suppressSizeToFit: true,
+    //   width: 25,
+    // }
   ];
 
   let selectedSequence: ExpandedSequence | null = null;
@@ -87,26 +125,9 @@
       <svelte:fragment slot="body">
         {#if selectedExpansionRun}
           <DataGrid
-            columnDefs={[
-              {
-                field: 'id',
-                filter: 'number',
-                headerName: 'ID',
-                resizable: true,
-                sortable: true,
-                suppressAutoSize: true,
-                suppressSizeToFit: true,
-                width: 60,
-              },
-              {
-                field: 'seq_id',
-                filter: 'text',
-                headerName: 'Sequence ID',
-                resizable: true,
-                sortable: true,
-              },
-            ]}
-            rowData={selectedExpansionRun?.expanded_sequences}
+            columnDefs={sequenceColumnDefs}
+            rowData={console.log('EXPANDED_SEQUENCES?', selectedExpansionRun?.expanded_sequences) ||
+              selectedExpansionRun?.expanded_sequences}
             rowSelection="single"
             selectedRowIds={selectedSequenceIds}
             on:rowSelected={toggleSequence}

--- a/src/components/expansion/ExpansionRuns.svelte
+++ b/src/components/expansion/ExpansionRuns.svelte
@@ -1,6 +1,8 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { base } from '$app/paths';
+  import type { ICellRendererParams } from 'ag-grid-community';
   import { expansionRunsColumns } from '../../stores/expansion';
   import type { DataGridColumnDef, DataGridRowSelection } from '../../types/data-grid';
   import type { ExpandedSequence, ExpansionRun } from '../../types/expansion';
@@ -68,9 +70,15 @@
 
         const cellContentContainer = document.createElement('div');
         Object.keys(simulatedActivitiesByType).forEach((activityType, i) => {
+          const simulationDataset = selectedExpansionRun.simulation_dataset;
+          const planId = simulationDataset.simulation.plan.id;
+          const datasetId = simulationDataset.dataset_id;
+
           const activitySpan = document.createElement('span');
           const activityIds = simulatedActivitiesByType[activityType].map(activityId => {
-            return `<a target="_blank" href="/plans/${selectedExpansionRun.simulation_dataset.simulation.plan.id}?simulationDatasetId=${selectedExpansionRun.simulation_dataset.dataset_id}&activityId=${activityId}">${activityId}</a>`;
+            return `<a
+              target="_blank"
+              href="${base}/plans/${planId}?simulationDatasetId=${datasetId}&activityId=${activityId}">${activityId}</a>`;
           });
           const spacer = i ? ', ' : '';
           activitySpan.innerHTML = spacer + `${activityType} (${activityIds.join(', ')})`;

--- a/src/components/expansion/ExpansionRuns.svelte
+++ b/src/components/expansion/ExpansionRuns.svelte
@@ -10,6 +10,7 @@
   import DataGrid from '../ui/DataGrid/DataGrid.svelte';
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
+  import ExpandedSequencesDownloadButton from './ExpandedSequencesDownloadButton.svelte';
 
   export let expansionRuns: ExpansionRun[] = [];
 
@@ -120,14 +121,21 @@
     <Panel>
       <svelte:fragment slot="header">
         <SectionTitle>Expanded Sequences</SectionTitle>
+        {#if selectedExpansionRun}
+          <div class="right">
+            <ExpandedSequencesDownloadButton
+              expandedSequences={selectedExpansionRun?.expanded_sequences}
+              filename={`expanded_sequences_${selectedExpansionRun?.created_at.split('.')[0]}`}
+            />
+          </div>
+        {/if}
       </svelte:fragment>
 
       <svelte:fragment slot="body">
         {#if selectedExpansionRun}
           <DataGrid
             columnDefs={sequenceColumnDefs}
-            rowData={console.log('EXPANDED_SEQUENCES?', selectedExpansionRun?.expanded_sequences) ||
-              selectedExpansionRun?.expanded_sequences}
+            rowData={selectedExpansionRun?.expanded_sequences}
             rowSelection="single"
             selectedRowIds={selectedSequenceIds}
             on:rowSelected={toggleSequence}

--- a/src/components/expansion/ExpansionRuns.svelte
+++ b/src/components/expansion/ExpansionRuns.svelte
@@ -123,7 +123,7 @@
     sequenceDefinition={selectedSequence?.edsl_string ?? 'No Sequence Selected'}
     sequenceCommandDictionaryId={selectedExpansionRun?.expansion_set?.command_dict_id}
     sequenceName={selectedSequence?.seq_id}
-    sequenceSeqJson={selectedSequence ? JSON.stringify(selectedSequence.expanded_sequence) : null}
+    sequenceSeqJson={selectedSequence ? JSON.stringify(selectedSequence.expanded_sequence, null, 2) : null}
     readOnly={true}
     title="Sequence - Definition Editor (Read-only)"
   />

--- a/src/components/expansion/ExpansionRuns.svelte
+++ b/src/components/expansion/ExpansionRuns.svelte
@@ -70,7 +70,7 @@
         Object.keys(simulatedActivitiesByType).forEach((activityType, i) => {
           const activitySpan = document.createElement('span');
           const activityIds = simulatedActivitiesByType[activityType].map(activityId => {
-            return `<a target="_blank" href="/plans/${selectedExpansionRun.simulation_dataset.simulation.plan.id}?activityId=${activityId}">${activityId}</a>`;
+            return `<a target="_blank" href="/plans/${selectedExpansionRun.simulation_dataset.simulation.plan.id}?simulationDatasetId=${selectedExpansionRun.simulation_dataset.dataset_id}&activityId=${activityId}">${activityId}</a>`;
           });
           const spacer = i ? ', ' : '';
           activitySpan.innerHTML = spacer + `${activityType} (${activityIds.join(', ')})`;

--- a/src/components/expansion/ExpansionRuns.svelte
+++ b/src/components/expansion/ExpansionRuns.svelte
@@ -49,7 +49,7 @@
     {
       autoHeight: true,
       cellRenderer: (params: ICellRendererParams<ExpandedSequence>) => {
-        const simulatedActivitiesByType = {};
+        const simulatedActivitiesByType: { [key: string]: number[] } = {};
         const activityInstances: ActivityInstanceJoin[] = params.value;
         activityInstances.reduce((acc, next) => {
           if (!acc[next.simulated_activity.activity_type_name]) {
@@ -62,9 +62,9 @@
 
         const cellContentContainer = document.createElement('div');
         Object.keys(simulatedActivitiesByType).forEach((activityType, i) => {
-          const simulationDataset = selectedExpansionRun.simulation_dataset;
-          const planId = simulationDataset.simulation.plan.id;
-          const datasetId = simulationDataset.dataset_id;
+          const simulationDataset = selectedExpansionRun?.simulation_dataset;
+          const planId = simulationDataset?.simulation.plan.id;
+          const datasetId = simulationDataset?.dataset_id;
 
           const activitySpan = document.createElement('span');
           const activityIds = simulatedActivitiesByType[activityType].map(activityId => {
@@ -174,7 +174,7 @@
     sequenceDefinition={selectedSequence?.edsl_string ?? 'No Sequence Selected'}
     sequenceCommandDictionaryId={selectedExpansionRun?.expansion_set?.command_dict_id}
     sequenceName={selectedSequence?.seq_id}
-    sequenceSeqJson={selectedSequence ? JSON.stringify(selectedSequence.expanded_sequence, null, 2) : null}
+    sequenceSeqJson={selectedSequence ? JSON.stringify(selectedSequence.expanded_sequence, null, 2) : undefined}
     readOnly={true}
     title="Sequence - Definition Editor (Read-only)"
   />

--- a/src/components/expansion/ExpansionRuns.svelte
+++ b/src/components/expansion/ExpansionRuns.svelte
@@ -26,9 +26,9 @@
     { field: 'created_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
   ];
 
-  let selectedExpansionRun: ExpansionRun | null = null;
   let selectedSequence: ExpandedSequence | null = null;
   let selectedSequenceIds: number[] = [];
+  let selectedExpansionRun: ExpansionRun | null = null;
 
   $: selectedSequenceIds = selectedSequence ? [selectedSequence.id] : [];
 
@@ -37,8 +37,6 @@
       detail: { data: clickedRun, isSelected },
     } = event;
 
-    console.trace('TOGGLE RUN');
-
     selectedSequence = null;
 
     if (isSelected) {
@@ -46,8 +44,6 @@
     } else if (selectedExpansionRun?.id === clickedRun.id) {
       selectedExpansionRun = null;
     }
-
-    console.log('SELECTED EXPANSION RUN', selectedExpansionRun);
   }
 
   function toggleSequence(event: CustomEvent<DataGridRowSelection<ExpandedSequence>>) {
@@ -60,8 +56,6 @@
     } else if (selectedSequence?.id === clickedSequence.id) {
       selectedSequence = null;
     }
-
-    console.trace('SELECTED SEQUENCE');
   }
 </script>
 

--- a/src/components/expansion/ExpansionRuns.svelte
+++ b/src/components/expansion/ExpansionRuns.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import { expansionRuns, expansionSetsColumns } from '../../stores/expansion';
+  import { expansionRunsColumns } from '../../stores/expansion';
   import type { DataGridColumnDef, DataGridRowSelection } from '../../types/data-grid';
   import type { ExpandedSequence, ExpansionRun } from '../../types/expansion';
   import SequenceEditor from '../sequencing/SequenceEditor.svelte';
@@ -10,6 +10,8 @@
   import DataGrid from '../ui/DataGrid/DataGrid.svelte';
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
+
+  export let expansionRuns: ExpansionRun[] = [];
 
   const columnDefs: DataGridColumnDef[] = [
     {
@@ -59,7 +61,7 @@
   }
 </script>
 
-<CssGrid bind:columns={$expansionSetsColumns}>
+<CssGrid bind:columns={$expansionRunsColumns}>
   <CssGrid rows="1fr 3px 1fr">
     <Panel>
       <svelte:fragment slot="header">
@@ -67,8 +69,8 @@
       </svelte:fragment>
 
       <svelte:fragment slot="body">
-        {#if $expansionRuns.length}
-          <DataGrid {columnDefs} rowSelection="single" rowData={$expansionRuns} on:rowSelected={toggleRun} />
+        {#if expansionRuns.length}
+          <DataGrid {columnDefs} rowSelection="single" rowData={expansionRuns} on:rowSelected={toggleRun} />
         {:else}
           No Expansion Runs Found
         {/if}

--- a/src/components/expansion/ExpansionRuns.svelte
+++ b/src/components/expansion/ExpansionRuns.svelte
@@ -1,0 +1,192 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import type { ICellRendererParams } from 'ag-grid-community';
+  import { expansionSets, expansionSetsColumns } from '../../stores/expansion';
+  import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
+  import type { ExpansionRule, ExpansionSet } from '../../types/expansion';
+  import effects from '../../utilities/effects';
+  import CssGrid from '../ui/CssGrid.svelte';
+  import CssGridGutter from '../ui/CssGridGutter.svelte';
+  import DataGrid from '../ui/DataGrid/DataGrid.svelte';
+  import DataGridActions from '../ui/DataGrid/DataGridActions.svelte';
+  import SingleActionDataGrid from '../ui/DataGrid/SingleActionDataGrid.svelte';
+  import Panel from '../ui/Panel.svelte';
+  import SectionTitle from '../ui/SectionTitle.svelte';
+  import ExpansionLogicEditor from './ExpansionLogicEditor.svelte';
+
+  type CellRendererParams = {
+    deleteSet: (sequence: ExpansionSet) => void;
+  };
+  type ExpansionSetCellRendererParams = ICellRendererParams<ExpansionSet> & CellRendererParams;
+
+  const columnDefs: DataGridColumnDef[] = [
+    {
+      field: 'id',
+      filter: 'number',
+      headerName: 'ID',
+      resizable: true,
+      sortable: true,
+      suppressAutoSize: true,
+      suppressSizeToFit: true,
+      width: 60,
+    },
+    {
+      field: 'command_dict_id',
+      filter: 'number',
+      headerName: 'Command Dictionary ID',
+      resizable: true,
+      sortable: true,
+    },
+    { field: 'mission_model_id', filter: 'number', headerName: 'Model ID', resizable: true, sortable: true },
+    { field: 'created_at', filter: 'text', headerName: 'Created At', resizable: true, sortable: true },
+    {
+      cellClass: 'action-cell-container',
+      cellRenderer: (params: ExpansionSetCellRendererParams) => {
+        const actionsDiv = document.createElement('div');
+        actionsDiv.className = 'actions-cell';
+        new DataGridActions({
+          props: {
+            deleteCallback: params.deleteSet,
+            deleteTooltip: {
+              content: 'Delete Expansion Set',
+              placement: 'bottom',
+            },
+            rowData: params.data,
+          },
+          target: actionsDiv,
+        });
+
+        return actionsDiv;
+      },
+      cellRendererParams: {
+        deleteSet,
+      } as CellRendererParams,
+      field: 'actions',
+      headerName: '',
+      resizable: false,
+      sortable: false,
+      suppressAutoSize: true,
+      suppressSizeToFit: true,
+      width: 25,
+    },
+  ];
+
+  let selectedExpansionRule: ExpansionRule | null = null;
+  let selectedExpansionRuleIds: number[] = [];
+  let selectedExpansionSet: ExpansionSet | null = null;
+
+  $: selectedExpansionRuleIds = selectedExpansionRule ? [selectedExpansionRule.id] : [];
+
+  async function deleteSet({ id }: Pick<ExpansionSet, 'id'>) {
+    const success = await effects.deleteExpansionSet(id);
+
+    if (success) {
+      expansionSets.filterValueById(id);
+
+      if (id === selectedExpansionSet?.id) {
+        selectedExpansionRule = null;
+        selectedExpansionSet = null;
+      }
+    }
+  }
+
+  function deleteSetContext(event: CustomEvent<RowId[]>) {
+    deleteSet({ id: event.detail[0] as number });
+  }
+
+  function toggleRule(event: CustomEvent<DataGridRowSelection<ExpansionRule>>) {
+    const {
+      detail: { data: clickedRule, isSelected },
+    } = event;
+
+    if (isSelected) {
+      selectedExpansionRule = clickedRule;
+    } else if (selectedExpansionRule?.id === clickedRule.id) {
+      selectedExpansionRule = null;
+    }
+  }
+
+  function toggleSet(event: CustomEvent<DataGridRowSelection<ExpansionSet>>) {
+    const {
+      detail: { data: clickedSet, isSelected },
+    } = event;
+
+    selectedExpansionRule = null;
+
+    if (isSelected) {
+      selectedExpansionSet = clickedSet;
+    } else if (selectedExpansionSet?.id === clickedSet.id) {
+      selectedExpansionSet = null;
+    }
+  }
+</script>
+
+<CssGrid bind:columns={$expansionSetsColumns}>
+  <CssGrid rows="1fr 3px 1fr">
+    <Panel>
+      <svelte:fragment slot="header">
+        <SectionTitle>Expansion Runs</SectionTitle>
+      </svelte:fragment>
+
+      <svelte:fragment slot="body">
+        {#if $expansionSets.length}
+          <SingleActionDataGrid
+            {columnDefs}
+            itemDisplayText="Expansion Set"
+            items={$expansionSets}
+            on:deleteItem={deleteSetContext}
+            on:rowSelected={toggleSet}
+          />
+        {:else}
+          No Expansion Sets Found
+        {/if}
+      </svelte:fragment>
+    </Panel>
+
+    <CssGridGutter track={1} type="row" />
+
+    <Panel>
+      <svelte:fragment slot="header">
+        <SectionTitle>Expansion Rules</SectionTitle>
+      </svelte:fragment>
+
+      <svelte:fragment slot="body">
+        {#if selectedExpansionSet}
+          <DataGrid
+            columnDefs={[
+              {
+                field: 'id',
+                filter: 'number',
+                headerName: 'ID',
+                resizable: true,
+                sortable: true,
+                suppressAutoSize: true,
+                suppressSizeToFit: true,
+                width: 60,
+              },
+              { field: 'activity_type', filter: 'text', headerName: 'Activity Type', sortable: true },
+            ]}
+            rowData={selectedExpansionSet?.expansion_rules}
+            rowSelection="single"
+            selectedRowIds={selectedExpansionRuleIds}
+            on:rowSelected={toggleRule}
+          />
+        {:else}
+          No Expansion Set Selected
+        {/if}
+      </svelte:fragment>
+    </Panel>
+  </CssGrid>
+
+  <CssGridGutter track={1} type="column" />
+
+  <ExpansionLogicEditor
+    readOnly={true}
+    ruleActivityType={selectedExpansionRule?.activity_type}
+    ruleDictionaryId={selectedExpansionRule?.authoring_command_dict_id}
+    ruleLogic={selectedExpansionRule?.expansion_logic ?? 'No Expansion Rule Selected'}
+    ruleModelId={selectedExpansionRule?.authoring_mission_model_id}
+    title="Expansion Rule - Logic Editor (Read-only)"
+  />
+</CssGrid>

--- a/src/components/expansion/ExpansionRuns.svelte
+++ b/src/components/expansion/ExpansionRuns.svelte
@@ -5,7 +5,7 @@
   import type { ICellRendererParams } from 'ag-grid-community';
   import { expansionRunsColumns } from '../../stores/expansion';
   import type { DataGridColumnDef, DataGridRowSelection } from '../../types/data-grid';
-  import type { ExpandedSequence, ExpansionRun } from '../../types/expansion';
+  import type { ActivityInstanceJoin, ExpandedSequence, ExpansionRun } from '../../types/expansion';
   import SequenceEditor from '../sequencing/SequenceEditor.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
@@ -47,9 +47,11 @@
       sortable: true,
     },
     {
+      autoHeight: true,
       cellRenderer: (params: ICellRendererParams<ExpandedSequence>) => {
         const simulatedActivitiesByType = {};
-        params.value.reduce((acc, next) => {
+        const activityInstances: ActivityInstanceJoin[] = params.value;
+        activityInstances.reduce((acc, next) => {
           if (!acc[next.simulated_activity.activity_type_name]) {
             acc[next.simulated_activity.activity_type_name] = [next.simulated_activity.id];
           } else {
@@ -81,6 +83,7 @@
       headerName: 'Activity Instance(s)',
       resizable: true,
       sortable: false,
+      wrapText: true,
     },
   ];
 

--- a/src/components/expansion/ExpansionRuns.svelte
+++ b/src/components/expansion/ExpansionRuns.svelte
@@ -54,17 +54,36 @@
       resizable: true,
       sortable: true,
     },
-    // {
-    //   cellRenderer: (params: ICellRendererParams<ExpandedSequence>) => {
-    //   },
-    //   field: 'actions',
-    //   headerName: '',
-    //   resizable: false,
-    //   sortable: false,
-    //   suppressAutoSize: true,
-    //   suppressSizeToFit: true,
-    //   width: 25,
-    // }
+    {
+      cellRenderer: (params: ICellRendererParams<ExpandedSequence>) => {
+        const simulatedActivitiesByType = {};
+        params.value.reduce((acc, next) => {
+          if (!acc[next.simulated_activity.activity_type_name]) {
+            acc[next.simulated_activity.activity_type_name] = [next.simulated_activity.id];
+          } else {
+            acc[next.simulated_activity.activity_type_name].push(next.simulated_activity.id);
+          }
+          return acc;
+        }, simulatedActivitiesByType);
+
+        const cellContentContainer = document.createElement('div');
+        Object.keys(simulatedActivitiesByType).forEach((activityType, i) => {
+          const activitySpan = document.createElement('span');
+          const activityIds = simulatedActivitiesByType[activityType].map(activityId => {
+            return `<a target="_blank" href="/plans/${selectedExpansionRun.simulation_dataset.simulation.plan.id}?activityId=${activityId}">${activityId}</a>`;
+          });
+          const spacer = i ? ', ' : '';
+          activitySpan.innerHTML = spacer + `${activityType} (${activityIds.join(', ')})`;
+          cellContentContainer.appendChild(activitySpan);
+        });
+
+        return cellContentContainer;
+      },
+      field: 'sequence.activity_instance_joins',
+      headerName: 'Activity Instance(s)',
+      resizable: true,
+      sortable: false,
+    },
   ];
 
   let selectedSequence: ExpandedSequence | null = null;

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -12,6 +12,7 @@
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
 
+  export let disableSeqJSONGeneration: boolean = false;
   export let readOnly: boolean = false;
   export let sequenceCommandDictionaryId: number | null = null;
   export let sequenceDefinition: string = '';
@@ -94,8 +95,10 @@
       <SectionTitle>Seq JSON (Read-only)</SectionTitle>
 
       <div class="right">
-        <button class="st-button secondary ellipsis" on:click={() => dispatch('generate')}> Generate </button>
-        <button class="st-button secondary ellipsis" on:click={downloadSeqJson}> Download </button>
+        {#if !disableSeqJSONGeneration}
+          <button class="st-button secondary ellipsis" on:click={() => dispatch('generate')}>Generate</button>
+        {/if}
+        <button class="st-button secondary ellipsis" on:click={downloadSeqJson}>Download</button>
       </div>
     </svelte:fragment>
     <svelte:fragment slot="body">

--- a/src/routes/expansion/+layout.svelte
+++ b/src/routes/expansion/+layout.svelte
@@ -4,6 +4,7 @@
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import { page } from '$app/stores';
+  import LayersIcon from '@nasa-jpl/stellar/icons/layers.svg?component';
   import CardListIcon from 'bootstrap-icons/icons/card-list.svg?component';
   import CodeSquareIcon from 'bootstrap-icons/icons/code-square.svg?component';
   import Nav from '../../components/app/Nav.svelte';
@@ -28,7 +29,7 @@
         title="Sets"
         on:click={() => goto(`${base}/expansion/sets`)}
       >
-        <CardListIcon />
+        <LayersIcon />
       </NavButton>
       <NavButton
         selected={$page.url.pathname.includes('runs')}

--- a/src/routes/expansion/+layout.svelte
+++ b/src/routes/expansion/+layout.svelte
@@ -30,6 +30,13 @@
       >
         <CardListIcon />
       </NavButton>
+      <NavButton
+        selected={$page.url.pathname.includes('runs')}
+        title="Runs"
+        on:click={() => goto(`${base}/expansion/runs`)}
+      >
+        <CardListIcon />
+      </NavButton>
     </svelte:fragment>
   </Nav>
 

--- a/src/routes/expansion/runs/+page.svelte
+++ b/src/routes/expansion/runs/+page.svelte
@@ -2,6 +2,9 @@
 
 <script lang="ts">
   import ExpansionRuns from '../../../components/expansion/ExpansionRuns.svelte';
+  import type { PageData } from './$types';
+
+  export let data: PageData;
 </script>
 
-<ExpansionRuns />
+<ExpansionRuns expansionRuns={data.expansionRuns} />

--- a/src/routes/expansion/runs/+page.svelte
+++ b/src/routes/expansion/runs/+page.svelte
@@ -1,0 +1,7 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import ExpansionRuns from '../../../components/expansion/ExpansionRuns.svelte';
+</script>
+
+<ExpansionRuns />

--- a/src/routes/expansion/runs/+page.ts
+++ b/src/routes/expansion/runs/+page.ts
@@ -1,5 +1,6 @@
 import { base } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
+import effects from '../../../utilities/effects';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
@@ -9,5 +10,6 @@ export const load: PageLoad = async ({ parent }) => {
     throw redirect(302, `${base}/login`);
   }
 
-  return {};
+  const expansionRuns = await effects.getExpansionRuns();
+  return { expansionRuns };
 };

--- a/src/routes/expansion/runs/+page.ts
+++ b/src/routes/expansion/runs/+page.ts
@@ -1,0 +1,13 @@
+import { base } from '$app/paths';
+import { redirect } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ parent }) => {
+  const { user } = await parent();
+
+  if (!user) {
+    throw redirect(302, `${base}/login`);
+  }
+
+  return {};
+};

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { page } from '$app/stores';
   import ActivityIcon from '@nasa-jpl/stellar/icons/activity.svg?component';
   import CalendarIcon from '@nasa-jpl/stellar/icons/calendar.svg?component';
   import PlanIcon from '@nasa-jpl/stellar/icons/plan.svg?component';
@@ -55,6 +56,7 @@
     externalResources,
     resetSimulationStores,
     resources,
+    selectedSpanId,
     simulationDataset,
     simulationDatasetId,
     simulationStatus,
@@ -70,6 +72,7 @@
   } from '../../../stores/views';
   import type { ViewSaveEvent, ViewToggleEvent } from '../../../types/view';
   import effects from '../../../utilities/effects';
+  import { removeQueryParam } from '../../../utilities/generic';
   import { isSaveEvent } from '../../../utilities/keyboardEvents';
   import { closeActiveModal, showPlanLockedModal } from '../../../utilities/modal';
   import { Status } from '../../../utilities/status';
@@ -88,7 +91,21 @@
     $planEndTimeMs = getUnixEpochTime(data.initialPlan.end_time_doy);
     $planStartTimeMs = getUnixEpochTime(data.initialPlan.start_time_doy);
     $maxTimeRange = { end: $planEndTimeMs, start: $planStartTimeMs };
-    $simulationDatasetId = data.initialPlan.simulations[0]?.simulation_datasets[0]?.id ?? -1;
+
+    const querySimulationDatasetId = $page.url.searchParams.get('simulationDatasetId');
+    if (querySimulationDatasetId) {
+      $simulationDatasetId = parseInt(querySimulationDatasetId);
+      removeQueryParam('simulationDatasetId');
+    } else {
+      $simulationDatasetId = data.initialPlan.simulations[0]?.simulation_datasets[0]?.id ?? -1;
+    }
+
+    const queryActivityId = $page.url.searchParams.get('activityId');
+    if (queryActivityId) {
+      $selectedSpanId = parseInt(queryActivityId);
+      removeQueryParam('activityId');
+    }
+
     $viewTimeRange = $maxTimeRange;
     activityTypes.updateValue(() => data.initialActivityTypes);
 

--- a/src/stores/expansion.ts
+++ b/src/stores/expansion.ts
@@ -1,5 +1,5 @@
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
-import type { ExpansionRule, ExpansionSequence, ExpansionSet } from '../types/expansion';
+import type { ExpansionRule, ExpansionRun, ExpansionSequence, ExpansionSet } from '../types/expansion';
 import gql from '../utilities/gql';
 import type { Status } from '../utilities/status';
 import { simulationDatasetId } from './simulation';
@@ -12,6 +12,8 @@ export const expansionRules = gqlSubscribable<ExpansionRule[]>(gql.SUB_EXPANSION
 export const expansionSequences = gqlSubscribable<ExpansionSequence[]>(gql.SUB_EXPANSION_SEQUENCES, {}, []);
 
 export const expansionSets = gqlSubscribable<ExpansionSet[]>(gql.SUB_EXPANSION_SETS, {}, []);
+
+export const expansionRuns = gqlSubscribable<ExpansionRun[]>(gql.SUB_EXPANSION_RUNS, {}, []);
 
 /* Writeable. */
 

--- a/src/stores/expansion.ts
+++ b/src/stores/expansion.ts
@@ -1,5 +1,5 @@
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
-import type { ExpansionRule, ExpansionRun, ExpansionSequence, ExpansionSet } from '../types/expansion';
+import type { ExpansionRule, ExpansionSequence, ExpansionSet } from '../types/expansion';
 import gql from '../utilities/gql';
 import type { Status } from '../utilities/status';
 import { simulationDatasetId } from './simulation';
@@ -13,8 +13,6 @@ export const expansionSequences = gqlSubscribable<ExpansionSequence[]>(gql.SUB_E
 
 export const expansionSets = gqlSubscribable<ExpansionSet[]>(gql.SUB_EXPANSION_SETS, {}, []);
 
-export const expansionRuns = gqlSubscribable<ExpansionRun[]>(gql.SUB_EXPANSION_RUNS, {}, []);
-
 /* Writeable. */
 
 export const creatingExpansionSequence: Writable<boolean> = writable(false);
@@ -22,6 +20,8 @@ export const creatingExpansionSequence: Writable<boolean> = writable(false);
 export const expansionRulesColumns: Writable<string> = writable('1fr 3px 2fr');
 
 export const expansionSetsColumns: Writable<string> = writable('1fr 3px 2fr');
+
+export const expansionRunsColumns: Writable<string> = writable('1fr 3px 2fr');
 
 export const savingExpansionRule: Writable<boolean> = writable(false);
 

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -1,3 +1,4 @@
+import type { SeqJson } from './sequencing';
 import type { SpanId } from './simulation';
 
 export type ExpansionRule = {
@@ -41,7 +42,7 @@ export type SeqId = Pick<ExpansionSequence, 'seq_id'>;
 export type ExpandedSequence = {
   created_at: string;
   edsl_string: string;
-  expanded_sequence: string;
+  expanded_sequence: SeqJson;
   id: number;
   seq_id: string;
   sequence: {

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -44,6 +44,14 @@ export type ExpandedSequence = {
   expanded_sequence: string;
   id: number;
   seq_id: string;
+  sequence: {
+    activity_instance_joins: {
+      simulated_activity: {
+        activity_type_name: string;
+        id: number;
+      };
+    }[];
+  };
 };
 
 export type ExpansionRun = {
@@ -51,4 +59,11 @@ export type ExpansionRun = {
   expanded_sequences: ExpandedSequence[];
   expansion_set: ExpansionSet;
   id: number;
+  simulation_dataset: {
+    simulation: {
+      plan: {
+        name: string;
+      };
+    };
+  };
 };

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -60,8 +60,10 @@ export type ExpansionRun = {
   expansion_set: ExpansionSet;
   id: number;
   simulation_dataset: {
+    dataset_id: number;
     simulation: {
       plan: {
+        id: number;
         name: string;
       };
     };

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -39,6 +39,13 @@ export type ExpansionSet = {
 
 export type SeqId = Pick<ExpansionSequence, 'seq_id'>;
 
+export type ActivityInstanceJoin = {
+  simulated_activity: {
+    activity_type_name: string;
+    id: number;
+  };
+};
+
 export type ExpandedSequence = {
   created_at: string;
   edsl_string: string;
@@ -46,12 +53,7 @@ export type ExpandedSequence = {
   id: number;
   seq_id: string;
   sequence: {
-    activity_instance_joins: {
-      simulated_activity: {
-        activity_type_name: string;
-        id: number;
-      };
-    }[];
+    activity_instance_joins: ActivityInstanceJoin[];
   };
 };
 

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -37,3 +37,18 @@ export type ExpansionSet = {
 };
 
 export type SeqId = Pick<ExpansionSequence, 'seq_id'>;
+
+export type ExpandedSequence = {
+  created_at: string;
+  edsl_string: string;
+  expanded_sequence: string;
+  id: number;
+  seq_id: string;
+};
+
+export type ExpansionRun = {
+  created_at: string;
+  expanded_sequences: ExpandedSequence[];
+  expansion_set: ExpansionSet;
+  id: number;
+};

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -34,6 +34,7 @@ import type { Constraint, ConstraintInsertInput, ConstraintViolation } from '../
 import type {
   ExpansionRule,
   ExpansionRuleInsertInput,
+  ExpansionRun,
   ExpansionSequence,
   ExpansionSequenceInsertInput,
   ExpansionSequenceToActivityInsertInput,
@@ -1399,6 +1400,17 @@ const effects = {
     } catch (e) {
       catchError(e as Error);
       return null;
+    }
+  },
+
+  async getExpansionRuns(): Promise<ExpansionRun[]> {
+    try {
+      const data = await reqHasura(gql.GET_EXPANSION_RUNS);
+      const { expansionRuns } = data;
+      return expansionRuns;
+    } catch (e) {
+      catchError(e);
+      return [];
     }
   },
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -1409,7 +1409,7 @@ const effects = {
       const { expansionRuns } = data;
       return expansionRuns;
     } catch (e) {
-      catchError(e);
+      catchError(e as Error);
       return [];
     }
   },

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -516,6 +516,21 @@ const gql = {
           expanded_sequence
           id
           seq_id
+          sequence {
+            activity_instance_joins {
+              simulated_activity {
+                id
+                activity_type_name
+              }
+            }
+          }
+        }
+        simulation_dataset {
+          simulation {
+            plan {
+              name
+            }
+          }
         }
         id
       }

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1121,6 +1121,26 @@ const gql = {
     }
   `,
 
+  SUB_EXPANSION_RUNS: `#graphql
+    subscription SubExpansionRuns {
+      expansionRuns: expansion_run(order_by: { id: desc }) {
+        created_at
+        expansion_set {
+          command_dict_id
+          created_at
+          id
+          name
+        }
+        expanded_sequences {
+          edsl_string
+          expanded_sequence
+          seq_id
+        }
+        id
+      }
+    }
+  `,
+
   SUB_EXPANSION_SEQUENCES: `#graphql
     subscription SubExpansionSequences {
       sequence {

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -526,8 +526,10 @@ const gql = {
           }
         }
         simulation_dataset {
+          dataset_id
           simulation {
             plan {
+              id
               name
             }
           }

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -501,6 +501,27 @@ const gql = {
     }
   `,
 
+  GET_EXPANSION_RUNS: `#graphql
+    query GetExpansionRuns {
+      expansionRuns: expansion_run(order_by: { id: desc }) {
+        created_at
+        expansion_set {
+          command_dict_id
+          created_at
+          id
+          name
+        }
+        expanded_sequences {
+          edsl_string
+          expanded_sequence
+          id
+          seq_id
+        }
+        id
+      }
+    }
+  `,
+
   GET_EXPANSION_SEQUENCE_ID: `#graphql
     query GetExpansionSequenceId($simulation_dataset_id: Int!, $simulated_activity_id: Int!) {
       expansionSequence: sequence_to_simulated_activity_by_pk(
@@ -1117,27 +1138,6 @@ const gql = {
         expansion_logic
         id
         updated_at
-      }
-    }
-  `,
-
-  SUB_EXPANSION_RUNS: `#graphql
-    subscription SubExpansionRuns {
-      expansionRuns: expansion_run(order_by: { id: desc }) {
-        created_at
-        expansion_set {
-          command_dict_id
-          created_at
-          id
-          name
-        }
-        expanded_sequences {
-          edsl_string
-          expanded_sequence
-          id
-          seq_id
-        }
-        id
       }
     }
   `,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1134,6 +1134,7 @@ const gql = {
         expanded_sequences {
           edsl_string
           expanded_sequence
+          id
           seq_id
         }
         id


### PR DESCRIPTION
Closes #577 
~~Depends on https://github.com/NASA-AMMOS/aerie/pull/957 first being merged.~~ (Done)

This implements the Expansion Runs UI as a new page under the "Expansions" heading. This presents a view that displays a history of all expansions run, and for each expansion provides details of the associated sequences and activity types.

A couple details to call out in particular:
- This adds jsZip as a dependency to allow for downloading all seqJSON for an entire expansion run in a zip file.
- This provides the ability to deep link directly to a specific plan + simulation dataset + selected activity. For now  this is intended only to be used for the expansion runs UI, so after the deep link is parsed, we remove the simulation dataset and selected activity from the URL params. In the future we will follow up and more thoroughly vet how we would like to use deep links throughout the app.

![2023-05-30 17 15 03](https://github.com/NASA-AMMOS/aerie-ui/assets/888818/3d55e7f2-0032-4542-8232-6f5aed544f43)
