### PR TITLE
Implement Permissions on Scheduling Page

### DIFF
--- a/src/components/scheduling/Scheduling.svelte
+++ b/src/components/scheduling/Scheduling.svelte
@@ -4,14 +4,16 @@
   import { schedulingColumns, schedulingConditions, schedulingGoals } from '../../stores/scheduling';
   import type { User } from '../../types/app';
   import type { DataGridRowSelection } from '../../types/data-grid';
+  import type { PlanSchedulingSpec } from '../../types/plan';
   import type { SchedulingCondition, SchedulingGoal } from '../../types/scheduling';
   import effects from '../../utilities/effects';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
+  import SchedulingEditor from './SchedulingEditor.svelte';
   import SchedulingConditions from './conditions/SchedulingConditions.svelte';
   import SchedulingGoals from './goals/SchedulingGoals.svelte';
-  import SchedulingEditor from './SchedulingEditor.svelte';
 
+  export let plans: PlanSchedulingSpec[] | null;
   export let user: User | null;
 
   let selectedCondition: SchedulingCondition | null = null;
@@ -105,6 +107,7 @@
 <CssGrid bind:columns={$schedulingColumns}>
   <CssGrid rows="1fr 3px 1fr">
     <SchedulingGoals
+      {plans}
       {selectedGoal}
       schedulingGoals={$schedulingGoals}
       {user}
@@ -113,6 +116,7 @@
     />
     <CssGridGutter track={1} type="row" />
     <SchedulingConditions
+      {plans}
       {selectedCondition}
       schedulingConditions={$schedulingConditions}
       {user}

--- a/src/components/scheduling/conditions/SchedulingConditions.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditions.svelte
@@ -9,6 +9,7 @@
   import type { DataGridColumnDef, RowId } from '../../../types/data-grid';
   import type { PlanSchedulingSpec } from '../../../types/plan';
   import type { SchedulingCondition } from '../../../types/scheduling';
+  import { permissionHandler } from '../../../utilities/permissionHandler';
   import { featurePermissions } from '../../../utilities/permissions';
   import Input from '../../form/Input.svelte';
   import DataGridActions from '../../ui/DataGrid/DataGridActions.svelte';
@@ -132,6 +133,10 @@
     const plan = plans.find(plan => plan.scheduling_specifications[0]?.id === specification_id);
     return featurePermissions.schedulingConditions.canUpdate(user, plan);
   }
+
+  function hasCreatePermission(user: User): boolean {
+    return plans.some(plan => featurePermissions.schedulingConditions.canCreate(user, plan));
+  }
 </script>
 
 <Panel>
@@ -143,7 +148,14 @@
     </Input>
 
     <div class="right">
-      <button class="st-button secondary ellipsis" on:click={() => goto(`${base}/scheduling/conditions/new`)}>
+      <button
+        class="st-button secondary ellipsis"
+        on:click={() => goto(`${base}/scheduling/conditions/new`)}
+        use:permissionHandler={{
+          hasPermission: hasCreatePermission(user),
+          permissionError: 'You do not have permission to create Scheduling Conditions',
+        }}
+      >
         New
       </button>
     </div>

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte
@@ -344,6 +344,7 @@
     scheduleItemModelId={goalModelId}
     title="{mode === 'create' ? 'New' : 'Edit'} Scheduling Goal - Definition Editor"
     {user}
