### PR TITLE
Added Balanced Time Checking to Custom Worker

### DIFF
--- a/src/workers/customCodes.ts
+++ b/src/workers/customCodes.ts
@@ -119,6 +119,51 @@ Expected: A signed value`,
   },
 
   /**
+   * MaxAbsolutTime error code and message.
+   */
+  MaxAbsoluteTime: (balancedTime: string): ErrorCode => {
+    return {
+      id: -1,
+      message: `Time Error: Maximum time reached
+  Received: Balanced time - ${balancedTime}.
+  Expected: ${balancedTime} <= 9999-365T23:59:59.999`,
+    };
+  },
+
+  /**
+   * MaxEpochTime error code and message.
+   */
+  MaxEpochTime: (balancedTime: string): ErrorCode => {
+    return {
+      id: -2,
+      message: `Time Error: Maximum time reached.
+Received: Balanced time - ${balancedTime}.
+Expected: ${balancedTime} <= 365T23:59:59.999`,
+    };
+  },
+
+  /**
+   * MaxRelativeTime error code and message.
+   */
+  MaxRelativeTime: (balancedTime: string): ErrorCode => {
+    return {
+      id: -2,
+      message: `Time Error: Maximum time reached.
+  Received: Balanced time - ${balancedTime}.
+  Expected: ${balancedTime} <= 23:59:59.999`,
+    };
+  },
+  /**
+   * UnbalancedTime error code and message.
+   */
+  UnbalancedTime: (balancedTime: string): ErrorCode => {
+    return {
+      id: -9,
+      message: `Time Warning: Unbalanced time used.
+Suggestion: Change time to ${balancedTime}`,
+    };
+  },
+  /**
    * UncaughtArgumentType error code and message.
    */
   UncaughtArgumentType: (): ErrorCode => {

--- a/src/workers/diagnostics/timeDiagnostics.ts
+++ b/src/workers/diagnostics/timeDiagnostics.ts
@@ -55,6 +55,14 @@ function generateRelativeTimeStringDiagnostics(
         if (tsc.isNoSubstitutionTemplateLiteral(timeNode.template)) {
           if (!regex.test(timeNode.template.text)) {
             diagnostics.push(makeDiagnostic(errorCode, sourceFile, timeNode));
+          } else {
+            const balanced = isTimeBalanced(timeNode.template.text, regex);
+            if (balanced.error) {
+              diagnostics.push(makeDiagnostic(balanced.error, sourceFile, timeNode, tsc.DiagnosticCategory.Error));
+            }
+            if (balanced.warning) {
+              diagnostics.push(makeDiagnostic(balanced.warning, sourceFile, timeNode, tsc.DiagnosticCategory.Warning));
+            }
           }
         }
       } else if (tsc.isCallExpression(timeNode)) {
@@ -62,6 +70,14 @@ function generateRelativeTimeStringDiagnostics(
         if (tsc.isStringLiteral(firstArg) || tsc.isNoSubstitutionTemplateLiteral(firstArg)) {
           if (!regex.test(firstArg.text)) {
             diagnostics.push(makeDiagnostic(errorCode, sourceFile, timeNode));
+          } else {
+            const balanced = isTimeBalanced(firstArg.text, regex);
+            if (balanced.error) {
+              diagnostics.push(makeDiagnostic(balanced.error, sourceFile, timeNode, tsc.DiagnosticCategory.Error));
+            }
+            if (balanced.warning) {
+              diagnostics.push(makeDiagnostic(balanced.warning, sourceFile, timeNode, tsc.DiagnosticCategory.Warning));
+            }
           }
         }
       }
@@ -137,6 +153,18 @@ function generateAbsoluteTimeStringDiagnostics(
       if (tsc.isNoSubstitutionTemplateLiteral(absoluteTimeNode.template)) {
         if (!DOY_REGEX.test(absoluteTimeNode.template.text)) {
           diagnostics.push(makeDiagnostic(CustomErrorCodes.InvalidAbsoluteTime(), sourceFile, absoluteTimeNode));
+        } else {
+          const balanced = isTimeBalanced(absoluteTimeNode.template.text, DOY_REGEX);
+          if (balanced.error) {
+            diagnostics.push(
+              makeDiagnostic(balanced.error, sourceFile, absoluteTimeNode, tsc.DiagnosticCategory.Error),
+            );
+          }
+          if (balanced.warning) {
+            diagnostics.push(
+              makeDiagnostic(balanced.warning, sourceFile, absoluteTimeNode, tsc.DiagnosticCategory.Warning),
+            );
+          }
         }
       }
     } else if (tsc.isCallExpression(absoluteTimeNode)) {
@@ -144,10 +172,240 @@ function generateAbsoluteTimeStringDiagnostics(
       if (tsc.isStringLiteral(firstArg) || tsc.isNoSubstitutionTemplateLiteral(firstArg)) {
         if (!DOY_REGEX.test(firstArg.text)) {
           diagnostics.push(makeDiagnostic(CustomErrorCodes.InvalidAbsoluteTime(), sourceFile, absoluteTimeNode));
+        } else {
+          const balanced = isTimeBalanced(firstArg.text, DOY_REGEX);
+          if (balanced.error) {
+            diagnostics.push(
+              makeDiagnostic(balanced.error, sourceFile, absoluteTimeNode, tsc.DiagnosticCategory.Error),
+            );
+          }
+          if (balanced.warning) {
+            diagnostics.push(
+              makeDiagnostic(balanced.warning, sourceFile, absoluteTimeNode, tsc.DiagnosticCategory.Warning),
+            );
+          }
         }
       }
     }
   }
 
   return diagnostics;
+}
+
+function isTimeBalanced(
+  time: string,
+  regex: RegExp,
+): { error?: ErrorCode | undefined; warning?: ErrorCode | undefined } {
+  const { years, days, hours, minutes, seconds, milliseconds } = extractTime(time, regex);
+
+  if (regex === DOY_REGEX && years && days) {
+    const isUnbalanced =
+      (years >= 0 &&
+        years <= 9999 &&
+        days >= 0 &&
+        days <= (isLeapYear(years) ? 366 : 365) &&
+        hours >= 0 &&
+        hours <= 23 &&
+        minutes >= 0 &&
+        minutes <= 59 &&
+        seconds >= 0 &&
+        seconds <= 59) === false;
+
+    if (isUnbalanced) {
+      return balanceAbsolute(years, days, hours, minutes, seconds, milliseconds);
+    }
+  } else {
+    const isUnbalanced =
+      (days !== undefined
+        ? days >= 1 &&
+          days <= 365 &&
+          hours >= 0 &&
+          hours <= 23 &&
+          minutes >= 0 &&
+          minutes <= 59 &&
+          seconds >= 0 &&
+          seconds <= 59
+        : hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59 && seconds >= 0 && seconds <= 59) === false;
+
+    if (isUnbalanced) {
+      return balanceDuration(days ?? 0, hours, minutes, seconds, milliseconds, regex);
+    }
+  }
+
+  return {};
+}
+
+function extractTime(
+  duration: string,
+  regex: RegExp,
+): {
+  days?: number;
+  hours: number;
+  milliseconds: number;
+  minutes: number;
+  seconds: number;
+  years?: number;
+} {
+  const matches = duration.match(regex);
+
+  if (!matches) {
+    return { hours: 0, milliseconds: 0, minutes: 0, seconds: 0 };
+  }
+
+  if (regex.source === DOY_REGEX.source) {
+    const [, years = '0', days = '0', hours = '0', minutes = '0', seconds = '0', milliseconds = '0'] = matches;
+    const [yearsNum, daysNum, hoursNum, minuteNum, secondsNum, millisecondNum] = [
+      years,
+      days,
+      hours,
+      minutes,
+      seconds,
+      milliseconds,
+    ].map(Number);
+    return {
+      days: daysNum,
+      hours: hoursNum,
+      milliseconds: millisecondNum,
+      minutes: minuteNum,
+      seconds: secondsNum,
+      years: yearsNum,
+    };
+  }
+  if (regex.source === HMS_EPOCH_REGEX.source) {
+    const [, , days = undefined, hours = '0', minutes = '0', seconds = '0', milliseconds = '0'] = matches;
+    const [hoursNum, minuteNum, secondsNum, millisecondNum] = [hours, minutes, seconds, milliseconds].map(Number);
+    const daysNum = days !== undefined ? Number(days.replace('T', '')) : days;
+    return {
+      days: daysNum,
+      hours: hoursNum,
+      milliseconds: millisecondNum,
+      minutes: minuteNum,
+      seconds: secondsNum,
+    };
+  } else if (regex.source === HMS_RELATIVE_REGEX.source) {
+    const [, hours = '0', minutes = '0', seconds = '0', milliseconds = '0'] = matches;
+    const [hoursNum, minuteNum, secondsNum, millisecondNum] = [hours, minutes, seconds, milliseconds].map(Number);
+    return {
+      hours: hoursNum,
+      milliseconds: millisecondNum,
+      minutes: minuteNum,
+      seconds: secondsNum,
+    };
+  }
+
+  return { hours: 0, milliseconds: 0, minutes: 0, seconds: 0 };
+}
+
+function balanceDuration(
+  unbalanceDays: number,
+  unbalancedHours: number,
+  unbalanceMinutes: number,
+  unbalanceSeconds: number,
+  unbalanceMilliseconds: number,
+  regex: RegExp,
+): { error?: ErrorCode | undefined; warning?: ErrorCode | undefined } {
+  const { days, hours, minutes, seconds, milliseconds } = normalizeTime(
+    unbalanceDays,
+    unbalancedHours,
+    unbalanceMinutes,
+    unbalanceSeconds,
+    unbalanceMilliseconds,
+  );
+
+  const DD = days !== 0 ? `${formatNumber(days, 3)}T` : '';
+  const HH = days !== 0 ? formatNumber(hours, 2) : formatNumber(hours, 2);
+  const MM = formatNumber(minutes, 2);
+  const SS = formatNumber(seconds, 2);
+  const sss = formatNumber(milliseconds, 3);
+
+  const balancedTime = `${DD}${HH}:${MM}:${SS}.${sss}`;
+
+  if (regex.source === HMS_EPOCH_REGEX.source && days > 365) {
+    return { error: CustomErrorCodes.MaxEpochTime(balancedTime) };
+  }
+
+  if (regex.source === HMS_RELATIVE_REGEX.source && days !== 0) {
+    return { error: CustomErrorCodes.MaxRelativeTime(balancedTime) };
+  }
+
+  return { warning: CustomErrorCodes.UnbalancedTime(balancedTime) };
+}
+
+function balanceAbsolute(
+  unbalanceYears: number,
+  unbalanceDays: number,
+  unbalancedHours: number,
+  unbalanceMinutes: number,
+  unbalanceSeconds: number,
+  unbalanceMilliseconds: number,
+): { error?: ErrorCode | undefined; warning?: ErrorCode | undefined } {
+  const { years, days, hours, minutes, seconds, milliseconds } = normalizeTime(
+    unbalanceDays,
+    unbalancedHours,
+    unbalanceMinutes,
+    unbalanceSeconds,
+    unbalanceMilliseconds,
+    unbalanceYears,
+  );
+
+  const YY = years !== 0 && years !== undefined ? `${formatNumber(years, 4)}-` : '';
+  const DD = days !== 0 ? `${formatNumber(days, 3)}T` : '';
+  const HH = days !== 0 ? formatNumber(hours, 2) : formatNumber(hours, 2);
+  const MM = formatNumber(minutes, 2);
+  const SS = formatNumber(seconds, 2);
+  const sss = formatNumber(milliseconds, 3);
+
+  const balancedTime = `${YY}${DD}${HH}:${MM}:${SS}.${sss}`;
+
+  if (years && years > 9999) {
+    return { error: CustomErrorCodes.MaxAbsoluteTime(balancedTime) };
+  }
+
+  return { warning: CustomErrorCodes.UnbalancedTime(balancedTime) };
+}
+
+function normalizeTime(
+  days: number,
+  hours: number,
+  minutes: number,
+  seconds: number,
+  milliseconds: number,
+  years?: number,
+): { days: number; hours: number; milliseconds: number; minutes: number; seconds: number; years?: number } {
+  // Normalize milliseconds and seconds
+  seconds += Math.floor(milliseconds / 1000);
+  milliseconds = milliseconds % 1000;
+
+  // Normalize seconds and minutes
+  minutes += Math.floor(seconds / 60);
+  seconds = seconds % 60;
+
+  // Normalize minutes and hours
+  hours += Math.floor(minutes / 60);
+  minutes = minutes % 60;
+
+  // Normalize hours and days
+  days += Math.floor(hours / 24);
+  hours = hours % 24;
+
+  // Normalize days and years
+  if (years) {
+    const isLY = isLeapYear(years);
+    years += Math.floor(days / (isLY ? 366 : 365));
+    days = days % (isLY ? 366 : 365);
+  }
+
+  // Return the normalized values
+  return { days, hours, milliseconds, minutes, seconds, years };
+}
+
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+function formatNumber(number: number, size: number): string {
+  const isNegative = number < 0;
+  const absoluteNumber = Math.abs(number).toString();
+  const formattedNumber = absoluteNumber.padStart(size, '0');
+  return isNegative ? `-${formattedNumber}` : formattedNumber;
 }

--- a/src/workers/workerHelpers.ts
+++ b/src/workers/workerHelpers.ts
@@ -214,11 +214,17 @@ export function zip<A, B>(arr1: Array<A>, arr2: B[]): [A, B][] {
  * @param {ErrorCode} errorCode - The error code for the diagnostic.
  * @param {tsc.SourceFile} sourceFile - The source file where the error occurred.
  * @param {tsc.Node} arg - The node associated with the error.
+ * @param {tsc.DiagnosticCategory} errorCategory - The DiagnosticCategory that should be used
  * @returns {ResponseDiagnostic} A diagnostic object representing the error.
  */
-export function makeDiagnostic(errorCode: ErrorCode, sourceFile: tsc.SourceFile, arg: tsc.Node): ResponseDiagnostic {
+export function makeDiagnostic(
+  errorCode: ErrorCode,
+  sourceFile: tsc.SourceFile,
+  arg: tsc.Node,
+  errorCategory: tsc.DiagnosticCategory = tsc.DiagnosticCategory.Error,
+): ResponseDiagnostic {
   return {
-    category: tsc.DiagnosticCategory.Error,
+    category: errorCategory,
     code: errorCode.id,
     file: { fileName: sourceFile.fileName },
     length: arg.getEnd() - arg.getStart(sourceFile),


### PR DESCRIPTION
The Custom Worker now includes time-balancing validation to match the eDSL.

- The eDSL has been extended to convert unbalanced time to balanced time and throw errors upon generation if any invalid time is encountered.
- The Custom Worker now checks for unbalanced time instances (e.g., 00:00:90 -> 00:01:30) and activates a warning in the editor. The warning message provides the correct balanced time suggestion to remove the warning.
- If a time exceeds the allowed duration of 9999-365T23:59:59.999 or 365:23:59:59.999, an error is thrown.
- Leap year is taken into account


ex. 

```ts
export default () =>
  Sequence.new({
    seqId: '',
    metadata: {},
       steps: [

        A("2021-366T00:00:00").ACTIVATE(''),  // warning - suggest 2022-001T00:00:00.000
        A("2021-365T00:00:00").ACTIVATE(''),
        A("2024-366T00:00:00").ACTIVATE(''),  // Leap year

        A("9999-366T00:00:00").ACTIVATE(''),  // error - 10000-001T00:00:00.000 <= 9999-365T23:59:59.999
        
        E("00:59:60").ACTIVATE('l'),          // warning - suggest 01:00:00.000
        E("01:00:00.000").ACTIVATE('l'),

        E("365T23:59:60").ACTIVATE('l'),      // error - 366T00:00:00.000 <= 365T23:59:59.999

        R("00:00:60").ACTIVATE('l'),          // warning - suggest 00:01:00.000
        E("00:01:00.000").ACTIVATE('l'),

        R("23:59:60").ACTIVATE('l'),          // error - 001T00:00:00.000 <= 23:59:59.999

        ]     
  });

```

