### PR TITLE
Update the admin constant to be consistent with the backend

### DIFF
--- a/src/components/app/Nav.svelte
+++ b/src/components/app/Nav.svelte
@@ -3,7 +3,7 @@
   import AppMenu from '../../components/menus/AppMenu.svelte';
   import type { User, UserRole } from '../../types/app';
   import { getTarget } from '../../utilities/generic';
-  import { changeUserRole } from '../../utilities/permissions';
+  import { changeUserRole, isAdminRole } from '../../utilities/permissions';
 
   export let user: User | null;
 
@@ -17,6 +17,13 @@
       await changeUserRole(value as string);
       await invalidateAll();
     }
+  }
+
+  function getRoleDisplayValue(userRole: UserRole) {
+    if (isAdminRole(userRole)) {
+      return 'admin';
+    }
+    return userRole;
   }
 </script>
 
@@ -34,7 +41,7 @@
     {#if userRoles.length > 1}
       <select value={user?.activeRole} class="st-select" on:change={changeRole}>
         {#each userRoles as userRole}
-          <option value={userRole}>{userRole}</option>
+          <option value={userRole}>{getRoleDisplayValue(userRole)}</option>
         {/each}
       </select>
     {/if}

--- a/src/components/app/Nav.svelte
+++ b/src/components/app/Nav.svelte
@@ -3,7 +3,7 @@
   import AppMenu from '../../components/menus/AppMenu.svelte';
   import type { User, UserRole } from '../../types/app';
   import { getTarget } from '../../utilities/generic';
-  import { changeUserRole, isAdminRole } from '../../utilities/permissions';
+  import { changeUserRole } from '../../utilities/permissions';
 
   export let user: User | null;
 
@@ -17,13 +17,6 @@
       await changeUserRole(value as string);
       await invalidateAll();
     }
-  }
-
-  function getRoleDisplayValue(userRole: UserRole) {
-    if (isAdminRole(userRole)) {
-      return 'admin';
-    }
-    return userRole;
   }
 </script>
 
@@ -41,7 +34,7 @@
     {#if userRoles.length > 1}
       <select value={user?.activeRole} class="st-select" on:change={changeRole}>
         {#each userRoles as userRole}
-          <option value={userRole}>{getRoleDisplayValue(userRole)}</option>
+          <option value={userRole}>{userRole}</option>
         {/each}
       </select>
     {/if}

--- a/src/components/plan/PlanMergeReview.test.ts
+++ b/src/components/plan/PlanMergeReview.test.ts
@@ -9,6 +9,7 @@ import type {
   PlanMergeNonConflictingActivity,
   PlanMergeRequestSchema,
 } from '../../types/plan';
+import { ADMIN_ROLE } from '../../utilities/permissions';
 import PlanMergeReview from './PlanMergeReview.svelte';
 
 vi.mock('$env/dynamic/public', () => import.meta.env); // https://github.com/sveltejs/kit/issues/8180
@@ -67,9 +68,9 @@ const mockInitialPlan: Plan = {
 };
 
 const user: User = {
-  activeRole: 'admin',
-  allowedRoles: ['admin'],
-  defaultRole: 'admin',
+  activeRole: ADMIN_ROLE,
+  allowedRoles: [ADMIN_ROLE],
+  defaultRole: ADMIN_ROLE,
   id: 'foo',
   permissibleQueries: {},
   token: '',

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte.test.ts
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte.test.ts
@@ -2,6 +2,7 @@ import { cleanup, render } from '@testing-library/svelte';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ModelSlim } from '../../../types/model';
 import type { PlanSchedulingSpec } from '../../../types/plan';
+import { ADMIN_ROLE } from '../../../utilities/permissions';
 import SchedulingGoalForm from './SchedulingGoalForm.svelte';
 
 vi.mock('$env/dynamic/public', () => import.meta.env); // https://github.com/sveltejs/kit/issues/8180
@@ -21,7 +22,7 @@ const plans: PlanSchedulingSpec[] = [
     id: 2,
     model_id: 1,
     name: 'Plan Without Scheduling Spec',
-    scheduling_specifications: undefined,
+    scheduling_specifications: [],
   },
 ];
 
@@ -48,21 +49,21 @@ describe('Scheduling Goal Form component', () => {
       models,
       plans,
       user: {
-        activeRole: 'admin',
-        allowedRoles: ['admin'],
-        defaultRole: 'admin',
+        activeRole: ADMIN_ROLE,
+        allowedRoles: [ADMIN_ROLE],
+        defaultRole: ADMIN_ROLE,
         id: 'foo',
         permissibleQueries: {},
         token: '',
       },
     });
 
-    const planDropdown: HTMLSelectElement = container.querySelector('.st-select[name="plan"]');
+    const planDropdown: HTMLSelectElement | null = container.querySelector('.st-select[name="plan"]');
 
     // Ensure the page and dropdown were rendered;
     expect(planDropdown).to.exist;
 
     // Ensure each plan is listed (plus one for empty option)
-    expect(planDropdown.options.length).toEqual(plans.length + 1);
+    expect(planDropdown?.options.length).toEqual(plans.length + 1);
   });
 });

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -7,7 +7,7 @@ export type BaseUser = {
   token: string;
 };
 
