### PR TITLE
Remove showName field from param

### DIFF
--- a/src/components/activity/ActivitySpanForm.svelte
+++ b/src/components/activity/ActivitySpanForm.svelte
@@ -191,13 +191,7 @@
       {#if !hasComputedAttributes}
         <div class="st-typography-label">No Computed Attributes Found</div>
       {:else}
-        <Parameters
-          disabled
-          expanded
-          formParameters={formParametersComputedAttributes}
-          levelPadding={0}
-          showName={false}
-        />
+        <Parameters disabled expanded formParameters={formParametersComputedAttributes} />
       {/if}
     </Collapse>
   </fieldset>

--- a/src/components/parameters/ParameterRec.svelte
+++ b/src/components/parameters/ParameterRec.svelte
@@ -12,7 +12,6 @@
   export let level: number = 0;
   export let levelPadding: number = 20;
   export let parameterType: ParameterType = 'activity';
-  export let showName: boolean = true;
   export let use: ActionArray = [];
 
   let component: any;
@@ -38,7 +37,6 @@
   {level}
   {levelPadding}
   {parameterType}
-  {showName}
   {use}
   on:change
   on:reset

--- a/src/components/parameters/ParameterRecSeries.svelte
+++ b/src/components/parameters/ParameterRecSeries.svelte
@@ -24,7 +24,6 @@
   export let level: number = 0;
   export let levelPadding: number = 20;
   export let parameterType: ParameterType = 'activity';
-  export let showName: boolean = true;
   export let use: ActionArray = [];
 
   const dispatch = createEventDispatcher();
@@ -78,80 +77,76 @@
   }
 </script>
 
