### PR TITLE
Fix redirecting to login

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,13 +1,13 @@
-import { env } from '$env/dynamic/public';
 import type { Handle } from '@sveltejs/kit';
 import { parse } from 'cookie';
 import jwtDecode from 'jwt-decode';
 import type { BaseUser, ParsedUserToken, User } from './types/app';
 import effects from './utilities/effects';
+import { isLoginEnabled } from './utilities/login';
 import { ADMIN_ROLE } from './utilities/permissions';
 
 export const handle: Handle = async ({ event, resolve }) => {
-  if (env.PUBLIC_LOGIN_PAGE === 'disabled') {
+  if (!isLoginEnabled()) {
     const permissibleQueries = await effects.getUserQueries(null);
     event.locals.user = {
       allowedRoles: [ADMIN_ROLE],

--- a/src/routes/constraints/+page.ts
+++ b/src/routes/constraints/+page.ts
@@ -1,14 +1,13 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../utilities/effects';
-import { hasNoAuthorization } from '../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/constraints/edit/[id]/+page.ts
+++ b/src/routes/constraints/edit/[id]/+page.ts
@@ -1,15 +1,14 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../../utilities/effects';
 import { parseFloatOrNull } from '../../../../utilities/generic';
-import { hasNoAuthorization } from '../../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/constraints/new/+page.ts
+++ b/src/routes/constraints/new/+page.ts
@@ -1,14 +1,13 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../utilities/effects';
-import { hasNoAuthorization } from '../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/dictionaries/+page.ts
+++ b/src/routes/dictionaries/+page.ts
@@ -1,13 +1,12 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
-import { hasNoAuthorization } from '../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/rules/+page.ts
+++ b/src/routes/expansion/rules/+page.ts
@@ -1,13 +1,12 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
-import { hasNoAuthorization } from '../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/rules/edit/[id]/+page.ts
+++ b/src/routes/expansion/rules/edit/[id]/+page.ts
@@ -1,14 +1,13 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../../../utilities/effects';
-import { hasNoAuthorization } from '../../../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/rules/new/+page.ts
+++ b/src/routes/expansion/rules/new/+page.ts
@@ -1,13 +1,12 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
-import { hasNoAuthorization } from '../../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/runs/+page.ts
+++ b/src/routes/expansion/runs/+page.ts
@@ -1,14 +1,13 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../utilities/effects';
-import { hasNoAuthorization } from '../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/sets/+page.ts
+++ b/src/routes/expansion/sets/+page.ts
@@ -1,13 +1,12 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
-import { hasNoAuthorization } from '../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/expansion/sets/new/+page.ts
+++ b/src/routes/expansion/sets/new/+page.ts
@@ -1,13 +1,12 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
-import { hasNoAuthorization } from '../../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -18,7 +18,7 @@
   let username = '';
   let usernameInput: HTMLInputElement | null = null;
 
-  $: if (hasNoAuthorization(data.user)) {
+  $: if (data.user?.permissibleQueries && hasNoAuthorization(data.user)) {
     error = 'You are not authorized';
     fullError =
       'You are not authorized to access the page that you attempted to view. Please contact a tool administrator to request access.';

--- a/src/routes/models/+page.ts
+++ b/src/routes/models/+page.ts
@@ -1,14 +1,13 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../utilities/effects';
-import { hasNoAuthorization } from '../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/plans/+page.ts
+++ b/src/routes/plans/+page.ts
@@ -1,14 +1,13 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../utilities/effects';
-import { hasNoAuthorization } from '../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -1,14 +1,13 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../utilities/effects';
-import { hasNoAuthorization } from '../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params, url }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/plans/[id]/merge/+page.ts
+++ b/src/routes/plans/[id]/merge/+page.ts
@@ -1,5 +1,4 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import type {
   PlanMergeConflictingActivity,
@@ -7,13 +6,13 @@ import type {
   PlanMergeRequestSchema,
 } from '../../../../types/plan';
 import effects from '../../../../utilities/effects';
-import { hasNoAuthorization } from '../../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/+page.ts
+++ b/src/routes/scheduling/+page.ts
@@ -1,14 +1,13 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../utilities/effects';
-import { hasNoAuthorization } from '../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/conditions/edit/[id]/+page.ts
+++ b/src/routes/scheduling/conditions/edit/[id]/+page.ts
@@ -1,15 +1,14 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../../../utilities/effects';
 import { parseFloatOrNull } from '../../../../../utilities/generic';
-import { hasNoAuthorization } from '../../../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/conditions/new/+page.ts
+++ b/src/routes/scheduling/conditions/new/+page.ts
@@ -1,15 +1,14 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../../utilities/effects';
 import { parseFloatOrNull } from '../../../../utilities/generic';
-import { hasNoAuthorization } from '../../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, url }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/goals/edit/[id]/+page.ts
+++ b/src/routes/scheduling/goals/edit/[id]/+page.ts
@@ -1,15 +1,14 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../../../utilities/effects';
 import { parseFloatOrNull } from '../../../../../utilities/generic';
-import { hasNoAuthorization } from '../../../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/scheduling/goals/new/+page.ts
+++ b/src/routes/scheduling/goals/new/+page.ts
@@ -1,15 +1,14 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import effects from '../../../../utilities/effects';
 import { parseFloatOrNull } from '../../../../utilities/generic';
-import { hasNoAuthorization } from '../../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, url }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/sequencing/+page.ts
+++ b/src/routes/sequencing/+page.ts
@@ -1,13 +1,12 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
-import { hasNoAuthorization } from '../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/sequencing/edit/[id]/+page.ts
+++ b/src/routes/sequencing/edit/[id]/+page.ts
@@ -1,16 +1,15 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import type { UserSequence } from '../../../../types/sequencing';
 import effects from '../../../../utilities/effects';
 import { parseFloatOrNull } from '../../../../utilities/generic';
-import { hasNoAuthorization } from '../../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent, params }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/routes/sequencing/new/+page.ts
+++ b/src/routes/sequencing/new/+page.ts
@@ -1,13 +1,12 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
-import { hasNoAuthorization } from '../../../utilities/permissions';
+import { shouldRedirectToLogin } from '../../../utilities/login';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'enabled' && (!user || hasNoAuthorization(user))) {
+  if (shouldRedirectToLogin(user)) {
     throw redirect(302, `${base}/login`);
   }
 

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -10,7 +10,7 @@ export type BaseUser = {
 export type User = BaseUser & {
   allowedRoles: string[];
   defaultRole: string;
-  permissibleQueries: PermissibleQueriesMap;
+  permissibleQueries: PermissibleQueriesMap | null;
 };
 
 export type ParsedUserToken = {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -1968,7 +1968,7 @@ const effects = {
     }
   },
 
-  async getUserQueries(user: BaseUser | null): Promise<PermissibleQueriesMap> {
+  async getUserQueries(user: BaseUser | null): Promise<PermissibleQueriesMap | null> {
     try {
       const data = await reqHasura<PermissibleQueryResponse>(gql.GET_PERMISSIBLE_QUERIES, {}, user, undefined);
       const {
@@ -1986,7 +1986,7 @@ const effects = {
       }, {});
     } catch (e) {
       catchError(e as Error);
-      return {};
+      return null;
     }
   },
 

--- a/src/utilities/login.test.ts
+++ b/src/utilities/login.test.ts
@@ -1,0 +1,84 @@
+import { env } from '$env/dynamic/public';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { isLoginEnabled, shouldRedirectToLogin } from './login';
+
+vi.mock('$env/dynamic/public', () => ({
+  env: {
+    PUBLIC_LOGIN_PAGE: '',
+  },
+}));
+
+describe('login util functions', () => {
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('isLoginEnabled', () => {
+    test('Should return whether or not the login page is enabled', () => {
+      vi.mocked(env).PUBLIC_LOGIN_PAGE = '';
+      expect(isLoginEnabled()).toEqual(true);
+
+      vi.mocked(env).PUBLIC_LOGIN_PAGE = 'enabled';
+      expect(isLoginEnabled()).toEqual(true);
+
+      vi.mocked(env).PUBLIC_LOGIN_PAGE = 'disabled';
+      expect(isLoginEnabled()).toEqual(false);
+    });
+  });
+
+  describe('shouldRedirectToLogin', () => {
+    test('Should determine if the route should redirect to the login page when login is enabled', () => {
+      vi.mocked(env).PUBLIC_LOGIN_PAGE = 'enabled';
+
+      expect(shouldRedirectToLogin(null)).toEqual(true);
+      expect(
+        shouldRedirectToLogin({
+          allowedRoles: ['admin', 'user'],
+          defaultRole: 'user',
+          id: 'foo',
+          permissibleQueries: {},
+          token: 'foo',
+        }),
+      ).toEqual(true);
+
+      expect(
+        shouldRedirectToLogin({
+          allowedRoles: ['admin', 'user'],
+          defaultRole: 'user',
+          id: 'foo',
+          permissibleQueries: {
+            constraints: true,
+          },
+          token: 'foo',
+        }),
+      ).toEqual(false);
+    });
+
+    test('Should not redirect if login is disabled', () => {
+      vi.mocked(env).PUBLIC_LOGIN_PAGE = 'disabled';
+
+      expect(shouldRedirectToLogin(null)).toEqual(false);
+      expect(
+        shouldRedirectToLogin({
+          allowedRoles: ['admin', 'user'],
+          defaultRole: 'user',
+          id: 'foo',
+          permissibleQueries: {},
+          token: 'foo',
+        }),
+      ).toEqual(false);
+
+      expect(
+        shouldRedirectToLogin({
+          allowedRoles: ['admin', 'user'],
+          defaultRole: 'user',
+          id: 'foo',
+          permissibleQueries: {
+            constraints: true,
+          },
+          token: 'foo',
+        }),
+      ).toEqual(false);
+    });
+  });
+});

--- a/src/utilities/login.ts
+++ b/src/utilities/login.ts
@@ -1,0 +1,12 @@
+import { env } from '$env/dynamic/public';
+import type { User } from '../types/app';
+import { hasNoAuthorization } from './permissions';
+
+export function isLoginEnabled() {
+  // if PUBLIC_LOGIN_PAGE is not explicitly set to "disabled", then assume it is enabled
+  return env.PUBLIC_LOGIN_PAGE !== 'disabled';
+}
+
+export function shouldRedirectToLogin(user: User | null) {
+  return isLoginEnabled() && (!user || hasNoAuthorization(user));
+}

--- a/src/utilities/permissions.test.ts
+++ b/src/utilities/permissions.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest';
+import { hasNoAuthorization } from './permissions';
+
+describe('hasNoAuthorization', () => {
+  test('Should return whether or not the user has authorization', () => {
+    expect(hasNoAuthorization(null)).toEqual(true);
+    expect(
+      hasNoAuthorization({
+        allowedRoles: ['admin', 'user'],
+        defaultRole: 'user',
+        id: 'foo',
+        permissibleQueries: {},
+        token: '',
+      }),
+    ).toEqual(true);
+
+    expect(
+      hasNoAuthorization({
+        allowedRoles: ['admin', 'user'],
+        defaultRole: 'user',
+        id: 'foo',
+        permissibleQueries: {
+          constraint: true,
+        },
+        token: '',
+      }),
+    ).toEqual(false);
+  });
+});

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -330,7 +330,7 @@ const featurePermissions: FeaturePermissions = {
 };
 
 function hasNoAuthorization(user: User | null) {
-  return user && !Object.keys(user.permissibleQueries).length;
+  return !user || (user.permissibleQueries && !Object.keys(user.permissibleQueries).length);
 }
 
 export { featurePermissions, hasNoAuthorization, queryPermissions };


### PR DESCRIPTION
The current issue is that if the `PUBLIC_LOGIN_PAGE` environment variable is set to anything but "disabled" (e.g. it is set to ""), the UI will not redirect to the login page regardless of if the user has a cookie or not.

To test:
1. Set `PUBLIC_LOGIN_PAGE` in `.env` to nothing or delete it altogether to simulate that the environment variable is not defined
1. Clear out your cookies for the UI
1. Navigate to the /plans page
1. Verify that you are correctly redirected to the login page
1. Verify that you don't get redirected to the login again after logging in

This also includes a fix where the user was presented the "Not authorized" error message on the login page when the backend services are still being spun up, resulting in an incomplete, but misleading, state.

To test:
1. Log out of the UI
1. Stop the backend containers, but keep the UI server running
1. Refresh the UI
1. Verify that there is no longer an "Not authorized" error message on the login page
