### PR TITLE
Nullable owner type and tag editor fixes

### DIFF
--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -34,7 +34,7 @@
     'export default function MyExpansion(props: {\n  activityInstance: ActivityType\n}): ExpansionReturn {\n  const { activityInstance } = props;\n  return [];\n}\n';
   export let initialRuleModelId: number | null = null;
   export let initialRuleName: string = '';
-  export let initialRuleOwner: string | null = null;
+  export let initialRuleOwner: UserId = null;
   export let initialRuleTags: Tag[] = [];
   export let initialRuleUpdatedAt: string | null = null;
   export let mode: 'create' | 'edit' = 'create';
@@ -54,7 +54,7 @@
   let ruleLogic: string = initialRuleLogic;
   let ruleModelId: number | null = initialRuleModelId;
   let ruleName: string = initialRuleName;
-  let ruleOwner: string | null = initialRuleOwner;
+  let ruleOwner: UserId = initialRuleOwner;
   let ruleTags: Tag[] | null = initialRuleTags;
   let ruleUpdatedAt: string | null = initialRuleUpdatedAt;
   let saveButtonClass: 'primary' | 'secondary' = 'primary';

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -5,7 +5,7 @@
   import { base } from '$app/paths';
   import { onMount } from 'svelte';
   import { commandDictionaries, userSequenceFormColumns } from '../../stores/sequencing';
-  import type { User } from '../../types/app';
+  import type { User, UserId } from '../../types/app';
   import type { UserSequence, UserSequenceInsertInput } from '../../types/sequencing';
   import effects from '../../utilities/effects';
   import { isSaveEvent } from '../../utilities/keyboardEvents';
@@ -23,7 +23,7 @@
   export let initialSequenceDefinition: string = `export default () =>\n  Sequence.new({\n    seqId: '',\n    metadata: {},\n    steps: []\n  });\n`;
   export let initialSequenceId: number | null = null;
   export let initialSequenceName: string = '';
-  export let initialSequenceOwner: string = '';
+  export let initialSequenceOwner: UserId = '';
   export let initialSequenceUpdatedAt: string | null = null;
   export let mode: 'create' | 'edit' = 'create';
   export let user: User | null;
@@ -41,7 +41,7 @@
   let sequenceId: number | null = initialSequenceId;
   let sequenceModified: boolean = false;
   let sequenceName: string = initialSequenceName;
-  let sequenceOwner: string = initialSequenceOwner;
+  let sequenceOwner: UserId = initialSequenceOwner;
   let savedSequenceName: string = sequenceName;
   let sequenceSeqJson: string = 'Seq JSON has not been generated yet';
   let sequenceUpdatedAt: string | null = initialSequenceUpdatedAt;

--- a/src/components/ui/Chip.svelte
+++ b/src/components/ui/Chip.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import CloseIcon from '@nasa-jpl/stellar/icons/close.svg?component';
   import { createEventDispatcher } from 'svelte';
-  import { pickTextColorBasedOnBgColor, shadeColor } from '../../utilities/color';
+  import { isValidHex, pickTextColorBasedOnBgColor, shadeColor } from '../../utilities/color';
   import { classNames } from '../../utilities/generic';
 
-  export let color: string = '#f8f8f8';
+  export let color: string | null | undefined = '#f8f8f8';
   export let disabled: boolean = false;
   export let label: string = '';
   export let className: string = '';
@@ -23,20 +23,21 @@
   });
 
   $: {
-    const mode = pickTextColorBasedOnBgColor(color);
+    let finalColor = typeof color === 'string' && isValidHex(color) ? color : '#f8f8f8';
+    const mode = pickTextColorBasedOnBgColor(finalColor);
     let textColor = '';
     let removeColor = '';
     let removeBgColor = '';
     if (mode === 'dark') {
-      textColor = shadeColor(color, 5);
-      removeColor = shadeColor(color || '', 5.5);
-      removeBgColor = shadeColor(color, 1.1);
+      textColor = shadeColor(finalColor, 5);
+      removeColor = shadeColor(finalColor || '', 5.5);
+      removeBgColor = shadeColor(finalColor, 1.1);
     } else {
       textColor = 'rgb(255,255,255)';
       removeColor = 'rgba(255,255,255, 0.9)';
-      removeBgColor = shadeColor(color, 0.7);
+      removeBgColor = shadeColor(finalColor, 0.7);
     }
-    chipStyle = `background:${color};color:${textColor}`;
+    chipStyle = `background:${finalColor};color:${textColor}`;
     removeStyle = `background:${removeBgColor};color:${removeColor}`;
   }
 </script>

