### PR TITLE
Update to accommodate initial tag changes

### DIFF
--- a/src/components/activity/ActivityTypesPanel.svelte
+++ b/src/components/activity/ActivityTypesPanel.svelte
@@ -23,7 +23,7 @@
 
   async function createActivityDirectiveAtPlanStart(activityType: ActivityType) {
     const { start_time_doy } = $plan;
-    effects.createActivityDirective({}, start_time_doy, activityType.name, activityType.name, [], {}, user);
+    effects.createActivityDirective({}, start_time_doy, activityType.name, activityType.name, {}, user);
   }
 
   function onDragEnd(): void {

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -146,7 +146,7 @@
       const unixEpochTime = xScaleView.invert(offsetX).getTime();
       const start_time = getDoyTime(new Date(unixEpochTime));
       const activityTypeName = e.dataTransfer.getData('activityTypeName');
-      effects.createActivityDirective({}, start_time, activityTypeName, activityTypeName, [], {}, user);
+      effects.createActivityDirective({}, start_time, activityTypeName, activityTypeName, {}, user);
     }
   }
 

--- a/src/components/ui/Tags.svelte
+++ b/src/components/ui/Tags.svelte
@@ -32,7 +32,7 @@
 
   function attemptCloseAutocomplete(event: MouseEvent | FocusEvent) {
     // Find autocomplete element
-    const autocompleteElement = container.getElementsByClassName('svelte-tags-input-matchs-parent');
+    const autocompleteElement = container.getElementsByClassName('svelte-tags-input-matches-parent');
 
     // If element does not exist it is not showing in the DOM
     if (autocompleteElement.length !== 1) {
@@ -150,7 +150,7 @@
     opacity: 1;
   }
 
-  :global(.svelte-tags-input-matchs) {
+  :global(.svelte-tags-input-matches) {
     overflow: auto !important;
     z-index: 1 !important;
   }
@@ -167,7 +167,7 @@
     cursor: not-allowed !important;
   }
 
-  :global(.svelte-tags-input-matchs) {
+  :global(.svelte-tags-input-matches) {
     border: var(--st-input-border) !important;
     border: 1px solid var(--st-gray-20) !important;
     border-radius: 4px !important;
@@ -177,7 +177,7 @@
     padding: 8px !important;
   }
 
-  :global(.svelte-tags-input-matchs li) {
+  :global(.svelte-tags-input-matches li) {
     color: var(--st-typography-body-color);
     font-family: var(--st-typography-body-font-family);
     font-size: var(--st-typography-body-font-size);
@@ -186,7 +186,7 @@
     line-height: var(--st-typography-body-line-height);
   }
 
-  :global(.svelte-tags-input-matchs li strong) {
+  :global(.svelte-tags-input-matches li strong) {
     color: var(--st-typography-bold-color);
     font-family: var(--st-typography-bold-font-family);
     font-size: var(--st-typography-bold-font-size);
@@ -195,7 +195,7 @@
     line-height: var(--st-typography-bold-line-height);
   }
 
-  :global(.svelte-tags-input-matchs li:hover, .svelte-tags-input-matchs li:focus) {
+  :global(.svelte-tags-input-matches li:hover, .svelte-tags-input-matches li:focus) {
     background: var(--st-gray-15) !important;
     color: inherit !important;
   }

--- a/src/stores/activities.ts
+++ b/src/stores/activities.ts
@@ -100,7 +100,7 @@ export const activityDirectivesByView: Readable<ActivityDirectivesByView> = deri
 export const allActivityDirectiveTags: Readable<string[]> = derived(activityDirectivesList, $activityDirectivesList => {
   const tagMap = $activityDirectivesList.reduce(
     (map: Record<string, boolean>, activityDirective: ActivityDirective) => {
-      activityDirective.tags.forEach(tag => (map[tag] = true));
+      activityDirective.tags.forEach(({ tag }) => (map[tag.name] = true));
       return map;
     },
     {},

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -4,6 +4,7 @@ import type { UserId } from './app';
 import type { ExpansionRule } from './expansion';
 import type { ArgumentsMap, ParametersMap } from './parameter';
 import type { ValueSchema } from './schema';
+import type { Tag } from './tags';
 
 export type ActivityDirectivesByView = {
   byLayerId: Record<number, ActivityDirective[]>;
@@ -45,7 +46,7 @@ export type ActivityDirective = {
   plan_id: number;
   source_scheduling_goal_id: number;
   start_offset: string;
-  tags: string[];
+  tags: { tag: Tag }[];
   type: string;
 };
 
@@ -57,7 +58,6 @@ export type ActivityDirectiveInsertInput = {
   name: string;
   plan_id: number;
   start_offset: string;
-  tags: string; // Hasura does not accept arrays so this must be in the form of "{1,2,3,...,n}"
   type: string;
 };
 

--- a/src/types/tags.ts
+++ b/src/types/tags.ts
@@ -1,0 +1,15 @@
+export type ActivityDirectiveTagsInsertInput = {
+  directive_id: number;
+  plan_id: number;
+  tag_id: number;
+};
+
+export type Tag = {
+  color: string;
+  created_at: string;
+  id: number;
+  name: string;
+  owner: string;
+};
+
+export type TagsInsertInput = Pick<Tag, 'color' | 'name'>;

--- a/src/utilities/generic.test.ts
+++ b/src/utilities/generic.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test, vi } from 'vitest';
-import { attemptStringConversion, clamp, classNames, filterEmpty, formatHasuraStringArray, isMacOs } from './generic';
+import { attemptStringConversion, clamp, classNames, filterEmpty, isMacOs } from './generic';
 
 const mockNavigator = {
   platform: 'MacIntel',
@@ -68,15 +68,6 @@ describe('filterEmpty', () => {
       false,
       { foo: 1 },
     ]);
-  });
-});
-
-describe('formatHasuraStringArray', () => {
-  test('Should generate the correct string given a string array', () => {
-    expect(formatHasuraStringArray(['foo', 'bar'])).toEqual('{foo,bar}');
-  });
-  test('Should generate the correct string given an empty string array', () => {
-    expect(formatHasuraStringArray([])).toEqual('{}');
   });
 });
 

--- a/src/utilities/generic.ts
+++ b/src/utilities/generic.ts
@@ -84,13 +84,6 @@ export function filterEmpty<T>(value: T | null | undefined): value is T {
 }
 
 /**
- * Returns a string formatted in the Hasura string array format of '{1,2,...n}'.
- */
-export function formatHasuraStringArray(stringArray: string[]): string {
-  return `{${stringArray.join(',')}}`;
-}
-
-/**
  * Returns a target based on an Event.
  */
 export function getTarget(event: Event) {

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -37,8 +37,25 @@ const gql = {
         plan_id
         source_scheduling_goal_id
         start_offset
-        tags
+        tags {
+          tag {
+            color
+          	id
+            name
+          }
+        }
         type
+      }
+    }
+  `,
+
+  CREATE_ACTIVITY_DIRECTIVE_TAGS: `#graphql
+    mutation CreateActivityDirectiveTags($tags: [activity_directive_tags_insert_input!]!) {
+      insert_activity_directive_tags(objects: $tags, on_conflict: {
+        constraint: activity_directive_tags_pkey,
+        update_columns: []
+      }) {
+        affected_rows
       }
     }
   `,
@@ -210,6 +227,24 @@ const gql = {
         arguments
         description
         id
+      }
+    }
+  `,
+
+  CREATE_TAGS: `#graphql
+    mutation CreateTags($tags: [tags_insert_input!]!) {
+      insert_tags(objects: $tags, on_conflict: {
+        constraint: tags_name_key,
+        update_columns: [color]
+      }) {
+        affected_rows
+        returning {
+          color
+          created_at
+          id
+          name
+          owner
+        }
       }
     }
   `,
@@ -1109,7 +1144,13 @@ const gql = {
         plan_id
         source_scheduling_goal_id
         start_offset
-        tags
+        tags {
+          tag {
+            color
+          	id
+            name
+          }
+        }
         type
       }
     }
@@ -1596,7 +1637,13 @@ const gql = {
         plan_id
         source_scheduling_goal_id
         start_offset
-        tags
+        tags {
+          tag {
+            color
+          	id
+            name
+          }
+        }
         type
       }
     }

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -77,6 +77,9 @@ const queryPermissions = {
   CREATE_ACTIVITY_DIRECTIVE: (user: User | null): boolean => {
     return getPermission(['insert_activity_directive_one'], user);
   },
+  CREATE_ACTIVITY_DIRECTIVE_TAGS: (user: User | null): boolean => {
+    return getPermission(['insert_activity_directive_tags'], user);
+  },
   CREATE_ACTIVITY_PRESET: (user: User | null): boolean => {
     return getPermission(['insert_activity_presets_one'], user);
   },
@@ -121,6 +124,9 @@ const queryPermissions = {
   },
   CREATE_SIMULATION_TEMPLATE: (user: User | null): boolean => {
     return getPermission(['insert_simulation_template_one'], user);
+  },
+  CREATE_TAGS: (user: User | null): boolean => {
+    return getPermission(['insert_tags'], user);
   },
   CREATE_USER_SEQUENCE: (user: User | null): boolean => {
     return getPermission(['insert_user_sequence_one'], user);


### PR DESCRIPTION
* Add tags
* Add activity directive tag associations
* Backend prereq: https://github.com/NASA-AMMOS/aerie/pull/959

## More Info

- Tags now need to be created before associated with objects (directives, plans, etc). So tag creation now takes two steps: (1) Create tag if it does not exist, see `CREATE_TAGS` query. Notice the conflict catch that just upserts. (2) Associate the tag from (1) to an object. This PR just handles activity directives.
- This PR just handles creating activity directive tags. It does not account for deleting them.
- Notice the nested `{ tags: { tag: {...} }[] }` on activity directives. This is because we now have Hasura joining the directive to the tag table. Ugly but unavoidable unless we switch to using a view.
- We need to replace `svelte-tags-input` since we need a component that gives us add/delete events so we can call the proper APIs more easily.