### PR TITLE
Test e2e with postgres:14.8 image

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -161,7 +161,7 @@ services:
       POSTGRES_DB: postgres
       POSTGRES_PASSWORD: '${POSTGRES_PASSWORD}'
       POSTGRES_USER: '${POSTGRES_USER}'
-    image: 'ghcr.io/nasa-ammos/aerie-postgres:develop'
+    image: 'ghcr.io/skovati/aerie-postgres:main'
     ports: ['5432:5432']
     restart: always
     volumes:


### PR DESCRIPTION
UI e2e tests were being flaky on my local machine. This PR is just to test updating postgres from 14.1 -> 14.8