### PR TITLE
Fix add new series parameter value

### DIFF
--- a/src/components/parameters/ParameterRecSeries.svelte
+++ b/src/components/parameters/ParameterRecSeries.svelte
@@ -6,7 +6,7 @@
   import { createEventDispatcher } from 'svelte';
   import type { FormParameter, ParameterType } from '../../types/parameter';
   import type { ValueSchemaSeries } from '../../types/schema';
-  import { getArgument } from '../../utilities/parameters';
+  import { getArgument, getValueSchemaDefaultValue } from '../../utilities/parameters';
   import { tooltip } from '../../utilities/tooltip';
   import type { ActionArray } from '../../utilities/useActions';
   import Collapse from '../Collapse.svelte';
@@ -32,7 +32,8 @@
 
   function getSubFormParameters(formParameter: FormParameter<ValueSchemaSeries>): FormParameter[] {
     const subFormParameters = [];
-    const { schema, value = [] } = formParameter;
+    const { schema } = formParameter;
+    const value = formParameter.value ?? [];
 
     for (let i = 0; i < value.length; ++i) {
       const subFormParameter: FormParameter = {
@@ -65,8 +66,8 @@
 
   function valueAdd() {
     const { schema } = formParameter;
-    const { value: newValue } = getArgument(null, schema.items);
-    const value = [...formParameter.value, newValue];
+    const newValue = getValueSchemaDefaultValue(schema.items);
+    const value = [...(formParameter?.value ?? []), newValue];
     dispatch('change', { ...formParameter, value });
   }
 

--- a/src/utilities/parameters.test.ts
+++ b/src/utilities/parameters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { getArgument } from './parameters';
+import { getArgument, getValueSchemaDefaultValue } from './parameters';
 
 describe('getArgument', () => {
   test('Should return the preset value', () => {
@@ -91,5 +91,52 @@ describe('getArgument', () => {
       value: null,
       valueSource: 'none',
     });
+  });
+});
+
+describe('getValueSchemaDefaultValue', () => {
+  test('boolean', () => {
+    const defaultBooleanValue = getValueSchemaDefaultValue({ type: 'boolean' });
+    expect(defaultBooleanValue).toEqual(false);
+  });
+
+  test('duration', () => {
+    const defaultDurationValue = getValueSchemaDefaultValue({ type: 'duration' });
+    expect(defaultDurationValue).toEqual(0);
+  });
+
+  test('int', () => {
+    const defaultIntValue = getValueSchemaDefaultValue({ type: 'int' });
+    expect(defaultIntValue).toEqual(0);
+  });
+
+  test('path', () => {
+    const defaultPathValue = getValueSchemaDefaultValue({ type: 'path' });
+    expect(defaultPathValue).toEqual('');
+  });
+
+  test('real', () => {
+    const defaultRealValue = getValueSchemaDefaultValue({ type: 'real' });
+    expect(defaultRealValue).toEqual(0);
+  });
+
+  test('series', () => {
+    const defaultSeriesValue = getValueSchemaDefaultValue({ items: { type: 'int' }, type: 'series' });
+    expect(defaultSeriesValue).toEqual([0]);
+  });
+
+  test('struct', () => {
+    const defaultStructValue = getValueSchemaDefaultValue({ items: { foo: { type: 'string' } }, type: 'struct' });
+    expect(defaultStructValue).toEqual({ foo: '' });
+  });
+
+  test('string', () => {
+    const defaultStringValue = getValueSchemaDefaultValue({ type: 'string' });
+    expect(defaultStringValue).toEqual('');
+  });
+
+  test('variant', () => {
+    const defaultVariantValue = getValueSchemaDefaultValue({ type: 'variant', variants: [{ key: 'A', label: 'A' }] });
+    expect(defaultVariantValue).toEqual('A');
   });
 });

--- a/src/utilities/parameters.ts
+++ b/src/utilities/parameters.ts
@@ -86,3 +86,36 @@ export function getFormParameters(
 
   return formParameters;
 }
+
+/**
+ * Returns a default value for a given value schema.
+ */
+export function getValueSchemaDefaultValue(schema: ValueSchema): any {
+  if (schema.type === 'boolean') {
+    return false;
+  } else if (schema.type === 'duration') {
+    return 0;
+  } else if (schema.type === 'int') {
+    return 0;
+  } else if (schema.type === 'path') {
+    return '';
+  } else if (schema.type === 'real') {
+    return 0;
+  } else if (schema.type === 'series') {
+    const seriesValue = getValueSchemaDefaultValue(schema.items);
+    return [seriesValue];
+  } else if (schema.type === 'struct') {
+    const struct = Object.entries(schema.items).reduce((struct, [key, subSchema]) => {
+      const value = getValueSchemaDefaultValue(subSchema);
+      return { ...struct, [key]: value };
+    }, {});
+    return struct;
+  } else if (schema.type === 'string') {
+    return '';
+  } else if (schema.type === 'variant') {
+    const variant = schema.variants.length ? schema.variants[0].key : '';
+    return variant;
+  } else {
+    throw new Error('Cannot get a default value for given value schema');
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/NASA-AMMOS/aerie-ui/issues/617
Fixes https://github.com/NASA-AMMOS/aerie-ui/issues/662

- There was a `null` getting in the new value, which was causing the backend to fail
- Adds a new function to get a sane default value for a given value schema
- Improved `null` protection in the series parameter component
- Adds unit tests for new function

To test:
- See #617 and make sure the issue is fixed