### PR TITLE
Expansion Editor: Fix the custom worker not starting up correctly

### DIFF
--- a/src/components/expansion/ExpansionLogicEditor.svelte
+++ b/src/components/expansion/ExpansionLogicEditor.svelte
@@ -34,13 +34,18 @@
     .getParsedAmpcsCommandDictionary(ruleDictionaryId, user)
     .then(parsedDictionary => (commandDictionaryJson = parsedDictionary));
 
-  $: if (monaco !== undefined && (commandDictionaryTsFiles !== undefined || activityTypeTsFiles !== undefined)) {
+  $: if (monaco !== undefined) {
     const { languages } = monaco;
     const { typescript } = languages;
     const { typescriptDefaults } = typescript;
     const options = typescriptDefaults.getCompilerOptions();
-
     typescriptDefaults.setCompilerOptions({ ...options, lib: ['esnext'], strictNullChecks: true });
+  }
+
+  $: if (monaco && commandDictionaryTsFiles && activityTypeTsFiles) {
+    const { languages } = monaco;
+    const { typescript } = languages;
+    const { typescriptDefaults } = typescript;
     typescriptDefaults.setExtraLibs([...commandDictionaryTsFiles, ...activityTypeTsFiles]);
   }
 


### PR DESCRIPTION
Closes [#812 ](https://github.com/NASA-AMMOS/aerie-ui/issues/823)
We should only invoke the custom work once as it will stomp on itself when trying to save the model information in the worker. This resulted in a null when trying to fetch the command dictionary to do the checks and not work.


It fully works now :)