### PR TITLE
Implement permissions for scheduling goal/conditions panels

### DIFF
--- a/src/components/scheduling/SchedulingConditionsPanel.svelte
+++ b/src/components/scheduling/SchedulingConditionsPanel.svelte
@@ -8,6 +8,8 @@
   import type { User } from '../../types/app';
   import type { SchedulingSpecCondition } from '../../types/scheduling';
   import type { ViewGridSection } from '../../types/view';
+  import { permissionHandler } from '../../utilities/permissionHandler';
+  import { featurePermissions } from '../../utilities/permissions';
   import CollapsibleListControls from '../CollapsibleListControls.svelte';
   import GridMenu from '../menus/GridMenu.svelte';
   import Panel from '../ui/Panel.svelte';
@@ -19,6 +21,10 @@
   let activeElement: HTMLElement;
   let conditionsFilterText: string = '';
   let filteredSchedulingSpecConditions: SchedulingSpecCondition[] = [];
+
+  $: hasCreatePermission = featurePermissions.schedulingConditions.canCreate(user, $plan);
+  $: hasDeletePermission = featurePermissions.schedulingConditions.canDelete(user, $plan);
+  $: hasEditPermission = featurePermissions.schedulingConditions.canUpdate(user, $plan);
 
   $: filteredSchedulingSpecConditions = $schedulingSpecConditions.filter(spec => {
     const filterTextLowerCase = conditionsFilterText.toLowerCase();
@@ -59,6 +65,10 @@
             `${base}/scheduling/conditions/new?modelId=${$plan?.model.id}&&specId=${$selectedSpecId}`,
             '_blank',
           )}
+        use:permissionHandler={{
+          hasPermission: hasCreatePermission,
+          permissionError: 'You do not have permission to create scheduling conditions for this plan.',
+        }}
       >
         New
       </button>
@@ -71,6 +81,8 @@
           <SchedulingCondition
             enabled={specCondition.enabled}
             condition={specCondition.condition}
+            {hasDeletePermission}
+            {hasEditPermission}
             specificationId={specCondition.specification_id}
             {user}
           />

--- a/src/components/scheduling/conditions/SchedulingCondition.svelte
+++ b/src/components/scheduling/conditions/SchedulingCondition.svelte
@@ -5,6 +5,7 @@
   import type { User } from '../../../types/app';
   import type { SchedulingCondition } from '../../../types/scheduling';
   import effects from '../../../utilities/effects';
+  import { permissionHandler } from '../../../utilities/permissionHandler';
   import Collapse from '../../Collapse.svelte';
   import ContextMenuHeader from '../../context-menu/ContextMenuHeader.svelte';
   import ContextMenuItem from '../../context-menu/ContextMenuItem.svelte';
@@ -12,8 +13,12 @@
 
   export let enabled: boolean;
   export let condition: SchedulingCondition;
+  export let hasDeletePermission: boolean = false;
+  export let hasEditPermission: boolean = false;
   export let specificationId: number;
   export let user: User | null;
+
+  const permissionError = 'You do not have permission to edit scheduling conditions for this plan.';
 </script>
 
 <div class="scheduling-condition" class:disabled={!enabled}>
@@ -26,17 +31,43 @@
             style:cursor="pointer"
             type="checkbox"
             on:change={() => effects.updateSchedulingSpecCondition(condition.id, specificationId, { enabled }, user)}
+            use:permissionHandler={{
+              hasPermission: hasEditPermission,
+              permissionError,
+            }}
           />
         </Input>
       </div>
     </svelte:fragment>
     <svelte:fragment slot="contextMenuContent">
       <ContextMenuHeader>Actions</ContextMenuHeader>
-      <ContextMenuItem on:click={() => window.open(`${base}/scheduling/conditions/edit/${condition.id}`, '_blank')}>
+      <ContextMenuItem
+        on:click={() => window.open(`${base}/scheduling/conditions/edit/${condition.id}`, '_blank')}
+        use={[
+          [
+            permissionHandler,
+            {
+              hasPermission: hasEditPermission,
+              permissionError,
+            },
+          ],
+        ]}
+      >
         Edit Condition
       </ContextMenuItem>
       <ContextMenuHeader>Modify</ContextMenuHeader>
