### PR TITLE
Add env var to enable or disable the login page

### DIFF
--- a/.env
+++ b/.env
@@ -4,3 +4,4 @@ PUBLIC_GATEWAY_SERVER_URL=http://localhost:9000
 PUBLIC_HASURA_CLIENT_URL=http://localhost:8080/v1/graphql
 PUBLIC_HASURA_SERVER_URL=http://localhost:8080/v1/graphql
 PUBLIC_HASURA_WEB_SOCKET_URL=ws://localhost:8080/v1/graphql
+PUBLIC_LOGIN_PAGE=enabled

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,37 +1,45 @@
+import { env } from '$env/dynamic/public';
 import type { Handle } from '@sveltejs/kit';
 import { parse } from 'cookie';
 import jwtDecode from 'jwt-decode';
 import type { BaseUser, ParsedUserToken, User } from './types/app';
 import effects from './utilities/effects';
+import { ADMIN_ROLE } from './utilities/permissions';
 
 export const handle: Handle = async ({ event, resolve }) => {
-  const cookieHeader = event.request.headers.get('cookie') ?? '';
-  const cookies = parse(cookieHeader);
-  const { user: userCookie = null } = cookies;
+  if (env.PUBLIC_LOGIN_PAGE === 'disabled') {
+    const permissibleQueries = await effects.getUserQueries('');
+    event.locals.user = { allowedRoles: [ADMIN_ROLE], defaultRole: ADMIN_ROLE, id: 'unknown', token: '' };
+    event.locals.permissibleQueries = permissibleQueries ?? {};
+  } else {
+    const cookieHeader = event.request.headers.get('cookie') ?? '';
+    const cookies = parse(cookieHeader);
+    const { user: userCookie = null } = cookies;
 
-  if (userCookie) {
-    const userBuffer = Buffer.from(userCookie, 'base64');
-    const userStr = userBuffer.toString('utf-8');
-    const parsedUser: BaseUser = JSON.parse(userStr);
-    const { success } = await effects.session(parsedUser.token);
-    const decodedToken: ParsedUserToken = jwtDecode(parsedUser.token);
+    if (userCookie) {
+      const userBuffer = Buffer.from(userCookie, 'base64');
+      const userStr = userBuffer.toString('utf-8');
+      const parsedUser: BaseUser = JSON.parse(userStr);
+      const { success } = await effects.session(parsedUser.token);
+      const decodedToken: ParsedUserToken = jwtDecode(parsedUser.token);
 
-    if (success) {
-      const user: User = {
-        ...parsedUser,
-        allowedRoles: decodedToken['https://hasura.io/jwt/claims']['x-hasura-allowed-roles'],
-        defaultRole: decodedToken['https://hasura.io/jwt/claims']['x-hasura-default-role'],
-      };
-      const permissibleQueries = await effects.getUserQueries(user.token);
-      event.locals.user = user;
-      event.locals.permissibleQueries = permissibleQueries ?? {};
+      if (success) {
+        const user: User = {
+          ...parsedUser,
+          allowedRoles: decodedToken['https://hasura.io/jwt/claims']['x-hasura-allowed-roles'],
+          defaultRole: decodedToken['https://hasura.io/jwt/claims']['x-hasura-default-role'],
+        };
+        const permissibleQueries = await effects.getUserQueries(user.token);
+        event.locals.user = user;
+        event.locals.permissibleQueries = permissibleQueries ?? {};
+      } else {
+        event.locals.user = null;
+        event.locals.permissibleQueries = null;
+      }
     } else {
       event.locals.user = null;
       event.locals.permissibleQueries = null;
     }
-  } else {
-    event.locals.user = null;
-    event.locals.permissibleQueries = null;
   }
 
   return await resolve(event);

--- a/src/routes/constraints/+page.ts
+++ b/src/routes/constraints/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../utilities/effects';
 import { hasNoAuthorization } from '../../utilities/permissions';
@@ -7,7 +8,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/constraints/edit/[id]/+page.ts
+++ b/src/routes/constraints/edit/[id]/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../../utilities/effects';
 import { parseFloatOrNull } from '../../../../utilities/generic';
@@ -8,7 +9,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, params }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/constraints/new/+page.ts
+++ b/src/routes/constraints/new/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../utilities/effects';
 import { hasNoAuthorization } from '../../../utilities/permissions';
@@ -7,7 +8,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/dictionaries/+page.ts
+++ b/src/routes/dictionaries/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import { hasNoAuthorization } from '../../utilities/permissions';
 import type { PageLoad } from './$types';
@@ -6,7 +7,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/rules/+page.ts
+++ b/src/routes/expansion/rules/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import { hasNoAuthorization } from '../../../utilities/permissions';
 import type { PageLoad } from './$types';
@@ -6,7 +7,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/rules/edit/[id]/+page.ts
+++ b/src/routes/expansion/rules/edit/[id]/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../../../utilities/effects';
 import { hasNoAuthorization } from '../../../../../utilities/permissions';
@@ -7,7 +8,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, params }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/rules/new/+page.ts
+++ b/src/routes/expansion/rules/new/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import { hasNoAuthorization } from '../../../../utilities/permissions';
 import type { PageLoad } from './$types';
@@ -6,7 +7,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/runs/+page.ts
+++ b/src/routes/expansion/runs/+page.ts
@@ -1,15 +1,18 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../utilities/effects';
+import { hasNoAuthorization } from '../../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
+  const { permissibleQueries, user } = await parent();
 
-  if (!user) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 
   const expansionRuns = await effects.getExpansionRuns();
+
   return { expansionRuns };
 };

