### PR TITLE
Table and timeline activity double click

### DIFF
--- a/src/components/activity/ActivityDirectivesTable.svelte
+++ b/src/components/activity/ActivityDirectivesTable.svelte
@@ -92,4 +92,5 @@
   on:bulkDeleteItems={deleteActivityDirectives}
   on:columnStateChange
   on:selectionChanged
+  on:rowDoubleClicked
 />

--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -12,7 +12,7 @@
   } from '../../stores/activities';
   import { plan, planId } from '../../stores/plan';
   import { spanUtilityMaps, spansMap } from '../../stores/simulation';
-  import { view, viewUpdateActivityDirectivesTable } from '../../stores/views';
+  import { view, viewTogglePanel, viewUpdateActivityDirectivesTable } from '../../stores/views';
   import type { ActivityDirective } from '../../types/activity';
   import type { ViewGridSection, ViewTable } from '../../types/view';
   import { filterEmpty } from '../../utilities/generic';
@@ -229,6 +229,10 @@
     selectActivity($selectedActivityDirectiveId, null, false);
   }
 
+  function onRowDoubleClicked() {
+    viewTogglePanel({ state: true, type: 'right', update: { rightComponentTop: 'ActivityFormPanel' } });
+  }
+
   function onShowHideAllColumns({ detail: { hide } }: CustomEvent<{ hide: boolean }>) {
     viewUpdateActivityDirectivesTable({
       columnStates: derivedColumnDefs
@@ -289,6 +293,7 @@
       planId={$planId}
       on:columnStateChange={onColumnStateChange}
       on:selectionChanged={onSelectionChanged}
+      on:rowDoubleClicked={onRowDoubleClicked}
     />
   </svelte:fragment>
 </Panel>

--- a/src/components/activity/ActivitySpansTable.svelte
+++ b/src/components/activity/ActivitySpansTable.svelte
@@ -40,4 +40,5 @@
   suppressDragLeaveHidesColumns={false}
   on:columnStateChange
   on:selectionChanged
+  on:rowDoubleClicked
 />

--- a/src/components/activity/ActivitySpansTablePanel.svelte
+++ b/src/components/activity/ActivitySpansTablePanel.svelte
@@ -6,7 +6,7 @@
   import type { ColDef, ColumnState } from 'ag-grid-community';
   import { selectActivity } from '../../stores/activities';
   import { selectedSpanId, simulationDataset, spans } from '../../stores/simulation';
-  import { view, viewUpdateActivitySpansTable } from '../../stores/views';
+  import { view, viewTogglePanel, viewUpdateActivitySpansTable } from '../../stores/views';
   import type { Span } from '../../types/simulation';
   import type { ViewGridSection, ViewTable } from '../../types/view';
   import { filterEmpty } from '../../utilities/generic';
@@ -175,6 +175,10 @@
     selectActivity(null, $selectedSpanId, false);
   }
 
+  function onRowDoubleClicked() {
+    viewTogglePanel({ state: true, type: 'right', update: { rightComponentTop: 'ActivityFormPanel' } });
+  }
+
   function onShowHideAllColumns({ detail: { hide } }: CustomEvent<{ hide: boolean }>) {
     viewUpdateActivitySpansTable({
       columnStates: derivedColumnDefs
@@ -234,6 +238,7 @@
       spans={$spans}
       on:columnStateChange={onColumnStateChange}
       on:selectionChanged={onSelectionChanged}
+      on:rowDoubleClicked={onRowDoubleClicked}
     />
   </svelte:fragment>
 </Panel>

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -44,6 +44,7 @@
   export let blur: FocusEvent | undefined;
   export let contextmenu: MouseEvent | undefined;
   export let debugMode: boolean = false;
+  export let dblclick: MouseEvent | undefined;
   export let drawHeight: number = 0;
   export let drawWidth: number = 0;
   export let filter: ActivityLayerFilter | undefined;
@@ -104,6 +105,7 @@
 
   $: onBlur(blur);
   $: onContextmenu(contextmenu);
+  $: onDblclick(dblclick);
   $: onFocus(focus);
   $: onMousedown(mousedown);
   $: onMousemove(mousemove);
@@ -308,6 +310,17 @@
     const showContextMenu = !!e && isRightClick(e);
     if (showContextMenu) {
       dispatch('contextMenu', {
+        e,
+        layerId: id,
+        selectedActivityDirectiveId,
+        selectedSpanId,
+      });
+    }
+  }
+
+  function onDblclick(e: MouseEvent | undefined): void {
+    if (e) {
+      dispatch('dblClick', {
         e,
         layerId: id,
         selectedActivityDirectiveId,

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -75,6 +75,7 @@
 
   let blur: FocusEvent;
   let contextmenu: MouseEvent;
+  let dblclick: MouseEvent;
   let dragenter: DragEvent;
   let dragleave: DragEvent;
   let dragover: DragEvent;
@@ -246,6 +247,7 @@
       on:mousemove={e => (mousemove = e)}
       on:mouseout={e => (mouseout = e)}
       on:mouseup={e => (mouseup = e)}
+      on:dblclick={e => (dblclick = e)}
     />
 
     <!-- SVG Elements. -->
@@ -284,6 +286,7 @@
             {drawWidth}
             filter={layer.filter.activity}
             {focus}
+            {dblclick}
             {mousedown}
             {mousemove}
             {mouseout}
@@ -301,6 +304,7 @@
             {xScaleView}
             on:contextMenu
             on:deleteActivityDirective
+            on:dblClick
             on:mouseDown={onMouseDown}
             on:mouseOver={onMouseOver}
             on:updateRowHeight={onUpdateRowHeightLayer}

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -315,6 +315,7 @@
           contextMenu = e.detail;
           tooltip.hide();
         }}
+        on:dblClick
         on:deleteActivityDirective
         on:mouseDown={onMouseDown}
         on:mouseDownRowMove={onMouseDownRowMove}

--- a/src/components/timeline/TimelineContextMenu.svelte
+++ b/src/components/timeline/TimelineContextMenu.svelte
@@ -42,10 +42,10 @@
     span = null;
     activityDirectiveSpans = null;
 
-    if (typeof selectedActivityDirectiveId === 'number') {
+    if (selectedActivityDirectiveId !== null) {
       activityDirective = activityDirectivesMap[selectedActivityDirectiveId];
       activityDirectiveSpans = getAllSpansForActivityDirective(selectedActivityDirectiveId, spansMap, spanUtilityMaps);
-    } else if (typeof selectedSpanId === 'number') {
+    } else if (selectedSpanId !== null) {
       span = spansMap[selectedSpanId];
     }
   } else {

--- a/src/components/timeline/TimelinePanel.svelte
+++ b/src/components/timeline/TimelinePanel.svelte
@@ -18,7 +18,7 @@
     spans,
     spansMap,
   } from '../../stores/simulation';
-  import { timelineLockStatus, view, viewUpdateRow, viewUpdateTimeline } from '../../stores/views';
+  import { timelineLockStatus, view, viewTogglePanel, viewUpdateRow, viewUpdateTimeline } from '../../stores/views';
   import type { ActivityDirectiveId } from '../../types/activity';
   import type { DirectiveVisibilityToggleMap, MouseDown, Row, Timeline as TimelineType } from '../../types/timeline';
   import effects from '../../utilities/effects';
@@ -39,6 +39,15 @@
   function deleteActivityDirective(event: CustomEvent<ActivityDirectiveId>) {
     const { detail: activityDirectiveId } = event;
     effects.deleteActivityDirective($planId, activityDirectiveId);
+  }
+
+  function openSelectedActivityPanel(event: CustomEvent) {
+    const {
+      detail: { selectedActivityDirectiveId, selectedSpanId },
+    } = event;
+    if (typeof selectedActivityDirectiveId === 'number' || typeof selectedSpanId === 'number') {
+      viewTogglePanel({ state: true, type: 'right', update: { rightComponentTop: 'ActivityFormPanel' } });
+    }
   }
 
   function generateDirectiveVisibilityToggles(
@@ -151,6 +160,7 @@
       timelineLockStatus={$timelineLockStatus}
       viewTimeRange={$viewTimeRange}
       on:deleteActivityDirective={deleteActivityDirective}
+      on:dblClick={openSelectedActivityPanel}
       on:jumpToActivityDirective={jumpToActivityDirective}
       on:jumpToSpan={jumpToSpan}
       on:mouseDown={onMouseDown}

--- a/src/components/timeline/TimelinePanel.svelte
+++ b/src/components/timeline/TimelinePanel.svelte
@@ -45,7 +45,7 @@
     const {
       detail: { selectedActivityDirectiveId, selectedSpanId },
     } = event;
-    if (typeof selectedActivityDirectiveId === 'number' || typeof selectedSpanId === 'number') {
+    if (selectedActivityDirectiveId !== null || selectedSpanId !== null) {
       viewTogglePanel({ state: true, type: 'right', update: { rightComponentTop: 'ActivityFormPanel' } });
     }
   }


### PR DESCRIPTION
Double click on a directive or span in a timeline or a table to open the selected activity panel on the right.
Closes #283