### PR TITLE
Fix how `user` cookie is fetched in `getTokenFromUserCookie`

### DIFF
--- a/src/stores/subscribable.ts
+++ b/src/stores/subscribable.ts
@@ -87,11 +87,12 @@ export function gqlSubscribable<T>(
    */
   function getTokenFromUserCookie(): string {
     if (browser && document?.cookie) {
-      const userCookie = document.cookie.split('user=')[1];
-
+      const cookies = document.cookie.split(/\s*;\s*/);
+      const userCookie = cookies.find(entry => entry.startsWith('user='));
       if (userCookie) {
         try {
-          const decodedUserCookie = atob(userCookie);
+          const splitCookie = userCookie.split('user=')[1];
+          const decodedUserCookie = atob(splitCookie);
           const parsedUserCookie: BaseUser = JSON.parse(decodedUserCookie);
           return parsedUserCookie.token;
         } catch (e) {


### PR DESCRIPTION
Prior, `getTokenFromUserCookie` would grab the entire `document.cookies` string and split it on `user=`, meaning that if there were more cookies after the user cookie, they would get included as part of `userCookie`, which would cause decoding it to fail. 

Now, it splits `document.cookies` into an array of all cookies and specifically grabs the `user` cookie. This not only ensures that we _only_ grab the `user` cookie, it prevents us from accidentally grabbing a different cookie that ends with `user`, ie `foo_user`.