--- a/src/routes/tags/+page.svelte
+++ b/src/routes/tags/+page.svelte
@@ -246,7 +246,10 @@
       if (constraintTagDeletionSuccess && expansionRuleTagDeletionSuccess && tagDeletionSuccess) {
         tags = tags.filter(t => t.id !== tag.id);
       }
-      exitEditing(false);
+      // Stop editing if the selected tag is the one being deleted
+      if (selectedTag?.id === tag.id) {
+        exitEditing(false);
+      }
     }
   }
 

--- a/src/routes/tags/+page.svelte
+++ b/src/routes/tags/+page.svelte
@@ -163,7 +163,7 @@
     const filterTextLowerCase = filterText.toLowerCase();
     const includesId = `${tag.id}`.includes(filterTextLowerCase);
     const includesName = tag.name.toLocaleLowerCase().includes(filterTextLowerCase);
-    const includesOwner = (tag.owner || '').toLocaleLowerCase().includes(filterTextLowerCase);
+    const includesOwner = (tag.owner ?? '').toLocaleLowerCase().includes(filterTextLowerCase);
     return includesId || includesName || includesOwner;
   });
 
@@ -281,7 +281,7 @@
   function showTag(tag: Tag) {
     selectedTag = tag;
     nameField.validateAndSet(tag.name);
-    colorField.validateAndSet(tag.color || '');
+    colorField.validateAndSet(tag.color ?? '');
   }
 </script>
 

--- a/src/routes/tags/+page.svelte
+++ b/src/routes/tags/+page.svelte
@@ -246,6 +246,7 @@
       if (constraintTagDeletionSuccess && expansionRuleTagDeletionSuccess && tagDeletionSuccess) {
         tags = tags.filter(t => t.id !== tag.id);
       }
+      exitEditing(false);
     }
   }
 
@@ -257,11 +258,11 @@
     }
   }
 
-  function exitEditing() {
+  function exitEditing(deselect: boolean = true) {
     resetTagFields();
     $createTagError = null;
     selectedTag = null;
-    if (dataGrid) {
+    if (deselect && dataGrid) {
       dataGrid.selectedItemId = null;
     }
   }
@@ -402,7 +403,12 @@
               </button>
             {:else}
               <div class="tags-save-buttons">
-                <button on:click={exitEditing} disabled={updatingTag} class="st-button secondary w-100" type="button">
+                <button
+                  on:click={() => exitEditing()}
+                  disabled={updatingTag}
+                  class="st-button secondary w-100"
+                  type="button"
+                >
                   Cancel
                 </button>
                 <button

--- a/src/routes/tags/+page.svelte
+++ b/src/routes/tags/+page.svelte
@@ -163,7 +163,7 @@
     const filterTextLowerCase = filterText.toLowerCase();
     const includesId = `${tag.id}`.includes(filterTextLowerCase);
     const includesName = tag.name.toLocaleLowerCase().includes(filterTextLowerCase);
-    const includesOwner = tag.owner.toLocaleLowerCase().includes(filterTextLowerCase);
+    const includesOwner = (tag.owner || '').toLocaleLowerCase().includes(filterTextLowerCase);
     return includesId || includesName || includesOwner;
   });
 
@@ -277,7 +277,7 @@
   function showTag(tag: Tag) {
     selectedTag = tag;
     nameField.validateAndSet(tag.name);
-    colorField.validateAndSet(tag.color);
+    colorField.validateAndSet(tag.color || '');
   }
 </script>
 

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -1,6 +1,6 @@
 import type { PermissibleQueriesMap } from './permissions';
 
