### PR TITLE
Add page redirection to login when no permissions available

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -2,7 +2,7 @@
 
 declare namespace App {
   interface Locals {
-    permissibleQueries: Record<string, true>;
+    permissibleQueries: Record<string, true> | null;
     user: User | null;
   }
 }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -20,11 +20,11 @@ export const handle: Handle = async ({ event, resolve }) => {
       event.locals.permissibleQueries = permissibleQueries ?? {};
     } else {
       event.locals.user = null;
-      event.locals.permissibleQueries = {};
+      event.locals.permissibleQueries = null;
     }
   } else {
     event.locals.user = null;
-    event.locals.permissibleQueries = {};
+    event.locals.permissibleQueries = null;
   }
 
   return await resolve(event);

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -8,6 +8,6 @@ export const load: LayoutLoad = async ({ data }) => {
   // TODO: Remove this for SSR!
   // See: https://kit.svelte.dev/docs/state-management#no-side-effects-in-load
   userStore.set(data?.user);
-  permissibleQueriesStore.set(data?.permissibleQueries);
+  permissibleQueriesStore.set(data?.permissibleQueries ?? null);
   return { ...data };
 };

--- a/src/routes/constraints/+page.ts
+++ b/src/routes/constraints/+page.ts
@@ -6,7 +6,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/constraints/+page.ts
+++ b/src/routes/constraints/+page.ts
@@ -4,9 +4,9 @@ import effects from '../../utilities/effects';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/constraints/edit/[id]/+page.ts
+++ b/src/routes/constraints/edit/[id]/+page.ts
@@ -7,7 +7,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, params }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/constraints/edit/[id]/+page.ts
+++ b/src/routes/constraints/edit/[id]/+page.ts
@@ -5,9 +5,9 @@ import { parseFloatOrNull } from '../../../../utilities/generic';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 
@@ -15,15 +15,18 @@ export const load: PageLoad = async ({ parent, params }) => {
 
   if (constraintIdParam !== null && constraintIdParam !== undefined) {
     const constraintId = parseFloatOrNull(constraintIdParam);
-    const initialConstraint = await effects.getConstraint(constraintId);
-    const { models: initialModels, plans: initialPlans } = await effects.getPlansAndModels();
 
-    if (initialConstraint !== null) {
-      return {
-        initialConstraint,
-        initialModels,
-        initialPlans,
-      };
+    if (constraintId !== null) {
+      const initialConstraint = await effects.getConstraint(constraintId);
+      const { models: initialModels, plans: initialPlans } = await effects.getPlansAndModels();
+
+      if (initialConstraint !== null) {
+        return {
+          initialConstraint,
+          initialModels,
+          initialPlans,
+        };
+      }
     }
   }
 

--- a/src/routes/constraints/new/+page.ts
+++ b/src/routes/constraints/new/+page.ts
@@ -4,9 +4,9 @@ import effects from '../../../utilities/effects';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/constraints/new/+page.ts
+++ b/src/routes/constraints/new/+page.ts
@@ -6,7 +6,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length.length)) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/constraints/new/+page.ts
+++ b/src/routes/constraints/new/+page.ts
@@ -6,7 +6,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length.length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/dictionaries/+page.ts
+++ b/src/routes/dictionaries/+page.ts
@@ -5,7 +5,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/dictionaries/+page.ts
+++ b/src/routes/dictionaries/+page.ts
@@ -3,9 +3,9 @@ import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/rules/+page.ts
+++ b/src/routes/expansion/rules/+page.ts
@@ -5,7 +5,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/rules/+page.ts
+++ b/src/routes/expansion/rules/+page.ts
@@ -3,9 +3,9 @@ import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/rules/edit/[id]/+page.ts
+++ b/src/routes/expansion/rules/edit/[id]/+page.ts
@@ -4,9 +4,9 @@ import effects from '../../../../../utilities/effects';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/rules/edit/[id]/+page.ts
+++ b/src/routes/expansion/rules/edit/[id]/+page.ts
@@ -6,7 +6,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, params }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/rules/new/+page.ts
+++ b/src/routes/expansion/rules/new/+page.ts
@@ -5,7 +5,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/rules/new/+page.ts
+++ b/src/routes/expansion/rules/new/+page.ts
@@ -3,9 +3,9 @@ import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/sets/+page.ts
+++ b/src/routes/expansion/sets/+page.ts
@@ -5,7 +5,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/sets/+page.ts
+++ b/src/routes/expansion/sets/+page.ts
@@ -3,9 +3,9 @@ import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/sets/new/+page.ts
+++ b/src/routes/expansion/sets/new/+page.ts
@@ -5,7 +5,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/sets/new/+page.ts
+++ b/src/routes/expansion/sets/new/+page.ts
@@ -3,9 +3,9 @@ import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -15,7 +15,7 @@
   let username = '';
   let usernameInput: HTMLInputElement | null = null;
 
