### PR TITLE
Remove user store and instead pass user in component tree

### DIFF
--- a/e2e-tests/tests/plan-activities.test.ts
+++ b/e2e-tests/tests/plan-activities.test.ts
@@ -69,7 +69,7 @@ test.describe.serial('Plan Activities', () => {
     );
 
     await plan.panelActivityForm.getByRole('group').filter({ hasText: 'Anchor' }).first().click();
-    expect(await plan.panelActivityForm.getByRole('textbox', { name: 'To Plan' })).toBeVisible();
+    expect(plan.panelActivityForm.getByRole('textbox', { name: 'To Plan' })).toBeVisible();
   });
 
   test('Deleting multiple activity directives but only 1 has a remaining anchored dependent should prompt for just the one with a remaining dependent', async () => {

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -2,8 +2,7 @@
 
 declare namespace App {
   interface Locals {
-    permissibleQueries: import('./types/permissions').PermissibleQueriesMap | null;
-    user: User | null;
+    user: import('./types/app').User | null;
   }
 }
 

--- a/src/components/activity/ActivityDirectiveSourceForm.svelte
+++ b/src/components/activity/ActivityDirectiveSourceForm.svelte
@@ -3,6 +3,7 @@
 <script lang="ts">
   import type { ActivityDirective, ActivityDirectivesMap, ActivityType } from '../../types/activity';
   import type { ActivityMetadataDefinition } from '../../types/activity-metadata';
+  import type { User } from '../../types/app';
   import type { PlanMergeActivityDirectiveSource } from '../../types/plan';
   import ActivityDirectiveForm from './ActivityDirectiveForm.svelte';
 
@@ -14,6 +15,7 @@
   export let modelId: number;
   export let planId: number;
   export let planStartTimeYmd: string;
+  export let user: User | null;
 
   let activityDirective: ActivityDirective;
 
@@ -35,5 +37,6 @@
     {planStartTimeYmd}
     showActivityName
     showHeader={false}
+    {user}
   />
 {/if}

--- a/src/components/activity/ActivityDirectivesTable.svelte
+++ b/src/components/activity/ActivityDirectivesTable.svelte
@@ -3,6 +3,7 @@
 <script lang="ts">
   import type { ColDef, ColumnState, ICellRendererParams } from 'ag-grid-community';
   import type { ActivityDirective, ActivityDirectiveId } from '../../types/activity';
+  import type { User } from '../../types/app';
   import type { DataGridColumnDef } from '../../types/data-grid';
   import effects from '../../utilities/effects';
   import BulkActionDataGrid from '../ui/DataGrid/BulkActionDataGrid.svelte';
@@ -15,6 +16,7 @@
   export let dataGrid: DataGrid<ActivityDirective> | undefined = undefined;
   export let planId: number;
   export let selectedActivityDirectiveId: ActivityDirectiveId | null = null;
+  export let user: User | null;
 
   type CellRendererParams = {
     deleteActivityDirective: (activity: ActivityDirective) => void;
@@ -58,7 +60,7 @@
   async function deleteActivityDirective({ id, plan_id }: ActivityDirective) {
     if (!isDeletingDirective) {
       isDeletingDirective = true;
-      await effects.deleteActivityDirective(plan_id, id);
+      await effects.deleteActivityDirective(plan_id, id, user);
       isDeletingDirective = false;
     }
   }
@@ -67,7 +69,7 @@
     if (!isDeletingDirective) {
       isDeletingDirective = true;
       const ids = activities.map(({ id }) => id);
-      await effects.deleteActivityDirectives(planId, ids);
+      await effects.deleteActivityDirectives(planId, ids, user);
       isDeletingDirective = false;
     }
   }

--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -14,6 +14,7 @@
   import { spanUtilityMaps, spansMap } from '../../stores/simulation';
   import { view, viewTogglePanel, viewUpdateActivityDirectivesTable } from '../../stores/views';
   import type { ActivityDirective } from '../../types/activity';
+  import type { User } from '../../types/app';
   import type { ViewGridSection, ViewTable } from '../../types/view';
   import { filterEmpty } from '../../utilities/generic';
   import { getActivityDirectiveStartTimeMs, getDoyTime } from '../../utilities/time';
@@ -25,6 +26,7 @@
   import ActivityTableMenu from './ActivityTableMenu.svelte';
 
   export let gridSection: ViewGridSection;
+  export let user: User | null;
 
   type ActivityDirectiveColumns = keyof ActivityDirective | 'derived_start_time';
   interface ActivityDirectiveColDef extends ColDef<ActivityDirective> {
@@ -291,6 +293,7 @@
       columnDefs={derivedColumnDefs ?? []}
       columnStates={activityDirectivesTable?.columnStates}
       planId={$planId}
+      {user}
       on:columnStateChange={onColumnStateChange}
       on:selectionChanged={onSelectionChanged}
       on:rowDoubleClicked={onRowDoubleClicked}

--- a/src/components/activity/ActivityFormPanel.svelte
+++ b/src/components/activity/ActivityFormPanel.svelte
@@ -13,7 +13,8 @@
   } from '../../stores/activities';
   import { filteredExpansionSequences } from '../../stores/expansion';
   import { activityEditingLocked, activityTypes, modelId, plan, setActivityEditingLocked } from '../../stores/plan';
-  import { selectedSpan, simulationDatasetId, spansMap, spanUtilityMaps } from '../../stores/simulation';
+  import { selectedSpan, simulationDatasetId, spanUtilityMaps, spansMap } from '../../stores/simulation';
+  import type { User } from '../../types/app';
   import type { SpanId } from '../../types/simulation';
   import type { ViewGridSection } from '../../types/view';
   import effects from '../../utilities/effects';
@@ -25,6 +26,7 @@
   import ActivitySpanForm from './ActivitySpanForm.svelte';
 
   export let gridSection: ViewGridSection;
+  export let user: User | null;
 
   function onSelectSpan(event: CustomEvent<SpanId>) {
     const { detail: spanId } = event;
@@ -57,7 +59,7 @@
         <button
           class="st-button icon activity-header-delete"
           on:click|stopPropagation={() =>
-            effects.deleteActivityDirective($selectedActivityDirective.plan_id, $selectedActivityDirective.id)}
+            effects.deleteActivityDirective($selectedActivityDirective.plan_id, $selectedActivityDirective.id, user)}
           use:tooltip={{ content: 'Delete Activity', placement: 'top' }}
         >
           <TrashIcon />
@@ -77,6 +79,7 @@
         editable={!$activityEditingLocked}
         modelId={$modelId}
         planStartTimeYmd={$plan.start_time}
+        {user}
       />
     {:else if $selectedSpan}
       <ActivitySpanForm
@@ -88,6 +91,7 @@
         span={$selectedSpan}
         spansMap={$spansMap}
         spanUtilityMaps={$spanUtilityMaps}
+        {user}
         on:select={onSelectSpan}
       />
     {:else}

--- a/src/components/activity/ActivityPresetInput.svelte
+++ b/src/components/activity/ActivityPresetInput.svelte
@@ -4,6 +4,7 @@
   import { createEventDispatcher } from 'svelte';
   import { gqlSubscribable } from '../../stores/subscribable';
   import type { ActivityDirective, ActivityPreset } from '../../types/activity';
+  import type { User } from '../../types/app';
   import type {
     DropdownOption,
     DropdownOptionValue,
@@ -21,6 +22,7 @@
   export let hasChanges: boolean = false;
   export let highlightKeysMap: Record<string, boolean> = {};
   export let modelId: number;
+  export let user: User | null;
 
   const dispatch = createEventDispatcher();
 
@@ -28,6 +30,7 @@
     gql.SUB_ACTIVITY_PRESETS,
     { activityTypeName: activityDirective.type, modelId },
     [],
+    user,
   );
   let options: DropdownOptions = [];
 

--- a/src/components/activity/ActivitySpanForm.svelte
+++ b/src/components/activity/ActivitySpanForm.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
   import type { ActivityType } from '../../types/activity';
+  import type { User } from '../../types/app';
   import type { ExpansionSequence } from '../../types/expansion';
   import type { ArgumentsMap, FormParameter, ParametersMap } from '../../types/parameter';
   import type { ValueSchema } from '../../types/schema';
@@ -24,6 +25,7 @@
   export let span: Span;
   export let spansMap: SpansMap = {};
   export let spanUtilityMaps: SpanUtilityMaps;
+  export let user: User | null;
 
   let endTimeDoy: string | null = null;
   let formParametersComputedAttributes: FormParameter[] = [];
@@ -50,7 +52,7 @@
 
   $: if (activityType && span.attributes.arguments) {
     effects
-      .getEffectiveActivityArguments(modelId, activityType.name, span.attributes.arguments)
+      .getEffectiveActivityArguments(modelId, activityType.name, span.attributes.arguments, user)
       .then(({ arguments: defaultArgumentsMap }) => {
         formParameters = getFormParameters(
           activityType.parameters,
@@ -70,7 +72,7 @@
   }
 
   $: if (simulationDatasetId !== null) {
-    effects.getExpansionSequenceId(span.id, simulationDatasetId).then(newSeqId => (seqId = newSeqId));
+    effects.getExpansionSequenceId(span.id, simulationDatasetId, user).then(newSeqId => (seqId = newSeqId));
   }
 
   $: setFormParametersComputedAttributes(
@@ -98,9 +100,9 @@
 
   async function updateExpansionSequenceToActivity() {
     if (seqId === null) {
-      await effects.deleteExpansionSequenceToActivity(simulationDatasetId, span.id);
+      await effects.deleteExpansionSequenceToActivity(simulationDatasetId, span.id, user);
     } else {
-      await effects.insertExpansionSequenceToActivity(simulationDatasetId, span.id, seqId);
+      await effects.insertExpansionSequenceToActivity(simulationDatasetId, span.id, seqId, user);
     }
   }
 

--- a/src/components/activity/ActivityTypesPanel.svelte
+++ b/src/components/activity/ActivityTypesPanel.svelte
@@ -4,6 +4,7 @@
   import PlusIcon from 'bootstrap-icons/icons/plus.svg?component';
   import { activityTypes, plan } from '../../stores/plan';
   import type { ActivityType } from '../../types/activity';
+  import type { User } from '../../types/app';
   import type { ViewGridSection } from '../../types/view';
   import effects from '../../utilities/effects';
   import { tooltip } from '../../utilities/tooltip';
@@ -12,6 +13,7 @@
   import Panel from '../ui/Panel.svelte';
 
   export let gridSection: ViewGridSection;
+  export let user: User | null;
 
   let filterText: string = '';
 
@@ -21,7 +23,7 @@
 
   async function createActivityDirectiveAtPlanStart(activityType: ActivityType) {
     const { start_time_doy } = $plan;
-    effects.createActivityDirective({}, start_time_doy, activityType.name, activityType.name, [], {});
+    effects.createActivityDirective({}, start_time_doy, activityType.name, activityType.name, [], {}, user);
   }
 
   function onDragEnd(): void {

--- a/src/components/constraints/ConstraintEditor.svelte
+++ b/src/components/constraints/ConstraintEditor.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import type { User } from '../../types/app';
   import type { Monaco, TypeScriptFile } from '../../types/monaco';
   import effects from '../../utilities/effects';
   import MonacoEditor from '../ui/MonacoEditor.svelte';
@@ -12,11 +13,14 @@
   export let constraintPlanId: number | null = null;
   export let readOnly: boolean = false;
   export let title: string = 'Constraint - Definition Editor';
+  export let user: User | null;
 
   let constraintsTsFiles: TypeScriptFile[];
   let monaco: Monaco;
 
-  $: effects.getTsFilesConstraints(constraintModelId, constraintPlanId).then(tsFiles => (constraintsTsFiles = tsFiles));
+  $: effects
+    .getTsFilesConstraints(constraintModelId, constraintPlanId, user)
+    .then(tsFiles => (constraintsTsFiles = tsFiles));
 
   $: if (monaco !== undefined && constraintsTsFiles !== undefined) {
     const { languages } = monaco;

--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -4,6 +4,7 @@
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import { constraintsColumns } from '../../stores/constraints';
+  import type { User } from '../../types/app';
   import type { Constraint } from '../../types/constraint';
   import type { ModelSlim } from '../../types/model';
   import type { PlanSlim } from '../../types/plan';
@@ -25,6 +26,7 @@
   export let initialModels: ModelSlim[] = [];
   export let initialPlans: PlanSlim[] = [];
   export let mode: 'create' | 'edit' = 'create';
+  export let user: User | null;
 
   let constraintDefinition: string = initialConstraintDefinition;
   let constraintDescription: string = initialConstraintDescription;
@@ -102,6 +104,7 @@
           constraintModelId,
           constraintName,
           constraintPlanId,
+          user,
         );
 
         if (newConstraintId !== null) {
@@ -115,6 +118,7 @@
           constraintModelId,
           constraintName,
           constraintPlanId,
+          user,
         );
 
         savedConstraint = {
@@ -217,6 +221,7 @@
     {constraintModelId}
     {constraintPlanId}
     title="{mode === 'create' ? 'New' : 'Edit'} Constraint - Definition Editor"
+    {user}
     on:didChangeModelContent={onDidChangeModelContent}
   />
 </CssGrid>

--- a/src/components/constraints/ConstraintListItem.svelte
+++ b/src/components/constraints/ConstraintListItem.svelte
@@ -7,6 +7,7 @@
   import VisibleHideIcon from '@nasa-jpl/stellar/icons/visible_hide.svg?component';
   import VisibleShowIcon from '@nasa-jpl/stellar/icons/visible_show.svg?component';
   import { createEventDispatcher } from 'svelte';
+  import type { User } from '../../types/app';
   import type { Constraint, ConstraintViolation } from '../../types/constraint';
   import effects from '../../utilities/effects';
   import { tooltip } from '../../utilities/tooltip';
@@ -19,6 +20,7 @@
   export let violation: ConstraintViolation;
   export let totalViolationCount: number = 0;
   export let visible: boolean = true;
+  export let user: User | null;
 
   const dispatch = createEventDispatcher();
 
@@ -87,7 +89,9 @@
         Edit Constraint
       </ContextMenuItem>
       <ContextMenuHeader>Modify</ContextMenuHeader>
-      <ContextMenuItem on:click={() => effects.deleteConstraint(constraint.id)}>Delete Constraint</ContextMenuItem>
+      <ContextMenuItem on:click={() => effects.deleteConstraint(constraint.id, user)}>
+        Delete Constraint
+      </ContextMenuItem>
     </svelte:fragment>
   </Collapse>
 </div>

--- a/src/components/constraints/Constraints.svelte
+++ b/src/components/constraints/Constraints.svelte
@@ -5,6 +5,7 @@
   import { base } from '$app/paths';
   import type { ICellRendererParams } from 'ag-grid-community';
   import { constraintsAll, constraintsColumns } from '../../stores/constraints';
+  import type { User } from '../../types/app';
   import type { Constraint } from '../../types/constraint';
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { PlanSlim } from '../../types/plan';
@@ -17,6 +18,8 @@
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
   import ConstraintEditor from './ConstraintEditor.svelte';
+
+  export let user: User | null;
 
   type CellRendererParams = {
     deleteConstraint: (constraint: Constraint) => void;
@@ -114,7 +117,7 @@
   $: constraintModelId = getConstraintModelId(selectedConstraint);
 
   async function deleteConstraint({ id }: Pick<Constraint, 'id'>) {
-    const success = await effects.deleteConstraint(id);
+    const success = await effects.deleteConstraint(id, user);
 
     if (success) {
       filteredConstraints = filteredConstraints.filter(constraint => constraint.id !== id);
@@ -193,6 +196,7 @@
           hasEdit={true}
           itemDisplayText="Constraint"
           items={filteredConstraints}
+          {user}
           on:deleteItem={deleteConstraintContext}
           on:editItem={editConstraintContext}
           on:rowSelected={toggleConstraint}
@@ -210,5 +214,6 @@
     {constraintModelId}
     readOnly={true}
     title="Constraint - Definition Editor (Read-only)"
+    {user}
   />
 </CssGrid>

--- a/src/components/constraints/ConstraintsPanel.svelte
+++ b/src/components/constraints/ConstraintsPanel.svelte
@@ -18,6 +18,7 @@
   } from '../../stores/constraints';
   import { field } from '../../stores/form';
   import { plan, viewTimeRange } from '../../stores/plan';
+  import type { User } from '../../types/app';
   import type { Constraint, ConstraintViolation } from '../../types/constraint';
   import type { FieldStore } from '../../types/form';
   import type { ViewGridSection } from '../../types/view';
@@ -35,6 +36,7 @@
   import ConstraintListItem from './ConstraintListItem.svelte';
 
   export let gridSection: ViewGridSection;
+  export let user: User | null;
 
   let showAll: boolean = true;
   let filterText: string = '';
@@ -170,7 +172,7 @@
   <svelte:fragment slot="header">
     <GridMenu {gridSection} title="Constraints" />
     <PanelHeaderActions status={$checkConstraintsStatus}>
-      <PanelHeaderActionButton title="Check Constraints" on:click={() => effects.checkConstraints()}>
+      <PanelHeaderActionButton title="Check Constraints" on:click={() => effects.checkConstraints(user)}>
         <ChecklistIcon />
       </PanelHeaderActionButton>
     </PanelHeaderActions>
@@ -267,6 +269,7 @@
             visible={$constraintVisibilityMap[constraint.id]}
             violation={filteredConstraintViolationMap[constraint.id]}
             totalViolationCount={constraintViolationMap[constraint.id]?.windows?.length}
+            {user}
             on:toggleVisibility={toggleVisibility}
           />
         {/each}

--- a/src/components/expansion/ExpansionLogicEditor.svelte
+++ b/src/components/expansion/ExpansionLogicEditor.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import type { User } from '../../types/app';
   import type { Monaco, TypeScriptFile } from '../../types/monaco';
   import effects from '../../utilities/effects';
   import MonacoEditor from '../ui/MonacoEditor.svelte';
@@ -13,13 +14,16 @@
   export let ruleLogic: string = '';
   export let ruleModelId: number | null = null;
   export let title: string = 'Expansion Rule - Logic Editor';
+  export let user: User | null;
 
   let activityTypeTsFiles: TypeScriptFile[] = [];
   let commandDictionaryTsFiles: TypeScriptFile[] = [];
   let monaco: Monaco;
 
-  $: effects.getTsFilesCommandDictionary(ruleDictionaryId).then(tsFiles => (commandDictionaryTsFiles = tsFiles));
-  $: effects.getTsFilesActivityType(ruleActivityType, ruleModelId).then(tsFiles => (activityTypeTsFiles = tsFiles));
+  $: effects.getTsFilesCommandDictionary(ruleDictionaryId, user).then(tsFiles => (commandDictionaryTsFiles = tsFiles));
+  $: effects
+    .getTsFilesActivityType(ruleActivityType, ruleModelId, user)
+    .then(tsFiles => (activityTypeTsFiles = tsFiles));
 
   $: if (monaco !== undefined && (commandDictionaryTsFiles !== undefined || activityTypeTsFiles !== undefined)) {
     const { languages } = monaco;

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -10,6 +10,7 @@
     selectedExpansionSetId,
   } from '../../stores/expansion';
   import { simulationDatasetId } from '../../stores/simulation';
+  import type { User } from '../../types/app';
   import type { DataGridColumnDef, RowId } from '../../types/data-grid';
   import type { ExpansionSequence } from '../../types/expansion';
   import type { ViewGridSection } from '../../types/view';
@@ -26,10 +27,11 @@
   import PanelHeaderActions from '../ui/PanelHeaderActions.svelte';
 
   export let gridSection: ViewGridSection;
+  export let user: User | null;
 
   type CellRendererParams = {
     deleteExpansionSequence: (sequence: ExpansionSequence) => void;
-    openExpansionSequence: (sequence: ExpansionSequence) => void;
+    openExpansionSequence: (sequence: ExpansionSequence, user: User) => void;
   };
   type ExpansionSequenceCellRendererParams = ICellRendererParams<ExpansionSequence> & CellRendererParams;
 
@@ -65,7 +67,7 @@
               placement: 'bottom',
             },
             rowData: params.data,
-            viewCallback: params.openExpansionSequence,
+            viewCallback: data => params.openExpansionSequence(data, user),
             viewTooltip: {
               content: 'Open Sequence',
               placement: 'bottom',
@@ -98,7 +100,7 @@
   $: expandButtonEnabled = $selectedExpansionSetId !== null;
 
   function deleteExpansionSequence(sequence: ExpansionSequence) {
-    effects.deleteExpansionSequence(sequence);
+    effects.deleteExpansionSequence(sequence, user);
   }
 
   function deleteExpansionSequenceContext(event: CustomEvent<RowId[]>) {
@@ -124,7 +126,7 @@
         disabled={$selectedExpansionSetId === null}
         on:click={() => {
           if ($selectedExpansionSetId) {
-            effects.expand($selectedExpansionSetId, $simulationDatasetId);
+            effects.expand($selectedExpansionSetId, $simulationDatasetId, user);
           }
         }}
       />
@@ -171,7 +173,8 @@
                   <button
                     class="st-button secondary"
                     disabled={!createButtonEnabled}
-                    on:click|stopPropagation={() => effects.createExpansionSequence(seqIdInput, $simulationDatasetId)}
+                    on:click|stopPropagation={() =>
+                      effects.createExpansionSequence(seqIdInput, $simulationDatasetId, user)}
                   >
                     {$creatingExpansionSequence ? 'Creating... ' : 'Create'}
                   </button>
@@ -183,8 +186,9 @@
                       {columnDefs}
                       itemDisplayText="Sequence"
                       items={$filteredExpansionSequences}
+                      {user}
                       on:deleteItem={deleteExpansionSequenceContext}
-                      on:rowDoubleClicked={event => showExpansionSequenceModal(event.detail)}
+                      on:rowDoubleClicked={event => showExpansionSequenceModal(event.detail, user)}
                     />
                   {:else}
                     <div class="st-typography-label">

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -6,6 +6,7 @@
   import { expansionRulesColumns, savingExpansionRule } from '../../stores/expansion';
   import { activityTypes, models } from '../../stores/plan';
   import { commandDictionaries } from '../../stores/sequencing';
+  import type { User } from '../../types/app';
   import type { ExpansionRule, ExpansionRuleInsertInput } from '../../types/expansion';
   import effects from '../../utilities/effects';
   import { isSaveEvent } from '../../utilities/keyboardEvents';
@@ -25,6 +26,7 @@
   export let initialRuleModelId: number | null = null;
   export let initialRuleUpdatedAt: string | null = null;
   export let mode: 'create' | 'edit' = 'create';
+  export let user: User | null;
 
   let ruleActivityType: string | null = initialRuleActivityType;
   let ruleCreatedAt: string | null = initialRuleCreatedAt;
@@ -81,7 +83,7 @@
           authoring_mission_model_id: ruleModelId,
           expansion_logic: ruleLogic,
         };
-        const newRuleId = await effects.createExpansionRule(newRule);
+        const newRuleId = await effects.createExpansionRule(newRule, user);
 
         if (newRuleId !== null) {
           goto(`${base}/expansion/rules/edit/${newRuleId}`);
@@ -93,7 +95,7 @@
           authoring_mission_model_id: ruleModelId,
           expansion_logic: ruleLogic,
         };
-        const updated_at = await effects.updateExpansionRule(ruleId, updatedRule);
+        const updated_at = await effects.updateExpansionRule(ruleId, updatedRule, user);
         if (updated_at !== null) {
           ruleUpdatedAt = updated_at;
           savedRule = updatedRule;
@@ -192,6 +194,7 @@
     {ruleLogic}
     {ruleModelId}
     title="{mode === 'create' ? 'New' : 'Edit'} Expansion Rule - Logic Editor"
+    {user}
     on:didChangeModelContent={onDidChangeModelContent}
   />
 </CssGrid>

--- a/src/components/expansion/ExpansionRules.svelte
+++ b/src/components/expansion/ExpansionRules.svelte
@@ -5,6 +5,7 @@
   import { base } from '$app/paths';
   import type { ICellRendererParams } from 'ag-grid-community';
   import { expansionRules, expansionRulesColumns } from '../../stores/expansion';
+  import type { User } from '../../types/app';
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { ExpansionRule } from '../../types/expansion';
   import effects from '../../utilities/effects';
@@ -16,6 +17,8 @@
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
   import ExpansionLogicEditor from './ExpansionLogicEditor.svelte';
+
+  export let user: User | null;
 
   type CellRendererParams = {
     deleteRule: (rule: ExpansionRule) => void;
@@ -95,7 +98,7 @@
   });
 
   async function deleteRule({ id }: Pick<ExpansionRule, 'id'>) {
-    const success = await effects.deleteExpansionRule(id);
+    const success = await effects.deleteExpansionRule(id, user);
 
     if (success) {
       expansionRules.filterValueById(id);
@@ -157,6 +160,7 @@
           hasEdit={true}
           itemDisplayText="Rule"
           items={filteredRules}
+          {user}
           on:deleteItem={deleteRuleContext}
           on:editItem={editRuleContext}
           on:rowSelected={toggleRule}
@@ -176,5 +180,6 @@
     ruleLogic={selectedExpansionRule?.expansion_logic ?? 'No Expansion Rule Selected'}
     ruleModelId={selectedExpansionRule?.authoring_mission_model_id}
     title="Expansion Rule - Logic Editor (Read-only)"
+    {user}
   />
 </CssGrid>

--- a/src/components/expansion/ExpansionRuns.svelte
+++ b/src/components/expansion/ExpansionRuns.svelte
@@ -4,6 +4,7 @@
   import { base } from '$app/paths';
   import type { ICellRendererParams } from 'ag-grid-community';
   import { expansionRunsColumns } from '../../stores/expansion';
+  import type { User } from '../../types/app';
   import type { DataGridColumnDef, DataGridRowSelection } from '../../types/data-grid';
   import type { ActivityInstanceJoin, ExpandedSequence, ExpansionRun } from '../../types/expansion';
   import SequenceEditor from '../sequencing/SequenceEditor.svelte';
@@ -15,6 +16,7 @@
   import ExpandedSequencesDownloadButton from './ExpandedSequencesDownloadButton.svelte';
 
   export let expansionRuns: ExpansionRun[] = [];
+  export let user: User | null;
 
   const columnDefs: DataGridColumnDef[] = [
     {
@@ -177,5 +179,6 @@
     sequenceSeqJson={selectedSequence ? JSON.stringify(selectedSequence.expanded_sequence, null, 2) : undefined}
     readOnly={true}
     title="Sequence - Definition Editor (Read-only)"
+    {user}
   />
 </CssGrid>

--- a/src/components/expansion/ExpansionSetForm.svelte
+++ b/src/components/expansion/ExpansionSetForm.svelte
@@ -8,6 +8,7 @@
   import { models } from '../../stores/plan';
   import { commandDictionaries } from '../../stores/sequencing';
   import type { ActivityTypeExpansionRules } from '../../types/activity';
+  import type { User } from '../../types/app';
   import type { DataGridColumnDef } from '../../types/data-grid';
   import type { ExpansionRule } from '../../types/expansion';
   import effects from '../../utilities/effects';
@@ -20,6 +21,7 @@
   import ExpansionSetRuleSelection from './ExpansionSetRuleSelection.svelte';
 
   export let mode: 'create' | 'edit' = 'create';
+  export let user: User | null;
 
   type CellRendererParams = {
     selectExpansionRule: (name: string, rule: ExpansionRule) => void;
@@ -39,7 +41,7 @@
   let setModelId: number | null = null;
 
   $: effects
-    .getActivityTypesExpansionRules(setModelId)
+    .getActivityTypesExpansionRules(setModelId, user)
     .then(activity_types => (activityTypesExpansionRules = activity_types));
 
   $: logicEditorActivityType = lastSelectedExpansionRule?.activity_type ?? null;
@@ -52,7 +54,7 @@
 
   async function saveSet() {
     if (mode === 'create' && setDictionaryId && setModelId) {
-      const newSetId = await effects.createExpansionSet(setDictionaryId, setModelId, setExpansionRuleIds);
+      const newSetId = await effects.createExpansionSet(setDictionaryId, setModelId, setExpansionRuleIds, user);
 
       if (newSetId !== null) {
         goto(`${base}/expansion/sets`);
@@ -186,6 +188,7 @@
     ruleLogic={logicEditorRuleLogic}
     ruleModelId={setModelId}
     title={logicEditorTitle}
+    {user}
   />
 </CssGrid>
 

--- a/src/components/expansion/ExpansionSets.svelte
+++ b/src/components/expansion/ExpansionSets.svelte
@@ -5,6 +5,7 @@
   import { base } from '$app/paths';
   import type { ICellRendererParams } from 'ag-grid-community';
   import { expansionSets, expansionSetsColumns } from '../../stores/expansion';
+  import type { User } from '../../types/app';
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { ExpansionRule, ExpansionSet } from '../../types/expansion';
   import effects from '../../utilities/effects';
@@ -16,6 +17,8 @@
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
   import ExpansionLogicEditor from './ExpansionLogicEditor.svelte';
+
+  export let user: User | null;
 
   type CellRendererParams = {
     deleteSet: (sequence: ExpansionSet) => void;
@@ -81,7 +84,7 @@
   $: selectedExpansionRuleIds = selectedExpansionRule ? [selectedExpansionRule.id] : [];
 
   async function deleteSet({ id }: Pick<ExpansionSet, 'id'>) {
-    const success = await effects.deleteExpansionSet(id);
+    const success = await effects.deleteExpansionSet(id, user);
 
     if (success) {
       expansionSets.filterValueById(id);
@@ -143,6 +146,7 @@
             {columnDefs}
             itemDisplayText="Expansion Set"
             items={$expansionSets}
+            {user}
             on:deleteItem={deleteSetContext}
             on:rowSelected={toggleSet}
           />
@@ -196,5 +200,6 @@
     ruleLogic={selectedExpansionRule?.expansion_logic ?? 'No Expansion Rule Selected'}
     ruleModelId={selectedExpansionRule?.authoring_mission_model_id}
     title="Expansion Rule - Logic Editor (Read-only)"
+    {user}
   />
 </CssGrid>

--- a/src/components/menus/AppMenu.svelte
+++ b/src/components/menus/AppMenu.svelte
@@ -18,7 +18,6 @@
   import JournalTextIcon from 'bootstrap-icons/icons/journal-text.svg?component';
   import JournalsIcon from 'bootstrap-icons/icons/journals.svg?component';
   import AerieWordmarkDark from '../../assets/aerie-wordmark-dark.svg?component';
-  import { user as userStore } from '../../stores/app';
   import { showAboutModal } from '../../utilities/modal';
   import Menu from './Menu.svelte';
   import MenuItem from './MenuItem.svelte';
@@ -27,7 +26,6 @@
 
   async function logout() {
     await fetch(`${base}/auth/logout`, { method: 'POST' });
-    $userStore = null;
     await invalidateAll();
     await goto(`${base}/login`);
   }

--- a/src/components/menus/PlanMenu.svelte
+++ b/src/components/menus/PlanMenu.svelte
@@ -5,6 +5,7 @@
   import { base } from '$app/paths';
   import BranchIcon from '@nasa-jpl/stellar/icons/branch.svg?component';
   import ChevronDownIcon from '@nasa-jpl/stellar/icons/chevron_down.svg?component';
+  import type { User } from '../../types/app';
   import type { Plan } from '../../types/plan';
   import effects from '../../utilities/effects';
   import { showPlanBranchesModal, showPlanMergeRequestsModal } from '../../utilities/modal';
@@ -12,15 +13,16 @@
   import MenuItem from '../menus/MenuItem.svelte';
 
   export let plan: Plan;
+  export let user: User | null;
 
   let planMenu: Menu;
 
   function createMergePlanBranchRequest() {
-    effects.createPlanBranchRequest(plan, 'merge');
+    effects.createPlanBranchRequest(plan, 'merge', user);
   }
 
   function createPlanBranch() {
-    effects.createPlanBranch(plan);
+    effects.createPlanBranch(plan, user);
   }
 
   function showPlanBranches() {
@@ -28,7 +30,7 @@
   }
 
   function showPlanMergeRequests() {
-    showPlanMergeRequestsModal();
+    showPlanMergeRequestsModal(user);
   }
 </script>
 

--- a/src/components/menus/ViewMenu.svelte
+++ b/src/components/menus/ViewMenu.svelte
@@ -13,14 +13,16 @@
   import ViewGridRightPanelSplitEmpty from '@nasa-jpl/stellar/icons/view_grid_right_panel_split_empty.svg?component';
   import ViewGridRightPanelSplitFilled from '@nasa-jpl/stellar/icons/view_grid_right_panel_split_filled.svg?component';
   import { createEventDispatcher } from 'svelte';
-  import { user as userStore } from '../../stores/app';
   import { view, viewIsModified } from '../../stores/views';
+  import type { User } from '../../types/app';
   import type { ViewToggleType } from '../../types/view';
   import { showSavedViewsModal } from '../../utilities/modal';
   import { Status } from '../../utilities/status';
   import PlanNavButton from '../plan/PlanNavButton.svelte';
   import ToggleableIcon from '../ui/ToggleableIcon.svelte';
   import MenuItem from './MenuItem.svelte';
+
+  export let user: User | null;
 
   const defaultViewName = 'Default View';
   const dispatch = createEventDispatcher();
@@ -32,7 +34,7 @@
   let rightSplitPanelIsOn: boolean = false;
   let saveViewDisabled: boolean = true;
 
-  $: saveViewDisabled = $view?.name === '' || $view?.owner !== $userStore?.id || !$viewIsModified;
+  $: saveViewDisabled = $view?.name === '' || $view?.owner !== user?.id || !$viewIsModified;
   $: if ($view.definition.plan.grid) {
     leftPanelIsOn = !$view.definition.plan.grid.leftHidden && !$view.definition.plan.grid.leftSplit;
     leftSplitPanelIsOn = !$view.definition.plan.grid.leftHidden && $view.definition.plan.grid.leftSplit;
@@ -43,13 +45,13 @@
 
   function editView() {
     if ($view) {
-      dispatch('editView', { definition: $view.definition, owner: $userStore?.id });
+      dispatch('editView', { definition: $view.definition, owner: user.id });
     }
   }
 
   function saveAsView() {
     if ($view) {
-      dispatch('createView', { definition: $view.definition, owner: $userStore?.id });
+      dispatch('createView', { definition: $view.definition, owner: user.id });
     }
   }
 
@@ -60,7 +62,7 @@
   }
 
   function saveView() {
-    if ($view && $view.owner === $userStore?.id && !saveViewDisabled) {
+    if ($view && $view.owner === user.id && !saveViewDisabled) {
       dispatch('saveView', { definition: $view.definition, id: $view.id, name: $view.name });
     }
   }
@@ -70,7 +72,7 @@
   }
 
   function uploadView() {
-    dispatch('uploadView', { owner: $userStore?.id });
+    dispatch('uploadView', { owner: user.id });
   }
 </script>
 
@@ -119,7 +121,7 @@
         Reset to {$view?.name && $view.name !== defaultViewName ? 'last saved' : 'default'}
       </MenuItem>
       <MenuItem on:click={uploadView}>Upload view file</MenuItem>
-      <MenuItem on:click={showSavedViewsModal}>Browse saved views</MenuItem>
+      <MenuItem on:click={() => showSavedViewsModal(user)}>Browse saved views</MenuItem>
       {#if $view?.name && $view.name !== defaultViewName}
         <hr />
         <MenuItem on:click={editView}>Rename view</MenuItem>

--- a/src/components/modals/ExpansionSequenceModal.svelte
+++ b/src/components/modals/ExpansionSequenceModal.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import type { User } from '../../types/app';
   import type { ExpansionSequence } from '../../types/expansion';
   import effects from '../../utilities/effects';
   import MonacoEditor from '../ui/MonacoEditor.svelte';
@@ -13,11 +14,12 @@
   const dispatch = createEventDispatcher();
 
   export let expansionSequence: ExpansionSequence;
+  export let user: User | null;
 
   let seqJsonStr: string | null = null;
 
   $: effects
-    .getExpansionSequenceSeqJson(expansionSequence.seq_id, expansionSequence.simulation_dataset_id)
+    .getExpansionSequenceSeqJson(expansionSequence.seq_id, expansionSequence.simulation_dataset_id, user)
     .then((result: string) => (seqJsonStr = result));
 </script>
 

--- a/src/components/modals/PlanMergeRequestsModal.svelte
+++ b/src/components/modals/PlanMergeRequestsModal.svelte
@@ -5,6 +5,7 @@
   import { base } from '$app/paths';
   import { createEventDispatcher } from 'svelte';
   import { planMergeRequestsIncoming, planMergeRequestsOutgoing } from '../../stores/plan';
+  import type { User } from '../../types/app';
   import type { PlanMergeRequest, PlanMergeRequestStatus, PlanMergeRequestTypeFilter } from '../../types/plan';
   import effects from '../../utilities/effects';
   import { classNames } from '../../utilities/generic';
@@ -17,6 +18,7 @@
 
   export let height: number = 550;
   export let selectedFilter: PlanMergeRequestTypeFilter = 'all';
+  export let user: User | null;
   export let width: number = 550;
 
   const dispatch = createEventDispatcher();
@@ -73,13 +75,13 @@
     if (planMergeRequest.type === 'incoming') {
       planMergeRequest.pending = true;
       filteredPlanMergeRequests = [...filteredPlanMergeRequests];
-      const success = await effects.planMergeBegin(planMergeRequest.id);
+      const success = await effects.planMergeBegin(planMergeRequest.id, user);
       if (success) {
         dispatch('close');
         goto(`${base}/plans/${planMergeRequest.plan_receiving_changes.id}/merge`);
       }
     } else if (planMergeRequest.type === 'outgoing') {
-      await effects.planMergeRequestWithdraw(planMergeRequest.id);
+      await effects.planMergeRequestWithdraw(planMergeRequest.id, user);
     }
 
     planMergeRequest.pending = false;

--- a/src/components/modals/SavedViewsModal.svelte
+++ b/src/components/modals/SavedViewsModal.svelte
@@ -2,8 +2,8 @@
 
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
-  import { user } from '../../stores/app';
   import { initializeView, view, views } from '../../stores/views';
+  import type { User } from '../../types/app';
   import type { View } from '../../types/view';
   import effects from '../../utilities/effects';
   import { setQueryParam } from '../../utilities/generic';
@@ -17,15 +17,16 @@
 
   export let height: number | string = 150;
   export let width: number | string = 380;
+  export let user: User | null;
 
   const dispatch = createEventDispatcher();
 
   let userViews: View[] = [];
 
-  $: userViews = $views.filter((view: View) => view.owner === $user.id);
+  $: userViews = $views.filter((view: View) => view.owner === user.id);
 
   async function deleteView({ detail: viewId }: CustomEvent<number>) {
-    const success = await effects.deleteView(viewId);
+    const success = await effects.deleteView(viewId, user);
 
     if (success) {
       if ($view.id === viewId) {
@@ -35,7 +36,7 @@
   }
 
   async function deleteViews({ detail: viewIds }: CustomEvent<number[]>) {
-    const success = await effects.deleteViews(viewIds);
+    const success = await effects.deleteViews(viewIds, user);
 
     if (success) {
       if (viewIds.includes($view.id)) {
@@ -45,14 +46,14 @@
   }
 
   async function goToNextView() {
-    const nextView = await effects.getView(null);
+    const nextView = await effects.getView(null, user);
     initializeView({ ...nextView });
     setQueryParam('viewId', `${nextView.id}`);
   }
 
   async function openView({ detail: viewId }: CustomEvent<number>) {
     const query = new URLSearchParams(`?viewId=${viewId}`);
-    const newView = await effects.getView(query);
+    const newView = await effects.getView(query, user);
 
     if (view) {
       initializeView({ ...newView });

--- a/src/components/plan/PlanMergeRequestsStatusButton.svelte
+++ b/src/components/plan/PlanMergeRequestsStatusButton.svelte
@@ -4,27 +4,30 @@
   import PlanWithDownArrowIcon from '@nasa-jpl/stellar/icons/plan_with_down_arrow.svg?component';
   import PlanWithUpArrowIcon from '@nasa-jpl/stellar/icons/plan_with_up_arrow.svg?component';
   import { planMergeRequestsIncoming, planMergeRequestsOutgoing } from '../../stores/plan';
+  import type { User } from '../../types/app';
   import { showPlanMergeRequestsModal } from '../../utilities/modal';
   import { tooltip } from '../../utilities/tooltip';
 
-  $: incomingPendingMergeRequets = $planMergeRequestsIncoming.filter(request => request.status === 'pending');
-  $: outgoingPendingMergeRequets = $planMergeRequestsOutgoing.filter(request => request.status === 'pending');
-  $: incomingPendingMergeRequetCount = incomingPendingMergeRequets.length;
-  $: outgoingPendingMergeRequetCount = outgoingPendingMergeRequets.length;
-  $: label = `${incomingPendingMergeRequetCount} incoming, ${outgoingPendingMergeRequetCount} outgoing`;
+  export let user: User | null;
+
+  $: incomingPendingMergeRequests = $planMergeRequestsIncoming.filter(request => request.status === 'pending');
+  $: outgoingPendingMergeRequests = $planMergeRequestsOutgoing.filter(request => request.status === 'pending');
+  $: incomingPendingMergeRequestCount = incomingPendingMergeRequests.length;
+  $: outgoingPendingMergeRequestCount = outgoingPendingMergeRequests.length;
+  $: label = `${incomingPendingMergeRequestCount} incoming, ${outgoingPendingMergeRequestCount} outgoing`;
 </script>
 
-{#if incomingPendingMergeRequetCount > 0 || outgoingPendingMergeRequetCount > 0}
+{#if incomingPendingMergeRequestCount > 0 || outgoingPendingMergeRequestCount > 0}
   <button
     aria-label={label}
     class="plan-merge-requests-status-button st-button tertiary st-typography-medium"
-    on:click|stopPropagation={() => showPlanMergeRequestsModal()}
+    on:click|stopPropagation={() => showPlanMergeRequestsModal(user)}
     use:tooltip={{ content: label, placement: 'top' }}
   >
-    <span class="status-icon" class:active={incomingPendingMergeRequetCount > 0}>
+    <span class="status-icon" class:active={incomingPendingMergeRequestCount > 0}>
       <PlanWithDownArrowIcon />
     </span>
-    <span class="status-icon" class:active={outgoingPendingMergeRequetCount > 0}>
+    <span class="status-icon" class:active={outgoingPendingMergeRequestCount > 0}>
       <PlanWithUpArrowIcon />
     </span>
     <span>Merge requests</span>

--- a/src/components/plan/PlanMergeReview.test.ts
+++ b/src/components/plan/PlanMergeReview.test.ts
@@ -2,6 +2,7 @@ import { cleanup, render } from '@testing-library/svelte';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { activityMetadataDefinitions } from '../../stores/activities';
 import { activityTypes } from '../../stores/plan';
+import type { User } from '../../types/app';
 import type {
   Plan,
   PlanMergeConflictingActivity,
@@ -58,6 +59,8 @@ const mockInitialPlan: Plan = {
   start_time_doy: '2023-047T00:00:00',
 };
 
+const user: User = { allowedRoles: ['admin'], defaultRole: 'admin', id: 'foo', permissibleQueries: {}, token: '' };
+
 describe('PlanMergeReview component', () => {
   beforeAll(() => {
     activityMetadataDefinitions.updateValue(() => []);
@@ -79,6 +82,7 @@ describe('PlanMergeReview component', () => {
       initialMergeRequest: { ...mockMergeRequest },
       initialNonConflictingActivities: [],
       initialPlan: { ...mockInitialPlan },
+      user,
     });
 
     expect(component).toBeTruthy();
@@ -137,6 +141,7 @@ describe('PlanMergeReview component', () => {
       initialMergeRequest: { ...mockMergeRequest },
       initialNonConflictingActivities,
       initialPlan: { ...mockInitialPlan },
+      user,
     });
 
     expect(component).toBeTruthy();
@@ -194,6 +199,7 @@ describe('PlanMergeReview component', () => {
       initialMergeRequest: { ...mockMergeRequest },
       initialNonConflictingActivities,
       initialPlan: { ...mockInitialPlan },
+      user,
     });
 
     expect(component).toBeTruthy();
@@ -293,6 +299,7 @@ describe('PlanMergeReview component', () => {
       initialMergeRequest: { ...mockMergeRequest },
       initialNonConflictingActivities,
       initialPlan: { ...mockInitialPlan },
+      user,
     });
 
     expect(component).toBeTruthy();

--- a/src/components/scheduling/Scheduling.svelte
+++ b/src/components/scheduling/Scheduling.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
   import { schedulingColumns, schedulingConditions, schedulingGoals } from '../../stores/scheduling';
+  import type { User } from '../../types/app';
   import type { DataGridRowSelection } from '../../types/data-grid';
   import type { SchedulingCondition, SchedulingGoal } from '../../types/scheduling';
   import effects from '../../utilities/effects';
@@ -10,6 +11,8 @@
   import SchedulingConditions from './conditions/SchedulingConditions.svelte';
   import SchedulingGoals from './goals/SchedulingGoals.svelte';
   import SchedulingEditor from './SchedulingEditor.svelte';
+
+  export let user: User | null;
 
   let selectedCondition: SchedulingCondition | null = null;
   let selectedGoal: SchedulingGoal | null = null;
@@ -31,7 +34,7 @@
   }
 
   async function deleteCondition({ id }: Pick<SchedulingCondition, 'id'>) {
-    const success = await effects.deleteSchedulingCondition(id);
+    const success = await effects.deleteSchedulingCondition(id, user);
 
     if (success) {
       schedulingConditions.filterValueById(id);
@@ -43,7 +46,7 @@
   }
 
   async function deleteGoal({ id }: Pick<SchedulingGoal, 'id'>) {
-    const success = await effects.deleteSchedulingGoal(id);
+    const success = await effects.deleteSchedulingGoal(id, user);
 
     if (success) {
       schedulingGoals.filterValueById(id);
@@ -104,6 +107,7 @@
     <SchedulingGoals
       {selectedGoal}
       schedulingGoals={$schedulingGoals}
+      {user}
       on:deleteGoal={deleteGoalContext}
       on:rowSelected={toggleGoal}
     />
@@ -111,6 +115,7 @@
     <SchedulingConditions
       {selectedCondition}
       schedulingConditions={$schedulingConditions}
+      {user}
       on:deleteCondition={deleteConditionContext}
       on:rowSelected={toggleCondition}
     />
@@ -123,5 +128,6 @@
     scheduleItemModelId={selectedItem?.model_id}
     readOnly={true}
     title={editorTitle}
+    {user}
   />
 </CssGrid>

--- a/src/components/scheduling/SchedulingConditionsPanel.svelte
+++ b/src/components/scheduling/SchedulingConditionsPanel.svelte
@@ -5,6 +5,7 @@
   import { afterUpdate, beforeUpdate } from 'svelte';
   import { plan } from '../../stores/plan';
   import { schedulingSpecConditions, selectedSpecId } from '../../stores/scheduling';
+  import type { User } from '../../types/app';
   import type { SchedulingSpecCondition } from '../../types/scheduling';
   import type { ViewGridSection } from '../../types/view';
   import CollapsibleListControls from '../CollapsibleListControls.svelte';
@@ -13,6 +14,7 @@
   import SchedulingCondition from './conditions/SchedulingCondition.svelte';
 
   export let gridSection: ViewGridSection;
+  export let user: User | null;
 
   let activeElement: HTMLElement;
   let conditionsFilterText: string = '';
@@ -70,6 +72,7 @@
             enabled={specCondition.enabled}
             condition={specCondition.condition}
             specificationId={specCondition.specification_id}
+            {user}
           />
         {/each}
       {/if}

--- a/src/components/scheduling/SchedulingEditor.svelte
+++ b/src/components/scheduling/SchedulingEditor.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import type { User } from '../../types/app';
   import type { Monaco, TypeScriptFile } from '../../types/monaco';
   import effects from '../../utilities/effects';
   import MonacoEditor from '../ui/MonacoEditor.svelte';
@@ -11,11 +12,12 @@
   export let scheduleItemModelId: number | null = null;
   export let readOnly: boolean = false;
   export let title: string = 'Scheduling Item - Definition Editor';
+  export let user: User | null;
 
   let monaco: Monaco;
   let schedulingTsFiles: TypeScriptFile[];
 
-  $: effects.getTsFilesScheduling(scheduleItemModelId).then(tsFiles => (schedulingTsFiles = tsFiles));
+  $: effects.getTsFilesScheduling(scheduleItemModelId, user).then(tsFiles => (schedulingTsFiles = tsFiles));
 
   $: if (monaco !== undefined && schedulingTsFiles !== undefined) {
     const { languages } = monaco;

--- a/src/components/scheduling/SchedulingGoalsPanel.svelte
+++ b/src/components/scheduling/SchedulingGoalsPanel.svelte
@@ -6,6 +6,7 @@
   import { afterUpdate, beforeUpdate } from 'svelte';
   import { plan } from '../../stores/plan';
   import { enableScheduling, schedulingSpecGoals, schedulingStatus, selectedSpecId } from '../../stores/scheduling';
+  import type { User } from '../../types/app';
   import type { SchedulingSpecGoal } from '../../types/scheduling';
   import type { ViewGridSection } from '../../types/view';
   import effects from '../../utilities/effects';
@@ -17,6 +18,7 @@
   import SchedulingGoal from './goals/SchedulingGoal.svelte';
 
   export let gridSection: ViewGridSection;
+  export let user: User | null;
 
   let activeElement: HTMLElement;
   let filterText: string = '';
@@ -46,10 +48,18 @@
   <svelte:fragment slot="header">
     <GridMenu {gridSection} title="Scheduling Goals" />
     <PanelHeaderActions status={$schedulingStatus}>
-      <PanelHeaderActionButton title="Analyze" on:click={() => effects.schedule(true)} disabled={!$enableScheduling}>
+      <PanelHeaderActionButton
+        title="Analyze"
+        on:click={() => effects.schedule(true, user)}
+        disabled={!$enableScheduling}
+      >
         <ChecklistIcon />
       </PanelHeaderActionButton>
-      <PanelHeaderActionButton title="Schedule" on:click={() => effects.schedule()} disabled={!$enableScheduling} />
+      <PanelHeaderActionButton
+        title="Schedule"
+        on:click={() => effects.schedule(false, user)}
+        disabled={!$enableScheduling}
+      />
     </PanelHeaderActions>
   </svelte:fragment>
 
@@ -79,6 +89,7 @@
             priority={specGoal.priority}
             simulateAfter={specGoal.simulate_after}
             specificationId={specGoal.specification_id}
+            {user}
           />
         {/each}
       {/if}

--- a/src/components/scheduling/conditions/SchedulingCondition.svelte
+++ b/src/components/scheduling/conditions/SchedulingCondition.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
   import { base } from '$app/paths';
+  import type { User } from '../../../types/app';
   import type { SchedulingCondition } from '../../../types/scheduling';
   import effects from '../../../utilities/effects';
   import Collapse from '../../Collapse.svelte';
@@ -12,6 +13,7 @@
   export let enabled: boolean;
   export let condition: SchedulingCondition;
   export let specificationId: number;
+  export let user: User | null;
 </script>
 
 <div class="scheduling-condition" class:disabled={!enabled}>
@@ -23,7 +25,7 @@
             bind:checked={enabled}
             style:cursor="pointer"
             type="checkbox"
-            on:change={() => effects.updateSchedulingSpecCondition(condition.id, specificationId, { enabled })}
+            on:change={() => effects.updateSchedulingSpecCondition(condition.id, specificationId, { enabled }, user)}
           />
         </Input>
       </div>
@@ -34,9 +36,9 @@
         Edit Condition
       </ContextMenuItem>
       <ContextMenuHeader>Modify</ContextMenuHeader>
-      <ContextMenuItem on:click={() => effects.deleteSchedulingCondition(condition.id)}
-        >Delete Condition</ContextMenuItem
-      >
+      <ContextMenuItem on:click={() => effects.deleteSchedulingCondition(condition.id, user)}>
+        Delete Condition
+      </ContextMenuItem>
     </svelte:fragment>
   </Collapse>
 </div>

--- a/src/components/scheduling/conditions/SchedulingConditionEditor.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditionEditor.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import type { User } from '../../../types/app';
   import type { Monaco, TypeScriptFile } from '../../../types/monaco';
   import effects from '../../../utilities/effects';
   import MonacoEditor from '../../ui/MonacoEditor.svelte';
@@ -11,11 +12,12 @@
   export let conditionModelId: number | null = null;
   export let readOnly: boolean = false;
   export let title: string = 'Scheduling Condition - Definition Editor';
+  export let user: User | null;
 
   let monaco: Monaco;
   let schedulingTsFiles: TypeScriptFile[];
 
-  $: effects.getTsFilesScheduling(conditionModelId).then(tsFiles => (schedulingTsFiles = tsFiles));
+  $: effects.getTsFilesScheduling(conditionModelId, user).then(tsFiles => (schedulingTsFiles = tsFiles));
 
   $: if (monaco !== undefined && schedulingTsFiles !== undefined) {
     const { languages } = monaco;

--- a/src/components/scheduling/conditions/SchedulingConditionForm.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditionForm.svelte
@@ -3,8 +3,8 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
-  import { user as userStore } from '../../../stores/app';
   import { schedulingColumns } from '../../../stores/scheduling';
+  import type { User } from '../../../types/app';
   import type { ModelSlim } from '../../../types/model';
   import type { PlanSchedulingSpec } from '../../../types/plan';
   import type { SchedulingCondition, SchedulingSpecConditionInsertInput } from '../../../types/scheduling';
@@ -28,6 +28,7 @@
   export let mode: 'create' | 'edit' = 'create';
   export let models: ModelSlim[] = [];
   export let plans: PlanSchedulingSpec[] = [];
+  export let user: User | null;
 
   let conditionAuthor: string | null = initialConditionAuthor;
   let conditionCreatedDate: string | null = initialConditionCreatedDate;
@@ -94,8 +95,8 @@
           conditionDefinition,
           conditionDescription,
           conditionName,
-          $userStore?.id,
           conditionModelId,
+          user,
         );
 
         if (newCondition !== null) {
@@ -106,7 +107,7 @@
             enabled: true,
             specification_id: specId,
           };
-          await effects.createSchedulingSpecCondition(specConditionInsertInput);
+          await effects.createSchedulingSpecCondition(specConditionInsertInput, user);
 
           goto(`${base}/scheduling/conditions/edit/${newConditionId}`);
         }
@@ -117,10 +118,10 @@
           model_id: conditionModelId,
           name: conditionName,
         };
-        const updatedCondition = await effects.updateSchedulingCondition(conditionId, condition);
+        const updatedCondition = await effects.updateSchedulingCondition(conditionId, condition, user);
         if (updatedCondition) {
           if (specId !== savedSpecId) {
-            await effects.updateSchedulingSpecConditionId(conditionId, savedSpecId, specId);
+            await effects.updateSchedulingSpecConditionId(conditionId, savedSpecId, specId, user);
             savedSpecId = specId;
           }
 
@@ -231,6 +232,7 @@
     scheduleItemDefinition={conditionDefinition}
     scheduleItemModelId={conditionModelId}
     title="{mode === 'create' ? 'New' : 'Edit'} Scheduling Condition - Definition Editor"
+    {user}
     on:didChangeModelContent={onDidChangeModelContent}
   />
 </CssGrid>

--- a/src/components/scheduling/conditions/SchedulingConditions.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditions.svelte
@@ -5,6 +5,7 @@
   import { base } from '$app/paths';
   import type { ICellRendererParams } from 'ag-grid-community';
   import { createEventDispatcher } from 'svelte';
+  import type { User } from '../../../types/app';
   import type { DataGridColumnDef, RowId } from '../../../types/data-grid';
   import type { SchedulingCondition } from '../../../types/scheduling';
   import Input from '../../form/Input.svelte';
@@ -15,6 +16,7 @@
 
   export let schedulingConditions: SchedulingCondition[] = [];
   export let selectedCondition: SchedulingCondition | null | undefined = null;
+  export let user: User | null;
 
   type CellRendererParams = {
     deleteCondition: (condition: SchedulingCondition) => void;
@@ -136,6 +138,7 @@
         itemDisplayText="Condition"
         items={filteredConditions}
         selectedItemId={selectedCondition?.id ?? null}
+        {user}
         on:deleteItem={deleteConditionContext}
         on:editItem={editConditionContext}
         on:rowSelected

--- a/src/components/scheduling/goals/SchedulingGoal.svelte
+++ b/src/components/scheduling/goals/SchedulingGoal.svelte
@@ -4,6 +4,7 @@
   import { base } from '$app/paths';
   import CaretDownFillIcon from 'bootstrap-icons/icons/caret-down-fill.svg?component';
   import CaretUpFillIcon from 'bootstrap-icons/icons/caret-up-fill.svg?component';
+  import type { User } from '../../../types/app';
   import type { SchedulingGoal } from '../../../types/scheduling';
   import effects from '../../../utilities/effects';
   import { tooltip } from '../../../utilities/tooltip';
@@ -19,6 +20,7 @@
   export let priority: number;
   export let specificationId: number;
   export let simulateAfter: boolean = true;
+  export let user: User | null;
 
   $: upButtonHidden = priority <= 0;
   $: simulateGoal = simulateAfter; // Copied to local var to reflect changed values immediately in the UI
@@ -34,7 +36,7 @@
   }
 
   function updatePriority(priority: number) {
-    effects.updateSchedulingSpecGoal(goal.id, specificationId, { priority });
+    effects.updateSchedulingSpecGoal(goal.id, specificationId, { priority }, user);
   }
 
   function onKeyDown(e: KeyboardEvent) {
@@ -93,7 +95,7 @@
             bind:checked={enabled}
             style:cursor="pointer"
             type="checkbox"
-            on:change={() => effects.updateSchedulingSpecGoal(goal.id, specificationId, { enabled })}
+            on:change={() => effects.updateSchedulingSpecGoal(goal.id, specificationId, { enabled }, user)}
           />
         </Input>
       </div>
@@ -107,14 +109,14 @@
         Edit Goal
       </ContextMenuItem>
       <ContextMenuHeader>Modify</ContextMenuHeader>
-      <ContextMenuItem on:click={() => effects.deleteSchedulingGoal(goal.id)}>Delete Goal</ContextMenuItem>
+      <ContextMenuItem on:click={() => effects.deleteSchedulingGoal(goal.id, user)}>Delete Goal</ContextMenuItem>
       <ContextMenuItem>
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <div
           class="scheduling-goal-simulate-toggle"
           on:click|stopPropagation={() => {
             simulateGoal = !simulateGoal;
-            effects.updateSchedulingSpecGoal(goal.id, specificationId, { simulate_after: simulateGoal });
+            effects.updateSchedulingSpecGoal(goal.id, specificationId, { simulate_after: simulateGoal }, user);
           }}
         >
           <input bind:checked={simulateGoal} style:cursor="pointer" type="checkbox" /> Simulate After

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte.test.ts
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte.test.ts
@@ -44,6 +44,7 @@ describe('Scheduling Goal Form component', () => {
       initialGoalModelId: models[0].id,
       models,
       plans,
+      user: { allowedRoles: ['admin'], defaultRole: 'admin', id: 'foo', permissibleQueries: {}, token: '' },
     });
 
     const planDropdown: HTMLSelectElement = container.querySelector('.st-select[name="plan"]');

--- a/src/components/scheduling/goals/SchedulingGoals.svelte
+++ b/src/components/scheduling/goals/SchedulingGoals.svelte
@@ -5,6 +5,7 @@
   import { base } from '$app/paths';
   import type { ICellRendererParams } from 'ag-grid-community';
   import { createEventDispatcher } from 'svelte';
+  import type { User } from '../../../types/app';
   import type { DataGridColumnDef, RowId } from '../../../types/data-grid';
   import type { SchedulingGoal } from '../../../types/scheduling';
   import Input from '../../form/Input.svelte';
@@ -15,6 +16,7 @@
 
   export let schedulingGoals: SchedulingGoal[] = [];
   export let selectedGoal: SchedulingGoal | null | undefined = null;
+  export let user: User | null;
 
   type CellRendererParams = {
     deleteGoal: (goal: SchedulingGoal) => void;
@@ -134,6 +136,7 @@
         itemDisplayText="Goal"
         items={filteredGoals}
         selectedItemId={selectedGoal?.id ?? null}
+        {user}
         on:deleteItem={deleteGoalContext}
         on:editItem={editGoalContext}
         on:rowSelected

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -4,6 +4,7 @@
   import type { editor as Editor, languages } from 'monaco-editor/esm/vs/editor/editor.api';
   import { createEventDispatcher } from 'svelte';
   import { userSequencesRows } from '../../stores/sequencing';
+  import type { User } from '../../types/app';
   import type { Monaco, TypeScriptFile } from '../../types/monaco';
   import effects from '../../utilities/effects';
   import CssGrid from '../ui/CssGrid.svelte';
@@ -19,6 +20,7 @@
   export let sequenceName: string = '';
   export let sequenceSeqJson: string = '';
   export let title: string = 'Sequence - Definition Editor';
+  export let user: User | null;
 
   const dispatch = createEventDispatcher();
 
@@ -26,7 +28,7 @@
   let monaco: Monaco;
 
   $: effects
-    .getTsFilesCommandDictionary(sequenceCommandDictionaryId)
+    .getTsFilesCommandDictionary(sequenceCommandDictionaryId, user)
     .then(tsFiles => (commandDictionaryTsFiles = tsFiles));
 
   $: if (monaco !== undefined) {

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -5,6 +5,7 @@
   import { base } from '$app/paths';
   import type { ICellRendererParams } from 'ag-grid-community';
   import { userSequences, userSequencesColumns } from '../../stores/sequencing';
+  import type { User } from '../../types/app';
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { UserSequence } from '../../types/sequencing';
   import effects from '../../utilities/effects';
@@ -16,6 +17,8 @@
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
   import SequenceEditor from './SequenceEditor.svelte';
+
+  export let user: User | null;
 
   type CellRendererParams = {
     deleteSequence: (sequence: UserSequence) => void;
@@ -102,7 +105,7 @@
   }
 
   async function deleteSequence({ id }: Pick<UserSequence, 'id'>) {
-    const success = await effects.deleteUserSequence(id);
+    const success = await effects.deleteUserSequence(id, user);
 
     if (success) {
       userSequences.filterValueById(id);
@@ -135,6 +138,7 @@
       const responseMessage = await effects.getUserSequenceSeqJson(
         selectedSequence.authoring_command_dict_id,
         selectedSequence.definition,
+        user,
         abortController.signal,
       );
 
@@ -185,6 +189,7 @@
           hasEdit={true}
           itemDisplayText="Sequence"
           items={filteredSequences}
+          {user}
           on:deleteItem={deleteSequenceContext}
           on:editItem={editSequenceContext}
           on:rowSelected={toggleSequence}
@@ -204,6 +209,7 @@
     sequenceSeqJson={selectedSequenceSeqJson}
     readOnly={true}
     title="Sequence - Definition Editor (Read-only)"
+    {user}
     on:generate={getUserSequenceSeqJson}
   />
 </CssGrid>

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -9,6 +9,7 @@
   import { createEventDispatcher, onDestroy, onMount, tick } from 'svelte';
   import SpanHashMarksSVG from '../../assets/span-hash-marks.svg?raw';
   import type { ActivityDirective, ActivityDirectiveId, ActivityDirectivesMap } from '../../types/activity';
+  import type { User } from '../../types/app';
   import type { SimulationDataset, Span, SpanId, SpansMap, SpanUtilityMaps } from '../../types/simulation';
   import type {
     ActivityLayerFilter,
@@ -64,6 +65,7 @@
   export let spanUtilityMaps: SpanUtilityMaps;
   export let spansMap: SpansMap = {};
   export let timelineLockStatus: TimelineLockStatus;
+  export let user: User | null;
   export let viewTimeRange: TimeRange = { end: 0, start: 0 };
   export let xScaleView: ScaleTime<number, number> | null = null;
 
@@ -205,7 +207,7 @@
     if (dragActivityDirectiveActive !== null && dragStartX !== null && dragCurrentX !== null) {
       if (dragStartX !== dragCurrentX) {
         const start_offset = getIntervalUnixEpochTime(planStartTimeMs, dragCurrentX);
-        effects.updateActivityDirective(planId, dragActivityDirectiveActive.id, { start_offset });
+        effects.updateActivityDirective(planId, dragActivityDirectiveActive.id, { start_offset }, user);
       }
 
       dragActivityDirectiveActive = null;

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -13,6 +13,7 @@
     ActivityDirectivesByView,
     ActivityDirectivesMap,
   } from '../../types/activity';
+  import type { User } from '../../types/app';
   import type { ConstraintViolation } from '../../types/constraint';
   import type { Resource, SimulationDataset, Span, SpanId, SpanUtilityMaps, SpansMap } from '../../types/simulation';
   import type {
@@ -70,6 +71,7 @@
   export let xScaleView: ScaleTime<number, number> | null = null;
   export let xTicksView: XAxisTick[] = [];
   export let yAxes: Axis[] = [];
+  export let user: User | null;
 
   const dispatch = createEventDispatcher();
 
@@ -143,7 +145,7 @@
       const unixEpochTime = xScaleView.invert(offsetX).getTime();
       const start_time = getDoyTime(new Date(unixEpochTime));
       const activityTypeName = e.dataTransfer.getData('activityTypeName');
-      effects.createActivityDirective({}, start_time, activityTypeName, activityTypeName, [], {});
+      effects.createActivityDirective({}, start_time, activityTypeName, activityTypeName, [], {}, user);
     }
   }
 
@@ -300,6 +302,7 @@
             {spanUtilityMaps}
             {spansMap}
             {timelineLockStatus}
+            {user}
             {viewTimeRange}
             {xScaleView}
             on:contextMenu

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -4,6 +4,7 @@
   import { afterUpdate, createEventDispatcher, tick } from 'svelte';
   import { SOURCES, TRIGGERS, dndzone } from 'svelte-dnd-action';
   import type { ActivityDirectiveId, ActivityDirectivesByView, ActivityDirectivesMap } from '../../types/activity';
+  import type { User } from '../../types/app';
   import type { ConstraintViolation } from '../../types/constraint';
   import type {
     Resource,
@@ -62,6 +63,7 @@
   export let timelineDirectiveVisibilityToggles: DirectiveVisibilityToggleMap = {};
   export let timelineLockStatus: TimelineLockStatus;
   export let viewTimeRange: TimeRange = { end: 0, start: 0 };
+  export let user: User | null;
 
   const dispatch = createEventDispatcher();
 
@@ -307,6 +309,7 @@
         {spanUtilityMaps}
         {spansMap}
         {timelineLockStatus}
+        {user}
         {viewTimeRange}
         {xScaleView}
         {xTicksView}
@@ -347,6 +350,7 @@
     {planStartTimeYmd}
     verticalGuides={timeline?.verticalGuides}
     {xScaleView}
+    {user}
   />
 </div>
 

--- a/src/components/timeline/TimelineContextMenu.svelte
+++ b/src/components/timeline/TimelineContextMenu.svelte
@@ -5,6 +5,7 @@
   import { createEventDispatcher } from 'svelte';
   import { view, viewUpdateGrid } from '../../stores/views';
   import type { ActivityDirective, ActivityDirectivesMap } from '../../types/activity';
+  import type { User } from '../../types/app';
   import type { Simulation, SimulationDataset, Span, SpanUtilityMaps, SpansMap } from '../../types/simulation';
   import type { MouseOver, VerticalGuide } from '../../types/timeline';
   import { getAllSpansForActivityDirective, getSpanRootParent } from '../../utilities/activities';
@@ -25,6 +26,7 @@
   export let contextMenu: MouseOver | undefined;
   export let verticalGuides: VerticalGuide[];
   export let xScaleView: ScaleTime<number, number> | null = null;
+  export let user: User | null;
 
   const dispatch = createEventDispatcher();
   let contextMenuComponent: ContextMenu;
@@ -80,14 +82,14 @@
   function updateSimulationStartTime(date: Date) {
     const doyString = getDoyTime(date, false);
     const newSimulation: Simulation = { ...simulation, simulation_start_time: doyString };
-    effects.updateSimulation(newSimulation);
+    effects.updateSimulation(newSimulation, user);
     switchToSimulation();
   }
 
   function updateSimulationEndTime(date: Date) {
     const doyString = getDoyTime(date, false);
     const newSimulation: Simulation = { ...simulation, simulation_end_time: doyString };
-    effects.updateSimulation(newSimulation);
+    effects.updateSimulation(newSimulation, user);
     switchToSimulation();
   }
 

--- a/src/components/timeline/TimelinePanel.svelte
+++ b/src/components/timeline/TimelinePanel.svelte
@@ -20,6 +20,7 @@
   } from '../../stores/simulation';
   import { timelineLockStatus, view, viewTogglePanel, viewUpdateRow, viewUpdateTimeline } from '../../stores/views';
   import type { ActivityDirectiveId } from '../../types/activity';
+  import type { User } from '../../types/app';
   import type { DirectiveVisibilityToggleMap, MouseDown, Row, Timeline as TimelineType } from '../../types/timeline';
   import effects from '../../utilities/effects';
   import Panel from '../ui/Panel.svelte';
@@ -27,6 +28,8 @@
   import Timeline from './Timeline.svelte';
   import TimelineLockControl from './TimelineLockControl.svelte';
   import TimelineViewControls from './TimelineViewControls.svelte';
+
+  export let user: User | null;
 
   let timelineId: number = 0;
   let timelineDirectiveVisibilityToggles: DirectiveVisibilityToggleMap = {};
@@ -38,7 +41,7 @@
 
   function deleteActivityDirective(event: CustomEvent<ActivityDirectiveId>) {
     const { detail: activityDirectiveId } = event;
-    effects.deleteActivityDirective($planId, activityDirectiveId);
+    effects.deleteActivityDirective($planId, activityDirectiveId, user);
   }
 
   function openSelectedActivityPanel(event: CustomEvent) {
@@ -158,6 +161,7 @@
       spansMap={$spansMap}
       spans={$spans}
       timelineLockStatus={$timelineLockStatus}
+      {user}
       viewTimeRange={$viewTimeRange}
       on:deleteActivityDirective={deleteActivityDirective}
       on:dblClick={openSelectedActivityPanel}

--- a/src/components/ui/DataGrid/SingleActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/SingleActionDataGrid.svelte
@@ -10,6 +10,7 @@
   import { browser } from '$app/environment';
   import type { ColDef, ColumnState, IRowNode } from 'ag-grid-community';
   import { createEventDispatcher, onDestroy, type ComponentEvents } from 'svelte';
+  import type { User } from '../../../types/app';
   import type { RowId, TRowData } from '../../../types/data-grid';
   import type { PermissionCheck } from '../../../types/permissions';
   import { isDeleteEvent } from '../../../utilities/keyboardEvents';
@@ -33,6 +34,7 @@
   export let hasDeletePermission: PermissionCheck<RowData> | boolean = true;
   export let hasEditPermission: PermissionCheck<RowData> | boolean = true;
   export let isRowSelectable: ((node: IRowNode<RowData>) => boolean) | undefined = undefined;
+  export let user: User | null;
 
   const dispatch = createEventDispatcher();
 
@@ -44,10 +46,10 @@
     const selectedItem = items.find(item => item.id === selectedItemId) ?? null;
     if (selectedItem) {
       if (typeof hasDeletePermission === 'function') {
-        deletePermission = hasDeletePermission(selectedItem);
+        deletePermission = hasDeletePermission(user, selectedItem);
       }
       if (typeof hasEditPermission === 'function') {
-        editPermission = hasEditPermission(selectedItem);
+        editPermission = hasEditPermission(user, selectedItem);
       }
     }
   }

--- a/src/components/ui/PlanGrid.svelte
+++ b/src/components/ui/PlanGrid.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import type { User } from '../../types/app';
   import type { ViewGridComponent } from '../../types/view';
   import ActivityDirectivesTablePanel from '../activity/ActivityDirectivesTablePanel.svelte';
   import ActivityFormPanel from '../activity/ActivityFormPanel.svelte';
@@ -32,6 +33,7 @@
   export let rightHidden: boolean = false;
   export let rightRowSizes: string = '1fr 3px 1fr';
   export let rightSplit: boolean = false;
+  export let user: User | null;
 
   const dispatch = createEventDispatcher();
 
@@ -71,16 +73,16 @@
     {#if leftSplit}
       <CssGrid class="plan-grid" rows={leftRowSizes} on:changeRowSizes={onChangeLeftRowSizes}>
         <div class="plan-grid-component" data-component-name={leftComponentTop}>
-          <svelte:component this={gridComponentsByName[leftComponentTop]} gridSection="LeftTop" />
+          <svelte:component this={gridComponentsByName[leftComponentTop]} gridSection="LeftTop" {user} />
         </div>
         <CssGridGutter track={1} type="row" />
         <div class="plan-grid-component" data-component-name={leftComponentBottom}>
-          <svelte:component this={gridComponentsByName[leftComponentBottom]} gridSection="LeftBottom" />
+          <svelte:component this={gridComponentsByName[leftComponentBottom]} gridSection="LeftBottom" {user} />
         </div>
       </CssGrid>
     {:else}
       <div class="plan-grid-component" data-component-name={leftComponentTop}>
-        <svelte:component this={gridComponentsByName[leftComponentTop]} gridSection="LeftTop" />
+        <svelte:component this={gridComponentsByName[leftComponentTop]} gridSection="LeftTop" {user} />
       </div>
     {/if}
 
@@ -90,16 +92,16 @@
   {#if middleSplit}
     <CssGrid class="plan-grid" rows={middleRowSizes} on:changeRowSizes={onChangeMiddleRowSizes}>
       <div class="plan-grid-component" data-component-name="TimelinePanel">
-        <TimelinePanel />
+        <TimelinePanel {user} />
       </div>
       <CssGridGutter track={1} type="row" />
       <div class="plan-grid-component" data-component-name={middleComponentBottom}>
-        <svelte:component this={gridComponentsByName[middleComponentBottom]} gridSection="MiddleBottom" />
+        <svelte:component this={gridComponentsByName[middleComponentBottom]} gridSection="MiddleBottom" {user} />
       </div>
     </CssGrid>
   {:else}
     <div class="plan-grid-component" data-component-name="TimelinePanel">
-      <TimelinePanel />
+      <TimelinePanel {user} />
     </div>
   {/if}
 
@@ -109,16 +111,16 @@
     {#if rightSplit}
       <CssGrid class="plan-grid" rows={rightRowSizes} on:changeRowSizes={onChangeRightRowSizes}>
         <div class="plan-grid-component" data-component-name={rightComponentTop}>
-          <svelte:component this={gridComponentsByName[rightComponentTop]} gridSection="RightTop" />
+          <svelte:component this={gridComponentsByName[rightComponentTop]} gridSection="RightTop" {user} />
         </div>
         <CssGridGutter track={1} type="row" />
         <div class="plan-grid-component" data-component-name={rightComponentBottom}>
-          <svelte:component this={gridComponentsByName[rightComponentBottom]} gridSection="RightBottom" />
+          <svelte:component this={gridComponentsByName[rightComponentBottom]} gridSection="RightBottom" {user} />
         </div>
       </CssGrid>
     {:else}
       <div class="plan-grid-component" data-component-name={rightComponentTop}>
-        <svelte:component this={gridComponentsByName[rightComponentTop]} gridSection="RightTop" />
+        <svelte:component this={gridComponentsByName[rightComponentTop]} gridSection="RightTop" {user} />
       </div>
     {/if}
   {/if}

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,13 +1,6 @@
-export const ssr = false; // SPA mode.
-
 import '../css/app.css';
-import { permissibleQueries as permissibleQueriesStore, user as userStore } from '../stores/app';
 import type { LayoutLoad } from './$types';
 
 export const load: LayoutLoad = async ({ data }) => {
-  // TODO: Remove this for SSR!
-  // See: https://kit.svelte.dev/docs/state-management#no-side-effects-in-load
-  userStore.set(data?.user);
-  permissibleQueriesStore.set(data?.permissibleQueries ?? null);
   return { ...data };
 };

--- a/src/routes/auth/logout/+server.ts
+++ b/src/routes/auth/logout/+server.ts
@@ -7,10 +7,9 @@ import effects from '../../../utilities/effects';
 export const POST: RequestHandler = async event => {
   const { locals } = event;
   const { user } = locals;
-  const { token = '' } = user;
 
   try {
-    const logoutResponse: ReqLogoutResponse = await effects.logout(token);
+    const logoutResponse: ReqLogoutResponse = await effects.logout(user);
     const { message, success } = logoutResponse;
 
     if (success) {

--- a/src/routes/constraints/+page.svelte
+++ b/src/routes/constraints/+page.svelte
@@ -10,4 +10,4 @@
 
 <PageTitle title="Constraints" />
 
-<Constraints initialPlans={data.initialPlans} />
+<Constraints initialPlans={data.initialPlans} user={data.user} />

--- a/src/routes/constraints/+page.ts
+++ b/src/routes/constraints/+page.ts
@@ -6,15 +6,16 @@ import { hasNoAuthorization } from '../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
-  const { plans: initialPlans } = await effects.getPlansAndModels();
+  const { plans: initialPlans } = await effects.getPlansAndModels(user);
 
   return {
     initialPlans,
+    user,
   };
 };

--- a/src/routes/constraints/edit/[id]/+page.svelte
+++ b/src/routes/constraints/edit/[id]/+page.svelte
@@ -17,4 +17,5 @@
   initialModels={data.initialModels}
   initialPlans={data.initialPlans}
   mode="edit"
+  user={data.user}
 />

--- a/src/routes/constraints/edit/[id]/+page.ts
+++ b/src/routes/constraints/edit/[id]/+page.ts
@@ -7,9 +7,9 @@ import { hasNoAuthorization } from '../../../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
@@ -19,14 +19,15 @@ export const load: PageLoad = async ({ parent, params }) => {
     const constraintId = parseFloatOrNull(constraintIdParam);
 
     if (constraintId !== null) {
-      const initialConstraint = await effects.getConstraint(constraintId);
-      const { models: initialModels, plans: initialPlans } = await effects.getPlansAndModels();
+      const initialConstraint = await effects.getConstraint(constraintId, user);
+      const { models: initialModels, plans: initialPlans } = await effects.getPlansAndModels(user);
 
       if (initialConstraint !== null) {
         return {
           initialConstraint,
           initialModels,
           initialPlans,
+          user,
         };
       }
     }

--- a/src/routes/constraints/new/+page.svelte
+++ b/src/routes/constraints/new/+page.svelte
@@ -7,4 +7,4 @@
   export let data: PageData;
 </script>
 
-<ConstraintForm initialModels={data.initialModels} initialPlans={data.initialPlans} mode="create" />
+<ConstraintForm initialModels={data.initialModels} initialPlans={data.initialPlans} mode="create" user={data.user} />

--- a/src/routes/constraints/new/+page.ts
+++ b/src/routes/constraints/new/+page.ts
@@ -6,16 +6,17 @@ import { hasNoAuthorization } from '../../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
-  const { models: initialModels, plans: initialPlans } = await effects.getPlansAndModels();
+  const { models: initialModels, plans: initialPlans } = await effects.getPlansAndModels(user);
 
   return {
     initialModels,
     initialPlans,
+    user,
   };
 };

--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -15,6 +15,9 @@
   import type { CommandDictionary } from '../../types/sequencing';
   import effects from '../../utilities/effects';
   import { showFailureToast, showSuccessToast } from '../../utilities/toast';
+  import type { PageData } from './$types';
+
+  export let data: PageData;
 
   type CellRendererParams = {
     deleteCommandDictionary: (dictionary: CommandDictionary) => void;
@@ -87,7 +90,7 @@
     creatingDictionary = true;
 
     try {
-      const newCommandDictionary = await effects.createCommandDictionary(files);
+      const newCommandDictionary = await effects.createCommandDictionary(files, data.user);
       commandDictionaries.updateValue((dictionaries: CommandDictionary[]) => [newCommandDictionary, ...dictionaries]);
       showSuccessToast('Command Dictionary Created Successfully');
     } catch (e) {
@@ -99,7 +102,7 @@
   }
 
   function deleteCommandDictionary({ id }: Pick<CommandDictionary, 'id'>) {
-    effects.deleteCommandDictionary(id);
+    effects.deleteCommandDictionary(id, data.user);
   }
 
   function deleteCommandDictionaryContext(event: CustomEvent<RowId[]>) {
@@ -149,6 +152,7 @@
             {columnDefs}
             itemDisplayText="Command Dictionary"
             items={$commandDictionaries}
+            user={data.user}
             on:deleteItem={deleteCommandDictionaryContext}
           />
         {:else}

--- a/src/routes/dictionaries/+page.ts
+++ b/src/routes/dictionaries/+page.ts
@@ -5,11 +5,11 @@ import { hasNoAuthorization } from '../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
-  return {};
+  return { user };
 };

--- a/src/routes/expansion/rules/+page.svelte
+++ b/src/routes/expansion/rules/+page.svelte
@@ -3,8 +3,11 @@
 <script lang="ts">
   import PageTitle from '../../../components/app/PageTitle.svelte';
   import ExpansionRules from '../../../components/expansion/ExpansionRules.svelte';
+  import type { PageData } from './$types';
+
+  export let data: PageData;
 </script>
 
 <PageTitle title="Expansion Rules" />
 
-<ExpansionRules />
+<ExpansionRules user={data.user} />

--- a/src/routes/expansion/rules/+page.ts
+++ b/src/routes/expansion/rules/+page.ts
@@ -5,11 +5,11 @@ import { hasNoAuthorization } from '../../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
-  return {};
+  return { user };
 };

--- a/src/routes/expansion/rules/edit/[id]/+page.svelte
+++ b/src/routes/expansion/rules/edit/[id]/+page.svelte
@@ -16,4 +16,5 @@
   initialRuleModelId={data.initialRule.authoring_mission_model_id}
   initialRuleUpdatedAt={data.initialRule.updated_at}
   mode="edit"
+  user={data.user}
 />

--- a/src/routes/expansion/rules/edit/[id]/+page.ts
+++ b/src/routes/expansion/rules/edit/[id]/+page.ts
@@ -6,9 +6,9 @@ import { hasNoAuthorization } from '../../../../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
@@ -16,11 +16,12 @@ export const load: PageLoad = async ({ parent, params }) => {
 
   if (ruleIdParam !== null && ruleIdParam !== undefined) {
     const ruleIdAsNumber = parseFloat(ruleIdParam);
-    const initialRule = await effects.getExpansionRule(ruleIdAsNumber);
+    const initialRule = await effects.getExpansionRule(ruleIdAsNumber, user);
 
     if (initialRule !== null) {
       return {
         initialRule,
+        user,
       };
     }
   }

--- a/src/routes/expansion/rules/new/+page.svelte
+++ b/src/routes/expansion/rules/new/+page.svelte
@@ -2,6 +2,9 @@
 
 <script lang="ts">
   import ExpansionRuleForm from '../../../../components/expansion/ExpansionRuleForm.svelte';
+  import type { PageData } from './$types';
+
+  export let data: PageData;
 </script>
 
-<ExpansionRuleForm mode="create" />
+<ExpansionRuleForm mode="create" user={data.user} />

--- a/src/routes/expansion/rules/new/+page.ts
+++ b/src/routes/expansion/rules/new/+page.ts
@@ -5,11 +5,11 @@ import { hasNoAuthorization } from '../../../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
-  return {};
+  return { user };
 };

--- a/src/routes/expansion/runs/+page.svelte
+++ b/src/routes/expansion/runs/+page.svelte
@@ -7,4 +7,4 @@
   export let data: PageData;
 </script>
 
-<ExpansionRuns expansionRuns={data.expansionRuns} />
+<ExpansionRuns expansionRuns={data.expansionRuns} user={data.user} />

--- a/src/routes/expansion/runs/+page.ts
+++ b/src/routes/expansion/runs/+page.ts
@@ -6,13 +6,13 @@ import { hasNoAuthorization } from '../../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { permissibleQueries, user } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
-  const expansionRuns = await effects.getExpansionRuns();
+  const expansionRuns = await effects.getExpansionRuns(user);
 
   return { expansionRuns };
 };

--- a/src/routes/expansion/sets/+page.svelte
+++ b/src/routes/expansion/sets/+page.svelte
@@ -2,6 +2,9 @@
 
 <script lang="ts">
   import ExpansionSets from '../../../components/expansion/ExpansionSets.svelte';
+  import type { PageData } from './$types';
+
+  export let data: PageData;
 </script>
 
-<ExpansionSets />
+<ExpansionSets user={data.user} />

--- a/src/routes/expansion/sets/+page.ts
+++ b/src/routes/expansion/sets/+page.ts
@@ -5,11 +5,11 @@ import { hasNoAuthorization } from '../../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
-  return {};
+  return { user };
 };

--- a/src/routes/expansion/sets/new/+page.svelte
+++ b/src/routes/expansion/sets/new/+page.svelte
@@ -2,6 +2,9 @@
 
 <script lang="ts">
   import ExpansionSetForm from '../../../../components/expansion/ExpansionSetForm.svelte';
+  import type { PageData } from './$types';
+
+  export let data: PageData;
 </script>
 
-<ExpansionSetForm mode="create" />
+<ExpansionSetForm mode="create" user={data.user} />

--- a/src/routes/expansion/sets/new/+page.ts
+++ b/src/routes/expansion/sets/new/+page.ts
@@ -5,11 +5,11 @@ import { hasNoAuthorization } from '../../../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
-  return {};
+  return { user };
 };

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -5,8 +5,11 @@
   import { base } from '$app/paths';
   import { onMount } from 'svelte';
   import AlertError from '../../components/ui/AlertError.svelte';
-  import { permissibleQueries as permissibleQueriesStore, user as userStore } from '../../stores/app';
   import type { LoginResponseBody } from '../../types/auth';
+  import { hasNoAuthorization } from '../../utilities/permissions';
+  import type { PageData } from './$types';
+
+  export let data: PageData;
 
   let error: string | null = null;
   let fullError: string | null = null;
@@ -15,7 +18,7 @@
   let username = '';
   let usernameInput: HTMLInputElement | null = null;
 
-  $: if ($userStore !== null && $permissibleQueriesStore && !Object.keys($permissibleQueriesStore).length) {
+  $: if (hasNoAuthorization(data.user)) {
     error = 'You are not authorized';
     fullError =
       'You are not authorized to access the page that you attempted to view. Please contact a tool administrator to request access.';
@@ -39,10 +42,9 @@
       };
       const response = await fetch(`${base}/auth/login`, options);
       const loginResponse: LoginResponseBody = await response.json();
-      const { message, success, user = null } = loginResponse;
+      const { message, success } = loginResponse;
 
       if (success) {
-        $userStore = user;
         await invalidateAll();
         await goto(`${base}/plans`);
       } else {

--- a/src/routes/login/+page.ts
+++ b/src/routes/login/+page.ts
@@ -5,11 +5,11 @@ import { hasNoAuthorization } from '../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'disabled' || (user && !hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'disabled' || (user && !hasNoAuthorization(user))) {
     throw redirect(302, `${base}/plans`);
   }
 
-  return {};
+  return { user };
 };

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -84,7 +84,7 @@
   });
 
   function deleteModel(model: ModelSlim) {
-    effects.deleteModel(model);
+    effects.deleteModel(model, data.user);
   }
 
   function deleteModelContext(event: CustomEvent<RowId[]>) {
@@ -100,7 +100,7 @@
   }
 
   async function submitForm(e: SubmitEvent) {
-    await effects.createModel(name, version, files);
+    await effects.createModel(name, version, files, data.user);
     if ($createModelError === null && e.target instanceof HTMLFormElement) {
       e.target.reset();
     }
@@ -169,6 +169,7 @@
             {columnDefs}
             itemDisplayText="Model"
             items={$models}
+            user={data.user}
             on:deleteItem={deleteModelContext}
             on:rowClicked={({ detail }) => showModel(detail.data)}
           />

--- a/src/routes/models/+page.ts
+++ b/src/routes/models/+page.ts
@@ -6,15 +6,16 @@ import { hasNoAuthorization } from '../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
-  const initialModels = await effects.getModels();
+  const initialModels = await effects.getModels(user);
 
   return {
     initialModels,
+    user,
   };
 };

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -66,7 +66,7 @@
               content: 'Delete Plan',
               placement: 'bottom',
             },
-            hasDeletePermission: params.data ? featurePermissions.plan.canDelete(params.data) : false,
+            hasDeletePermission: params.data ? featurePermissions.plan.canDelete(data.user, params.data) : false,
             rowData: params.data,
           },
           target: actionsDiv,
@@ -86,7 +86,7 @@
       width: 25,
     },
   ];
-  const canCreate: boolean = featurePermissions.plan.canCreate();
+  const canCreate: boolean = featurePermissions.plan.canCreate(data.user);
   const permissionError: string = 'You do not have permission to create a plan';
 
   let durationString: string = 'None';
@@ -139,6 +139,7 @@
       $nameField.value,
       $startTimeDoyField.value,
       $simTemplateField.value,
+      data.user,
     );
 
     if (newPlan) {
@@ -147,7 +148,7 @@
   }
 
   async function deletePlan({ id }: Pick<Plan, 'id'>): Promise<void> {
-    const success = await effects.deletePlan(id);
+    const success = await effects.deletePlan(id, data.user);
 
     if (success) {
       plans = plans.filter(plan => plan.id !== id);
@@ -336,6 +337,7 @@
             hasDeletePermission={featurePermissions.plan.canDelete}
             itemDisplayText="Plan"
             items={filteredPlans}
+            user={data.user}
             on:cellMouseOver={({ detail }) => prefetchPlan(detail.data)}
             on:deleteItem={deletePlanContext}
             on:rowClicked={({ detail }) => showPlan(detail.data)}

--- a/src/routes/plans/+page.ts
+++ b/src/routes/plans/+page.ts
@@ -6,16 +6,17 @@ import { hasNoAuthorization } from '../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
-  const { models = [], plans = [] } = await effects.getPlansAndModels();
+  const { models = [], plans = [] } = await effects.getPlansAndModels(user);
 
   return {
     models,
     plans,
+    user,
   };
 };

--- a/src/routes/plans/[id]/merge/+page.svelte
+++ b/src/routes/plans/[id]/merge/+page.svelte
@@ -17,4 +17,5 @@
   initialPlan={data.initialPlan}
   initialMergeRequest={data.initialMergeRequest}
   initialNonConflictingActivities={data.initialNonConflictingActivities}
+  user={data.user}
 />

--- a/src/routes/scheduling/+page.svelte
+++ b/src/routes/scheduling/+page.svelte
@@ -3,7 +3,11 @@
 <script lang="ts">
   import PageTitle from '../../components/app/PageTitle.svelte';
   import Scheduling from '../../components/scheduling/Scheduling.svelte';
+  import type { PageData } from './$types';
+
+  export let data: PageData;
 </script>
 
 <PageTitle title="Scheduling" />
-<Scheduling />
+
+<Scheduling user={data.user} />

--- a/src/routes/scheduling/+page.ts
+++ b/src/routes/scheduling/+page.ts
@@ -6,16 +6,17 @@ import { hasNoAuthorization } from '../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
-  const { models = [], plans = [] } = await effects.getPlansAndModels();
+  const { models = [], plans = [] } = await effects.getPlansAndModels(user);
 
   return {
     models,
     plans,
+    user,
   };
 };

--- a/src/routes/scheduling/conditions/edit/[id]/+page.svelte
+++ b/src/routes/scheduling/conditions/edit/[id]/+page.svelte
@@ -23,4 +23,5 @@
   models={data.models}
   plans={data.plans}
   mode="edit"
+  user={data.user}
 />

--- a/src/routes/scheduling/conditions/edit/[id]/+page.ts
+++ b/src/routes/scheduling/conditions/edit/[id]/+page.ts
@@ -7,19 +7,19 @@ import { hasNoAuthorization } from '../../../../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
   const { id: conditionIdParam } = params;
-  const { models = [], plans = [] } = await effects.getPlansAndModelsForScheduling();
+  const { models = [], plans = [] } = await effects.getPlansAndModelsForScheduling(user);
 
   if (conditionIdParam !== null && conditionIdParam !== undefined) {
     const conditionId = parseFloatOrNull(conditionIdParam);
-    const initialCondition = await effects.getSchedulingCondition(conditionId);
-    const schedulingSpecConditions = await effects.getSchedulingSpecConditionsForCondition(conditionId);
+    const initialCondition = await effects.getSchedulingCondition(conditionId, user);
+    const schedulingSpecConditions = await effects.getSchedulingSpecConditionsForCondition(conditionId, user);
 
     if (initialCondition !== null) {
       return {
@@ -27,6 +27,7 @@ export const load: PageLoad = async ({ parent, params }) => {
         initialSpecId: schedulingSpecConditions?.[0]?.specification_id,
         models,
         plans,
+        user,
       };
     }
   }

--- a/src/routes/scheduling/conditions/new/+page.svelte
+++ b/src/routes/scheduling/conditions/new/+page.svelte
@@ -16,4 +16,5 @@
   models={data.models}
   plans={data.plans}
   mode="create"
+  user={data.user}
 />

--- a/src/routes/scheduling/conditions/new/+page.ts
+++ b/src/routes/scheduling/conditions/new/+page.ts
@@ -7,13 +7,13 @@ import { hasNoAuthorization } from '../../../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, url }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
-  const { models = [], plans = [] } = await effects.getPlansAndModelsForScheduling();
+  const { models = [], plans = [] } = await effects.getPlansAndModelsForScheduling(user);
 
   const modelId: string | null = url.searchParams.get('modelId');
   const specId: string | null = url.searchParams.get('specId');
@@ -25,5 +25,6 @@ export const load: PageLoad = async ({ parent, url }) => {
     initialSpecId,
     models,
     plans,
+    user,
   };
 };

--- a/src/routes/scheduling/goals/edit/[id]/+page.svelte
+++ b/src/routes/scheduling/goals/edit/[id]/+page.svelte
@@ -23,4 +23,5 @@
   models={data.models}
   plans={data.plans}
   mode="edit"
+  user={data.user}
 />

--- a/src/routes/scheduling/goals/edit/[id]/+page.ts
+++ b/src/routes/scheduling/goals/edit/[id]/+page.ts
@@ -7,19 +7,19 @@ import { hasNoAuthorization } from '../../../../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
   const { id: goalIdParam } = params;
-  const { models = [], plans = [] } = await effects.getPlansAndModelsForScheduling();
+  const { models = [], plans = [] } = await effects.getPlansAndModelsForScheduling(user);
 
   if (goalIdParam !== null && goalIdParam !== undefined) {
     const goalId = parseFloatOrNull(goalIdParam);
-    const initialGoal = await effects.getSchedulingGoal(goalId);
-    const schedulingSpecGoals = await effects.getSchedulingSpecGoalsForGoal(goalId);
+    const initialGoal = await effects.getSchedulingGoal(goalId, user);
+    const schedulingSpecGoals = await effects.getSchedulingSpecGoalsForGoal(goalId, user);
 
     if (initialGoal !== null) {
       return {
@@ -27,6 +27,7 @@ export const load: PageLoad = async ({ parent, params }) => {
         initialSpecId: schedulingSpecGoals?.[0]?.specification_id,
         models,
         plans,
+        user,
       };
     }
   }

--- a/src/routes/scheduling/goals/new/+page.svelte
+++ b/src/routes/scheduling/goals/new/+page.svelte
@@ -16,4 +16,5 @@
   mode="create"
   models={data.models}
   plans={data.plans}
+  user={data.user}
 />

--- a/src/routes/scheduling/goals/new/+page.ts
+++ b/src/routes/scheduling/goals/new/+page.ts
@@ -7,13 +7,13 @@ import { hasNoAuthorization } from '../../../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, url }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
-  const { models = [], plans = [] } = await effects.getPlansAndModelsForScheduling();
+  const { models = [], plans = [] } = await effects.getPlansAndModelsForScheduling(user);
 
   const modelId: string | null = url.searchParams.get('modelId');
   const specId: string | null = url.searchParams.get('specId');
@@ -25,5 +25,6 @@ export const load: PageLoad = async ({ parent, url }) => {
     initialSpecId,
     models,
     plans,
+    user,
   };
 };

--- a/src/routes/sequencing/+page.svelte
+++ b/src/routes/sequencing/+page.svelte
@@ -3,8 +3,11 @@
 <script lang="ts">
   import PageTitle from '../../components/app/PageTitle.svelte';
   import Sequences from '../../components/sequencing/Sequences.svelte';
+  import type { PageData } from './$types';
+
+  export let data: PageData;
 </script>
 
 <PageTitle title="Sequencing" />
 
-<Sequences />
+<Sequences user={data.user} />

--- a/src/routes/sequencing/+page.ts
+++ b/src/routes/sequencing/+page.ts
@@ -5,11 +5,11 @@ import { hasNoAuthorization } from '../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
-  return {};
+  return { user };
 };

--- a/src/routes/sequencing/edit/[id]/+page.svelte
+++ b/src/routes/sequencing/edit/[id]/+page.svelte
@@ -15,4 +15,5 @@
   initialSequenceId={data.initialSequence.id}
   initialSequenceUpdatedAt={data.initialSequence.updated_at}
   mode="edit"
+  user={data.user}
 />

--- a/src/routes/sequencing/edit/[id]/+page.ts
+++ b/src/routes/sequencing/edit/[id]/+page.ts
@@ -8,9 +8,9 @@ import { hasNoAuthorization } from '../../../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
@@ -20,11 +20,12 @@ export const load: PageLoad = async ({ parent, params }) => {
     const sequenceIdAsNumber = parseFloatOrNull(sequenceIdParam);
 
     if (sequenceIdAsNumber !== null) {
-      const initialSequence: UserSequence | null = await effects.getUserSequence(sequenceIdAsNumber);
+      const initialSequence: UserSequence | null = await effects.getUserSequence(sequenceIdAsNumber, user);
 
       if (initialSequence !== null) {
         return {
           initialSequence,
+          user,
         };
       }
     }

--- a/src/routes/sequencing/new/+page.svelte
+++ b/src/routes/sequencing/new/+page.svelte
@@ -2,6 +2,9 @@
 
 <script lang="ts">
   import SequenceForm from '../../../components/sequencing/SequenceForm.svelte';
+  import type { PageData } from './$types';
+
+  export let data: PageData;
 </script>
 
-<SequenceForm mode="create" />
+<SequenceForm mode="create" user={data.user} />

--- a/src/routes/sequencing/new/+page.ts
+++ b/src/routes/sequencing/new/+page.ts
@@ -5,11 +5,11 @@ import { hasNoAuthorization } from '../../../utilities/permissions';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-  const { user, permissibleQueries } = await parent();
+  const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(permissibleQueries))) {
+  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
     throw redirect(302, `${base}/login`);
   }
 
-  return {};
+  return { user };
 };

--- a/src/stores/activities.ts
+++ b/src/stores/activities.ts
@@ -16,18 +16,25 @@ import { view, viewUpdateGrid } from './views';
 
 /* Subscriptions. */
 
-export const activityDirectives = gqlSubscribable<ActivityDirective[]>(gql.SUB_ACTIVITY_DIRECTIVES, { planId }, []);
+export const activityDirectives = gqlSubscribable<ActivityDirective[]>(
+  gql.SUB_ACTIVITY_DIRECTIVES,
+  { planId },
+  [],
+  null,
+);
 
 export const anchorValidationStatuses = gqlSubscribable<AnchorValidationStatus[]>(
   gql.SUB_ANCHOR_VALIDATION_STATUS,
   { planId },
   [],
+  null,
 );
 
 export const activityMetadataDefinitions = gqlSubscribable<ActivityMetadataDefinition[]>(
   gql.SUB_ACTIVITY_DIRECTIVE_METADATA_SCHEMAS,
   {},
   [],
+  null,
 );
 
 /* Writeable. */

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -1,6 +1,0 @@
-import { writable } from 'svelte/store';
-import type { User } from '../types/app';
-
-export const user = writable<User | null>(null);
-
-export const permissibleQueries = writable<Record<string, boolean> | null>(null);

--- a/src/stores/constraints.ts
+++ b/src/stores/constraints.ts
@@ -8,9 +8,9 @@ import { gqlSubscribable } from './subscribable';
 
 /* Subscriptions. */
 
-export const constraints = gqlSubscribable<Constraint[]>(gql.SUB_CONSTRAINTS, { modelId, planId }, []);
+export const constraints = gqlSubscribable<Constraint[]>(gql.SUB_CONSTRAINTS, { modelId, planId }, [], null);
 
-export const constraintsAll = gqlSubscribable<Constraint[]>(gql.SUB_CONSTRAINTS_ALL, {}, []);
+export const constraintsAll = gqlSubscribable<Constraint[]>(gql.SUB_CONSTRAINTS_ALL, {}, [], null);
 
 export const constraintsMap: Readable<Record<string, Constraint>> = derived([constraints], ([$constraints]) =>
   keyBy($constraints, 'id'),

--- a/src/stores/expansion.ts
+++ b/src/stores/expansion.ts
@@ -7,11 +7,11 @@ import { gqlSubscribable } from './subscribable';
 
 /* Subscriptions. */
 
-export const expansionRules = gqlSubscribable<ExpansionRule[]>(gql.SUB_EXPANSION_RULES, {}, []);
+export const expansionRules = gqlSubscribable<ExpansionRule[]>(gql.SUB_EXPANSION_RULES, {}, [], null);
 
-export const expansionSequences = gqlSubscribable<ExpansionSequence[]>(gql.SUB_EXPANSION_SEQUENCES, {}, []);
+export const expansionSequences = gqlSubscribable<ExpansionSequence[]>(gql.SUB_EXPANSION_SEQUENCES, {}, [], null);
 
-export const expansionSets = gqlSubscribable<ExpansionSet[]>(gql.SUB_EXPANSION_SETS, {}, []);
+export const expansionSets = gqlSubscribable<ExpansionSet[]>(gql.SUB_EXPANSION_SETS, {}, [], null);
 
 /* Writeable. */
 

--- a/src/stores/plan.ts
+++ b/src/stores/plan.ts
@@ -36,14 +36,15 @@ export const planId: Readable<number> = derived(plan, $plan => ($plan ? $plan.id
 
 /* Subscriptions. */
 
-export const activityTypes = gqlSubscribable<ActivityType[]>(gql.SUB_ACTIVITY_TYPES, { modelId }, []);
+export const activityTypes = gqlSubscribable<ActivityType[]>(gql.SUB_ACTIVITY_TYPES, { modelId }, [], null);
 
-export const models = gqlSubscribable<ModelSlim[]>(gql.SUB_MODELS, {}, []);
+export const models = gqlSubscribable<ModelSlim[]>(gql.SUB_MODELS, {}, [], null);
 
 export const planLocked = gqlSubscribable<boolean>(
   gql.SUB_PLAN_LOCKED,
   { planId },
   false,
+  null,
   ({ is_locked }) => is_locked,
 );
 
@@ -51,6 +52,7 @@ export const planMergeRequestsIncoming = gqlSubscribable<PlanMergeRequest[]>(
   gql.SUB_PLAN_MERGE_REQUESTS_INCOMING,
   { planId },
   [],
+  null,
   (planMergeRequests: PlanMergeRequestSchema[]): PlanMergeRequest[] =>
     planMergeRequests.map(planMergeRequest => ({ ...planMergeRequest, pending: false, type: 'incoming' })),
 );
@@ -59,6 +61,7 @@ export const planMergeRequestsOutgoing = gqlSubscribable<PlanMergeRequest[]>(
   gql.SUB_PLAN_MERGE_REQUESTS_OUTGOING,
   { planId },
   [],
+  null,
   (planMergeRequests: PlanMergeRequestSchema[]): PlanMergeRequest[] =>
     planMergeRequests.map(planMergeRequest => ({ ...planMergeRequest, pending: false, type: 'outgoing' })),
 );
@@ -67,6 +70,7 @@ export const planRevision = gqlSubscribable<number>(
   gql.SUB_PLAN_REVISION,
   { planId },
   -1,
+  null,
   ({ revision }: Pick<Plan, 'revision'>) => revision,
 );
 

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -24,20 +24,22 @@ export const selectedSpecId = derived(plan, $plan => $plan?.scheduling_specifica
 
 /* Subscriptions. */
 
-export const schedulingConditions = gqlSubscribable<SchedulingCondition[]>(gql.SUB_SCHEDULING_CONDITIONS, {}, []);
+export const schedulingConditions = gqlSubscribable<SchedulingCondition[]>(gql.SUB_SCHEDULING_CONDITIONS, {}, [], null);
 
-export const schedulingGoals = gqlSubscribable<SchedulingGoal[]>(gql.SUB_SCHEDULING_GOALS, {}, []);
+export const schedulingGoals = gqlSubscribable<SchedulingGoal[]>(gql.SUB_SCHEDULING_GOALS, {}, [], null);
 
 export const schedulingSpecConditions = gqlSubscribable<SchedulingSpecCondition[]>(
   gql.SUB_SCHEDULING_SPEC_CONDITIONS,
   { specification_id: selectedSpecId },
   [],
+  null,
 );
 
 export const schedulingSpecGoals = gqlSubscribable<SchedulingSpecGoal[]>(
   gql.SUB_SCHEDULING_SPEC_GOALS,
   { specification_id: selectedSpecId },
   [],
+  null,
 );
 
 export const latestAnalyses = derived(schedulingSpecGoals, $schedulingSpecGoals => {

--- a/src/stores/sequencing.ts
+++ b/src/stores/sequencing.ts
@@ -5,9 +5,9 @@ import { gqlSubscribable } from './subscribable';
 
 /* Subscriptions. */
 
-export const commandDictionaries = gqlSubscribable<CommandDictionary[]>(gql.SUB_COMMAND_DICTIONARIES, {}, []);
+export const commandDictionaries = gqlSubscribable<CommandDictionary[]>(gql.SUB_COMMAND_DICTIONARIES, {}, [], null);
 
-export const userSequences = gqlSubscribable<UserSequence[]>(gql.SUB_USER_SEQUENCES, {}, []);
+export const userSequences = gqlSubscribable<UserSequence[]>(gql.SUB_USER_SEQUENCES, {}, [], null);
 
 /* Writeable. */
 

--- a/src/stores/simulation.ts
+++ b/src/stores/simulation.ts
@@ -33,6 +33,7 @@ export const simulation = gqlSubscribable<Simulation>(
   gql.SUB_SIMULATION,
   { planId },
   null,
+  null,
   (simulations: Simulation[]): Simulation => simulations[0],
 );
 
@@ -40,12 +41,14 @@ export const simulationDataset = gqlSubscribable<SimulationDataset | null>(
   gql.SUB_SIMULATION_DATASET,
   { simulationDatasetId },
   null,
+  null,
 );
 
 export const simulationDatasetIds = gqlSubscribable<number[]>(
   gql.SUB_SIMULATION_DATASET_IDS,
   { planId },
   [],
+  null,
   (simulations: { simulation_dataset_ids: { id: number }[] }[]): number[] => {
     if (simulations.length) {
       return simulations[0].simulation_dataset_ids.map(({ id }) => id);
@@ -54,7 +57,12 @@ export const simulationDatasetIds = gqlSubscribable<number[]>(
   },
 );
 
-export const simulationTemplates = gqlSubscribable<SimulationTemplate[]>(gql.SUB_SIMULATION_TEMPLATES, { modelId }, []);
+export const simulationTemplates = gqlSubscribable<SimulationTemplate[]>(
+  gql.SUB_SIMULATION_TEMPLATES,
+  { modelId },
+  [],
+  null,
+);
 
 export const selectedSpanId: Writable<SpanId | null> = writable(null);
 

--- a/src/stores/views.ts
+++ b/src/stores/views.ts
@@ -9,7 +9,7 @@ import { gqlSubscribable } from './subscribable';
 
 /* Subscriptions. */
 
-export const views = gqlSubscribable<View[]>(gql.SUB_VIEWS, {}, []);
+export const views = gqlSubscribable<View[]>(gql.SUB_VIEWS, {}, [], null);
 
 /* Writeable. */
 

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -1,3 +1,5 @@
+import type { PermissibleQueriesMap } from './permissions';
+
 export type UserId = string;
 
 export type BaseUser = {
@@ -8,6 +10,7 @@ export type BaseUser = {
 export type User = BaseUser & {
   allowedRoles: string[];
   defaultRole: string;
+  permissibleQueries: PermissibleQueriesMap;
 };
 
 export type ParsedUserToken = {

--- a/src/types/permissions.ts
+++ b/src/types/permissions.ts
@@ -1,3 +1,4 @@
+import type { User } from './app';
 import type { Plan } from './plan';
 
 export type PermissibleQueriesMap = Record<string, true>;
@@ -19,21 +20,21 @@ export type PermissibleQuery = {
 
 export type PermissionCheck<T = null> = ReadPermissionCheck<T> | CreatePermissionCheck | UpdatePermissionCheck<T>;
 
-export type ReadPermissionCheck<T = null> = (asset?: T) => boolean;
+export type ReadPermissionCheck<T = null> = (user: User, asset?: T) => boolean;
 
-export type CreatePermissionCheck = () => boolean;
+export type CreatePermissionCheck = (user: User) => boolean;
 
-export type UpdatePermissionCheck<T = null> = (asset: T) => boolean;
+export type UpdatePermissionCheck<T = null> = (user: User, asset: T) => boolean;
 
 export type PlanAssetPermissionCheck<T = null> =
   | PlanAssetReadPermissionCheck
   | PlanAssetCreatePermissionCheck
   | PlanAssetUpdatePermissionCheck<T>;
 
-export type PlanAssetReadPermissionCheck = () => boolean;
+export type PlanAssetReadPermissionCheck = (user: User) => boolean;
 
-export type PlanAssetCreatePermissionCheck = (plan: PlanWithOwners) => boolean;
+export type PlanAssetCreatePermissionCheck = (user: User, plan: PlanWithOwners) => boolean;
 
-export type PlanAssetUpdatePermissionCheck<T = null> = (plan: PlanWithOwners, asset: T) => boolean;
+export type PlanAssetUpdatePermissionCheck<T = null> = (user: User, plan: PlanWithOwners, asset: T) => boolean;
 
 export type PlanWithOwners = Pick<Plan, 'id' | 'owner' | 'collaborators'>;

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -13,6 +13,7 @@ import PlanMergeRequestsModal from '../components/modals/PlanMergeRequestsModal.
 import SavedViewsModal from '../components/modals/SavedViewsModal.svelte';
 import UploadViewModal from '../components/modals/UploadViewModal.svelte';
 import type { ActivityDirectiveDeletionMap, ActivityDirectiveId } from '../types/activity';
+import type { User } from '../types/app';
 import type { ExpansionSequence } from '../types/expansion';
 import type { ModalElement, ModalElementValue } from '../types/modal';
 import type { Plan, PlanBranchRequestAction, PlanMergeRequestStatus, PlanMergeRequestTypeFilter } from '../types/plan';
@@ -275,12 +276,15 @@ export async function showEditViewModal(): Promise<ModalElementValue<{ id: numbe
 /**
  * Shows a SequenceModal with the supplied arguments.
  */
-export async function showExpansionSequenceModal(expansionSequence: ExpansionSequence): Promise<ModalElementValue> {
+export async function showExpansionSequenceModal(
+  expansionSequence: ExpansionSequence,
+  user: User | null,
+): Promise<ModalElementValue> {
   return new Promise(resolve => {
     const target: ModalElement = document.querySelector('#svelte-modal');
 
     if (target) {
-      const sequenceModal = new ExpansionSequenceModal({ props: { expansionSequence }, target });
+      const sequenceModal = new ExpansionSequenceModal({ props: { expansionSequence, user }, target });
       target.resolve = resolve;
 
       sequenceModal.$on('close', () => {
@@ -345,13 +349,14 @@ export async function showPlanBranchesModal(plan: Plan): Promise<ModalElementVal
  * Shows a PlanMergeRequestsModal with the supplied arguments.
  */
 export async function showPlanMergeRequestsModal(
+  user: User | null,
   selectedFilter?: PlanMergeRequestTypeFilter,
 ): Promise<ModalElementValue> {
   return new Promise(resolve => {
     const target: ModalElement = document.querySelector('#svelte-modal');
 
     if (target) {
-      const planMergeRequestsModal = new PlanMergeRequestsModal({ props: { selectedFilter }, target });
+      const planMergeRequestsModal = new PlanMergeRequestsModal({ props: { selectedFilter, user }, target });
       target.resolve = resolve;
 
       planMergeRequestsModal.$on('close', () => {
@@ -366,12 +371,14 @@ export async function showPlanMergeRequestsModal(
 /**
  * Shows a SavedViewsModal component.
  */
-export async function showSavedViewsModal(): Promise<ModalElementValue<{ id: number; modelId: number; name: string }>> {
+export async function showSavedViewsModal(
+  user: User | null,
+): Promise<ModalElementValue<{ id: number; modelId: number; name: string }>> {
   return new Promise(resolve => {
     const target: ModalElement = document.querySelector('#svelte-modal');
 
     if (target) {
-      const savedViewsModal = new SavedViewsModal({ props: { height: 400, width: '50%' }, target });
+      const savedViewsModal = new SavedViewsModal({ props: { height: 400, user, width: '50%' }, target });
       target.resolve = resolve;
 
       savedViewsModal.$on('close', () => {

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -1,11 +1,8 @@
-import { get } from 'svelte/store';
-import { permissibleQueries as permissibleQueriesStore, user as userStore } from '../stores/app';
 import type { ActivityDirective, ActivityPreset } from '../types/activity';
-import type { UserId } from '../types/app';
+import type { User, UserId } from '../types/app';
 import type { Constraint } from '../types/constraint';
 import type {
   CreatePermissionCheck,
-  PermissibleQueriesMap,
   PermissionCheck,
   PlanAssetCreatePermissionCheck,
   PlanAssetReadPermissionCheck,
@@ -17,25 +14,21 @@ import type {
 
 export const ADMIN_ROLE = 'admin';
 
-function getPermission(queries: string[]): boolean {
-  const permissibleQueries = get(permissibleQueriesStore);
-  if (permissibleQueries) {
+function getPermission(queries: string[], user: User | null): boolean {
+  if (user && user.permissibleQueries) {
     return queries.reduce((prevValue: boolean, queryName) => {
-      return prevValue && !!permissibleQueries[queryName];
+      return prevValue && !!user.permissibleQueries[queryName];
     }, true);
   }
   return false;
 }
 
-function isUserAdmin() {
-  const user = get(userStore);
+function isUserAdmin(user: User | null) {
   return user?.allowedRoles.includes(ADMIN_ROLE) || user?.defaultRole === ADMIN_ROLE;
 }
 
-function isUserOwner(thingWithOwner?: { owner: UserId } | null): boolean {
+function isUserOwner(user: User | null, thingWithOwner?: { owner: UserId } | null): boolean {
   if (thingWithOwner !== null) {
-    const user = get(userStore);
-
     if (thingWithOwner && user) {
       return thingWithOwner.owner === user.id;
     }
@@ -43,14 +36,12 @@ function isUserOwner(thingWithOwner?: { owner: UserId } | null): boolean {
   return false;
 }
 
-function isPlanOwner(plan: PlanWithOwners): boolean {
+function isPlanOwner(user: User | null, plan: PlanWithOwners): boolean {
   const currentPlan = plan;
-  return isUserOwner(currentPlan);
+  return isUserOwner(user, currentPlan);
 }
 
-function isPlanCollaborator(plan: PlanWithOwners): boolean {
-  const user = get(userStore);
-
+function isPlanCollaborator(user: User | null, plan: PlanWithOwners): boolean {
   if (plan && user) {
     return !!plan.collaborators.find(({ collaborator }) => collaborator === user.id);
   }
@@ -58,212 +49,212 @@ function isPlanCollaborator(plan: PlanWithOwners): boolean {
 }
 
 const queryPermissions = {
-  APPLY_PRESET_TO_ACTIVITY: (): boolean => {
-    return getPermission(['apply_preset_to_activity']);
+  APPLY_PRESET_TO_ACTIVITY: (user: User | null): boolean => {
+    return getPermission(['apply_preset_to_activity'], user);
   },
-  CREATE_ACTIVITY_DIRECTIVE: (): boolean => {
-    return getPermission(['insert_activity_directive_one']);
+  CREATE_ACTIVITY_DIRECTIVE: (user: User | null): boolean => {
+    return getPermission(['insert_activity_directive_one'], user);
   },
-  CREATE_ACTIVITY_PRESET: (): boolean => {
-    return getPermission(['insert_activity_presets_one']);
+  CREATE_ACTIVITY_PRESET: (user: User | null): boolean => {
+    return getPermission(['insert_activity_presets_one'], user);
   },
-  CREATE_COMMAND_DICTIONARY: (): boolean => {
-    return getPermission(['uploadDictionary']);
+  CREATE_COMMAND_DICTIONARY: (user: User | null): boolean => {
+    return getPermission(['uploadDictionary'], user);
   },
-  CREATE_CONSTRAINT: (): boolean => {
-    return getPermission(['insert_constraint_one']);
+  CREATE_CONSTRAINT: (user: User | null): boolean => {
+    return getPermission(['insert_constraint_one'], user);
   },
-  CREATE_EXPANSION_RULE: (): boolean => {
-    return getPermission(['insert_expansion_rule_one']);
+  CREATE_EXPANSION_RULE: (user: User | null): boolean => {
+    return getPermission(['insert_expansion_rule_one'], user);
   },
-  CREATE_EXPANSION_SEQUENCE: (): boolean => {
-    return getPermission(['insert_sequence_one']);
+  CREATE_EXPANSION_SEQUENCE: (user: User | null): boolean => {
+    return getPermission(['insert_sequence_one'], user);
   },
-  CREATE_EXPANSION_SET: (): boolean => {
-    return getPermission(['createExpansionSet']);
+  CREATE_EXPANSION_SET: (user: User | null): boolean => {
+    return getPermission(['createExpansionSet'], user);
   },
-  CREATE_MODEL: (): boolean => {
-    return getPermission(['insert_mission_model_one']);
+  CREATE_MODEL: (user: User | null): boolean => {
+    return getPermission(['insert_mission_model_one'], user);
   },
-  CREATE_PLAN: (): boolean => {
-    return getPermission(['insert_plan_one']);
+  CREATE_PLAN: (user: User | null): boolean => {
+    return getPermission(['insert_plan_one'], user);
   },
-  CREATE_PLAN_MERGE_REQUEST: (): boolean => {
-    return getPermission(['create_merge_request']);
+  CREATE_PLAN_MERGE_REQUEST: (user: User | null): boolean => {
+    return getPermission(['create_merge_request'], user);
   },
-  CREATE_SCHEDULING_CONDITION: (): boolean => {
-    return getPermission(['insert_scheduling_condition_one']);
+  CREATE_SCHEDULING_CONDITION: (user: User | null): boolean => {
+    return getPermission(['insert_scheduling_condition_one'], user);
   },
-  CREATE_SCHEDULING_GOAL: (): boolean => {
-    return getPermission(['insert_scheduling_goal_one']);
+  CREATE_SCHEDULING_GOAL: (user: User | null): boolean => {
+    return getPermission(['insert_scheduling_goal_one'], user);
   },
-  CREATE_SCHEDULING_SPEC: (): boolean => {
-    return getPermission(['insert_scheduling_specification_one']);
+  CREATE_SCHEDULING_SPEC: (user: User | null): boolean => {
+    return getPermission(['insert_scheduling_specification_one'], user);
   },
-  CREATE_SCHEDULING_SPEC_CONDITION: (): boolean => {
-    return getPermission(['insert_scheduling_specification_conditions_one']);
+  CREATE_SCHEDULING_SPEC_CONDITION: (user: User | null): boolean => {
+    return getPermission(['insert_scheduling_specification_conditions_one'], user);
   },
-  CREATE_SCHEDULING_SPEC_GOAL: (): boolean => {
-    return getPermission(['insert_scheduling_specification_goals_one']);
+  CREATE_SCHEDULING_SPEC_GOAL: (user: User | null): boolean => {
+    return getPermission(['insert_scheduling_specification_goals_one'], user);
   },
-  CREATE_SIMULATION_TEMPLATE: (): boolean => {
-    return getPermission(['insert_simulation_template_one']);
+  CREATE_SIMULATION_TEMPLATE: (user: User | null): boolean => {
+    return getPermission(['insert_simulation_template_one'], user);
   },
-  CREATE_USER_SEQUENCE: (): boolean => {
-    return getPermission(['insert_user_sequence_one']);
+  CREATE_USER_SEQUENCE: (user: User | null): boolean => {
+    return getPermission(['insert_user_sequence_one'], user);
   },
-  CREATE_VIEW: (): boolean => {
-    return getPermission(['insert_view_one']);
+  CREATE_VIEW: (user: User | null): boolean => {
+    return getPermission(['insert_view_one'], user);
   },
-  DELETE_ACTIVITY_DIRECTIVES: (): boolean => {
-    return getPermission(['delete_activity_directive']);
+  DELETE_ACTIVITY_DIRECTIVES: (user: User | null): boolean => {
+    return getPermission(['delete_activity_directive'], user);
   },
-  DELETE_ACTIVITY_DIRECTIVES_REANCHOR_PLAN_START: (): boolean => {
-    return getPermission(['delete_activity_by_pk_reanchor_plan_start_bulk']);
+  DELETE_ACTIVITY_DIRECTIVES_REANCHOR_PLAN_START: (user: User | null): boolean => {
+    return getPermission(['delete_activity_by_pk_reanchor_plan_start_bulk'], user);
   },
-  DELETE_ACTIVITY_DIRECTIVES_REANCHOR_TO_ANCHOR: (): boolean => {
-    return getPermission(['delete_activity_by_pk_reanchor_to_anchor_bulk']);
+  DELETE_ACTIVITY_DIRECTIVES_REANCHOR_TO_ANCHOR: (user: User | null): boolean => {
+    return getPermission(['delete_activity_by_pk_reanchor_to_anchor_bulk'], user);
   },
-  DELETE_ACTIVITY_DIRECTIVES_SUBTREE: (): boolean => {
-    return getPermission(['delete_activity_by_pk_delete_subtree_bulk']);
+  DELETE_ACTIVITY_DIRECTIVES_SUBTREE: (user: User | null): boolean => {
+    return getPermission(['delete_activity_by_pk_delete_subtree_bulk'], user);
   },
-  DELETE_ACTIVITY_PRESET: (): boolean => {
-    return getPermission(['delete_activity_presets_by_pk']);
+  DELETE_ACTIVITY_PRESET: (user: User | null): boolean => {
+    return getPermission(['delete_activity_presets_by_pk'], user);
   },
-  DELETE_COMMAND_DICTIONARY: (): boolean => {
-    return getPermission(['delete_command_dictionary_by_pk']);
+  DELETE_COMMAND_DICTIONARY: (user: User | null): boolean => {
+    return getPermission(['delete_command_dictionary_by_pk'], user);
   },
-  DELETE_CONSTRAINT: (): boolean => {
-    return getPermission(['delete_constraint_by_pk']);
+  DELETE_CONSTRAINT: (user: User | null): boolean => {
+    return getPermission(['delete_constraint_by_pk'], user);
   },
-  DELETE_EXPANSION_RULE: (): boolean => {
-    return getPermission(['delete_expansion_rule_by_pk']);
+  DELETE_EXPANSION_RULE: (user: User | null): boolean => {
+    return getPermission(['delete_expansion_rule_by_pk'], user);
   },
-  DELETE_EXPANSION_SEQUENCE: (): boolean => {
-    return getPermission(['delete_sequence_by_pk']);
+  DELETE_EXPANSION_SEQUENCE: (user: User | null): boolean => {
+    return getPermission(['delete_sequence_by_pk'], user);
   },
-  DELETE_EXPANSION_SEQUENCE_TO_ACTIVITY: (): boolean => {
-    return getPermission(['delete_sequence_to_simulated_activity_by_pk']);
+  DELETE_EXPANSION_SEQUENCE_TO_ACTIVITY: (user: User | null): boolean => {
+    return getPermission(['delete_sequence_to_simulated_activity_by_pk'], user);
   },
-  DELETE_EXPANSION_SET: (): boolean => {
-    return getPermission(['delete_expansion_set_by_pk']);
+  DELETE_EXPANSION_SET: (user: User | null): boolean => {
+    return getPermission(['delete_expansion_set_by_pk'], user);
   },
-  DELETE_MODEL: (): boolean => {
-    return getPermission(['delete_mission_model_by_pk']);
+  DELETE_MODEL: (user: User | null): boolean => {
+    return getPermission(['delete_mission_model_by_pk'], user);
   },
-  DELETE_PLAN: (): boolean => {
-    return getPermission(['delete_plan_by_pk', 'delete_scheduling_specification', 'delete_simulation']);
+  DELETE_PLAN: (user: User | null): boolean => {
+    return getPermission(['delete_plan_by_pk', 'delete_scheduling_specification', 'delete_simulation'], user);
   },
-  DELETE_PRESET_TO_DIRECTIVE: (): boolean => {
-    return getPermission(['delete_preset_to_directive_by_pk']);
+  DELETE_PRESET_TO_DIRECTIVE: (user: User | null): boolean => {
+    return getPermission(['delete_preset_to_directive_by_pk'], user);
   },
-  DELETE_SCHEDULING_CONDITION: (): boolean => {
-    return getPermission(['delete_scheduling_condition_by_pk']);
+  DELETE_SCHEDULING_CONDITION: (user: User | null): boolean => {
+    return getPermission(['delete_scheduling_condition_by_pk'], user);
   },
-  DELETE_SCHEDULING_GOAL: (): boolean => {
-    return getPermission(['delete_scheduling_goal_by_pk']);
+  DELETE_SCHEDULING_GOAL: (user: User | null): boolean => {
+    return getPermission(['delete_scheduling_goal_by_pk'], user);
   },
-  DELETE_SCHEDULING_SPEC_GOAL: (): boolean => {
-    return getPermission(['delete_scheduling_specification_goals_by_pk']);
+  DELETE_SCHEDULING_SPEC_GOAL: (user: User | null): boolean => {
+    return getPermission(['delete_scheduling_specification_goals_by_pk'], user);
   },
-  DELETE_SIMULATION_TEMPLATE: (): boolean => {
-    return getPermission(['delete_simulation_template_by_pk']);
+  DELETE_SIMULATION_TEMPLATE: (user: User | null): boolean => {
+    return getPermission(['delete_simulation_template_by_pk'], user);
   },
-  DELETE_USER_SEQUENCE: (): boolean => {
-    return getPermission(['delete_user_sequence_by_pk']);
+  DELETE_USER_SEQUENCE: (user: User | null): boolean => {
+    return getPermission(['delete_user_sequence_by_pk'], user);
   },
-  DELETE_VIEW: (): boolean => {
-    return getPermission(['delete_view_by_pk']);
+  DELETE_VIEW: (user: User | null): boolean => {
+    return getPermission(['delete_view_by_pk'], user);
   },
-  DELETE_VIEWS: (): boolean => {
-    return getPermission(['delete_view']);
+  DELETE_VIEWS: (user: User | null): boolean => {
+    return getPermission(['delete_view'], user);
   },
-  DUPLICATE_PLAN: (): boolean => {
-    return getPermission(['duplicate_plan']);
+  DUPLICATE_PLAN: (user: User | null): boolean => {
+    return getPermission(['duplicate_plan'], user);
   },
-  EXPAND: (): boolean => {
-    return getPermission(['expandAllActivities']);
+  EXPAND: (user: User | null): boolean => {
+    return getPermission(['expandAllActivities'], user);
   },
-  GET_PLAN: (): boolean => {
-    return getPermission(['plan_by_pk']);
+  GET_PLAN: (user: User | null): boolean => {
+    return getPermission(['plan_by_pk'], user);
   },
-  GET_PLANS_AND_MODELS: (): boolean => {
-    return getPermission(['mission_model']);
+  GET_PLANS_AND_MODELS: (user: User | null): boolean => {
+    return getPermission(['mission_model'], user);
   },
-  INITIAL_SIMULATION_UPDATE: (): boolean => {
-    return getPermission(['update_simulation']);
+  INITIAL_SIMULATION_UPDATE: (user: User | null): boolean => {
+    return getPermission(['update_simulation'], user);
   },
-  INSERT_EXPANSION_SEQUENCE_TO_ACTIVITY: (): boolean => {
-    return getPermission(['insert_sequence_to_simulated_activity_one']);
+  INSERT_EXPANSION_SEQUENCE_TO_ACTIVITY: (user: User | null): boolean => {
+    return getPermission(['insert_sequence_to_simulated_activity_one'], user);
   },
-  PLAN_MERGE_BEGIN: (): boolean => {
-    return getPermission(['begin_merge']);
+  PLAN_MERGE_BEGIN: (user: User | null): boolean => {
+    return getPermission(['begin_merge'], user);
   },
-  PLAN_MERGE_CANCEL: (): boolean => {
-    return getPermission(['cancel_merge']);
+  PLAN_MERGE_CANCEL: (user: User | null): boolean => {
+    return getPermission(['cancel_merge'], user);
   },
-  PLAN_MERGE_COMMIT: (): boolean => {
-    return getPermission(['commit_merge']);
+  PLAN_MERGE_COMMIT: (user: User | null): boolean => {
+    return getPermission(['commit_merge'], user);
   },
-  PLAN_MERGE_DENY: (): boolean => {
-    return getPermission(['deny_merge']);
+  PLAN_MERGE_DENY: (user: User | null): boolean => {
+    return getPermission(['deny_merge'], user);
   },
-  PLAN_MERGE_REQUEST_WITHDRAW: (): boolean => {
-    return getPermission(['withdraw_merge_request']);
+  PLAN_MERGE_REQUEST_WITHDRAW: (user: User | null): boolean => {
+    return getPermission(['withdraw_merge_request'], user);
   },
-  PLAN_MERGE_RESOLVE_ALL_CONFLICTS: (): boolean => {
-    return getPermission(['set_resolution_bulk']);
+  PLAN_MERGE_RESOLVE_ALL_CONFLICTS: (user: User | null): boolean => {
+    return getPermission(['set_resolution_bulk'], user);
   },
-  PLAN_MERGE_RESOLVE_CONFLICT: (): boolean => {
-    return getPermission(['set_resolution']);
+  PLAN_MERGE_RESOLVE_CONFLICT: (user: User | null): boolean => {
+    return getPermission(['set_resolution'], user);
   },
-  SIMULATE: (): boolean => {
-    return getPermission(['simulate']);
+  SIMULATE: (user: User | null): boolean => {
+    return getPermission(['simulate'], user);
   },
-  SUB_ACTIVITY_PRESETS: (): boolean => {
-    return getPermission(['activity_presets']);
+  SUB_ACTIVITY_PRESETS: (user: User | null): boolean => {
+    return getPermission(['activity_presets'], user);
   },
-  SUB_CONSTRAINTS_ALL: (): boolean => {
-    return getPermission(['constraint']);
+  SUB_CONSTRAINTS_ALL: (user: User | null): boolean => {
+    return getPermission(['constraint'], user);
   },
-  UPDATE_ACTIVITY_DIRECTIVE: (): boolean => {
-    return getPermission(['update_activity_directive_by_pk']);
+  UPDATE_ACTIVITY_DIRECTIVE: (user: User | null): boolean => {
+    return getPermission(['update_activity_directive_by_pk'], user);
   },
-  UPDATE_ACTIVITY_PRESET: (): boolean => {
-    return getPermission(['update_activity_presets_by_pk']);
+  UPDATE_ACTIVITY_PRESET: (user: User | null): boolean => {
+    return getPermission(['update_activity_presets_by_pk'], user);
   },
-  UPDATE_CONSTRAINT: (): boolean => {
-    return getPermission(['update_constraint_by_pk']);
+  UPDATE_CONSTRAINT: (user: User | null): boolean => {
+    return getPermission(['update_constraint_by_pk'], user);
   },
-  UPDATE_EXPANSION_RULE: (): boolean => {
-    return getPermission(['update_expansion_rule_by_pk']);
+  UPDATE_EXPANSION_RULE: (user: User | null): boolean => {
+    return getPermission(['update_expansion_rule_by_pk'], user);
   },
-  UPDATE_SCHEDULING_CONDITION: (): boolean => {
-    return getPermission(['update_scheduling_condition_by_pk']);
+  UPDATE_SCHEDULING_CONDITION: (user: User | null): boolean => {
+    return getPermission(['update_scheduling_condition_by_pk'], user);
   },
-  UPDATE_SCHEDULING_GOAL: (): boolean => {
-    return getPermission(['update_scheduling_goal_by_pk']);
+  UPDATE_SCHEDULING_GOAL: (user: User | null): boolean => {
+    return getPermission(['update_scheduling_goal_by_pk'], user);
   },
-  UPDATE_SCHEDULING_SPEC: (): boolean => {
-    return getPermission(['update_scheduling_specification_by_pk']);
+  UPDATE_SCHEDULING_SPEC: (user: User | null): boolean => {
+    return getPermission(['update_scheduling_specification_by_pk'], user);
   },
-  UPDATE_SCHEDULING_SPEC_CONDITION_ID: (): boolean => {
-    return getPermission(['update_scheduling_specification_conditions_by_pk']);
+  UPDATE_SCHEDULING_SPEC_CONDITION_ID: (user: User | null): boolean => {
+    return getPermission(['update_scheduling_specification_conditions_by_pk'], user);
   },
-  UPDATE_SCHEDULING_SPEC_GOAL: (): boolean => {
-    return getPermission(['update_scheduling_specification_goals_by_pk']);
+  UPDATE_SCHEDULING_SPEC_GOAL: (user: User | null): boolean => {
+    return getPermission(['update_scheduling_specification_goals_by_pk'], user);
   },
-  UPDATE_SIMULATION: (): boolean => {
-    return getPermission(['update_simulation_by_pk']);
+  UPDATE_SIMULATION: (user: User | null): boolean => {
+    return getPermission(['update_simulation_by_pk'], user);
   },
-  UPDATE_SIMULATION_TEMPLATE: (): boolean => {
-    return getPermission(['update_simulation_template_by_pk']);
+  UPDATE_SIMULATION_TEMPLATE: (user: User | null): boolean => {
+    return getPermission(['update_simulation_template_by_pk'], user);
   },
-  UPDATE_USER_SEQUENCE: (): boolean => {
-    return getPermission(['update_user_sequence_by_pk']);
+  UPDATE_USER_SEQUENCE: (user: User | null): boolean => {
+    return getPermission(['update_user_sequence_by_pk'], user);
   },
-  UPDATE_VIEW: (): boolean => {
-    return getPermission(['update_view_by_pk']);
+  UPDATE_VIEW: (user: User | null): boolean => {
+    return getPermission(['update_view_by_pk'], user);
   },
 };
 
@@ -289,7 +280,7 @@ interface PlanAssetCRUDPermission<T = null> {
 }
 
 interface AssignablePlanAssetCRUDPermission<T = null> extends PlanAssetCRUDPermission<T> {
-  canAssign: (plan: PlanWithOwners, asset?: T) => boolean;
+  canAssign: (user: User | null, plan: PlanWithOwners, asset?: T) => boolean;
 }
 
 interface FeaturePermissions {
@@ -302,46 +293,44 @@ interface FeaturePermissions {
 
 const featurePermissions: FeaturePermissions = {
   activityDirective: {
-    canCreate: (plan: PlanWithOwners) =>
-      (isPlanOwner(plan) || isPlanCollaborator(plan)) && queryPermissions.CREATE_ACTIVITY_DIRECTIVE(),
-    canDelete: (plan: PlanWithOwners) =>
-      (isPlanOwner(plan) || isPlanCollaborator(plan)) && queryPermissions.DELETE_ACTIVITY_DIRECTIVES(),
-    canRead: queryPermissions.GET_PLAN,
-    canUpdate: (plan: PlanWithOwners) =>
-      (isPlanOwner(plan) || isPlanCollaborator(plan)) && queryPermissions.UPDATE_ACTIVITY_DIRECTIVE(),
+    canCreate: (user, plan) =>
+      (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) && queryPermissions.CREATE_ACTIVITY_DIRECTIVE(user),
+    canDelete: (user, plan) =>
+      (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) && queryPermissions.DELETE_ACTIVITY_DIRECTIVES(user),
+    canRead: user => queryPermissions.GET_PLAN(user),
+    canUpdate: (user, plan) =>
+      (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) && queryPermissions.UPDATE_ACTIVITY_DIRECTIVE(user),
   },
   activityPresets: {
-    canAssign: (plan: PlanWithOwners) =>
-      (isPlanOwner(plan) || isPlanCollaborator(plan)) && queryPermissions.APPLY_PRESET_TO_ACTIVITY(),
-    canCreate: queryPermissions.CREATE_ACTIVITY_PRESET,
-    canDelete: (plan: PlanWithOwners, preset: ActivityPreset) =>
-      isUserOwner(preset) && queryPermissions.DELETE_ACTIVITY_PRESET(),
-    canRead: queryPermissions.SUB_ACTIVITY_PRESETS,
-    canUpdate: (plan: PlanWithOwners, preset: ActivityPreset) =>
-      isUserOwner(preset) && queryPermissions.UPDATE_ACTIVITY_PRESET(),
+    canAssign: (user, plan) =>
+      (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) && queryPermissions.APPLY_PRESET_TO_ACTIVITY(user),
+    canCreate: user => queryPermissions.CREATE_ACTIVITY_PRESET(user),
+    canDelete: (user, preset) => isUserOwner(user, preset) && queryPermissions.DELETE_ACTIVITY_PRESET(user),
+    canRead: user => queryPermissions.SUB_ACTIVITY_PRESETS(user),
+    canUpdate: (user, preset) => isUserOwner(user, preset) && queryPermissions.UPDATE_ACTIVITY_PRESET(user),
   },
   constraints: {
-    canCreate: () => isUserAdmin() || queryPermissions.CREATE_CONSTRAINT(),
-    canDelete: () => isUserAdmin() || queryPermissions.DELETE_CONSTRAINT(),
-    canRead: () => isUserAdmin() || queryPermissions.SUB_CONSTRAINTS_ALL(),
-    canUpdate: () => isUserAdmin() || queryPermissions.UPDATE_CONSTRAINT(),
+    canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_CONSTRAINT(user),
+    canDelete: user => isUserAdmin(user) || queryPermissions.DELETE_CONSTRAINT(user),
+    canRead: user => isUserAdmin(user) || queryPermissions.SUB_CONSTRAINTS_ALL(user),
+    canUpdate: user => isUserAdmin(user) || queryPermissions.UPDATE_CONSTRAINT(user),
   },
   model: {
-    canCreate: () => isUserAdmin() || queryPermissions.CREATE_MODEL(),
-    canDelete: () => isUserAdmin() || queryPermissions.DELETE_MODEL(),
-    canRead: () => isUserAdmin() || queryPermissions.GET_PLANS_AND_MODELS(),
+    canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_MODEL(user),
+    canDelete: user => isUserAdmin(user) || queryPermissions.DELETE_MODEL(user),
+    canRead: user => isUserAdmin(user) || queryPermissions.GET_PLANS_AND_MODELS(user),
     canUpdate: () => false, // no feature to update models exists
   },
   plan: {
-    canCreate: () => isUserAdmin() || queryPermissions.CREATE_PLAN(),
-    canDelete: (plan: PlanWithOwners) => isUserAdmin() || (isPlanOwner(plan) && queryPermissions.DELETE_PLAN()),
-    canRead: () => isUserAdmin() || queryPermissions.GET_PLAN(),
+    canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_PLAN(user),
+    canDelete: (user, plan) => isUserAdmin(user) || (isPlanOwner(user, plan) && queryPermissions.DELETE_PLAN(user)),
+    canRead: user => isUserAdmin(user) || queryPermissions.GET_PLAN(user),
     canUpdate: () => false, // no feature to update plans exists
   },
 };
 
-function hasNoAuthorization(permissibleQueries?: PermissibleQueriesMap | null) {
-  return permissibleQueries && !Object.keys(permissibleQueries).length;
+function hasNoAuthorization(user: User | null) {
+  return user && !Object.keys(user.permissibleQueries).length;
 }
 
 export { featurePermissions, hasNoAuthorization, queryPermissions };

--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -1,8 +1,6 @@
 import { browser } from '$app/environment';
 import { env } from '$env/dynamic/public';
-import { get } from 'svelte/store';
-import { user as userStore } from '../stores/app';
-import type { User } from '../types/app';
+import type { BaseUser, User } from '../types/app';
 import type { QueryVariables } from '../types/subscribable';
 
 /**
@@ -12,36 +10,34 @@ export async function reqGateway<T = any>(
   url: string,
   method: string,
   body: any | null,
-  token: string | null,
+  user: BaseUser | User | null,
   excludeContentType: boolean,
 ): Promise<T> {
   const GATEWAY_URL = browser ? env.PUBLIC_GATEWAY_CLIENT_URL : env.PUBLIC_GATEWAY_SERVER_URL;
-  const user = get<User | null>(userStore);
 
   const headers: HeadersInit = {
     Authorization: `Bearer ${user?.token ?? ''}`,
     'Content-Type': 'application/json',
   };
-
-  if (token !== null) {
-    // This overrides the auth header (e.g. if the user is not set yet during SSR).
-    headers['Authorization'] = `Bearer ${token ?? ''}`;
-  }
+  const options: RequestInit = {
+    headers,
+    method,
+  };
 
   if (excludeContentType === true) {
-    delete headers['Content-Type'];
+    delete options.headers['Content-Type'];
   }
-
-  const options: RequestInit = { headers, method };
 
   if (body !== null) {
     options.body = body;
   }
 
   const response = await fetch(`${GATEWAY_URL}${url}`, options);
+
   if (!response.ok) {
     throw new Error(response.statusText);
   }
+
   const data = await response.json();
 
   return data;
@@ -53,22 +49,15 @@ export async function reqGateway<T = any>(
 export async function reqHasura<T = any>(
   query: string,
   variables: QueryVariables = {},
-  signal?: AbortSignal,
-  token?: string,
+  user: BaseUser | User | null,
+  signal: AbortSignal = undefined,
 ): Promise<Record<string, T>> {
   const HASURA_URL = browser ? env.PUBLIC_HASURA_CLIENT_URL : env.PUBLIC_HASURA_SERVER_URL;
-  const user = get<User | null>(userStore);
 
   const headers: HeadersInit = {
     Authorization: `Bearer ${user?.token ?? ''}`,
     'Content-Type': 'application/json',
   };
-
-  if (token !== undefined) {
-    // This overrides the auth header (e.g. if the user is not set yet during SSR).
-    headers['Authorization'] = `Bearer ${token ?? ''}`;
-  }
-
   const options: RequestInit = {
     body: JSON.stringify({ query, variables }),
     headers,


### PR DESCRIPTION
Closes https://github.com/NASA-AMMOS/aerie-ui/issues/665

- Remove the user store and instead pass the user in the component tree, starting in the server hook.
- Should make reasoning about the user much easier, at the cost of passing it around more.
- Moves the permissible queries into the `User` object in the server hook.
- Import `User` type in `app.d.ts` properly.
- Turns back on SSR.

### TODO

- [x] Update subscriptions - ended up just using the cookie since the subscription is in the browser
- Test, test, test