-export type UserRole = string | 'admin';
+export type UserRole = string | 'aerie_admin';
 
 export type User = BaseUser & {
   activeRole: UserRole;

--- a/src/utilities/login.test.ts
+++ b/src/utilities/login.test.ts
@@ -1,6 +1,7 @@
 import { env } from '$env/dynamic/public';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { isLoginEnabled, shouldRedirectToLogin } from './login';
+import { ADMIN_ROLE } from './permissions';
 
 vi.mock('$env/dynamic/public', () => ({
   env: {
@@ -34,7 +35,7 @@ describe('login util functions', () => {
       expect(
         shouldRedirectToLogin({
           activeRole: 'user',
-          allowedRoles: ['admin', 'user'],
+          allowedRoles: [ADMIN_ROLE, 'user'],
           defaultRole: 'user',
           id: 'foo',
           permissibleQueries: {},
@@ -45,7 +46,7 @@ describe('login util functions', () => {
       expect(
         shouldRedirectToLogin({
           activeRole: 'user',
-          allowedRoles: ['admin', 'user'],
+          allowedRoles: [ADMIN_ROLE, 'user'],
           defaultRole: 'user',
           id: 'foo',
           permissibleQueries: {
@@ -63,7 +64,7 @@ describe('login util functions', () => {
       expect(
         shouldRedirectToLogin({
           activeRole: 'user',
-          allowedRoles: ['admin', 'user'],
+          allowedRoles: [ADMIN_ROLE, 'user'],
           defaultRole: 'user',
           id: 'foo',
           permissibleQueries: {},
@@ -74,7 +75,7 @@ describe('login util functions', () => {
       expect(
         shouldRedirectToLogin({
           activeRole: 'user',
-          allowedRoles: ['admin', 'user'],
+          allowedRoles: [ADMIN_ROLE, 'user'],
           defaultRole: 'user',
           id: 'foo',
           permissibleQueries: {

--- a/src/utilities/permissions.test.ts
+++ b/src/utilities/permissions.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from 'vitest';
-import { hasNoAuthorization, isPlanCollaborator, isPlanOwner, isUserAdmin, isUserOwner } from './permissions';
+import {
+  ADMIN_ROLE,
+  hasNoAuthorization,
+  isAdminRole,
+  isPlanCollaborator,
+  isPlanOwner,
+  isUserAdmin,
+  isUserOwner,
+} from './permissions';
 
 describe('hasNoAuthorization', () => {
   test('Should return whether or not the user has authorization', () => {
@@ -7,7 +15,7 @@ describe('hasNoAuthorization', () => {
     expect(
       hasNoAuthorization({
         activeRole: 'user',
-        allowedRoles: ['admin', 'user'],
+        allowedRoles: [ADMIN_ROLE, 'user'],
         defaultRole: 'user',
         id: 'foo',
         permissibleQueries: {},
@@ -18,7 +26,7 @@ describe('hasNoAuthorization', () => {
     expect(
       hasNoAuthorization({
         activeRole: 'user',
-        allowedRoles: ['admin', 'user'],
+        allowedRoles: [ADMIN_ROLE, 'user'],
         defaultRole: 'user',
         id: 'foo',
         permissibleQueries: {
@@ -31,11 +39,20 @@ describe('hasNoAuthorization', () => {
 });
 
 describe('Check roles', () => {
+  test('Should return whether or not the provided role an "admin" role', () => {
+    expect(isAdminRole('user')).toEqual(false);
+    expect(isAdminRole('viewer')).toEqual(false);
+    expect(isAdminRole('foo')).toEqual(false);
+    expect(isAdminRole('admin')).toEqual(false);
+
+    expect(isAdminRole(ADMIN_ROLE)).toEqual(true);
+  });
+
   test('Should return whether or not the current role of the user is "admin"', () => {
     expect(
       isUserAdmin({
         activeRole: 'user',
-        allowedRoles: ['admin', 'user'],
+        allowedRoles: [ADMIN_ROLE, 'user'],
         defaultRole: 'user',
         id: 'foo',
         permissibleQueries: {
@@ -47,8 +64,8 @@ describe('Check roles', () => {
 
     expect(
       isUserAdmin({
-        activeRole: 'admin',
-        allowedRoles: ['admin', 'user'],
+        activeRole: ADMIN_ROLE,
+        allowedRoles: [ADMIN_ROLE, 'user'],
         defaultRole: 'user',
         id: 'foo',
         permissibleQueries: {},
@@ -62,7 +79,7 @@ describe('Check roles', () => {
       isUserOwner(
         {
           activeRole: 'user',
-          allowedRoles: ['admin', 'user'],
+          allowedRoles: [ADMIN_ROLE, 'user'],
           defaultRole: 'user',
           id: 'foo',
           permissibleQueries: {
@@ -79,8 +96,8 @@ describe('Check roles', () => {
     expect(
       isUserOwner(
         {
-          activeRole: 'admin',
-          allowedRoles: ['admin', 'user'],
+          activeRole: ADMIN_ROLE,
+          allowedRoles: [ADMIN_ROLE, 'user'],
           defaultRole: 'user',
           id: 'foo',
           permissibleQueries: {},
@@ -98,7 +115,7 @@ describe('Check roles', () => {
       isPlanOwner(
         {
           activeRole: 'user',
-          allowedRoles: ['admin', 'user'],
+          allowedRoles: [ADMIN_ROLE, 'user'],
           defaultRole: 'user',
           id: 'foo',
           permissibleQueries: {
@@ -117,8 +134,8 @@ describe('Check roles', () => {
     expect(
       isPlanOwner(
         {
-          activeRole: 'admin',
-          allowedRoles: ['admin', 'user'],
+          activeRole: ADMIN_ROLE,
+          allowedRoles: [ADMIN_ROLE, 'user'],
           defaultRole: 'user',
           id: 'foo',
           permissibleQueries: {},
@@ -138,7 +155,7 @@ describe('Check roles', () => {
       isPlanCollaborator(
         {
           activeRole: 'user',
-          allowedRoles: ['admin', 'user'],
+          allowedRoles: [ADMIN_ROLE, 'user'],
           defaultRole: 'user',
           id: 'baz',
           permissibleQueries: {
@@ -157,8 +174,8 @@ describe('Check roles', () => {
     expect(
       isPlanCollaborator(
         {
-          activeRole: 'admin',
-          allowedRoles: ['admin', 'user'],
+          activeRole: ADMIN_ROLE,
+          allowedRoles: [ADMIN_ROLE, 'user'],
           defaultRole: 'user',
           id: 'foo',
           permissibleQueries: {},

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -16,7 +16,7 @@ import type {
 import type { SimulationTemplate } from '../types/simulation';
 import { showFailureToast } from './toast';
 
-export const ADMIN_ROLE = 'admin';
+export const ADMIN_ROLE = 'aerie_admin';
 
 export const INVALID_JWT = 'invalid-jwt';
 export const EXPIRED_JWT = 'JWTExpired';
@@ -30,8 +30,12 @@ function getPermission(queries: string[], user: User | null): boolean {
   return false;
 }
 
+export function isAdminRole(userRole?: UserRole) {
+  return userRole === ADMIN_ROLE;
+}
+
 export function isUserAdmin(user: User | null) {
-  return user?.activeRole === ADMIN_ROLE;
+  return isAdminRole(user?.activeRole);
 }
 
 export function isUserOwner(user: User | null, thingWithOwner?: { owner: UserId } | null): boolean {


### PR DESCRIPTION
The new value of the admin role is now "aerie_admin" (via https://github.com/NASA-AMMOS/aerie/pull/1019). 
This PR updates the UI to match it.