-      <ContextMenuItem on:click={() => effects.deleteSchedulingCondition(condition.id, user)}>
+      <ContextMenuItem
+        on:click={() => effects.deleteSchedulingCondition(condition.id, user)}
+        use={[
+          [
+            permissionHandler,
+            {
+              hasPermission: hasDeletePermission,
+              permissionError,
+            },
+          ],
+        ]}
+      >
         Delete Condition
       </ContextMenuItem>
     </svelte:fragment>

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -370,6 +370,12 @@ interface ExpansionSequenceCRUDPermission<T = null> extends CRUDPermission<T> {
   canExpand: (user: User | null, plan: PlanWithOwners) => boolean;
 }
 
+interface SchedulingCRUDPermission<T = null> extends PlanAssetCRUDPermission<T> {
+  canAnalyze: (user: User | null) => boolean;
+  canRun: (user: User | null, plan: PlanWithOwners) => boolean;
+  canUpdateSpecification: (user: User | null, plan: PlanWithOwners) => boolean;
+}
+
 interface SimulationCRUDPermission<T = null> extends PlanAssetCRUDPermission<T> {
   canRun: (user: User | null, plan: PlanWithOwners) => boolean;
 }
@@ -389,7 +395,7 @@ interface FeaturePermissions {
   model: CRUDPermission<void>;
   plan: CRUDPermission<PlanWithOwners>;
   schedulingConditions: PlanAssetCRUDPermission<AssetWithOwner>;
-  schedulingGoals: PlanAssetCRUDPermission<AssetWithOwner>;
+  schedulingGoals: SchedulingCRUDPermission<AssetWithOwner>;
   sequences: CRUDPermission<AssetWithOwner>;
   simulation: SimulationCRUDPermission<AssetWithOwner>;
   simulationTemplates: AssignablePlanAssetCRUDPermission<SimulationTemplate>;
@@ -490,6 +496,7 @@ const featurePermissions: FeaturePermissions = {
         queryPermissions.UPDATE_SCHEDULING_CONDITION(user)),
   },
   schedulingGoals: {
+    canAnalyze: user => isUserAdmin(user) || queryPermissions.UPDATE_SCHEDULING_SPEC(user),
     canCreate: (user, plan) =>
       isUserAdmin(user) ||
       ((isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) && queryPermissions.CREATE_SCHEDULING_GOAL(user)),
@@ -497,9 +504,16 @@ const featurePermissions: FeaturePermissions = {
       isUserAdmin(user) ||
       ((isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) && queryPermissions.DELETE_SCHEDULING_GOAL(user)),
     canRead: () => false,
+    canRun: (user, plan) =>
+      isUserAdmin(user) ||
+      ((isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) && queryPermissions.UPDATE_SCHEDULING_SPEC(user)),
     canUpdate: (user, plan) =>
       isUserAdmin(user) ||
       ((isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) && queryPermissions.UPDATE_SCHEDULING_GOAL(user)),
+    canUpdateSpecification: (user, plan) =>
+      isUserAdmin(user) ||
+      ((isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) &&
+        queryPermissions.UPDATE_SCHEDULING_SPEC_GOAL(user)),
   },
   sequences: {
     canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_USER_SEQUENCE(user),


### PR DESCRIPTION
Resolves #782 
Resolves #783 

This builds off of the scheduling permissions work in https://github.com/NASA-AMMOS/aerie-ui/pull/790 to implement permissions in the scheduling goals and conditions panels. I'm basing this PR off of that branch, since it depends on work already in there. I figure once both have been approved, I will just merge them together.

To test:
- Create at least one scheduling goal and scheduling condition as "user" for a plan you have permission for.
- Open the plan, and go to the scheduling goal pane.
- Ensure that the goal can be changed in priority, enabled/disabled, and the context menu items are available.
- Switch to "viewer" and confirm that the goal is no longer editable. The "simulate" button should also be disabled.
- Confirm the above steps for the scheduling conditions pane as well.