--- a/src/routes/expansion/sets/+page.ts
+++ b/src/routes/expansion/sets/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import { hasNoAuthorization } from '../../../utilities/permissions';
 import type { PageLoad } from './$types';
@@ -6,7 +7,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/sets/new/+page.ts
+++ b/src/routes/expansion/sets/new/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import { hasNoAuthorization } from '../../../../utilities/permissions';
 import type { PageLoad } from './$types';
@@ -6,7 +7,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/login/+page.ts
+++ b/src/routes/login/+page.ts
@@ -1,11 +1,13 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
+import { hasNoAuthorization } from '../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (user && permissibleQueries && Object.keys(permissibleQueries).length) {
+  if (env.PUBLIC_LOGIN_PAGE === 'disabled' || (user && !hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/plans`);
   }
 

--- a/src/routes/models/+page.ts
+++ b/src/routes/models/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../utilities/effects';
 import { hasNoAuthorization } from '../../utilities/permissions';
@@ -7,7 +8,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/plans/+page.ts
+++ b/src/routes/plans/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../utilities/effects';
 import { hasNoAuthorization } from '../../utilities/permissions';
@@ -7,7 +8,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../utilities/effects';
 import { hasNoAuthorization } from '../../../utilities/permissions';
@@ -7,7 +8,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, params, url }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/plans/[id]/merge/+page.ts
+++ b/src/routes/plans/[id]/merge/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import type {
   PlanMergeConflictingActivity,
@@ -12,7 +13,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, params }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/+page.ts
+++ b/src/routes/scheduling/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../utilities/effects';
 import { hasNoAuthorization } from '../../utilities/permissions';
@@ -7,7 +8,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/conditions/edit/[id]/+page.ts
+++ b/src/routes/scheduling/conditions/edit/[id]/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../../../utilities/effects';
 import { parseFloatOrNull } from '../../../../../utilities/generic';
@@ -8,7 +9,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, params }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/conditions/new/+page.ts
+++ b/src/routes/scheduling/conditions/new/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../../utilities/effects';
 import { parseFloatOrNull } from '../../../../utilities/generic';
@@ -8,7 +9,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, url }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/goals/edit/[id]/+page.ts
+++ b/src/routes/scheduling/goals/edit/[id]/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../../../utilities/effects';
 import { parseFloatOrNull } from '../../../../../utilities/generic';
@@ -8,7 +9,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, params }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/goals/new/+page.ts
+++ b/src/routes/scheduling/goals/new/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../../utilities/effects';
 import { parseFloatOrNull } from '../../../../utilities/generic';
@@ -8,7 +9,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, url }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/sequencing/+page.ts
+++ b/src/routes/sequencing/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import { hasNoAuthorization } from '../../utilities/permissions';
 import type { PageLoad } from './$types';
@@ -6,7 +7,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/sequencing/edit/[id]/+page.ts
+++ b/src/routes/sequencing/edit/[id]/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import type { UserSequence } from '../../../../types/sequencing';
 import effects from '../../../../utilities/effects';
@@ -9,7 +10,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent, params }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/sequencing/new/+page.ts
+++ b/src/routes/sequencing/new/+page.ts
@@ -1,4 +1,5 @@
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import { hasNoAuthorization } from '../../../utilities/permissions';
 import type { PageLoad } from './$types';
@@ -6,7 +7,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user, permissibleQueries } = await parent();
 
-  if (!user || hasNoAuthorization(permissibleQueries)) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -15,7 +15,7 @@ import type {
   UpdatePermissionCheck,
 } from '../types/permissions';
 
-const ADMIN_ROLE = 'admin';
+export const ADMIN_ROLE = 'admin';
 
 function getPermission(queries: string[]): boolean {
   const permissibleQueries = get(permissibleQueriesStore);


### PR DESCRIPTION
Closes https://github.com/NASA-AMMOS/aerie-ui/issues/688

* Add `PUBLIC_LOGIN_PAGE` env var
* Allows for enabling or disabling the UI login page
* Update hooks and routes to read env var

To test:

- Start Hasura with auth disabled by commenting out the`HASURA_GRAPHQL_ADMIN_SECRET` and `HASURA_GRAPHQL_JWT_SECRET` in Hasura only
- Start the Gayeway with `AUTH_TYPE` set to `none` (Make sure it still receives a `HASURA_GRAPHQL_JWT_SECRET`)
- Run this UI branch locally and toggle `PUBLIC_LOGIN_PAGE` to `disabled`. The login page should never come up.
- Toggle `PUBLIC_LOGIN_PAGE` to `enabled`. The login pages should come up if you don't have a cookie.