-export type UserId = string;
+export type UserId = string | null;
 
 export type BaseUser = {
   id: UserId;

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -13,7 +13,7 @@ export type Constraint = {
   plan_id: number | null;
   tags: { tag: Tag }[];
   updated_at: string;
-  updated_by: string;
+  updated_by: UserId;
 };
 
 export type ConstraintInsertInput = Omit<

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -1,3 +1,4 @@
+import type { UserId } from './app';
 import type { Tag } from './tags';
 import type { TimeRange } from './timeline';
 
@@ -8,7 +9,7 @@ export type Constraint = {
   id: number;
   model_id: number | null;
   name: string;
-  owner: string;
+  owner: UserId;
   plan_id: number | null;
   tags: { tag: Tag }[];
   updated_at: string;

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -15,7 +15,7 @@ export type ExpansionRule = {
   owner: UserId;
   tags: { tag: Tag }[];
   updated_at: string;
-  updated_by: string;
+  updated_by: UserId;
 };
 
 export type ExpansionRuleSlim = Omit<ExpansionRule, 'tags'> & { tags: { tag_id: number }[] };
@@ -50,7 +50,7 @@ export type ExpansionSet = {
   name: string;
   owner: UserId;
   updated_at: string;
-  updated_by: string;
+  updated_by: UserId;
 };
 
 export type SeqId = Pick<ExpansionSequence, 'seq_id'>;

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -1,3 +1,4 @@
+import type { UserId } from './app';
 import type { SeqJson } from './sequencing';
 import type { SpanId } from './simulation';
 import type { Tag } from './tags';
@@ -11,7 +12,7 @@ export type ExpansionRule = {
   expansion_logic: string;
   id: number;
   name: string;
-  owner: string;
+  owner: UserId;
   tags: { tag: Tag }[];
   updated_at: string;
   updated_by: string;
@@ -47,7 +48,7 @@ export type ExpansionSet = {
   id: number;
   mission_model_id: number;
   name: string;
-  owner: string;
+  owner: UserId;
   updated_at: string;
   updated_by: string;
 };

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -1,3 +1,4 @@
+import type { UserId } from './app';
 import type { ParametersMap } from './parameter';
 
 export type Model = ModelSchema;
@@ -11,7 +12,7 @@ export type ModelSchema = {
   jar_id: number;
   mission: string;
   name: string;
-  owner: string;
+  owner: UserId;
   parameters: { parameters: ParametersMap };
   plans: { id: number }[];
   version: string;

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -93,7 +93,7 @@ export type PlanSchema = {
   start_time: string;
   tags: { tag: Tag }[];
   updated_at: string;
-  updated_by: string;
+  updated_by: UserId;
 };
 
 export type PlanSlim = Pick<

--- a/src/types/sequencing.ts
+++ b/src/types/sequencing.ts
@@ -1,3 +1,5 @@
+import type { UserId } from './app';
+
 export type CommandDictionary = {
   command_types_typescript_path: string;
   created_at: string;
@@ -29,7 +31,7 @@ export type UserSequence = {
   definition: string;
   id: number;
   name: string;
-  owner: string;
+  owner: UserId;
   updated_at: string;
 };
 

--- a/src/types/tags.ts
+++ b/src/types/tags.ts
@@ -25,11 +25,11 @@ export type PlanTagsInsertInput = {
 };
 
 export type Tag = {
-  color: string;
+  color: string | null;
   created_at: string;
   id: number;
   name: string;
-  owner: string;
+  owner: string | null;
 };
 
 export type TagsMap = Record<Tag['id'], Tag>;

--- a/src/types/tags.ts
+++ b/src/types/tags.ts
@@ -1,3 +1,5 @@
+import type { UserId } from './app';
+
 export type ActivityDirectiveTagsInsertInput = {
   directive_id: number;
   plan_id: number;
@@ -29,7 +31,7 @@ export type Tag = {
   created_at: string;
   id: number;
   name: string;
-  owner: string | null;
+  owner: UserId;
 };
 
 export type TagsMap = Record<Tag['id'], Tag>;

--- a/src/types/view.ts
+++ b/src/types/view.ts
@@ -1,4 +1,5 @@
 import type { ColDef, ColumnState } from 'ag-grid-community';
+import type { UserId } from './app';
 import type { Timeline } from './timeline';
 
 export type ViewTable = {
@@ -85,6 +86,6 @@ export type View = {
   definition: ViewDefinition;
   id: number;
   name: string;
-  owner: string;
+  owner: UserId;
   updated_at: string;
 };


### PR DESCRIPTION
- Closes #827 
- Changes `UserId` type from `string` to `string | null`
- Updates `user`, `owner`, and `updated_by` to always use `UserId` type.
- Updates Tag type and components to reflect nullable owner and color db fields.