### PR TITLE
Add basic handling of expired JWTs

### DIFF
--- a/src/components/menus/AppMenu.svelte
+++ b/src/components/menus/AppMenu.svelte
@@ -1,7 +1,7 @@
 <svelte:options accessors={true} />
 
 <script lang="ts">
-  import { goto, invalidateAll, preloadData } from '$app/navigation';
+  import { goto, preloadData } from '$app/navigation';
   import { base } from '$app/paths';
   import { env } from '$env/dynamic/public';
   import CalendarIcon from '@nasa-jpl/stellar/icons/calendar.svg?component';
@@ -18,17 +18,12 @@
   import JournalTextIcon from 'bootstrap-icons/icons/journal-text.svg?component';
   import JournalsIcon from 'bootstrap-icons/icons/journals.svg?component';
   import AerieWordmarkDark from '../../assets/aerie-wordmark-dark.svg?component';
+  import { logout } from '../../utilities/login';
   import { showAboutModal } from '../../utilities/modal';
   import Menu from './Menu.svelte';
   import MenuItem from './MenuItem.svelte';
 
   let appMenu: Menu;
-
-  async function logout() {
-    await fetch(`${base}/auth/logout`, { method: 'POST' });
-    await invalidateAll();
-    await goto(`${base}/login`);
-  }
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -8,7 +8,7 @@
   import AlertError from '../../components/ui/AlertError.svelte';
   import type { LoginResponseBody } from '../../types/auth';
   import { removeQueryParam } from '../../utilities/generic';
-  import { hasNoAuthorization } from '../../utilities/permissions';
+  import { EXPIRED_JWT, hasNoAuthorization } from '../../utilities/permissions';
   import type { PageData } from './$types';
 
   export let data: PageData;
@@ -21,8 +21,6 @@
   let username = '';
   let usernameInput: HTMLInputElement | null = null;
 
-  const JWT_EXPIRED = 'JWTExpired';
-
   $: if (data.user?.permissibleQueries && hasNoAuthorization(data.user)) {
     error = 'You are not authorized';
     fullError =
@@ -30,7 +28,7 @@
   }
 
   $: if (reason) {
-    if (reason.includes(JWT_EXPIRED)) {
+    if (reason.includes(EXPIRED_JWT)) {
       error = 'Your session has expired.';
       fullError = 'Your session has expired. Please log in again.';
     } else {

--- a/src/utilities/generic.ts
+++ b/src/utilities/generic.ts
@@ -1,3 +1,5 @@
+import { browser } from '$app/environment';
+
 /**
  * Returns the string version of an object of unknown type or returns null if this operation fails.
  */
@@ -170,6 +172,10 @@ export function convertToQuery(gql: string): string {
  * Removes a query param from the current URL.
  */
 export function removeQueryParam(key: string): void {
+  if (!browser) {
+    return;
+  }
+
   const { history, location } = window;
   const { hash, host, pathname, protocol, search } = location;
 

--- a/src/utilities/login.ts
+++ b/src/utilities/login.ts
@@ -1,3 +1,6 @@
+import { browser } from '$app/environment';
+import { goto } from '$app/navigation';
+import { base } from '$app/paths';
 import { env } from '$env/dynamic/public';
 import type { User } from '../types/app';
 import { hasNoAuthorization } from './permissions';
@@ -9,4 +12,11 @@ export function isLoginEnabled() {
 
 export function shouldRedirectToLogin(user: User | null) {
   return isLoginEnabled() && (!user || hasNoAuthorization(user));
+}
+
+export async function logout(reason?: string) {
+  if (browser) {
+    await fetch(`${base}/auth/logout`, { method: 'POST' });
+    await goto(`${base}/login${reason ? '?reason=' + reason : ''}`, { invalidateAll: true });
+  }
 }

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -17,6 +17,9 @@ import { showFailureToast } from './toast';
 
 export const ADMIN_ROLE = 'admin';
 
+export const INVALID_JWT = 'invalid-jwt';
+export const EXPIRED_JWT = 'JWTExpired';
+
 function getPermission(queries: string[], user: User | null): boolean {
   if (user && user.permissibleQueries) {
     return queries.reduce((prevValue: boolean, queryName) => {

--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -1,7 +1,11 @@
 import { browser } from '$app/environment';
+import { goto } from '$app/navigation';
+import { base } from '$app/paths';
 import { env } from '$env/dynamic/public';
 import type { BaseUser, User } from '../types/app';
 import type { QueryVariables } from '../types/subscribable';
+
+const INVALID_JWT = 'invalid-jwt';
 
 /**
  * Function to make HTTP requests to the Aerie Gateway.
@@ -88,6 +92,13 @@ export async function reqHasura<T = any>(
       // This is often thrown when a Postgres exception is raised for a Hasura query.
       // @see https://github.com/hasura/graphql-engine/issues/3658
       throw new Error(error?.extensions?.internal?.error?.message ?? error?.message ?? defaultError);
+    } else if (code === INVALID_JWT) {
+      if (browser) {
+        await fetch(`${base}/auth/logout`, { method: 'POST' });
+        await goto(`${base}/login?reason=${encodeURIComponent(error?.message)}`, { invalidateAll: true });
+      }
+
+      throw new Error(error?.message ?? defaultError);
     } else {
       throw new Error(error?.message ?? defaultError);
     }

--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -1,11 +1,9 @@
 import { browser } from '$app/environment';
-import { goto } from '$app/navigation';
-import { base } from '$app/paths';
 import { env } from '$env/dynamic/public';
 import type { BaseUser, User } from '../types/app';
 import type { QueryVariables } from '../types/subscribable';
-
-const INVALID_JWT = 'invalid-jwt';
+import { logout } from '../utilities/login';
+import { INVALID_JWT } from '../utilities/permissions';
 
 /**
  * Function to make HTTP requests to the Aerie Gateway.
@@ -93,11 +91,7 @@ export async function reqHasura<T = any>(
       // @see https://github.com/hasura/graphql-engine/issues/3658
       throw new Error(error?.extensions?.internal?.error?.message ?? error?.message ?? defaultError);
     } else if (code === INVALID_JWT) {
-      if (browser) {
-        await fetch(`${base}/auth/logout`, { method: 'POST' });
-        await goto(`${base}/login?reason=${encodeURIComponent(error?.message)}`, { invalidateAll: true });
-      }
-
+      await logout(error?.message);
       throw new Error(error?.message ?? defaultError);
     } else {
       throw new Error(error?.message ?? defaultError);


### PR DESCRIPTION
Resolves #659 
Fixes https://github.com/NASA-AMMOS/aerie-ui/issues/718

This seems like a simple first step for generally handling expired JWTs. Any time a request to Hasura fails with a "JWTExpired" exception, we manually hit the logout endpoint, invalidateAll, and redirect to the login page. This should essentially capture any scenario where the user tries to perform an action, but their JWT has expired in the meantime.

To more easily test this, I modified my local `aerie-gateway` to issue tokens that expire in 5 seconds.

Future work: at some point I think we should add an endpoint to the gateway that will allow us to periodically poll and check the validity of the user's token. This will allow us to be more proactive in handling expired/invalid tokens, and/or automatically refresh them.

![2023-06-21 17 24 01](https://github.com/NASA-AMMOS/aerie-ui/assets/888818/93a2f6cb-eb63-4350-ae26-be98bd922777)