-  $: if ($permissibleQueriesStore && !Object.keys($permissibleQueriesStore).length) {
+  $: if ($userStore !== null && $permissibleQueriesStore && !Object.keys($permissibleQueriesStore).length) {
     error = 'You are not authorized';
     fullError =
       'You are not authorized to access the page that you attempted to view. Please contact a tool administrator to request access.';

--- a/src/routes/login/+page.ts
+++ b/src/routes/login/+page.ts
@@ -1,12 +1,11 @@
 import { base } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
-import { permissibleQueries as permissibleQueriesStore } from '../../stores/app';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (user && Object.keys(permissibleQueriesStore).length) {
+  if (user && permissibleQueries && Object.keys(permissibleQueries).length) {
     throw redirect(302, `${base}/plans`);
   }
 

--- a/src/routes/models/+page.ts
+++ b/src/routes/models/+page.ts
@@ -6,7 +6,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/models/+page.ts
+++ b/src/routes/models/+page.ts
@@ -4,9 +4,9 @@ import effects from '../../utilities/effects';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/plans/+page.ts
+++ b/src/routes/plans/+page.ts
@@ -6,7 +6,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/plans/+page.ts
+++ b/src/routes/plans/+page.ts
@@ -5,6 +5,7 @@ import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
+
   if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -4,9 +4,9 @@ import effects from '../../../utilities/effects';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params, url }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 
@@ -35,7 +35,7 @@ export const load: PageLoad = async ({ parent, params, url }) => {
 
         initialPlan = {
           ...initialPlan,
-          scheduling_specifications: [schedulingSpec],
+          scheduling_specifications: schedulingSpec ? [schedulingSpec] : [],
         };
       }
 

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -6,7 +6,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, params, url }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/plans/[id]/merge/+page.ts
+++ b/src/routes/plans/[id]/merge/+page.ts
@@ -9,9 +9,9 @@ import effects from '../../../../utilities/effects';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 
@@ -26,7 +26,7 @@ export const load: PageLoad = async ({ parent, params }) => {
         throw redirect(302, `${base}/plans/${id}`);
       }
 
-      const initialMergeRequest: PlanMergeRequestSchema = await effects.getPlanMergeRequestInProgress(planId);
+      const initialMergeRequest: PlanMergeRequestSchema | null = await effects.getPlanMergeRequestInProgress(planId);
       let initialConflictingActivities: PlanMergeConflictingActivity[] = [];
       let initialNonConflictingActivities: PlanMergeNonConflictingActivity[] = [];
 

--- a/src/routes/plans/[id]/merge/+page.ts
+++ b/src/routes/plans/[id]/merge/+page.ts
@@ -11,7 +11,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, params }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/+page.ts
+++ b/src/routes/scheduling/+page.ts
@@ -6,7 +6,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/+page.ts
+++ b/src/routes/scheduling/+page.ts
@@ -4,9 +4,9 @@ import effects from '../../utilities/effects';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/conditions/edit/[id]/+page.ts
+++ b/src/routes/scheduling/conditions/edit/[id]/+page.ts
@@ -7,7 +7,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, params }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/conditions/edit/[id]/+page.ts
+++ b/src/routes/scheduling/conditions/edit/[id]/+page.ts
@@ -5,9 +5,9 @@ import { parseFloatOrNull } from '../../../../../utilities/generic';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 
@@ -22,7 +22,7 @@ export const load: PageLoad = async ({ parent, params }) => {
     if (initialCondition !== null) {
       return {
         initialCondition,
-        initialSpecId: schedulingSpecConditions[0]?.specification_id,
+        initialSpecId: schedulingSpecConditions?.[0]?.specification_id,
         models,
         plans,
       };

--- a/src/routes/scheduling/conditions/new/+page.ts
+++ b/src/routes/scheduling/conditions/new/+page.ts
@@ -5,9 +5,9 @@ import { parseFloatOrNull } from '../../../../utilities/generic';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, url }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/conditions/new/+page.ts
+++ b/src/routes/scheduling/conditions/new/+page.ts
@@ -7,7 +7,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, url }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/goals/edit/[id]/+page.ts
+++ b/src/routes/scheduling/goals/edit/[id]/+page.ts
@@ -7,7 +7,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, params }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/goals/edit/[id]/+page.ts
+++ b/src/routes/scheduling/goals/edit/[id]/+page.ts
@@ -5,9 +5,9 @@ import { parseFloatOrNull } from '../../../../../utilities/generic';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 
@@ -22,7 +22,7 @@ export const load: PageLoad = async ({ parent, params }) => {
     if (initialGoal !== null) {
       return {
         initialGoal,
-        initialSpecId: schedulingSpecGoals[0]?.specification_id,
+        initialSpecId: schedulingSpecGoals?.[0]?.specification_id,
         models,
         plans,
       };

--- a/src/routes/scheduling/goals/new/+page.ts
+++ b/src/routes/scheduling/goals/new/+page.ts
@@ -5,9 +5,9 @@ import { parseFloatOrNull } from '../../../../utilities/generic';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, url }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/goals/new/+page.ts
+++ b/src/routes/scheduling/goals/new/+page.ts
@@ -7,7 +7,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, url }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/sequencing/+page.ts
+++ b/src/routes/sequencing/+page.ts
@@ -5,7 +5,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/sequencing/+page.ts
+++ b/src/routes/sequencing/+page.ts
@@ -3,9 +3,9 @@ import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/sequencing/edit/[id]/+page.ts
+++ b/src/routes/sequencing/edit/[id]/+page.ts
@@ -8,7 +8,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, params }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/sequencing/edit/[id]/+page.ts
+++ b/src/routes/sequencing/edit/[id]/+page.ts
@@ -6,9 +6,9 @@ import { parseFloatOrNull } from '../../../../utilities/generic';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/sequencing/new/+page.ts
+++ b/src/routes/sequencing/new/+page.ts
@@ -5,7 +5,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries).length)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/sequencing/new/+page.ts
+++ b/src/routes/sequencing/new/+page.ts
@@ -3,9 +3,9 @@ import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
+  const { user, permissibleQueries } = await parent();
 
-  if (!user) {
+  if (!user || (permissibleQueries && !Object.keys(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 


### PR DESCRIPTION
This is to handle the case when a user with a role that has no permissions. They should now be redirected to the login page where an appropriate error is displayed.

This also prevents the bug where the error is shown on the login page regardless if permissions are present.