### PR TITLE
Tags for plan creation, constraint, and expansion rules

### DIFF
--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -35,7 +35,7 @@ export class Plan {
   panelActivityTypes: Locator;
   panelConstraints: Locator;
   panelExpansion: Locator;
-  panelPlanManagement: Locator;
+  panelPlanMetadata: Locator;
   panelSchedulingConditions: Locator;
   panelSchedulingGoals: Locator;
   panelSimulation: Locator;
@@ -331,7 +331,7 @@ export class Plan {
     this.panelActivityTypes = page.locator('[data-component-name="ActivityTypesPanel"]');
     this.panelConstraints = page.locator('[data-component-name="ConstraintsPanel"]');
     this.panelExpansion = page.locator('[data-component-name="ExpansionPanel"]');
-    this.panelPlanManagement = page.locator('[data-component-name="PlanManagementPanel"]');
+    this.panelPlanMetadata = page.locator('[data-component-name="PlanMetadataPanel"]');
     this.panelSchedulingConditions = page.locator('[data-component-name="SchedulingConditionsPanel"]');
     this.panelSchedulingGoals = page.locator('[data-component-name="SchedulingGoalsPanel"]');
     this.panelSimulation = page.locator('[data-component-name="SimulationPanel"]');

--- a/e2e-tests/tests/plan.test.ts
+++ b/e2e-tests/tests/plan.test.ts
@@ -67,10 +67,10 @@ test.describe.serial('Plan', () => {
     await expect(plan.panelExpansion).toBeVisible();
   });
 
-  test(`Clicking on 'Plan Management' in the grid menu should show the plan management panel`, async () => {
-    await expect(plan.panelPlanManagement).not.toBeVisible();
-    await plan.showPanel('Plan Management');
-    await expect(plan.panelPlanManagement).toBeVisible();
+  test(`Clicking on 'Plan Metadata' in the grid menu should show the plan metadata panel`, async () => {
+    await expect(plan.panelPlanMetadata).not.toBeVisible();
+    await plan.showPanel('Plan Metadata');
+    await expect(plan.panelPlanMetadata).toBeVisible();
   });
 
   test(`Clicking on 'Scheduling Goals' in the grid menu should show the scheduling goals panel`, async () => {

--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -427,6 +427,7 @@
           <label use:tooltip={{ content: 'Tags', placement: 'top' }} for="activityDirectiveTags"> Tags </label>
           <TagsInput
             options={tags}
+            editable={hasUpdatePermission}
             disabled={!editable}
             selected={activityDirective.tags.map(({ tag }) => tag)}
             use={[

--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -126,15 +126,15 @@
       constraintA.description !== constraintB.description ||
       constraintA.name !== constraintB.name ||
       constraintA.plan_id !== constraintB.plan_id ||
-      // TODO make this better
+      // TODO make this better?
       (constraintA.tags || [])
-        .map(tag => tag.tag.id)
+        .map(({ tag }) => tag.id)
         .sort()
         .join() !==
         (constraintB.tags || [])
-          .map(tag => tag.tag.id)
+          .map(({ tag }) => tag.id)
           .sort()
-          .join('')
+          .join()
     ) {
       return true;
     } else if (constraintA.plan_id === null && constraintB.plan_id === null) {
@@ -217,7 +217,6 @@
         const unusedTags = initialConstraintTags
           .filter(tag => !constraintTags.find(t => tag.id === t.id))
           .map(tag => tag.id);
-        console.log('unusedTags :>> ', unusedTags);
         await effects.deleteConstraintTags(unusedTags, user);
 
         savedConstraint = {

--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -172,7 +172,6 @@
   async function saveConstraint() {
     if (saveButtonEnabled) {
       if (mode === 'create') {
-        console.log('creating');
         const newConstraintId = await effects.createConstraint(
           constraintDefinition,
           constraintModelId,

--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -352,7 +352,7 @@
             ],
           ]}
           options={initialTags}
-          disabled={!hasPermission}
+          editable={!hasPermission}
           selected={constraintTags}
           on:change={onTagsInputChange}
         />

--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -13,6 +13,7 @@
   import { isSaveEvent } from '../../utilities/keyboardEvents';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
+  import { diffTags } from '../../utilities/tags';
   import PageTitle from '../app/PageTitle.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
@@ -126,15 +127,10 @@
       constraintA.description !== constraintB.description ||
       constraintA.name !== constraintB.name ||
       constraintA.plan_id !== constraintB.plan_id ||
-      // TODO make this better?
-      (constraintA.tags || [])
-        .map(({ tag }) => tag.id)
-        .sort()
-        .join() !==
-        (constraintB.tags || [])
-          .map(({ tag }) => tag.id)
-          .sort()
-          .join()
+      diffTags(
+        (constraintA.tags || []).map(({ tag }) => tag),
+        (constraintB.tags || []).map(({ tag }) => tag),
+      )
     ) {
       return true;
     } else if (constraintA.plan_id === null && constraintB.plan_id === null) {
@@ -352,7 +348,7 @@
             ],
           ]}
           options={initialTags}
-          editable={!hasPermission}
+          editable={hasPermission}
           selected={constraintTags}
           on:change={onTagsInputChange}
         />

--- a/src/components/constraints/Constraints.svelte
+++ b/src/components/constraints/Constraints.svelte
@@ -17,6 +17,7 @@
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
   import DataGridActions from '../ui/DataGrid/DataGridActions.svelte';
+  import { tagsCellRenderer } from '../ui/DataGrid/DataGridTagsCellRenderer';
   import SingleActionDataGrid from '../ui/DataGrid/SingleActionDataGrid.svelte';
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
@@ -85,6 +86,17 @@
       suppressAutoSize: true,
       suppressSizeToFit: true,
       width: 120,
+    },
+    {
+      cellRenderer: tagsCellRenderer,
+      field: 'tags',
+      filter: 'text',
+      headerName: 'Tags',
+      resizable: true,
+      sortable: false,
+      width: 220,
+      autoHeight: true,
+      wrapText: true,
     },
   ];
   const permissionError = 'You do not have permission to create a constraint.';

--- a/src/components/constraints/Constraints.svelte
+++ b/src/components/constraints/Constraints.svelte
@@ -88,6 +88,7 @@
       width: 120,
     },
     {
+      autoHeight: true,
       cellRenderer: tagsCellRenderer,
       field: 'tags',
       filter: 'text',
@@ -95,7 +96,6 @@
       resizable: true,
       sortable: false,
       width: 220,
-      autoHeight: true,
       wrapText: true,
     },
   ];

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -365,7 +365,7 @@
             ],
           ]}
           options={$tags}
