### PR TITLE
Fix directives getting removed from UI when not actually being deleted

### DIFF
--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -1086,7 +1086,7 @@ const effects = {
             user,
           );
 
-          if (response.delete_activity_by_pk_reanchor_to_anchor_bulk) {
+          if (response.delete_activity_by_pk_reanchor_to_anchor_bulk != null) {
             const deletedActivityIds = response.delete_activity_by_pk_reanchor_to_anchor_bulk
               .filter(({ change_type }) => {
                 return change_type === 'deleted';
@@ -1125,7 +1125,7 @@ const effects = {
             user,
           );
 
-          if (response.delete_activity_by_pk_reanchor_plan_start_bulk) {
+          if (response.delete_activity_by_pk_reanchor_plan_start_bulk != null) {
             const deletedActivityIds = response.delete_activity_by_pk_reanchor_plan_start_bulk
               .filter(({ change_type }) => {
                 return change_type === 'deleted';


### PR DESCRIPTION
Resolves #748

This PR basically just doesn't remove activities that weren't successfully deleted.

To test (a little janky):
1. Create a plan and add some activities
2. For a more thorough test, anchor a bunch of directives to each other
3. Go to `utilities/permissions.ts` and change line 39 to ```return userRole !== ADMIN_ROLE;```, which will intentionally make the UI think that you're an "admin" to allow for certain buttons to be available
4. Switch to a different user and choose the "user" role
5. Navigate back to the plan that you created in step 1
6. Attempt to delete a few directives
7. Verify that an error now shows up for failed directive deletions and that the directive is still present on the page