### PR TITLE
Custom Worker- EPOCH HMS String Parsing should support Negative Duration.

### DIFF
--- a/src/workers/customCodes.ts
+++ b/src/workers/customCodes.ts
@@ -47,6 +47,18 @@ Expected: ${expectedValue}`,
   },
 
   /**
+   * InvalidEpochTime error code and message.
+   */
+  InvalidEpochTime: (): ErrorCode => {
+    return {
+      id: -2,
+      message: `Time Error: Incorrectly formatted duration string.
+Received: A malformed duration.
+Expected: [+/-]hh:mm:ss[.sss] or [+/-]DDDThh:mm:ss[.sss]`,
+    };
+  },
+
+  /**
    * InvalidInteger error code and message.
    */
   InvalidInteger: (argValue: string): ErrorCode => {


### PR DESCRIPTION
The epoch duration should allow both positive and negative durations, while the relative duration should only accept positive durations. We have made updates to the custom worker on the user interface (UI) to inform users about invalid time formats. 

```ts
E`-12:30:00`.SEQ_VAR_CMD
E`+12:30:00`.SEQ_VAR_CMD
E`-003T12:30:00`.SEQ_VAR_CMD

R`12:30:00`.SEQ_VAR_CMD
R`-12:30:00`.SEQ_VAR_CMD <-- invalid
R`003T12:30:00`.SEQ_VAR_CMD <-- invalid
```