### PR TITLE
Add permission to model create button

### DIFF
--- a/src/routes/models/+page.svelte
+++ b/src/routes/models/+page.svelte
@@ -214,7 +214,15 @@
           </fieldset>
 
           <fieldset>
-            <button class="st-button w-100" disabled={createButtonDisabled} type="submit">
+            <button
+              class="st-button w-100"
+              disabled={createButtonDisabled}
+              type="submit"
+              use:permissionHandler={{
+                hasPermission: hasCreatePermission,
+                permissionError: creationPermissionError,
+              }}
+            >
               {$creatingModel ? 'Creating...' : 'Create'}
             </button>
           </fieldset>


### PR DESCRIPTION
Fixes the case where the create button is still clickable if the user as `admin` fills out the model upload form and then switches to `user`