+    readOnly={!hasPermission}
     on:didChangeModelContent={onDidChangeModelContent}
   />
 </CssGrid>

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte.test.ts
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte.test.ts
@@ -9,9 +9,11 @@ vi.mock('$env/dynamic/public', () => import.meta.env); // https://github.com/sve
 
 const plans: PlanSchedulingSpec[] = [
   {
+    collaborators: [],
     id: 1,
     model_id: 1,
     name: 'Plan With Scheduling Spec',
+    owner: 'foo',
     scheduling_specifications: [
       {
         id: 1,
@@ -19,9 +21,11 @@ const plans: PlanSchedulingSpec[] = [
     ],
   },
   {
+    collaborators: [],
     id: 2,
     model_id: 1,
     name: 'Plan Without Scheduling Spec',
+    owner: 'foo',
     scheduling_specifications: [],
   },
 ];

--- a/src/components/scheduling/goals/SchedulingGoals.svelte
+++ b/src/components/scheduling/goals/SchedulingGoals.svelte
@@ -11,6 +11,7 @@
   import type { PlanSchedulingSpec } from '../../../types/plan';
   import type { SchedulingGoal, SchedulingGoalSlim } from '../../../types/scheduling';
   import type { Tag } from '../../../types/tags';
+  import { permissionHandler } from '../../../utilities/permissionHandler';
   import { featurePermissions } from '../../../utilities/permissions';
   import Input from '../../form/Input.svelte';
   import DataGridActions from '../../ui/DataGrid/DataGridActions.svelte';
@@ -162,6 +163,10 @@
     const plan = plans.find(plan => plan.scheduling_specifications[0]?.id === specification_id);
     return featurePermissions.schedulingGoals.canUpdate(user, plan);
   }
+
+  function hasCreatePermission(user: User): boolean {
+    return plans.some(plan => featurePermissions.schedulingGoals.canCreate(user, plan));
+  }
 </script>
 
 <Panel>
@@ -173,7 +178,16 @@
     </Input>
 
     <div class="right">
-      <button class="st-button secondary ellipsis" on:click={() => goto(`${base}/scheduling/goals/new`)}> New </button>
+      <button
+        class="st-button secondary ellipsis"
+        on:click={() => goto(`${base}/scheduling/goals/new`)}
+        use:permissionHandler={{
+          hasPermission: hasCreatePermission(user),
+          permissionError: 'You do not have permission to create Scheduling Goals',
+        }}
+      >
+        New
+      </button>
     </div>
   </svelte:fragment>
 

--- a/src/routes/scheduling/+page.svelte
+++ b/src/routes/scheduling/+page.svelte
@@ -10,4 +10,4 @@
 
 <PageTitle title="Scheduling" />
 
-<Scheduling user={data.user} />
+<Scheduling plans={data.plans} user={data.user} />

--- a/src/routes/scheduling/+page.ts
+++ b/src/routes/scheduling/+page.ts
@@ -11,7 +11,7 @@ export const load: PageLoad = async ({ parent }) => {
     throw redirect(302, `${base}/login`);
   }
 
-  const { models = [], plans = [] } = await effects.getPlansAndModels(user);
+  const { models = [], plans = [] } = await effects.getPlansAndModelsForScheduling(user);
 
   return {
     models,

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -112,4 +112,7 @@ export type PlanSlim = Pick<
 
 export type PlanSlimmer = Pick<PlanSlim, 'id' | 'start_time' | 'end_time_doy'>;
 
-export type PlanSchedulingSpec = Pick<Plan, 'id' | 'name' | 'scheduling_specifications' | 'model_id'>;
+export type PlanSchedulingSpec = Pick<
+  Plan,
+  'id' | 'name' | 'scheduling_specifications' | 'model_id' | 'owner' | 'collaborators'
+>;

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -46,12 +46,26 @@ export type SchedulingGoalAnalysis = {
 
 export type SchedulingConditionInsertInput = Omit<
   SchedulingCondition,
-  'author' | 'created_date' | 'id' | 'last_modified_by' | 'modified_date' | 'revision'
+  | 'author'
+  | 'created_date'
+  | 'id'
+  | 'last_modified_by'
+  | 'modified_date'
+  | 'revision'
+  | 'scheduling_specification_conditions'
 >;
 
 export type SchedulingGoalInsertInput = Omit<
   SchedulingGoal,
-  'analyses' | 'author' | 'created_date' | 'id' | 'last_modified_by' | 'modified_date' | 'revision' | 'tags'
+  | 'analyses'
+  | 'author'
+  | 'created_date'
+  | 'id'
+  | 'last_modified_by'
+  | 'modified_date'
+  | 'revision'
+  | 'scheduling_specification_goal'
+  | 'tags'
 >;
 
 export type SchedulingResponse = {

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -14,6 +14,9 @@ export type SchedulingGoal = {
   modified_date: string;
   name: string;
   revision: number;
+  scheduling_specification_goal: {
+    specification_id: number;
+  };
   tags: { tag: Tag }[];
 };
 
@@ -30,6 +33,9 @@ export type SchedulingCondition = {
   modified_date: string;
   name: string;
   revision: number;
+  scheduling_specification_conditions: {
+    specification_id: number;
+  }[];
 };
 
 export type SchedulingGoalAnalysis = {

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1586,6 +1586,9 @@ const gql = {
         model_id
         modified_date
         name
+        scheduling_specification_conditions {
+          specification_id
+        }
         revision
       }
     }
@@ -1606,6 +1609,9 @@ const gql = {
         model_id
         modified_date
         name
+        scheduling_specification_goal {
+          specification_id
+        }
         revision
         tags {
           tag_id

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -388,6 +388,8 @@ interface FeaturePermissions {
   expansionSets: ExpansionSetsCRUDPermission<AssetWithOwner>;
   model: CRUDPermission<void>;
   plan: CRUDPermission<PlanWithOwners>;
+  schedulingConditions: PlanAssetCRUDPermission<AssetWithOwner>;
+  schedulingGoals: PlanAssetCRUDPermission<AssetWithOwner>;
   sequences: CRUDPermission<AssetWithOwner>;
   simulation: SimulationCRUDPermission<AssetWithOwner>;
   simulationTemplates: AssignablePlanAssetCRUDPermission<SimulationTemplate>;
@@ -471,6 +473,33 @@ const featurePermissions: FeaturePermissions = {
     canDelete: (user, plan) => isUserAdmin(user) || (isPlanOwner(user, plan) && queryPermissions.DELETE_PLAN(user)),
     canRead: user => isUserAdmin(user) || queryPermissions.GET_PLAN(user),
     canUpdate: (user, plan) => isUserAdmin(user) || (isPlanOwner(user, plan) && queryPermissions.UPDATE_PLAN(user)),
+  },
+  schedulingConditions: {
+    canCreate: (user, plan) =>
+      isUserAdmin(user) ||
+      ((isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) &&
+        queryPermissions.CREATE_SCHEDULING_CONDITION(user)),
+    canDelete: (user, plan) =>
+      isUserAdmin(user) ||
+      ((isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) &&
+        queryPermissions.DELETE_SCHEDULING_CONDITION(user)),
+    canRead: () => false,
+    canUpdate: (user, plan) =>
+      isUserAdmin(user) ||
+      ((isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) &&
+        queryPermissions.UPDATE_SCHEDULING_CONDITION(user)),
+  },
+  schedulingGoals: {
+    canCreate: (user, plan) =>
+      isUserAdmin(user) ||
+      ((isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) && queryPermissions.CREATE_SCHEDULING_GOAL(user)),
+    canDelete: (user, plan) =>
+      isUserAdmin(user) ||
+      ((isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) && queryPermissions.DELETE_SCHEDULING_GOAL(user)),
+    canRead: () => false,
+    canUpdate: (user, plan) =>
+      isUserAdmin(user) ||
+      ((isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) && queryPermissions.UPDATE_SCHEDULING_GOAL(user)),
   },
   sequences: {
     canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_USER_SEQUENCE(user),


### PR DESCRIPTION
Resolves #730 
Depends on https://github.com/NASA-AMMOS/aerie/pull/1031

This adds permissions checks for creating/editing/deleting scheduling goals and conditions on the scheduling page. I was originally also going to include the work for the scheduling panes, but decided to split that into a separate PR to make this easier to review.

Testing this will follow a similar pattern as previous permissions tasks. What we want to confirm is that users can only create goals or conditions in plans they own or collaborate on. And goals/conditions can only be edited by those who are owners/collaborators in the associated plan.

To test:

1. Upload two models
2. Create a few plans using each model
3. Go to http://localhost:8080/console/data/AerieMerlin/schema/public/tables/plan/browse and change one plan's owner to be the owner that you want to test with
4. Log in as that owner and switch to the "user" role from the top right dropdown
5. Navigate to http://localhost:3000/scheduling
6. Create a new scheduling goal
7. Verify that only plans that your user is owner of are selectable from the "Plan" dropdown
8. Verify that only models that have instances of plans that your user is owner of are selectable from the "Model" dropdown
9. Navigate back to http://localhost:3000/scheduling
10. Verify that the goal that you created is editable
11. Log out and log in with a different username and switch to the "user" role again
12. Navigate back to http://localhost:3000/scheduling again
13. Verify that the goal that you previously created is no longer editable/deletable
14. Navigate to the edit view of that constraint by manually going to: http://localhost:3000/scheduling/goals/edit/[CONSTRAINT ID]
15. Verify that everything is read only

Repeat above steps for scheduling conditions.