### PR TITLE
Fix tables not updating when user is changed

### DIFF
--- a/src/components/activity/ActivityDirectivesTable.svelte
+++ b/src/components/activity/ActivityDirectivesTable.svelte
@@ -91,6 +91,7 @@
   scrollToSelection={true}
   singleItemDisplayText="Activity Directive"
   suppressDragLeaveHidesColumns={false}
+  {user}
   on:bulkDeleteItems={deleteActivityDirectives}
   on:columnStateChange
   on:selectionChanged

--- a/src/components/modals/SavedViewsModal.svelte
+++ b/src/components/modals/SavedViewsModal.svelte
@@ -74,10 +74,22 @@
         <Tab class="view-tab">My Views</Tab>
       </svelte:fragment>
       <TabPanel>
-        <ViewsTable views={$views} on:deleteView={deleteView} on:deleteViews={deleteViews} on:openView={openView} />
+        <ViewsTable
+          {user}
+          views={$views}
+          on:deleteView={deleteView}
+          on:deleteViews={deleteViews}
+          on:openView={openView}
+        />
       </TabPanel>
       <TabPanel>
-        <ViewsTable views={userViews} on:deleteView={deleteView} on:deleteViews={deleteViews} on:openView={openView} />
+        <ViewsTable
+          {user}
+          views={userViews}
+          on:deleteView={deleteView}
+          on:deleteViews={deleteViews}
+          on:openView={openView}
+        />
       </TabPanel>
     </Tabs>
   </ModalContent>

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -7,9 +7,10 @@
     bulkDeleteItems: CustomEvent<RowData[]>;
   }
   import { browser } from '$app/environment';
-  import type { ColDef, ColumnState, IRowNode } from 'ag-grid-community';
+  import type { ColDef, ColumnState, IRowNode, RedrawRowsParams } from 'ag-grid-community';
   import { keyBy } from 'lodash-es';
   import { createEventDispatcher, onDestroy, type ComponentEvents } from 'svelte';
+  import type { User } from '../../../types/app';
   import type { RowId, TRowData } from '../../../types/data-grid';
   import { isDeleteEvent } from '../../../utilities/keyboardEvents';
   import ContextMenuHeader from '../../context-menu/ContextMenuHeader.svelte';
@@ -29,9 +30,11 @@
   export let singleItemDisplayText: string = '';
   export let suppressDragLeaveHidesColumns: boolean = true;
   export let suppressRowClickSelection: boolean = false;
+  export let user: User | null;
 
   export let getRowId: (data: RowData) => RowId = (data: RowData): RowId => parseInt(data[idKey]);
   export let isRowSelectable: ((node: IRowNode<RowData>) => boolean) | undefined = undefined;
+  export let redrawRows: ((params?: RedrawRowsParams<RowData> | undefined) => void) | undefined = undefined;
 
   const dispatch = createEventDispatcher();
 
@@ -42,6 +45,9 @@
     selectedItemIds = [selectedItemId];
   } else if (selectedItemId === null) {
     selectedItemIds = [];
+  }
+  $: if (user !== undefined) {
+    redrawRows?.();
   }
 
   onDestroy(() => onBlur());
@@ -93,6 +99,7 @@
   bind:this={dataGrid}
   bind:currentSelectedRowId={selectedItemId}
   bind:selectedRowIds={selectedItemIds}
+  bind:redrawRows
   {autoSizeColumnsToFit}
   {columnDefs}
   {columnStates}

--- a/src/components/ui/DataGrid/SingleActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/SingleActionDataGrid.svelte
@@ -23,19 +23,19 @@
   export let columnDefs: ColDef[];
   export let columnStates: ColumnState[] = [];
   export let dataGrid: DataGrid<RowData> | undefined = undefined;
+  export let hasDeletePermission: PermissionCheck<RowData> | boolean = true;
   export let hasEdit: boolean = false;
