### PR TITLE
Add permissions to Simulations panel

### DIFF
--- a/src/components/activity/ActivityPresetInput.svelte
+++ b/src/components/activity/ActivityPresetInput.svelte
@@ -27,11 +27,6 @@
   export let plan: Plan | null;
   export let user: User | null;
 
-  let hasAssignPermission: boolean = false;
-  let hasCreatePermission: boolean = false;
-  let hasDeletePermission: boolean = false;
-  let hasUpdatePermission: boolean = false;
-
   const dispatch = createEventDispatcher();
 
   let activityPresets: GqlSubscribable<ActivityPreset[]> = gqlSubscribable<ActivityPreset[]>(
@@ -40,6 +35,10 @@
     [],
     user,
   );
+  let hasAssignPermission: boolean = false;
+  let hasCreatePermission: boolean = false;
+  let hasDeletePermission: boolean = false;
+  let hasUpdatePermission: boolean = false;
   let options: DropdownOptions = [];
 
   $: if (activityDirective != null) {

--- a/src/components/parameters/ParameterBasePath.svelte
+++ b/src/components/parameters/ParameterBasePath.svelte
@@ -54,7 +54,7 @@
         on:reset={() => dispatch('reset', formParameter)}
       />
     </Input>
-    <input type="file" on:change={onChange} />
+    <input type="file" on:change={onChange} use:useActions={use} />
   </div>
 </div>
 

--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -45,6 +45,7 @@
   let endTimeDoy: string;
   let endTimeDoyField: FieldStore<string>;
   let formParameters: FormParameter[] = [];
+  let hasRunPermission: boolean = false;
   let hasUpdatePermission: boolean = false;
   let numOfUserChanges: number = 0;
   let startTimeDoy: string;
@@ -53,6 +54,7 @@
   let simulationDatasets: GqlSubscribable<SimulationDataset[]>;
 
   $: if (user !== null && $plan !== null) {
+    hasRunPermission = featurePermissions.simulation.canRun(user, $plan);
     hasUpdatePermission = featurePermissions.simulation.canUpdate(user, $plan);
   }
   $: if ($plan) {
@@ -253,6 +255,15 @@
           : ''}
         title="Simulate"
         showLabel
+        use={[
+          [
+            permissionHandler,
+            {
+              hasPermission: hasRunPermission,
+              permissionError: 'You do not have permission to run a simulation',
+            },
+          ],
+        ]}
         on:click={() => effects.simulate(user)}
       />
     </PanelHeaderActions>

--- a/src/components/simulation/SimulationTemplateInput.svelte
+++ b/src/components/simulation/SimulationTemplateInput.svelte
@@ -89,6 +89,7 @@
       optionLabel="template"
       placeholder="None"
       selectedOptionValue={selectedSimulationTemplate?.id}
+      showPlaceholderOption={hasAssignPermission}
       on:deleteOption={onDeleteTemplate}
       on:saveNewOption={onSaveNewTemplate}
       on:saveOption={onSaveTemplate}

--- a/src/components/simulation/SimulationTemplateInput.svelte
+++ b/src/components/simulation/SimulationTemplateInput.svelte
@@ -3,28 +3,53 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
   import { simulationTemplates } from '../../stores/simulation';
+  import type { User } from '../../types/app';
   import type {
     DropdownOption,
     DropdownOptions,
     DropdownOptionValue,
     SelectedDropdownOptionValue,
   } from '../../types/dropdown';
+  import type { Plan } from '../../types/plan';
   import type { SimulationTemplate } from '../../types/simulation';
+  import { featurePermissions } from '../../utilities/permissions';
   import { tooltip } from '../../utilities/tooltip';
   import EditableDropdown from '../ui/EditableDropdown.svelte';
 
   export let disabled: boolean = false;
   export let hasChanges: boolean = false;
   export let selectedSimulationTemplate: SimulationTemplate | null | undefined;
+  export let plan: Plan | null;
+  export let user: User | null;
 
   const dispatch = createEventDispatcher();
 
+  let hasAssignPermission: boolean = false;
+  let hasCreatePermission: boolean = false;
+  let hasDeletePermission: boolean = false;
+  let hasUpdatePermission: boolean = false;
   let options: DropdownOptions = [];
 
   $: options = $simulationTemplates.map((simulationTemplate: SimulationTemplate) => ({
     display: simulationTemplate.description,
+    hasSelectPermission: hasAssignPermission,
     value: simulationTemplate.id,
   }));
+  $: if (plan !== null) {
+    hasAssignPermission = featurePermissions.simulationTemplates.canAssign(user, plan);
+    // because we also assign after template creation, we must include both checks here as part of the creation permission check
+    hasCreatePermission =
+      featurePermissions.simulationTemplates.canCreate(user, plan) &&
+      featurePermissions.simulationTemplates.canAssign(user, plan);
+
+    const selectedTemplate = $simulationTemplates.find(
+      simulationTemplate => simulationTemplate.id === selectedSimulationTemplate?.id,
+    );
+    if (selectedTemplate !== undefined) {
+      hasDeletePermission = featurePermissions.simulationTemplates.canDelete(user, plan, selectedTemplate);
+      hasUpdatePermission = featurePermissions.simulationTemplates.canUpdate(user, plan, selectedTemplate);
+    }
+  }
 
   function onDeleteTemplate(event: CustomEvent<DropdownOptionValue>) {
     const { detail: templateId } = event;
@@ -57,6 +82,9 @@
     <EditableDropdown
       {disabled}
       canSaveOver={hasChanges}
+      {hasCreatePermission}
+      {hasDeletePermission}
+      {hasUpdatePermission}
       {options}
       optionLabel="template"
       placeholder="None"

--- a/src/stores/simulation.ts
+++ b/src/stores/simulation.ts
@@ -32,7 +32,7 @@ export const spans: Writable<Span[]> = writable([]);
 
 /* Subscriptions. */
 
-export const simulation = gqlSubscribable<Simulation>(
+export const simulation = gqlSubscribable<Simulation | null>(
   gql.SUB_SIMULATION,
   { planId },
   null,
@@ -80,41 +80,43 @@ export const spanUtilityMaps: Readable<SpanUtilityMaps> = derived(spans, $spans 
 export const resourcesByViewLayerId: Readable<Record<number, Resource[]>> = derived(
   [externalResources, resources, view],
   ([$externalResources, $resources, $view]) => {
-    const resources: Resource[] = [...$externalResources, ...$resources];
-    const { definition } = $view;
-    const { plan } = definition;
-    const { timelines } = plan;
-    const resourcesByViewLayerId: Record<number, Resource[]> = {};
+    if ($view) {
+      const resources: Resource[] = [...$externalResources, ...$resources];
+      const { definition } = $view;
+      const { plan } = definition;
+      const { timelines } = plan;
+      const resourcesByViewLayerId: Record<number, Resource[]> = {};
 
-    for (const resource of resources) {
-      for (const timeline of timelines) {
-        const { rows } = timeline;
+      for (const resource of resources) {
+        for (const timeline of timelines) {
+          const { rows } = timeline;
 
-        for (const row of rows) {
-          const { layers } = row;
+          for (const row of rows) {
+            const { layers } = row;
 
-          for (const layer of layers) {
-            const { filter } = layer;
+            for (const layer of layers) {
+              const { filter } = layer;
 
-            if (filter.resource !== undefined) {
-              const { resource: resourceFilter } = filter;
-              const { names } = resourceFilter;
-              const includeResource = names.indexOf(resource.name) > -1;
+              if (filter.resource !== undefined) {
+                const { resource: resourceFilter } = filter;
+                const { names } = resourceFilter;
+                const includeResource = names.indexOf(resource.name) > -1;
 
-              if (includeResource) {
-                if (resourcesByViewLayerId[layer.id] === undefined) {
-                  resourcesByViewLayerId[layer.id] = [resource];
-                } else {
-                  resourcesByViewLayerId[layer.id].push(resource);
+                if (includeResource) {
+                  if (resourcesByViewLayerId[layer.id] === undefined) {
+                    resourcesByViewLayerId[layer.id] = [resource];
+                  } else {
+                    resourcesByViewLayerId[layer.id].push(resource);
+                  }
                 }
               }
             }
           }
         }
       }
+      return resourcesByViewLayerId;
     }
-
-    return resourcesByViewLayerId;
+    return {};
   },
 );
 
@@ -151,10 +153,13 @@ export const enableSimulation: Readable<boolean> = derived(simulationStatus, $si
   return $simulationStatus === Status.Modified || $simulationStatus === null;
 });
 
-export const selectedSpan = derived(
-  [spansMap, selectedSpanId],
-  ([$spansMap, $selectedSpanId]) => $spansMap[$selectedSpanId] || null,
-);
+export const selectedSpan = derived([spansMap, selectedSpanId], ([$spansMap, $selectedSpanId]) => {
+  if ($selectedSpanId !== null) {
+    return $spansMap[$selectedSpanId] || null;
+  }
+
+  return null;
+});
 
 /* Helper Functions. */
 

--- a/src/types/simulation.ts
+++ b/src/types/simulation.ts
@@ -1,4 +1,5 @@
 import type { ActivityDirectiveId } from './activity';
+import type { UserId } from './app';
 import type { BaseError, SimulationDatasetError } from './errors';
 import type { ArgumentsMap } from './parameter';
 import type { ValueSchema } from './schema';
@@ -87,6 +88,7 @@ export type SimulationTemplate = {
   arguments: ArgumentsMap;
   description: string;
   id: number;
+  owner: UserId;
 };
 
 export type SimulationTemplateInsertInput = {

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1663,6 +1663,7 @@ const gql = {
           arguments
           description
           id
+          owner
         }
       }
     }
@@ -1715,6 +1716,7 @@ const gql = {
         arguments
         description
         id
+        owner
       }
     }
   `,


### PR DESCRIPTION
Resolves #774 

To test: 
1. Create a plan with a specific user as the `user` role
2. Add some directives and run the simulation
3. Make some modifications to arguments and run the simulation again
4. Make a simulation preset with those argument modifications and switch between None and the new preset
5. In the Simulations panel, arguments should still be editable
6. Log out and log in as a different user under the `user` role
7. Navigate to the plan that was created and open the Simulations panel
8. Verify that nothing should be editable
9. Verify that simulation presets are no longer selectable/editable