-          disabled={!hasPermission}
+          editable={!hasPermission}
           selected={ruleTags || []}
           on:change={onTagsInputChange}
         />

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -15,6 +15,7 @@
   import { isSaveEvent } from '../../utilities/keyboardEvents';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions, isUserAdmin } from '../../utilities/permissions';
+  import { diffTags } from '../../utilities/tags';
   import PageTitle from '../app/PageTitle.svelte';
   import AlertError from '../ui/AlertError.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
@@ -96,15 +97,9 @@
   function diffRule(ruleA: Partial<ExpansionRule>, ruleB: Partial<ExpansionRule>) {
     return Object.entries(ruleA).some(([key, value]) => {
       if (key === 'tags') {
-        return (
-          (ruleA.tags || [])
-            .map(({ tag }) => tag.id)
-            .sort()
-            .join() !==
-          (ruleB.tags || [])
-            .map(({ tag }) => tag.id)
-            .sort()
-            .join()
+        return diffTags(
+          (ruleA.tags || []).map(({ tag }) => tag),
+          (ruleB.tags || []).map(({ tag }) => tag),
         );
       } else {
         return ruleB[key as keyof ExpansionRule] !== value;
@@ -365,7 +360,7 @@
             ],
           ]}
           options={$tags}
-          editable={!hasPermission}
+          editable={hasPermission}
           selected={ruleTags || []}
           on:change={onTagsInputChange}
         />

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -366,7 +366,7 @@
           ]}
           options={$tags}
           disabled={!hasPermission}
-          selected={ruleTags}
+          selected={ruleTags || []}
           on:change={onTagsInputChange}
         />
       </fieldset>

--- a/src/components/expansion/ExpansionRules.svelte
+++ b/src/components/expansion/ExpansionRules.svelte
@@ -145,7 +145,7 @@
             matchingTags.push({ tag: matchingTag });
           }
         });
-        let ruleWithTags: ExpansionRule = { ...rule, tags: matchingTags };
+        const ruleWithTags: ExpansionRule = { ...rule, tags: matchingTags };
         return ruleWithTags;
       });
   }

--- a/src/components/expansion/ExpansionRules.svelte
+++ b/src/components/expansion/ExpansionRules.svelte
@@ -14,6 +14,7 @@
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
   import DataGridActions from '../ui/DataGrid/DataGridActions.svelte';
+  import { tagsCellRenderer } from '../ui/DataGrid/DataGridTagsCellRenderer';
   import SingleActionDataGrid from '../ui/DataGrid/SingleActionDataGrid.svelte';
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
@@ -111,6 +112,17 @@
       suppressAutoSize: true,
       suppressSizeToFit: true,
       width: 55,
+    },
+    {
+      autoHeight: true,
+      cellRenderer: tagsCellRenderer,
+      field: 'tags',
+      filter: 'text',
+      headerName: 'Tags',
+      resizable: true,
+      sortable: false,
+      width: 220,
+      wrapText: true,
     },
   ];
   $: filteredRules = $expansionRules.filter(rule => {

--- a/src/components/expansion/ExpansionSetForm.svelte
+++ b/src/components/expansion/ExpansionSetForm.svelte
@@ -10,7 +10,7 @@
   import type { ActivityTypeExpansionRules } from '../../types/activity';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef } from '../../types/data-grid';
-  import type { ExpansionRuleSimpleTags } from '../../types/expansion';
+  import type { ExpansionRuleSlim } from '../../types/expansion';
   import effects from '../../utilities/effects';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
@@ -26,14 +26,14 @@
   export let user: User | null;
 
   type CellRendererParams = {
-    selectExpansionRule: (name: string, rule: ExpansionRuleSimpleTags) => void;
+    selectExpansionRule: (name: string, rule: ExpansionRuleSlim) => void;
   };
   type ExpansionSetRuleSelectionRendererParams = ICellRendererParams<ActivityTypeExpansionRules> & CellRendererParams;
 
   let activityTypesExpansionRules: ActivityTypeExpansionRules[] = [];
   let dataGrid: DataGrid<ActivityTypeExpansionRules>;
   let hasPermission: boolean = false;
-  let lastSelectedExpansionRule: ExpansionRuleSimpleTags | null = null;
+  let lastSelectedExpansionRule: ExpansionRuleSlim | null = null;
   let logicEditorActivityType: string | null = null;
   let logicEditorRuleLogic: string = 'No Expansion Rule Selected';
   let logicEditorTitle: string = 'Expansion Rule - Logic Editor (Read-only)';
@@ -78,7 +78,7 @@
     }
   }
 
-  function selectExpansionRule(activityTypeName: string, rule: ExpansionRuleSimpleTags) {
+  function selectExpansionRule(activityTypeName: string, rule: ExpansionRuleSlim) {
     const currentRuleId = selectedExpansionRules[activityTypeName];
 
     if (currentRuleId === rule.id) {

--- a/src/components/expansion/ExpansionSetForm.svelte
+++ b/src/components/expansion/ExpansionSetForm.svelte
@@ -10,7 +10,7 @@
   import type { ActivityTypeExpansionRules } from '../../types/activity';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef } from '../../types/data-grid';
-  import type { ExpansionRule } from '../../types/expansion';
+  import type { ExpansionRuleSimpleTags } from '../../types/expansion';
   import effects from '../../utilities/effects';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
@@ -26,14 +26,14 @@
   export let user: User | null;
 
   type CellRendererParams = {
-    selectExpansionRule: (name: string, rule: ExpansionRule) => void;
+    selectExpansionRule: (name: string, rule: ExpansionRuleSimpleTags) => void;
   };
   type ExpansionSetRuleSelectionRendererParams = ICellRendererParams<ActivityTypeExpansionRules> & CellRendererParams;
 
   let activityTypesExpansionRules: ActivityTypeExpansionRules[] = [];
   let dataGrid: DataGrid<ActivityTypeExpansionRules>;
   let hasPermission: boolean = false;
-  let lastSelectedExpansionRule: ExpansionRule | null = null;
+  let lastSelectedExpansionRule: ExpansionRuleSimpleTags | null = null;
   let logicEditorActivityType: string | null = null;
   let logicEditorRuleLogic: string = 'No Expansion Rule Selected';
   let logicEditorTitle: string = 'Expansion Rule - Logic Editor (Read-only)';
@@ -78,7 +78,7 @@
     }
   }
 
