### PR TITLE
Fix redundant simulation deletion query preventing plan deletion

### DIFF
--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -386,11 +386,6 @@ const gql = {
           id
         }
       }
-      deleteSimulation: delete_simulation(where: { plan_id: { _eq: $id } }) {
-        returning {
-          id
-        }
-      }
     }
   `,
 

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -174,7 +174,7 @@ const queryPermissions = {
     return getPermission(['delete_mission_model_by_pk'], user);
   },
   DELETE_PLAN: (user: User | null): boolean => {
-    return getPermission(['delete_plan_by_pk', 'delete_scheduling_specification', 'delete_simulation'], user);
+    return getPermission(['delete_plan_by_pk', 'delete_scheduling_specification'], user);
   },
   DELETE_PRESET_TO_DIRECTIVE: (user: User | null): boolean => {
     return getPermission(['delete_preset_to_directive_by_pk'], user);


### PR DESCRIPTION
The mutation query `delete_simulation` is not returned as an available query to use because it is already performed when a plan is deleted. As a result, all the plans appear undeleteable even as an `admin` role. This removes the `deletion_simulation` query check and removes the query being performed.

To test:
1. Create a plan
2. Hover over the plan delete icon
3. Verify that it is clickable as an `admin` role