### PR TITLE
Disable events in child elements for permission disabled components

### DIFF
--- a/src/css/app.css
+++ b/src/css/app.css
@@ -70,6 +70,10 @@ fieldset {
   cursor: not-allowed;
 }
 
+.permission-disabled * {
+  pointer-events: none;
+}
+
 .st-button.permission-disabled {
   opacity: var(--st-button-disabled-opacity);
 }


### PR DESCRIPTION
This is just to make sure that the child elements don't have weird interactions when the parent element is disabled via permissions.

~~Depends on #804~~

To test:
1. Go to the plan creation page
2. As a "user" fill out the Tags input
3. Swap to the "viewer" role
4. Verify that hovering over the individual tags no longer presents the "X" icon