### PR TITLE
Display version in model selector in plan form

### DIFF
--- a/e2e-tests/tests/plans.test.ts
+++ b/e2e-tests/tests/plans.test.ts
@@ -42,7 +42,7 @@ test.describe.serial('Plans', () => {
     await models.tableRow.click();
     await expect(page).toHaveURL(`${baseURL}/plans`);
     const { text } = await plans.selectedModel();
-    expect(text).toEqual(models.modelName);
+    expect(text).toEqual(`${models.modelName} (Version: ${models.modelVersion})`);
   });
 
   test('Create plan button should be disabled after only entering a name', async () => {

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -321,6 +321,7 @@
               {#each models as model}
                 <option value={model.id}>
                   {model.name}
+                  (Version: {model.version})
                 </option>
               {/each}
             </select>


### PR DESCRIPTION
Closes #644, thoughts on this formatting and approach? Note, tests will fail due to the new formatting, can fix this if we decide to pursue this change.
<img width="223" alt="image" src="https://github.com/NASA-AMMOS/aerie-ui/assets/4419607/771dd3b5-2723-4145-9161-be18935d8ae5">
