### PR TITLE
Merge review fix

### DIFF
--- a/src/components/plan/PlanMergeReview.svelte
+++ b/src/components/plan/PlanMergeReview.svelte
@@ -656,11 +656,11 @@
     border-right: 1px solid var(--st-gray-20);
   }
 
-  .merge-review-content :global(.collapse > button) {
+  .merge-review-changes-content :global(.collapse > button.collapse-header) {
     padding: 8px 16px;
   }
 
-  .merge-review-content :global(.collapse .content) {
+  .merge-review-changes-content :global(.collapse .content) {
     gap: 0;
     margin: 0;
   }

--- a/src/components/ui/SearchableDropdown.svelte
+++ b/src/components/ui/SearchableDropdown.svelte
@@ -51,7 +51,7 @@
   const dispatch = createEventDispatcher();
 
   let displayedOptions: DisplayOptions = [];
-  let presetMenu: Menu;
+  let presetMenu: Menu | undefined;
   let searchFilter: string = '';
   let selectedOption: DropdownOption | undefined;
 

--- a/src/components/ui/SearchableDropdown.svelte
+++ b/src/components/ui/SearchableDropdown.svelte
@@ -36,11 +36,13 @@
   export let settingsIconTooltipPlacement: string = 'top';
 
   export function hideMenu() {
-    dispatch('hideMenu');
-    presetMenu.hide();
+    if (presetMenu) {
+      dispatch('hideMenu');
+      presetMenu.hide();
+    }
   }
   export function openMenu() {
-    if (!disabled) {
+    if (!disabled && presetMenu) {
       dispatch('openMenu');
       presetMenu.show();
     }


### PR DESCRIPTION
Closes #699. Ensures SearchableDropdown's reference to the menu element still exists when opening and hiding.
Additionally fixes a small style bug introduced by #620 