+  export let hasEditPermission: PermissionCheck<RowData> | boolean = true;
   export let idKey: keyof RowData = 'id';
   export let items: RowData[];
   export let itemDisplayText: string;
   export let selectedItemId: RowId | null = null;
   export let scrollToSelection: boolean = false;
+  export let user: User | null;
 
   export let getRowId: (data: RowData) => RowId = (data: RowData): RowId => parseInt(data[idKey]);
-  export let hasDeletePermission: PermissionCheck<RowData> | boolean = true;
-  export let hasEditPermission: PermissionCheck<RowData> | boolean = true;
   export let isRowSelectable: ((node: IRowNode<RowData>) => boolean) | undefined = undefined;
   export let redrawRows: ((params?: RedrawRowsParams<RowData> | undefined) => void) | undefined = undefined;
-  export let user: User | null;
 
   const dispatch = createEventDispatcher();
 
@@ -64,6 +64,9 @@
     selectedItemIds = [selectedItemId];
   } else if (selectedItemId === null) {
     selectedItemIds = [];
+  }
+  $: if (user !== undefined) {
+    redrawRows?.();
   }
 
   onDestroy(() => onBlur());

--- a/src/components/view/ViewsTable.svelte
+++ b/src/components/view/ViewsTable.svelte
@@ -3,12 +3,14 @@
 <script lang="ts">
   import type { ICellRendererParams, ValueFormatterParams } from 'ag-grid-community';
   import { createEventDispatcher } from 'svelte';
+  import type { User } from '../../types/app';
   import type { DataGridColumnDef } from '../../types/data-grid';
   import type { View } from '../../types/view';
   import BulkActionDataGrid from '../ui/DataGrid/BulkActionDataGrid.svelte';
   import DataGridActions from '../ui/DataGrid/DataGridActions.svelte';
 
   export let views: View[] = [];
+  export let user: User | null;
 
   type CellRendererParams = {
     deleteView: (view: View) => void;
@@ -120,6 +122,7 @@
   items={views}
   pluralItemDisplayText="Views"
   singleItemDisplayText="View"
+  {user}
   on:bulkDeleteItems={deleteViews}
   on:rowDoubleClicked={event => openView(event.detail)}
 />

--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -70,8 +70,6 @@
   let version = '';
   let description = '';
 
-  let redrawRows: () => void;
-
   $: createButtonDisabled = !files || name === '' || version === '' || $creatingModel === true;
   $: {
     user = data.user;
@@ -111,8 +109,6 @@
         width: 25,
       },
     ];
-    // Need to force the table to redraw the DataGridAction cells after the user's role is changed
-    redrawRows?.();
   }
 
   onMount(() => {
@@ -237,7 +233,6 @@
       <svelte:fragment slot="body">
         {#if $models.length}
           <SingleActionDataGrid
-            bind:redrawRows
             {columnDefs}
             {hasDeletePermission}
             itemDisplayText="Model"

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -116,8 +116,6 @@
   let plans: PlanSlim[];
   let user: User | null = null;
 
-  let redrawRows: () => void;
-
   let endTimeDoyField = field<string>('', [required, timestamp]);
   let modelIdField = field<number>(-1, [min(1, 'Field is required')]);
   let nameField = field<string>('', [required]);
@@ -163,8 +161,6 @@
         width: 25,
       },
     ];
-    // Need to force the table to redraw the DataGridAction cells after the user's role is changed
-    redrawRows?.();
   }
   $: createButtonEnabled =
     $endTimeDoyField.dirtyAndValid &&
@@ -396,7 +392,6 @@
       <svelte:fragment slot="body">
         {#if filteredPlans.length}
           <SingleActionDataGrid
-            bind:redrawRows
             {columnDefs}
             hasDeletePermission={featurePermissions.plan.canDelete}
             itemDisplayText="Plan"


### PR DESCRIPTION
To test:
1. Go to the plans page and make sure your role is set to "admin"
2. Hover over a plan row (ideally one that your current user does not own) and verify that you are able to click on the delete button
3. Switch your role to "user"
4. Hover over the same plan row and verify that you are no longer able to delete the plan