### PR TITLE
Remove explicit setting of owner in view creation/update

### DIFF
--- a/src/components/menus/ViewMenu.svelte
+++ b/src/components/menus/ViewMenu.svelte
@@ -35,7 +35,7 @@
   let saveViewDisabled: boolean = true;
 
   $: saveViewDisabled = $view?.name === '' || $view?.owner !== user?.id || !$viewIsModified;
-  $: if ($view.definition.plan.grid) {
+  $: if ($view?.definition.plan.grid) {
     leftPanelIsOn = !$view.definition.plan.grid.leftHidden && !$view.definition.plan.grid.leftSplit;
     leftSplitPanelIsOn = !$view.definition.plan.grid.leftHidden && $view.definition.plan.grid.leftSplit;
     bottomPanelIsOn = $view.definition.plan.grid.middleSplit;
@@ -44,13 +44,13 @@
   }
 
   function editView() {
-    if ($view) {
+    if ($view && user) {
       dispatch('editView', { definition: $view.definition, owner: user.id });
     }
   }
 
   function saveAsView() {
-    if ($view) {
+    if ($view && user) {
       dispatch('createView', { definition: $view.definition, owner: user.id });
     }
   }
@@ -62,7 +62,7 @@
   }
 
   function saveView() {
-    if ($view && $view.owner === user.id && !saveViewDisabled) {
+    if ($view && user && $view.owner === user.id && !saveViewDisabled) {
       dispatch('saveView', { definition: $view.definition, id: $view.id, name: $view.name });
     }
   }
@@ -72,7 +72,7 @@
   }
 
   function uploadView() {
-    dispatch('uploadView', { owner: user.id });
+    dispatch('uploadView');
   }
 </script>
 

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -196,7 +196,7 @@
     const { detail } = event;
     const { owner, definition } = detail;
     if (owner != null && definition) {
-      const success = await effects.createView(owner, definition, data.user);
+      const success = await effects.createView(definition, data.user);
       if (success) {
         resetOriginalView();
       }
@@ -207,7 +207,7 @@
     const { detail } = event;
     const { owner, definition } = detail;
     if (owner != null && definition) {
-      const success = await effects.editView(owner, definition, data.user);
+      const success = await effects.editView(definition, data.user);
       if (success) {
         resetOriginalView();
       }
@@ -234,11 +234,8 @@
     resetView();
   }
 
-  async function onUploadView(event: CustomEvent<{ owner: string }>) {
-    const { detail } = event;
-    const { owner } = detail;
-
-    const success = await effects.uploadView(owner, data.user);
+  async function onUploadView() {
+    const success = await effects.uploadView(data.user);
     if (success) {
       resetOriginalView();
     }

--- a/src/types/view.ts
+++ b/src/types/view.ts
@@ -23,8 +23,8 @@ export type ViewIFrame = {
 export type ViewInsertInput = {
   definition: ViewDefinition;
   name: string;
-  owner: string;
 };
+export type ViewUpdateInput = ViewInsertInput;
 
 export type ViewGridComponent =
   | 'ActivityDirectivesTablePanel'

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -98,7 +98,7 @@ import type {
   Span,
 } from '../types/simulation';
 import type { ActivityDirectiveTagsInsertInput, PlanTagsInsertInput, Tag, TagsInsertInput } from '../types/tags';
-import type { View, ViewDefinition, ViewInsertInput } from '../types/view';
+import type { View, ViewDefinition, ViewInsertInput, ViewUpdateInput } from '../types/view';
 import { ActivityDeletionAction } from './activities';
 import { convertToQuery, parseFloatOrNull, setQueryParam, sleep } from './generic';
 import gql, { convertToGQLArray } from './gql';
@@ -900,7 +900,7 @@ const effects = {
     }
   },
 
-  async createView(owner: string, definition: ViewDefinition, user: User | null): Promise<boolean> {
+  async createView(definition: ViewDefinition, user: User | null): Promise<boolean> {
     try {
       if (!queryPermissions.CREATE_VIEW(user)) {
         throwPermissionError('create a view');
@@ -910,7 +910,7 @@ const effects = {
 
       if (confirm && value) {
         const { name } = value;
-        const viewInsertInput: ViewInsertInput = { definition, name, owner };
+        const viewInsertInput: ViewInsertInput = { definition, name };
         const data = await reqHasura<View>(gql.CREATE_VIEW, { view: viewInsertInput }, user);
         const { newView } = data;
 
@@ -1487,7 +1487,7 @@ const effects = {
     return false;
   },
 
-  async editView(owner: string, definition: ViewDefinition, user: User | null): Promise<boolean> {
+  async editView(definition: ViewDefinition, user: User | null): Promise<boolean> {
     try {
       if (!queryPermissions.UPDATE_VIEW(user)) {
         throwPermissionError('edit this view');
@@ -1496,7 +1496,7 @@ const effects = {
       const { confirm, value = null } = await showEditViewModal();
       if (confirm && value) {
         const { id, name } = value;
-        const viewUpdateInput: ViewInsertInput = { definition, name, owner };
+        const viewUpdateInput: ViewUpdateInput = { definition, name };
         const data = await reqHasura<View>(gql.UPDATE_VIEW, { id, view: viewUpdateInput }, user);
         const {
           updatedView: { name: updatedName, updated_at },
@@ -2977,7 +2977,7 @@ const effects = {
     }
   },
 
-  async uploadView(owner: string, user: User | null): Promise<boolean> {
+  async uploadView(user: User | null): Promise<boolean> {
     try {
       if (!queryPermissions.CREATE_VIEW(user)) {
         throwPermissionError('upload a new view');
@@ -2987,7 +2987,7 @@ const effects = {
       if (confirm && value) {
         const { name, definition } = value;
 
-        const viewInsertInput: ViewInsertInput = { definition, name, owner };
+        const viewInsertInput: ViewInsertInput = { definition, name };
         const data = await reqHasura<View>(gql.CREATE_VIEW, { view: viewInsertInput }, user);
         const { newView } = data;
 


### PR DESCRIPTION
This fixes an issue where view creation fails when the user is not `admin` due to the `owner` field being supplied in the payload.