### PR TITLE
Add permission checks to Command Dictionaries page

### DIFF
--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -17,6 +17,9 @@
   import { showFailureToast, showSuccessToast } from '../../utilities/toast';
   import type { PageData } from './$types';
 
+  import { permissionHandler } from '../../utilities/permissionHandler';
+  import { featurePermissions } from '../../utilities/permissions';
+
   export let data: PageData;
 
   type CellRendererParams = {
@@ -58,6 +61,7 @@
               content: 'Delete Command Dictionary',
               placement: 'bottom',
             },
+            hasDeletePermission,
             rowData: params.data,
           },
           target: actionsDiv,
@@ -78,11 +82,15 @@
     },
   ];
 
+  const createPermissionError = 'You do not have permission to create Command Dictionaries';
+
   let createButtonDisabled: boolean = false;
   let createDictionaryError: string | null = null;
   let creatingDictionary: boolean = false;
   let files: FileList;
 
+  $: hasCreatePermission = featurePermissions.commandDictionary.canCreate(data.user);
+  $: hasDeletePermission = featurePermissions.commandDictionary.canDelete(data.user);
   $: createButtonDisabled = !files;
 
   async function createCommandDictionary(files: FileList) {
@@ -141,11 +149,29 @@
 
           <fieldset>
             <label for="file">AMPCS Command Dictionary XML File</label>
-            <input class="w-100 st-typography-body" name="file" required type="file" bind:files />
+            <input
+              class="w-100 st-typography-body"
+              name="file"
+              required
+              type="file"
+              bind:files
+              use:permissionHandler={{
+                hasPermission: hasCreatePermission,
+                permissionError: createPermissionError,
+              }}
+            />
           </fieldset>
 
           <fieldset>
-            <button class="st-button w-100" disabled={createButtonDisabled} type="submit">
+            <button
+              class="st-button w-100"
+              disabled={createButtonDisabled}
+              type="submit"
+              use:permissionHandler={{
+                hasPermission: hasCreatePermission,
+                permissionError: createPermissionError,
+              }}
+            >
               {creatingDictionary ? 'Creating...' : 'Create'}
             </button>
           </fieldset>
@@ -162,6 +188,7 @@
         {#if $commandDictionaries.length}
           <SingleActionDataGrid
             {columnDefs}
+            {hasDeletePermission}
             itemDisplayText="Command Dictionary"
             items={$commandDictionaries}
             user={data.user}

--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -14,11 +14,10 @@
   import type { DataGridColumnDef, RowId } from '../../types/data-grid';
   import type { CommandDictionary } from '../../types/sequencing';
   import effects from '../../utilities/effects';
-  import { showFailureToast, showSuccessToast } from '../../utilities/toast';
-  import type { PageData } from './$types';
-
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
+  import { showFailureToast, showSuccessToast } from '../../utilities/toast';
+  import type { PageData } from './$types';
 
   export let data: PageData;
 

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -329,6 +329,7 @@ interface AssignablePlanAssetCRUDPermission<T = null> extends PlanAssetCRUDPermi
 interface FeaturePermissions {
   activityDirective: PlanAssetCRUDPermission<ActivityDirective>;
   activityPresets: AssignablePlanAssetCRUDPermission<ActivityPreset>;
+  commandDictionary: CRUDPermission<void>;
   constraints: PlanAssetCRUDPermission<AssetWithOwner>;
   expansionRules: CRUDPermission<AssetWithOwner>;
   expansionSets: ExpansionSetsCRUDPermission<AssetWithOwner>;
@@ -353,6 +354,12 @@ const featurePermissions: FeaturePermissions = {
     canDelete: (user, preset) => isUserOwner(user, preset) && queryPermissions.DELETE_ACTIVITY_PRESET(user),
     canRead: user => queryPermissions.SUB_ACTIVITY_PRESETS(user),
     canUpdate: (user, preset) => isUserOwner(user, preset) && queryPermissions.UPDATE_ACTIVITY_PRESET(user),
+  },
+  commandDictionary: {
+    canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_COMMAND_DICTIONARY(user),
+    canDelete: user => isUserAdmin(user) || queryPermissions.DELETE_COMMAND_DICTIONARY(user),
+    canRead: () => false, // Not implemented
+    canUpdate: () => false, // Not implemented
   },
   constraints: {
     canCreate: (user, plan) =>


### PR DESCRIPTION
Resolves #692 

This one seems pretty straightforward: adds checks to the command dictionaries page to ensure user has the required permissions before uploading and/or deleting dictionaries.

To test
- Open command dictionaries page as Admin, confirm you are able to upload new and delete existing command dictionaries
- Switch role to User and confirm you are no longer able to upload or delete.
 
![2023-06-28 17 03 13](https://github.com/NASA-AMMOS/aerie-ui/assets/888818/bdeb0ab4-1d64-4231-a3b2-9c3c883e3480)