-  function selectExpansionRule(activityTypeName: string, rule: ExpansionRule) {
+  function selectExpansionRule(activityTypeName: string, rule: ExpansionRuleSimpleTags) {
     const currentRuleId = selectedExpansionRules[activityTypeName];
 
     if (currentRuleId === rule.id) {

--- a/src/components/expansion/ExpansionSetRuleSelection.svelte
+++ b/src/components/expansion/ExpansionSetRuleSelection.svelte
@@ -1,12 +1,12 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import type { ExpansionRuleSimpleTags } from '../../types/expansion';
+  import type { ExpansionRuleSlim } from '../../types/expansion';
 
   export let activityName: string;
-  export let expansionRules: ExpansionRuleSimpleTags[];
+  export let expansionRules: ExpansionRuleSlim[];
   export let selectedExpansionRules: Record<string, number> = {};
-  export let selectExpansionRule: (name: string, rule: ExpansionRuleSimpleTags) => void = undefined;
+  export let selectExpansionRule: (name: string, rule: ExpansionRuleSlim) => void = undefined;
 </script>
 
 {#each expansionRules as rule}

--- a/src/components/expansion/ExpansionSetRuleSelection.svelte
+++ b/src/components/expansion/ExpansionSetRuleSelection.svelte
@@ -1,12 +1,12 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import type { ExpansionRule } from '../../types/expansion';
+  import type { ExpansionRuleSimpleTags } from '../../types/expansion';
 
   export let activityName: string;
-  export let expansionRules: ExpansionRule[];
+  export let expansionRules: ExpansionRuleSimpleTags[];
   export let selectedExpansionRules: Record<string, number> = {};
-  export let selectExpansionRule: (name: string, rule: ExpansionRule) => void = undefined;
+  export let selectExpansionRule: (name: string, rule: ExpansionRuleSimpleTags) => void = undefined;
 </script>
 
 {#each expansionRules as rule}

--- a/src/components/expansion/ExpansionSets.svelte
+++ b/src/components/expansion/ExpansionSets.svelte
@@ -7,7 +7,7 @@
   import { expansionSets, expansionSetsColumns } from '../../stores/expansion';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
-  import type { ExpansionRuleSimpleTags, ExpansionSet } from '../../types/expansion';
+  import type { ExpansionRuleSlim, ExpansionSet } from '../../types/expansion';
   import effects from '../../utilities/effects';
   import { featurePermissions } from '../../utilities/permissions';
   import CssGrid from '../ui/CssGrid.svelte';
@@ -25,8 +25,8 @@
     deleteSet: (sequence: ExpansionSet) => void;
   };
   type ExpansionSetCellRendererParams = ICellRendererParams<ExpansionSet> & CellRendererParams;
-  type ExpansionRuleCellRendererParams = ICellRendererParams<ExpansionRuleSimpleTags> & {
-    editRule: (expansionRule: ExpansionRuleSimpleTags) => void;
+  type ExpansionRuleCellRendererParams = ICellRendererParams<ExpansionRuleSlim> & {
+    editRule: (expansionRule: ExpansionRuleSlim) => void;
   };
 
   const baseExpansionSetColumnDefs: DataGridColumnDef[] = [
@@ -69,8 +69,8 @@
 
   let expansionSetColumnDefs = baseExpansionSetColumnDefs;
   let expansionRuleColumnDefs = baseExpansionRuleColumnDefs;
-  let redrawRows: ((params?: RedrawRowsParams<ExpansionRuleSimpleTags> | undefined) => void) | undefined = undefined;
-  let selectedExpansionRule: ExpansionRuleSimpleTags | null = null;
+  let redrawRows: ((params?: RedrawRowsParams<ExpansionRuleSlim> | undefined) => void) | undefined = undefined;
+  let selectedExpansionRule: ExpansionRuleSlim | null = null;
   let selectedExpansionRuleIds: number[] = [];
   let selectedExpansionSet: ExpansionSet | null = null;
 
@@ -164,7 +164,7 @@
     deleteSet({ id: event.detail[0] as number });
   }
 
-  function editRule({ id }: Pick<ExpansionRuleSimpleTags, 'id'>) {
+  function editRule({ id }: Pick<ExpansionRuleSlim, 'id'>) {
     goto(`${base}/expansion/rules/edit/${id}`);
   }
 
@@ -172,11 +172,11 @@
     return featurePermissions.expansionSets.canDelete(user, expansionSet);
   }
 
-  function hasEditExpansionRulePermission(user: User | null, expansionRule: ExpansionRuleSimpleTags) {
+  function hasEditExpansionRulePermission(user: User | null, expansionRule: ExpansionRuleSlim) {
     return featurePermissions.expansionRules.canUpdate(user, expansionRule);
   }
 
-  function toggleRule(event: CustomEvent<DataGridRowSelection<ExpansionRuleSimpleTags>>) {
+  function toggleRule(event: CustomEvent<DataGridRowSelection<ExpansionRuleSlim>>) {
     const {
       detail: { data: clickedRule, isSelected },
     } = event;

--- a/src/components/expansion/ExpansionSets.svelte
+++ b/src/components/expansion/ExpansionSets.svelte
@@ -7,7 +7,7 @@
   import { expansionSets, expansionSetsColumns } from '../../stores/expansion';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
-  import type { ExpansionRule, ExpansionSet } from '../../types/expansion';
+  import type { ExpansionRuleSimpleTags, ExpansionSet } from '../../types/expansion';
   import effects from '../../utilities/effects';
   import { featurePermissions } from '../../utilities/permissions';
   import CssGrid from '../ui/CssGrid.svelte';
@@ -25,8 +25,8 @@
     deleteSet: (sequence: ExpansionSet) => void;
   };
   type ExpansionSetCellRendererParams = ICellRendererParams<ExpansionSet> & CellRendererParams;
-  type ExpansionRuleCellRendererParams = ICellRendererParams<ExpansionRule> & {
-    editRule: (expansionRule: ExpansionRule) => void;
+  type ExpansionRuleCellRendererParams = ICellRendererParams<ExpansionRuleSimpleTags> & {
+    editRule: (expansionRule: ExpansionRuleSimpleTags) => void;
   };
 
   const baseExpansionSetColumnDefs: DataGridColumnDef[] = [
@@ -69,8 +69,8 @@
 
   let expansionSetColumnDefs = baseExpansionSetColumnDefs;
   let expansionRuleColumnDefs = baseExpansionRuleColumnDefs;
-  let redrawRows: ((params?: RedrawRowsParams<ExpansionRule> | undefined) => void) | undefined = undefined;
-  let selectedExpansionRule: ExpansionRule | null = null;
+  let redrawRows: ((params?: RedrawRowsParams<ExpansionRuleSimpleTags> | undefined) => void) | undefined = undefined;
+  let selectedExpansionRule: ExpansionRuleSimpleTags | null = null;
   let selectedExpansionRuleIds: number[] = [];
   let selectedExpansionSet: ExpansionSet | null = null;
 
@@ -164,7 +164,7 @@
     deleteSet({ id: event.detail[0] as number });
   }
 
-  function editRule({ id }: Pick<ExpansionRule, 'id'>) {
+  function editRule({ id }: Pick<ExpansionRuleSimpleTags, 'id'>) {
     goto(`${base}/expansion/rules/edit/${id}`);
   }
 
@@ -172,11 +172,11 @@
     return featurePermissions.expansionSets.canDelete(user, expansionSet);
   }
 
-  function hasEditExpansionRulePermission(user: User | null, expansionRule: ExpansionRule) {
+  function hasEditExpansionRulePermission(user: User | null, expansionRule: ExpansionRuleSimpleTags) {
     return featurePermissions.expansionRules.canUpdate(user, expansionRule);
   }
 
-  function toggleRule(event: CustomEvent<DataGridRowSelection<ExpansionRule>>) {
+  function toggleRule(event: CustomEvent<DataGridRowSelection<ExpansionRuleSimpleTags>>) {
     const {
       detail: { data: clickedRule, isSelected },
     } = event;

--- a/src/components/menus/GridMenu.svelte
+++ b/src/components/menus/GridMenu.svelte
@@ -70,9 +70,9 @@
       <WindowFullscreenIcon />
       External Application
     </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('PlanManagementPanel')}>
+    <MenuItem on:click={() => onClickMenuItem('PlanMetadataPanel')}>
       <PlanIcon />
-      Plan Management
+      Plan Metadata
     </MenuItem>
     <MenuItem on:click={() => onClickMenuItem('SchedulingGoalsPanel')}>
       <CalendarIcon />

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -133,7 +133,7 @@
               ],
             ]}
             options={tags}
-            disabled={!hasPermission}
+            editable={hasPermission}
             selected={planTags}
             on:change={onTagsInputChange}
           />

--- a/src/components/plan/PlanMetadataPanel.svelte
+++ b/src/components/plan/PlanMetadataPanel.svelte
@@ -15,7 +15,7 @@
 
 <Panel padBody={false}>
   <svelte:fragment slot="header">
-    <GridMenu {gridSection} title="Plan Management" />
+    <GridMenu {gridSection} title="Plan Metadata" />
   </svelte:fragment>
   <svelte:fragment slot="body">
     <PlanForm plan={$plan} planTags={$planTags} tags={$tags} {user} />

--- a/src/components/ui/Chip.svelte
+++ b/src/components/ui/Chip.svelte
@@ -28,7 +28,12 @@
   class={rootClasses}
   role={ariaRole}
   {disabled}
-  on:click|preventDefault={() => dispatch('click')}
+  tabindex={removable ? 0 : -1}
+  on:click|preventDefault={() => {
+    if (removable) {
+      dispatch('click');
+    }
+  }}
 >
   <div class="chip-label">{label}</div>
   {#if removable}

--- a/src/components/ui/PlanGrid.svelte
+++ b/src/components/ui/PlanGrid.svelte
@@ -10,7 +10,7 @@
   import ActivityTypesPanel from '../activity/ActivityTypesPanel.svelte';
   import ConstraintsPanel from '../constraints/ConstraintsPanel.svelte';
   import ExpansionPanel from '../expansion/ExpansionPanel.svelte';
-  import PlanManagementPanel from '../plan/PlanManagementPanel.svelte';
+  import PlanMetadataPanel from '../plan/PlanMetadataPanel.svelte';
   import SchedulingConditionsPanel from '../scheduling/SchedulingConditionsPanel.svelte';
   import SchedulingGoalsPanel from '../scheduling/SchedulingGoalsPanel.svelte';
   import SimulationPanel from '../simulation/SimulationPanel.svelte';
@@ -46,7 +46,7 @@
     ConstraintsPanel,
     ExpansionPanel,
     IFramePanel,
-    PlanManagementPanel,
+    PlanMetadataPanel,
     SchedulingConditionsPanel,
     SchedulingGoalsPanel,
     SimulationPanel,

--- a/src/components/ui/Tags/Tags.svelte
+++ b/src/components/ui/Tags/Tags.svelte
@@ -181,7 +181,6 @@
   }
 
   function onTagRemove(tag: Tag) {
-    console.log('wat', tag);
     // Find the tag by name since it may not have an ID yet
     selectedTags = selectedTags.filter(t => t.name !== tag.name);
     removeTag(tag);

--- a/src/components/ui/Tags/Tags.svelte
+++ b/src/components/ui/Tags/Tags.svelte
@@ -13,6 +13,7 @@
     return { color: generateRandomPastelColor(), created_at: '', id: -1, name, owner: '' };
   };
   export let disabled: boolean = false;
+  export let editable: boolean = true;
   export let id: string = '';
   export let inputRef: HTMLInputElement | null = null;
   export let name: string = '';
@@ -53,6 +54,7 @@
   let selectedTags: Tag[] = [];
   let tagsWidth: number = 100;
 
+  $: console.log('editable :>> ', editable);
   $: selectedTags = [...selected]; // copy of selected prop for internal reference and temporary modification
   $: if (options && searchText !== null) {
     // Determine if searchText exactly matches any of the available options
@@ -104,7 +106,7 @@
   }
 
   function openSuggestions() {
-    if (disabled) {
+    if (disabled || !editable) {
       return;
     }
     suggestionsVisible = true;
@@ -199,10 +201,10 @@
 
 <svelte:window on:click={onClickOutside} on:touchstart={onClickOutside} />
 
-<div class="tags" class:disabled use:popperRef bind:this={tagsRef} bind:clientWidth={tagsWidth}>
+<div class="tags" class:disabled={disabled || !editable} use:popperRef bind:this={tagsRef} bind:clientWidth={tagsWidth}>
   <div class="tags-selected-items">
     {#each selectedTags as tag}
-      <TagChip {tag} removable={!disabled} on:click={() => onTagRemove(tag)} {disabled} ariaRole="option" />
+      <TagChip {tag} removable={!disabled && editable} on:click={() => onTagRemove(tag)} {disabled} ariaRole="option" />
     {/each}
     {#if !disabled || (disabled && !selectedTags.length)}
       <input
@@ -275,6 +277,10 @@
   .tags.disabled {
     cursor: not-allowed;
     opacity: 0.5;
+  }
+
+  .tags.disabled input {
+    opacity: 1;
   }
 
   .tags-selected-items {

--- a/src/components/ui/Tags/Tags.svelte
+++ b/src/components/ui/Tags/Tags.svelte
@@ -54,7 +54,6 @@
   let selectedTags: Tag[] = [];
   let tagsWidth: number = 100;
 
-  $: console.log('editable :>> ', editable);
   $: selectedTags = [...selected]; // copy of selected prop for internal reference and temporary modification
   $: if (options && searchText !== null) {
     // Determine if searchText exactly matches any of the available options

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -44,6 +44,8 @@ span.error {
 fieldset {
   border: 0;
   color: var(--st-typography-body-color);
+  display: flex;
+  flex-direction: column;
   font-family: var(--st-typography-body-font-family);
   font-size: var(--st-typography-body-font-size);
   font-weight: var(--st-typography-body-font-weight);

--- a/src/routes/constraints/edit/[id]/+page.svelte
+++ b/src/routes/constraints/edit/[id]/+page.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
   import ConstraintForm from '../../../../components/constraints/ConstraintForm.svelte';
+  import { tags } from '../../../../stores/tags';
   import type { PageData } from './$types';
 
   export let data: PageData;
@@ -14,10 +15,12 @@
   initialConstraintModelId={data.initialConstraint.model_id}
   initialConstraintName={data.initialConstraint.name}
   initialConstraintPlanId={data.initialConstraint.plan_id}
+  initialConstraintTags={data.initialConstraint.tags.map(({ tag }) => tag)}
   initialModelMap={data.initialModelMap}
   initialModels={data.initialModels}
   initialPlanMap={data.initialPlanMap}
   initialPlans={data.initialPlans}
+  initialTags={$tags}
   mode="edit"
   user={data.user}
 />

--- a/src/routes/constraints/new/+page.svelte
+++ b/src/routes/constraints/new/+page.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
   import ConstraintForm from '../../../components/constraints/ConstraintForm.svelte';
+  import { tags } from '../../../stores/tags';
   import type { PageData } from './$types';
 
   export let data: PageData;
@@ -12,6 +13,7 @@
   initialModels={data.initialModels}
   initialPlanMap={data.initialPlanMap}
   initialPlans={data.initialPlans}
+  initialTags={$tags}
   mode="create"
   user={data.user}
 />

--- a/src/routes/expansion/rules/edit/[id]/+page.svelte
+++ b/src/routes/expansion/rules/edit/[id]/+page.svelte
@@ -17,6 +17,7 @@
   initialRuleModelId={data.initialRule.authoring_mission_model_id}
   initialRuleName={data.initialRule.name}
   initialRuleOwner={data.initialRule.owner}
+  initialRuleTags={data.initialRule.tags.map(({ tag }) => tag)}
   initialRuleUpdatedAt={data.initialRule.updated_at}
   mode="edit"
   user={data.user}

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -19,13 +19,16 @@
   import SingleActionDataGrid from '../../components/ui/DataGrid/SingleActionDataGrid.svelte';
   import Panel from '../../components/ui/Panel.svelte';
   import SectionTitle from '../../components/ui/SectionTitle.svelte';
+  import TagsInput from '../../components/ui/Tags/Tags.svelte';
   import { field } from '../../stores/form';
   import { createPlanError, creatingPlan } from '../../stores/plan';
   import { simulationTemplates } from '../../stores/simulation';
+  import { tags } from '../../stores/tags';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef, RowId } from '../../types/data-grid';
   import type { ModelSlim } from '../../types/model';
   import type { Plan, PlanSlim } from '../../types/plan';
+  import type { PlanTagsInsertInput, Tag, TagsChangeEvent } from '../../types/tags';
   import effects from '../../utilities/effects';
   import { removeQueryParam } from '../../utilities/generic';
   import { permissionHandler } from '../../utilities/permissionHandler';
@@ -126,6 +129,7 @@
   let filterText: string = '';
   let models: ModelSlim[];
   let nameInputField: HTMLInputElement;
+  let planTags: Tag[] = [];
   let plans: PlanSlim[];
   let user: User | null = null;
 
@@ -215,6 +219,13 @@
     );
 
     if (newPlan) {
+      // Associate new tags with plan
+      const newPlanTags: PlanTagsInsertInput[] = (planTags || []).map(({ id: tag_id }) => ({
+        plan_id: newPlan.id,
+        tag_id,
+      }));
+      await effects.createPlanTags(newPlanTags, user, false);
+      newPlan.tags = planTags.map(tag => ({ tag }));
       plans = [...plans, newPlan];
     }
   }
@@ -224,6 +235,21 @@
 
     if (success) {
       plans = plans.filter(plan => plan.id !== id);
+    }
+  }
+
+  async function onTagsInputChange(event: TagsChangeEvent) {
+    const {
+      detail: { tag, type },
+    } = event;
+    if (type === 'remove') {
+      planTags = planTags.filter(t => t.name !== tag.name);
+    } else if (type === 'create' || type === 'select') {
+      let tagsToAdd: Tag[] = [tag];
+      if (type === 'create') {
+        tagsToAdd = (await effects.createTags([{ color: tag.color, name: tag.name }], user)) || [];
+      }
+      planTags = planTags.concat(tagsToAdd);
     }
   }
 
@@ -381,6 +407,25 @@
               {/if}
             </select>
           </Field>
+
+          <fieldset>
+            <label for="plan-duration">Tags</label>
+            <TagsInput
+              use={[
+                [
+                  permissionHandler,
+                  {
+                    hasPermission: canCreate,
+                    permissionError,
+                  },
+                ],
+              ]}
+              options={$tags}
+              disabled={!canCreate}
+              selected={planTags}
+              on:change={onTagsInputChange}
+            />
+          </fieldset>
 
           <fieldset>
             <button class="st-button w-100" disabled={!createButtonEnabled} type="submit">

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -421,7 +421,7 @@
                 ],
               ]}
               options={$tags}
-              disabled={!canCreate}
+              editable={!canCreate}
               selected={planTags}
               on:change={onTagsInputChange}
             />

--- a/src/stores/expansion.ts
+++ b/src/stores/expansion.ts
@@ -1,5 +1,5 @@
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
-import type { ExpansionRule, ExpansionSequence, ExpansionSet } from '../types/expansion';
+import type { ExpansionRuleSimpleTags, ExpansionSequence, ExpansionSet } from '../types/expansion';
 import gql from '../utilities/gql';
 import type { Status } from '../utilities/status';
 import { simulationDatasetId } from './simulation';
@@ -7,7 +7,7 @@ import { gqlSubscribable } from './subscribable';
 
 /* Subscriptions. */
 
-export const expansionRules = gqlSubscribable<ExpansionRule[]>(gql.SUB_EXPANSION_RULES, {}, [], null);
+export const expansionRules = gqlSubscribable<ExpansionRuleSimpleTags[]>(gql.SUB_EXPANSION_RULES, {}, [], null);
 
 export const expansionSequences = gqlSubscribable<ExpansionSequence[]>(gql.SUB_EXPANSION_SEQUENCES, {}, [], null);
 

--- a/src/stores/expansion.ts
+++ b/src/stores/expansion.ts
@@ -1,5 +1,5 @@
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
-import type { ExpansionRuleSimpleTags, ExpansionSequence, ExpansionSet } from '../types/expansion';
+import type { ExpansionRuleSlim, ExpansionSequence, ExpansionSet } from '../types/expansion';
 import gql from '../utilities/gql';
 import type { Status } from '../utilities/status';
 import { simulationDatasetId } from './simulation';
@@ -7,7 +7,7 @@ import { gqlSubscribable } from './subscribable';
 
 /* Subscriptions. */
 
-export const expansionRules = gqlSubscribable<ExpansionRuleSimpleTags[]>(gql.SUB_EXPANSION_RULES, {}, [], null);
+export const expansionRules = gqlSubscribable<ExpansionRuleSlim[]>(gql.SUB_EXPANSION_RULES, {}, [], null);
 
 export const expansionSequences = gqlSubscribable<ExpansionSequence[]>(gql.SUB_EXPANSION_SEQUENCES, {}, [], null);
 

--- a/src/stores/tags.ts
+++ b/src/stores/tags.ts
@@ -1,7 +1,17 @@
-import type { Tag } from '../types/tags';
+import type { Readable } from 'svelte/motion';
+import { derived } from 'svelte/store';
+import type { Tag, TagsMap } from '../types/tags';
 import gql from '../utilities/gql';
 import { gqlSubscribable } from './subscribable';
 
 /* Subscriptions. */
 
 export const tags = gqlSubscribable<Tag[]>(gql.SUB_TAGS, {}, [], null);
+
+/* Derived. */
+export const tagsMap: Readable<TagsMap> = derived([tags], ([$tags]) =>
+  $tags.reduce((map: TagsMap, tag) => {
+    map[tag.id] = tag;
+    return map;
+  }, {}),
+);

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -1,7 +1,7 @@
 import type { ActivityDeletionAction } from '../utilities/activities';
 import type { ActivityMetadata } from './activity-metadata';
 import type { UserId } from './app';
-import type { ExpansionRuleSimpleTags } from './expansion';
+import type { ExpansionRuleSlim } from './expansion';
 import type { ArgumentsMap, ParametersMap } from './parameter';
 import type { ValueSchema } from './schema';
 import type { Tag } from './tags';
@@ -19,7 +19,7 @@ export type ActivityType = {
 };
 
 export type ActivityTypeExpansionRules = {
-  expansion_rules: ExpansionRuleSimpleTags[];
+  expansion_rules: ExpansionRuleSlim[];
   name: ActivityType['name'];
 };
 

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -1,7 +1,7 @@
 import type { ActivityDeletionAction } from '../utilities/activities';
 import type { ActivityMetadata } from './activity-metadata';
 import type { UserId } from './app';
-import type { ExpansionRule } from './expansion';
+import type { ExpansionRuleSimpleTags } from './expansion';
 import type { ArgumentsMap, ParametersMap } from './parameter';
 import type { ValueSchema } from './schema';
 import type { Tag } from './tags';
@@ -19,7 +19,7 @@ export type ActivityType = {
 };
 
 export type ActivityTypeExpansionRules = {
-  expansion_rules: ExpansionRule[];
+  expansion_rules: ExpansionRuleSimpleTags[];
   name: ActivityType['name'];
 };
 

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -10,9 +10,9 @@ export type Constraint = {
   name: string;
   owner: string;
   plan_id: number | null;
+  tags: { tag: Tag }[];
   updated_at: string;
   updated_by: string;
-  tags: { tag: Tag }[];
 };
 
 export type ConstraintInsertInput = Omit<

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -1,3 +1,4 @@
+import type { Tag } from './tags';
 import type { TimeRange } from './timeline';
 
 export type Constraint = {
@@ -11,9 +12,13 @@ export type Constraint = {
   plan_id: number | null;
   updated_at: string;
   updated_by: string;
+  tags: { tag: Tag }[];
 };
 
-export type ConstraintInsertInput = Omit<Constraint, 'id' | 'created_at' | 'updated_at' | 'owner' | 'updated_by'>;
+export type ConstraintInsertInput = Omit<
+  Constraint,
+  'id' | 'created_at' | 'updated_at' | 'owner' | 'updated_by' | 'tags'
+>;
 
 export type ConstraintType = 'model' | 'plan';
 

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -1,5 +1,6 @@
 import type { SeqJson } from './sequencing';
 import type { SpanId } from './simulation';
+import type { Tag } from './tags';
 
 export type ExpansionRule = {
   activity_type: string;
@@ -11,11 +12,30 @@ export type ExpansionRule = {
   id: number;
   name: string;
   owner: string;
+  tags: { tag: Tag }[];
   updated_at: string;
   updated_by: string;
 };
 
-export type ExpansionRuleInsertInput = Omit<ExpansionRule, 'created_at' | 'id' | 'updated_at' | 'updated_by' | 'owner'>;
+export type ExpansionRuleSimpleTags = {
+  activity_type: string;
+  authoring_command_dict_id: number;
+  authoring_mission_model_id: number;
+  created_at: string;
+  description: string;
+  expansion_logic: string;
+  id: number;
+  name: string;
+  owner: string;
+  tags: { tag_id: number }[];
+  updated_at: string;
+  updated_by: string;
+};
+
+export type ExpansionRuleInsertInput = Omit<
+  ExpansionRuleSimpleTags,
+  'created_at' | 'id' | 'updated_at' | 'updated_by' | 'owner' | 'tags'
+>;
 
 export type ExpansionSequenceToActivityInsertInput = {
   seq_id: string;
@@ -36,7 +56,7 @@ export type ExpansionSet = {
   command_dict_id: number;
   created_at: string;
   description: string;
-  expansion_rules: ExpansionRule[];
+  expansion_rules: ExpansionRuleSimpleTags[];
   id: number;
   mission_model_id: number;
   name: string;

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -17,23 +17,10 @@ export type ExpansionRule = {
   updated_by: string;
 };
 
-export type ExpansionRuleSimpleTags = {
-  activity_type: string;
-  authoring_command_dict_id: number;
-  authoring_mission_model_id: number;
-  created_at: string;
-  description: string;
-  expansion_logic: string;
-  id: number;
-  name: string;
-  owner: string;
-  tags: { tag_id: number }[];
-  updated_at: string;
-  updated_by: string;
-};
+export type ExpansionRuleSlim = Omit<ExpansionRule, 'tags'> & { tags: { tag_id: number }[] };
 
 export type ExpansionRuleInsertInput = Omit<
-  ExpansionRuleSimpleTags,
+  ExpansionRuleSlim,
   'created_at' | 'id' | 'updated_at' | 'updated_by' | 'owner' | 'tags'
 >;
 
@@ -56,7 +43,7 @@ export type ExpansionSet = {
   command_dict_id: number;
   created_at: string;
   description: string;
-  expansion_rules: ExpansionRuleSimpleTags[];
+  expansion_rules: ExpansionRuleSlim[];
   id: number;
   mission_model_id: number;
   name: string;

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -105,6 +105,7 @@ export type PlanSlim = Pick<
   | 'revision'
   | 'start_time'
   | 'start_time_doy'
+  | 'tags'
   | 'updated_at'
   | 'updated_by'
 >;

--- a/src/types/tags.ts
+++ b/src/types/tags.ts
@@ -9,6 +9,11 @@ export type ConstraintTagsInsertInput = {
   tag_id: number;
 };
 
+export type ExpansionRuleTagsInsertInput = {
+  rule_id: number;
+  tag_id: number;
+};
+
 export type PlanTagsInsertInput = {
   plan_id: number;
   tag_id: number;
@@ -21,6 +26,8 @@ export type Tag = {
   name: string;
   owner: string;
 };
+
+export type TagsMap = Record<Tag['id'], Tag>;
 
 export type TagsInsertInput = Pick<Tag, 'color' | 'name'>;
 

--- a/src/types/tags.ts
+++ b/src/types/tags.ts
@@ -4,6 +4,11 @@ export type ActivityDirectiveTagsInsertInput = {
   tag_id: number;
 };
 
+export type ConstraintTagsInsertInput = {
+  constraint_id: number;
+  tag_id: number;
+};
+
 export type PlanTagsInsertInput = {
   plan_id: number;
   tag_id: number;
@@ -18,3 +23,5 @@ export type Tag = {
 };
 
 export type TagsInsertInput = Pick<Tag, 'color' | 'name'>;
+
+export type TagsChangeEvent = CustomEvent<{ tag: Tag; type: 'select' | 'create' | 'remove' }>;

--- a/src/types/view.ts
+++ b/src/types/view.ts
@@ -34,7 +34,7 @@ export type ViewGridComponent =
   | 'ConstraintsPanel'
   | 'ExpansionPanel'
   | 'IFramePanel'
-  | 'PlanManagementPanel'
+  | 'PlanMetadataPanel'
   | 'SchedulingConditionsPanel'
   | 'SchedulingGoalsPanel'
   | 'SimulationPanel'

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -40,7 +40,7 @@ const gql = {
         tags {
           tag {
             color
-          	id
+            id
             name
           }
         }
@@ -570,7 +570,7 @@ const gql = {
         tags {
           tag {
             color
-          	id
+            id
             name
           }
         }
@@ -622,7 +622,7 @@ const gql = {
         tags {
           tag {
             color
-          	id
+            id
             name
           }
         }
@@ -783,7 +783,7 @@ const gql = {
         tags {
           tag {
             color
-          	id
+            id
             name
           }
         }
@@ -819,7 +819,7 @@ const gql = {
         tags {
           tag {
             color
-          	id
+            id
             name
           }
         }
@@ -1237,7 +1237,7 @@ const gql = {
         tags {
           tag {
             color
-          	id
+            id
             name
           }
         }
@@ -1325,7 +1325,7 @@ const gql = {
         tags {
           tag {
             color
-          	id
+            id
             name
           }
         }
@@ -1349,7 +1349,7 @@ const gql = {
         tags {
           tag {
             color
-          	id
+            id
             name
           }
         }
@@ -1544,7 +1544,7 @@ const gql = {
         tags {
           tag {
             color
-          	id
+            id
             name
           }
         }
@@ -1785,7 +1785,7 @@ const gql = {
         tags {
           tag {
             color
-          	id
+            id
             name
           }
         }

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -112,6 +112,17 @@ const gql = {
     }
   `,
 
+  CREATE_EXPANSION_RULE_TAGS: `#graphql
+    mutation CreateExpansionRuleTags($tags: [expansion_rule_tags_insert_input!]!) {
+      insert_expansion_rule_tags(objects: $tags, on_conflict: {
+        constraint: expansion_rule_tags_pkey,
+        update_columns: []
+      }) {
+        affected_rows
+      }
+    }
+  `,
+
   CREATE_EXPANSION_SEQUENCE: `#graphql
     mutation CreateExpansionSequence($sequence: sequence_insert_input!) {
       createExpansionSequence: insert_sequence_one(object: $sequence) {
@@ -379,6 +390,14 @@ const gql = {
     }
   `,
 
+  DELETE_EXPANSION_RULE_TAGS: `#graphql
+    mutation DeleteExpansionRuleTags($ids: [Int!]!) {
+        delete_expansion_rule_tags(where: { tag_id: { _in: $ids } }) {
+          affected_rows
+      }
+    }
+  `,
+
   DELETE_EXPANSION_SEQUENCE: `#graphql
     mutation DeleteExpansionSequence($seqId: String!, $simulationDatasetId: Int!) {
       deleteExpansionSequence: delete_sequence_by_pk(seq_id: $seqId, simulation_dataset_id: $simulationDatasetId) {
@@ -600,6 +619,13 @@ const gql = {
         owner
         updated_at
         updated_by
+        tags {
+          tag {
+            color
+          	id
+            name
+          }
+        }
       }
     }
   `,
@@ -1346,12 +1372,17 @@ const gql = {
         updated_at
         updated_by
         tags {
-          tag {
-            color
-          	id
-            name
-          }
+          tag_id
         }
+      }
+    }
+  `,
+
+  SUB_EXPANSION_RULE_TAGS: `#graphql
+    subscription SubExpansionRuleTags {
+      expansionRuleTags: expansion_rule_tags(order_by: { rule_id: desc }) {
+        rule_id
+        tag_id
       }
     }
   `,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -93,6 +93,17 @@ const gql = {
     }
   `,
 
+  CREATE_CONSTRAINT_TAGS: `#graphql
+    mutation CreateConstraintTags($tags: [constraint_tags_insert_input!]!) {
+      insert_constraint_tags(objects: $tags, on_conflict: {
+        constraint: constraint_tags_pkey,
+        update_columns: []
+      }) {
+        affected_rows
+      }
+    }
+`,
+
   CREATE_EXPANSION_RULE: `#graphql
     mutation CreateExpansionRule($rule: expansion_rule_insert_input!) {
       createExpansionRule: insert_expansion_rule_one(object: $rule) {
@@ -352,6 +363,14 @@ const gql = {
     }
   `,
 
+  DELETE_CONSTRAINT_TAGS: `#graphql
+    mutation DeleteConstraintTags($ids: [Int!]!) {
+        delete_constraint_tags(where: { tag_id: { _in: $ids } }) {
+          affected_rows
+      }
+    }
+`,
+
   DELETE_EXPANSION_RULE: `#graphql
     mutation DeleteExpansionRule($id: Int!) {
       deleteExpansionRule: delete_expansion_rule_by_pk(id: $id) {
@@ -529,6 +548,13 @@ const gql = {
         plan_id
         updated_at
         updated_by
+        tags {
+          tag {
+            color
+          	id
+            name
+          }
+        }
       }
     }
   `,
@@ -1270,6 +1296,13 @@ const gql = {
         plan_id
         updated_at
         updated_by
+        tags {
+          tag {
+            color
+          	id
+            name
+          }
+        }
       }
     }
   `,
@@ -1287,6 +1320,13 @@ const gql = {
         plan_id
         updated_at
         updated_by
+        tags {
+          tag {
+            color
+          	id
+            name
+          }
+        }
       }
     }
   `,
@@ -1305,6 +1345,13 @@ const gql = {
         owner
         updated_at
         updated_by
+        tags {
+          tag {
+            color
+          	id
+            name
+          }
+        }
       }
     }
   `,
@@ -1643,7 +1690,7 @@ const gql = {
 
   SUB_TAGS: `#graphql
     subscription SubTags {
-      tags(order_by: { id: desc })  {
+      tags(order_by: { name: desc })  {
         color
         created_at
         id

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -91,6 +91,9 @@ const queryPermissions = {
   CREATE_CONSTRAINT: (user: User | null): boolean => {
     return getPermission(['insert_constraint_one'], user);
   },
+  CREATE_CONSTRAINT_TAGS: (user: User | null): boolean => {
+    return getPermission(['insert_constraint_tags'], user);
+  },
   CREATE_EXPANSION_RULE: (user: User | null): boolean => {
     return getPermission(['insert_expansion_rule_one'], user);
   },
@@ -162,6 +165,9 @@ const queryPermissions = {
   },
   DELETE_CONSTRAINT: (user: User | null): boolean => {
     return getPermission(['delete_constraint_by_pk'], user);
+  },
+  DELETE_CONSTRAINT_TAGS: (user: User | null): boolean => {
+    return getPermission(['delete_constraint_tags'], user);
   },
   DELETE_EXPANSION_RULE: (user: User | null): boolean => {
     return getPermission(['delete_expansion_rule_by_pk'], user);

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -97,6 +97,9 @@ const queryPermissions = {
   CREATE_EXPANSION_RULE: (user: User | null): boolean => {
     return getPermission(['insert_expansion_rule_one'], user);
   },
+  CREATE_EXPANSION_RULE_TAGS: (user: User | null): boolean => {
+    return getPermission(['insert_expansion_rule_tags'], user);
+  },
   CREATE_EXPANSION_SEQUENCE: (user: User | null): boolean => {
     return getPermission(['insert_sequence_one'], user);
   },
@@ -171,6 +174,9 @@ const queryPermissions = {
   },
   DELETE_EXPANSION_RULE: (user: User | null): boolean => {
     return getPermission(['delete_expansion_rule_by_pk'], user);
+  },
+  DELETE_EXPANSION_RULE_TAGS: (user: User | null): boolean => {
+    return getPermission(['delete_expansion_rule_tags'], user);
   },
   DELETE_EXPANSION_SEQUENCE: (user: User | null): boolean => {
     return getPermission(['delete_sequence_by_pk'], user);

--- a/src/utilities/tags.ts
+++ b/src/utilities/tags.ts
@@ -1,0 +1,17 @@
+import type { Tag } from '../types/tags';
+
+/**
+ * Returns true if the IDs of tagsA match the order and IDs of tagsB.
+ */
+export function diffTags(tagsA: Tag[], tagsB: Tag[]): boolean {
+  return (
+    tagsA
+      .map(tag => tag.id)
+      .sort()
+      .join() !==
+    tagsB
+      .map(tag => tag.id)
+      .sort()
+      .join()
+  );
+}


### PR DESCRIPTION
Implements tag viewing and management for plan creation, constraints, and expansion rules. Additionally refactors the tag input events and makes a distinct `ExpansionRuleSimpleTags` type that reflects the limited relational tags response that we can get from hasura for Expansion Rules. Also renames Plan Management -> Plan Metadata.

Partially addresses #605 