-{#if showName}
-  <div class="parameter-rec-series">
-    <Collapse defaultExpanded={expanded}>
-      <div slot="left">
-        <ParameterName {formParameter} />
-      </div>
-      <div class="series-right" slot="right">
-        <CssGrid gap="3px" columns="auto auto auto" class="parameter-rec-series-css-grid">
-          <button
-            class="st-button icon"
-            disabled={subFormParameters?.length === 0 || disabled}
-            on:click|stopPropagation={valueRemove}
-            use:tooltip={{ content: 'Remove Value', placement: 'left' }}
-          >
-            <DashIcon />
-          </button>
-          <button
-            {disabled}
-            class="st-button icon"
-            on:click|stopPropagation={valueAdd}
-            use:tooltip={{ content: 'Add Value', placement: 'left' }}
-          >
-            <PlusIcon />
-          </button>
-          <ParameterBaseRightAdornments
-            hidden={hideRightAdornments}
-            {formParameter}
-            {parameterType}
-            {use}
-            on:reset={onResetSeries}
-          />
-        </CssGrid>
-      </div>
-      <ul style="padding-inline-start: {levelPadding}px">
-        {#if subFormParameters?.length}
-          {#each subFormParameters as subFormParameter (subFormParameter.name)}
-            <li>
-              {#if subFormParameter.schema.type === 'series' || subFormParameter.schema.type === 'struct'}
-                <ParameterRec
-                  {disabled}
-                  hideRightAdornments
-                  expanded
-                  formParameter={subFormParameter}
-                  {labelColumnWidth}
-                  level={++level}
-                  {levelPadding}
-                  {parameterType}
-                  {use}
-                  on:change={onChange}
-                />
-              {:else}
-                <ParameterBase
-                  {disabled}
-                  formParameter={subFormParameter}
-                  hideRightAdornments
-                  {labelColumnWidth}
-                  level={++level}
-                  {levelPadding}
-                  {parameterType}
-                  {use}
-                  on:change={onChange}
-                />
-              {/if}
-            </li>
-          {/each}
-        {:else}
-          <div class="p-1">This series has no values</div>
-        {/if}
-      </ul>
-    </Collapse>
-  </div>
-{:else}
-  <div class="parameter-rec-series" />
-{/if}
+<div class="parameter-rec-series">
+  <Collapse defaultExpanded={expanded}>
+    <div slot="left">
+      <ParameterName {formParameter} />
+    </div>
+    <div class="series-right" slot="right">
+      <CssGrid gap="3px" columns="auto auto auto" class="parameter-rec-series-css-grid">
+        <button
+          class="st-button icon"
+          disabled={subFormParameters?.length === 0 || disabled}
+          on:click|stopPropagation={valueRemove}
+          use:tooltip={{ content: 'Remove Value', placement: 'left' }}
+        >
+          <DashIcon />
+        </button>
+        <button
+          {disabled}
+          class="st-button icon"
+          on:click|stopPropagation={valueAdd}
+          use:tooltip={{ content: 'Add Value', placement: 'left' }}
+        >
+          <PlusIcon />
+        </button>
+        <ParameterBaseRightAdornments
+          hidden={hideRightAdornments}
+          {formParameter}
+          {parameterType}
+          {use}
+          on:reset={onResetSeries}
+        />
+      </CssGrid>
+    </div>
+    <ul style="padding-inline-start: {levelPadding}px">
+      {#if subFormParameters?.length}
+        {#each subFormParameters as subFormParameter (subFormParameter.name)}
+          <li>
+            {#if subFormParameter.schema.type === 'series' || subFormParameter.schema.type === 'struct'}
+              <ParameterRec
+                {disabled}
+                hideRightAdornments
+                expanded
+                formParameter={subFormParameter}
+                {labelColumnWidth}
+                level={++level}
+                {levelPadding}
+                {parameterType}
+                {use}
+                on:change={onChange}
+              />
+            {:else}
+              <ParameterBase
+                {disabled}
+                formParameter={subFormParameter}
+                hideRightAdornments
+                {labelColumnWidth}
+                level={++level}
+                {levelPadding}
+                {parameterType}
+                {use}
+                on:change={onChange}
+              />
+            {/if}
+          </li>
+        {/each}
+      {:else}
+        <div class="p-1">This series has no values</div>
+      {/if}
+    </ul>
+  </Collapse>
+</div>
 
 <style>
   ul {

--- a/src/components/parameters/ParameterRecStruct.svelte
+++ b/src/components/parameters/ParameterRecStruct.svelte
@@ -19,7 +19,6 @@
   export let level: number = 0;
   export let levelPadding: number = 20;
   export let parameterType: ParameterType = 'activity';
-  export let showName: boolean = true;
   export let use: ActionArray = [];
 
   const dispatch = createEventDispatcher();
@@ -62,57 +61,53 @@
   }
 </script>
 
-{#if showName}
-  <div class="parameter-rec-struct">
-    <Collapse defaultExpanded={expanded}>
-      <div slot="left">
-        <ParameterName {formParameter} />
-      </div>
-      <div class="right" slot="right">
-        <ParameterBaseRightAdornments
-          hidden={hideRightAdornments}
-          {formParameter}
-          {parameterType}
-          {use}
-          on:reset={onResetStruct}
-        />
-      </div>
-      <ul style="padding-inline-start: {levelPadding}px">
-        {#each subFormParameters as subFormParameter (subFormParameter.name)}
-          <li>
-            {#if subFormParameter.schema.type === 'series' || subFormParameter.schema.type === 'struct'}
-              <ParameterRec
-                {disabled}
-                {hideRightAdornments}
-                formParameter={subFormParameter}
-                {labelColumnWidth}
-                level={++level}
-                {levelPadding}
-                {parameterType}
-                {use}
-                on:change={onChange}
-              />
-            {:else}
-              <ParameterBase
-                {disabled}
-                {hideRightAdornments}
-                formParameter={subFormParameter}
-                {labelColumnWidth}
-                level={++level}
-                {levelPadding}
-                {parameterType}
-                {use}
-                on:change={onChange}
-              />
-            {/if}
-          </li>
-        {/each}
-      </ul>
-    </Collapse>
-  </div>
-{:else}
-  <div class="parameter-rec-struct p-0" />
-{/if}
+<div class="parameter-rec-struct">
+  <Collapse defaultExpanded={expanded}>
+    <div slot="left">
+      <ParameterName {formParameter} />
+    </div>
+    <div class="right" slot="right">
+      <ParameterBaseRightAdornments
+        hidden={hideRightAdornments}
+        {formParameter}
+        {parameterType}
+        {use}
+        on:reset={onResetStruct}
+      />
+    </div>
+    <ul style="padding-inline-start: {levelPadding}px">
+      {#each subFormParameters as subFormParameter (subFormParameter.name)}
+        <li>
+          {#if subFormParameter.schema.type === 'series' || subFormParameter.schema.type === 'struct'}
+            <ParameterRec
+              {disabled}
+              {hideRightAdornments}
+              formParameter={subFormParameter}
+              {labelColumnWidth}
+              level={++level}
+              {levelPadding}
+              {parameterType}
+              {use}
+              on:change={onChange}
+            />
+          {:else}
+            <ParameterBase
+              {disabled}
+              {hideRightAdornments}
+              formParameter={subFormParameter}
+              {labelColumnWidth}
+              level={++level}
+              {levelPadding}
+              {parameterType}
+              {use}
+              on:change={onChange}
+            />
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  </Collapse>
+</div>
 
 <style>
   ul {

--- a/src/components/parameters/Parameters.svelte
+++ b/src/components/parameters/Parameters.svelte
@@ -15,7 +15,6 @@
   export let highlightKeysMap: Record<string, boolean> = {};
   export let levelPadding: number = 20;
   export let parameterType: ParameterType = 'activity';
-  export let showName: boolean = true;
   export let use: ActionArray = [];
 
   let clientWidth: number;
@@ -38,7 +37,6 @@
           {level}
           {levelPadding}
           {parameterType}
-          {showName}
           on:change
           on:reset
           {use}


### PR DESCRIPTION
- It caused issues with rendering computed attributes
- Removing the field for now since it's not actually needed
- Caveat, this will show 'Value' as the name for all computed attribute types (including structs). But this is necessary given we get to reuse the `Parameter` component for computed attributes.
- In the future we can refactor to see about removing the 'Value' name for computed attributes, but it will require more work.