### PR TITLE
Add permissions to plan constraints panel

### DIFF
--- a/src/components/constraints/ConstraintListItem.svelte
+++ b/src/components/constraints/ConstraintListItem.svelte
@@ -10,6 +10,7 @@
   import type { User } from '../../types/app';
   import type { Constraint, ConstraintViolation } from '../../types/constraint';
   import effects from '../../utilities/effects';
+  import { permissionHandler } from '../../utilities/permissionHandler';
   import { tooltip } from '../../utilities/tooltip';
   import Collapse from '../Collapse.svelte';
   import ContextMenuHeader from '../context-menu/ContextMenuHeader.svelte';
@@ -17,8 +18,10 @@
   import ConstraintViolationButton from './ConstraintViolationButton.svelte';
 
   export let constraint: Constraint;
-  export let violation: ConstraintViolation;
+  export let hasDeletePermission: boolean = false;
+  export let hasEditPermission: boolean = false;
   export let totalViolationCount: number = 0;
+  export let violation: ConstraintViolation;
   export let visible: boolean = true;
   export let user: User | null;
 
@@ -85,11 +88,33 @@
 
     <svelte:fragment slot="contextMenuContent">
       <ContextMenuHeader>Actions</ContextMenuHeader>
-      <ContextMenuItem on:click={() => window.open(`${base}/constraints/edit/${constraint.id}`, '_blank')}>
+      <ContextMenuItem
+        on:click={() => window.open(`${base}/constraints/edit/${constraint.id}`, '_blank')}
+        use={[
+          [
+            permissionHandler,
+            {
+              hasPermission: hasEditPermission,
+              permissionError: 'You do not have permission to edit this constraint',
+            },
+          ],
+        ]}
+      >
         Edit Constraint
       </ContextMenuItem>
       <ContextMenuHeader>Modify</ContextMenuHeader>
-      <ContextMenuItem on:click={() => effects.deleteConstraint(constraint.id, user)}>
+      <ContextMenuItem
+        on:click={() => effects.deleteConstraint(constraint.id, user)}
+        use={[
+          [
+            permissionHandler,
+            {
+              hasPermission: hasDeletePermission,
+              permissionError: 'You do not have permission to delete this constraint',
+            },
+          ],
+        ]}
+      >
         Delete Constraint
       </ContextMenuItem>
     </svelte:fragment>

--- a/src/components/constraints/ConstraintsPanel.svelte
+++ b/src/components/constraints/ConstraintsPanel.svelte
@@ -23,6 +23,8 @@
   import type { FieldStore } from '../../types/form';
   import type { ViewGridSection } from '../../types/view';
   import effects from '../../utilities/effects';
+  import { permissionHandler } from '../../utilities/permissionHandler';
+  import { featurePermissions } from '../../utilities/permissions';
   import { getDoyTime, getUnixEpochTime } from '../../utilities/time';
   import { tooltip } from '../../utilities/tooltip';
   import { required, timestamp } from '../../utilities/validators';
@@ -172,7 +174,19 @@
   <svelte:fragment slot="header">
     <GridMenu {gridSection} title="Constraints" />
     <PanelHeaderActions status={$checkConstraintsStatus}>
-      <PanelHeaderActionButton title="Check Constraints" on:click={() => effects.checkConstraints(user)}>
+      <PanelHeaderActionButton
+        title="Check Constraints"
+        on:click={() => effects.checkConstraints(user)}
+        use={[
+          [
+            permissionHandler,
+            {
+              hasPermission: featurePermissions.constraints.canCheck(user, $plan),
+              permissionError: 'You do not have permission to run constraint checks',
+            },
+          ],
+        ]}
+      >
         <ChecklistIcon />
       </PanelHeaderActionButton>
     </PanelHeaderActions>
@@ -193,6 +207,10 @@
           name="new-constraint"
           class="st-button secondary"
           on:click={() => window.open(`${base}/constraints/new`, '_blank')}
+          use:permissionHandler={{
+            hasPermission: featurePermissions.constraints.canCreate(user, $plan),
+            permissionError: 'You do not have permission to create constraints',
+          }}
         >
           New
         </button>
@@ -266,6 +284,8 @@
         {#each filteredConstraints as constraint}
           <ConstraintListItem
             {constraint}
+            hasDeletePermission={featurePermissions.constraints.canDelete(user, $plan)}
+            hasEditPermission={featurePermissions.constraints.canUpdate(user, $plan)}
             visible={$constraintVisibilityMap[constraint.id]}
             violation={filteredConstraintViolationMap[constraint.id]}
             totalViolationCount={constraintViolationMap[constraint.id]?.windows?.length}

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -362,6 +362,10 @@ interface PlanAssetCRUDPermission<T = null> {
   canUpdate: PlanAssetUpdatePermissionCheck<T>;
 }
 
+interface ConstraintCRUDPermission<T = null> extends PlanAssetCRUDPermission<T> {
+  canCheck: (user: User | null, plan: PlanWithOwners) => boolean;
+}
+
 interface ExpansionSetsCRUDPermission<T = null> extends CRUDPermission<T> {
   canUpdate: () => boolean;
 }
@@ -388,7 +392,7 @@ interface FeaturePermissions {
   activityDirective: PlanAssetCRUDPermission<ActivityDirective>;
   activityPresets: AssignablePlanAssetCRUDPermission<ActivityPreset>;
   commandDictionary: CRUDPermission<void>;
-  constraints: PlanAssetCRUDPermission<AssetWithOwner>;
+  constraints: ConstraintCRUDPermission<AssetWithOwner>;
   expansionRules: CRUDPermission<AssetWithOwner>;
   expansionSequences: ExpansionSequenceCRUDPermission<AssetWithOwner>;
   expansionSets: ExpansionSetsCRUDPermission<AssetWithOwner>;
@@ -433,6 +437,9 @@ const featurePermissions: FeaturePermissions = {
     canUpdate: () => false, // Not implemented
   },
   constraints: {
+    canCheck: (user, plan) =>
+      isUserAdmin(user) ||
+      ((isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) && queryPermissions.UPDATE_CONSTRAINT(user)),
     canCreate: (user, plan) =>
       isUserAdmin(user) ||
       ((isPlanOwner(user, plan) || isPlanCollaborator(user, plan)) && queryPermissions.CREATE_CONSTRAINT(user)),


### PR DESCRIPTION
Resolves #757 

To test:
- Add at least one constraint as a user to a plan that you have permission to do so.
- Load the plan and navigate to the constraints panel
- Ensure you can run constraint checks, can create new constraints, and have access to the edit/delete context menu actions on your constraint
- Switch to "viewer" role, and confirm that the above controls are now disabled.