### PR TITLE
Fix incorrect User object being used for permissions query

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -30,15 +30,18 @@ export const handle: Handle = async ({ event, resolve }) => {
       const decodedToken: ParsedUserToken = jwtDecode(baseUser.token);
 
       if (success) {
-        const permissibleQueries = await effects.getUserQueries(baseUser);
         const user: User = {
           ...baseUser,
           activeRole: decodedToken.activeRole,
           allowedRoles: decodedToken['https://hasura.io/jwt/claims']['x-hasura-allowed-roles'],
           defaultRole: decodedToken['https://hasura.io/jwt/claims']['x-hasura-default-role'],
+          permissibleQueries: null,
+        };
+        const permissibleQueries = await effects.getUserQueries(user);
+        event.locals.user = {
+          ...user,
           permissibleQueries,
         };
-        event.locals.user = user;
       } else {
         event.locals.user = null;
       }

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -70,6 +70,8 @@
   let version = '';
   let description = '';
 
+  let redrawRows: () => void;
+
   $: createButtonDisabled = !files || name === '' || version === '' || $creatingModel === true;
   $: {
     user = data.user;
@@ -109,6 +111,8 @@
         width: 25,
       },
     ];
+    // Need to force the table to redraw the DataGridAction cells after the user's role is changed
+    redrawRows?.();
   }
 
   onMount(() => {
@@ -233,6 +237,7 @@
       <svelte:fragment slot="body">
         {#if $models.length}
           <SingleActionDataGrid
+            bind:redrawRows
             {columnDefs}
             {hasDeletePermission}
             itemDisplayText="Model"

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -2012,7 +2012,7 @@ const effects = {
     }
   },
 
-  async getUserQueries(user: BaseUser | null): Promise<PermissibleQueriesMap | null> {
+  async getUserQueries(user: User | null): Promise<PermissibleQueriesMap | null> {
     try {
       const data = await reqHasura<PermissibleQueryResponse>(gql.GET_PERMISSIBLE_QUERIES, {}, user, undefined);
       const {


### PR DESCRIPTION
This fixes an issue where an incomplete user object was being used to query for permissions. Because the user object was not fully formed, the `activeUser` field was not being set, thus the return permissions were not accurate.