### PR TITLE
Sequence permissions

### DIFF
--- a/src/routes/sequencing/edit/[id]/+page.svelte
+++ b/src/routes/sequencing/edit/[id]/+page.svelte
@@ -12,6 +12,7 @@
   initialSequenceCreatedAt={data.initialSequence.created_at}
   initialSequenceDefinition={data.initialSequence.definition}
   initialSequenceName={data.initialSequence.name}
+  initialSequenceOwner={data.initialSequence.owner}
   initialSequenceId={data.initialSequence.id}
   initialSequenceUpdatedAt={data.initialSequence.updated_at}
   mode="edit"

--- a/src/types/sequencing.ts
+++ b/src/types/sequencing.ts
@@ -33,4 +33,4 @@ export type UserSequence = {
   updated_at: string;
 };
 
-export type UserSequenceInsertInput = Omit<UserSequence, 'created_at' | 'id' | 'updated_at'>;
+export type UserSequenceInsertInput = Omit<UserSequence, 'created_at' | 'id' | 'owner' | 'updated_at'>;

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -256,6 +256,9 @@ const queryPermissions = {
   SUB_EXPANSION_SETS: (user: User | null): boolean => {
     return getPermission(['expansion_set'], user);
   },
+  SUB_USER_SEQUENCES: (user: User | null): boolean => {
+    return getPermission(['user_sequence'], user);
+  },
   UPDATE_ACTIVITY_DIRECTIVE: (user: User | null): boolean => {
     return getPermission(['update_activity_directive_by_pk'], user);
   },
@@ -335,6 +338,7 @@ interface FeaturePermissions {
   expansionSets: ExpansionSetsCRUDPermission<AssetWithOwner>;
   model: CRUDPermission<void>;
   plan: CRUDPermission<PlanWithOwners>;
+  sequences: CRUDPermission<AssetWithOwner>;
 }
 
 const featurePermissions: FeaturePermissions = {
@@ -399,6 +403,14 @@ const featurePermissions: FeaturePermissions = {
     canDelete: (user, plan) => isUserAdmin(user) || (isPlanOwner(user, plan) && queryPermissions.DELETE_PLAN(user)),
     canRead: user => isUserAdmin(user) || queryPermissions.GET_PLAN(user),
     canUpdate: () => false, // no feature to update plans exists
+  },
+  sequences: {
+    canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_USER_SEQUENCE(user),
+    canDelete: (user, sequence) =>
+      isUserAdmin(user) || (isUserOwner(user, sequence) && queryPermissions.DELETE_USER_SEQUENCE(user)),
+    canRead: user => isUserAdmin(user) || queryPermissions.SUB_USER_SEQUENCES(user),
+    canUpdate: (user, sequence) =>
+      isUserAdmin(user) || (isUserOwner(user, sequence) && queryPermissions.UPDATE_USER_SEQUENCE(user)),
   },
 };
 


### PR DESCRIPTION
Resolves #742 

This also removes the `owner` field from the insert sequence payload as it is automatically derived.

To test:
1. Create a few sequences with different users
2. Switch to the `user` role
3. Verify that sequences created by the current user are the only ones editable