### PR TITLE
Simulation history dataset checkbox fix

### DIFF
--- a/src/components/simulation/SimulationHistoryDataset.svelte
+++ b/src/components/simulation/SimulationHistoryDataset.svelte
@@ -22,7 +22,6 @@
   let endTimeText = '';
 
   $: timeVizRangeWidthStyle = timeVizRangeWidth < 1 ? '4px' : `${timeVizRangeWidth}%`;
-
   $: {
     // Compute time range left and width
     if (simulationDataset.simulation_start_time) {
@@ -47,13 +46,17 @@
       }
     }
   }
+
+  function onCheckboxClick(e: MouseEventHandler<HTMLInputElement>) {
+    e.target.checked = checked;
+  }
 </script>
 
 <button class="simulation-dataset st-typography-label" class:active={checked} on:click={() => dispatch('click')}>
   <div class="simulation-dataset-top-row">
     <div class="simulation-dataset-input-container">
       <Input class="simulation-dataset-input">
-        <input {checked} type="checkbox" tabIndex={-1} />
+        <input {checked} type="checkbox" tabIndex={-1} on:click={onCheckboxClick} />
       </Input>
       ID: {simulationDataset.id}
     </div>
@@ -146,6 +149,7 @@
   }
 
   .simulation-dataset-top-row :global(.input.simulation-dataset-input input) {
+    cursor: pointer;
     margin: 0;
     padding: 0;
   }

--- a/src/components/simulation/SimulationHistoryDataset.svelte
+++ b/src/components/simulation/SimulationHistoryDataset.svelte
@@ -22,6 +22,7 @@
   let endTimeText = '';
 
   $: timeVizRangeWidthStyle = timeVizRangeWidth < 1 ? '4px' : `${timeVizRangeWidth}%`;
+
   $: {
     // Compute time range left and width
     if (simulationDataset.simulation_start_time) {
@@ -47,8 +48,8 @@
     }
   }
 
-  function onCheckboxClick(e: MouseEventHandler<HTMLInputElement>) {
-    e.target.checked = checked;
+  function onCheckboxClick(e: Event) {
+    (e.target as HTMLInputElement).checked = checked;
   }
 </script>
 


### PR DESCRIPTION
Prevent checkbox in SimulationHistoryDataset from changing on click and desyncing with the actual state. Doesn't appear possible to just use `preventDefault` to stop the checkbox from toggling on click so need to explicitly set it.

Closes #710 