### PR TITLE
Update Constraint Violations to Use New Schema

### DIFF
--- a/src/components/constraints/ConstraintListItem.svelte
+++ b/src/components/constraints/ConstraintListItem.svelte
@@ -8,7 +8,7 @@
   import VisibleShowIcon from '@nasa-jpl/stellar/icons/visible_show.svg?component';
   import { createEventDispatcher } from 'svelte';
   import type { User } from '../../types/app';
-  import type { Constraint, ConstraintViolation } from '../../types/constraint';
+  import type { Constraint, ConstraintResult } from '../../types/constraint';
   import effects from '../../utilities/effects';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { tooltip } from '../../utilities/tooltip';
@@ -21,20 +21,20 @@
   export let hasDeletePermission: boolean = false;
   export let hasEditPermission: boolean = false;
   export let totalViolationCount: number = 0;
-  export let violation: ConstraintViolation;
+  export let constraintResult: ConstraintResult;
   export let visible: boolean = true;
   export let user: User | null;
 
   const dispatch = createEventDispatcher();
 
-  $: violationCount = violation?.windows?.length;
+  $: violationCount = constraintResult?.violations?.length;
 </script>
 
 <div class="constraint-list-item">
   <Collapse title={constraint.name} tooltipContent={constraint.name} defaultExpanded={false}>
     <svelte:fragment slot="right">
       <div class="right-content">
-        {#if violation}
+        {#if violationCount}
           <div
             class="st-badge violation-badge"
             use:tooltip={{ content: `${violationCount} Violation${violationCount !== 1 ? 's' : ''}`, placement: 'top' }}
@@ -75,10 +75,12 @@
     </Collapse>
 
     <Collapse title="Violations" defaultExpanded={false}>
-      {#if violation}
+      {#if constraintResult?.violations?.length}
         <div class="violations">
-          {#each violation.windows as window}
-            <ConstraintViolationButton {window} />
+          {#each constraintResult.violations as violation}
+            {#each violation.windows as window}
+              <ConstraintViolationButton {window} />
+            {/each}
           {/each}
         </div>
       {:else}

--- a/src/components/timeline/ConstraintViolations.svelte
+++ b/src/components/timeline/ConstraintViolations.svelte
@@ -4,10 +4,10 @@
   import type { ScaleTime } from 'd3-scale';
   import { select } from 'd3-selection';
   import { createEventDispatcher, onMount } from 'svelte';
-  import type { ConstraintViolation } from '../../types/constraint';
+  import type { ConstraintResult } from '../../types/constraint';
   import type { TimeRange } from '../../types/timeline';
 
-  export let constraintViolations: ConstraintViolation[] = [];
+  export let constraintResults: ConstraintResult[] = [];
   export let drawHeight: number = 0;
   export let drawWidth: number = 0;
   export let mousemove: MouseEvent | undefined;
@@ -20,7 +20,7 @@
   let g: SVGGElement;
   let mounted = false;
 
-  $: if (constraintViolations && drawWidth && drawHeight && mounted && viewTimeRange && xScaleView) {
+  $: if (constraintResults && drawWidth && drawHeight && mounted && viewTimeRange && xScaleView) {
     draw();
   }
   $: onMousemove(mousemove);
@@ -50,28 +50,30 @@
     const constraintViolationClass = 'constraint-violation';
     gSelection.selectAll(`.${constraintViolationClass}`).remove();
 
-    for (const constraintViolation of constraintViolations || []) {
-      const { windows } = constraintViolation;
-      const filteredWindows = windows.filter(({ start, end }) => {
-        if (viewTimeRange) {
-          return start <= viewTimeRange.end && end >= viewTimeRange.start;
-        }
-        return false;
-      });
+    for (const constraintResult of constraintResults || []) {
+      for (const constraintViolation of constraintResult.violations || []) {
+        const { windows } = constraintViolation;
+        const filteredWindows = windows.filter(({ start, end }) => {
+          if (viewTimeRange) {
+            return start <= viewTimeRange.end && end >= viewTimeRange.start;
+          }
+          return false;
+        });
 
-      if (filteredWindows.length) {
-        const group = gSelection.append('g').attr('class', constraintViolationClass);
+        if (filteredWindows.length) {
+          const group = gSelection.append('g').attr('class', constraintViolationClass);
 
-        for (const window of filteredWindows) {
-          const { start, width } = clampWindow(window);
-          group
-            .append('rect')
-            .attr('fill', '#B00020')
-            .attr('fill-opacity', 0.15)
-            .attr('height', drawHeight)
-            .attr('width', width)
-            .attr('x', start)
-            .attr('y', 0);
+          for (const window of filteredWindows) {
+            const { start, width } = clampWindow(window);
+            group
+              .append('rect')
+              .attr('fill', '#B00020')
+              .attr('fill-opacity', 0.15)
+              .attr('height', drawHeight)
+              .attr('width', width)
+              .attr('x', start)
+              .attr('y', 0);
+          }
         }
       }
     }
@@ -82,20 +84,22 @@
       const { offsetX } = e;
       const violations = [];
 
-      for (const constraintViolation of constraintViolations || []) {
-        const { windows } = constraintViolation;
-        let count = 0;
+      for (const constraintResult of constraintResults || []) {
+        for (const constraintViolation of constraintResult.violations || []) {
+          const { windows } = constraintViolation;
+          let count = 0;
 
-        for (const window of windows) {
-          const { start, width } = clampWindow(window);
-          const end = start + width;
-          if (start <= offsetX && offsetX <= end) {
-            ++count;
+          for (const window of windows) {
+            const { start, width } = clampWindow(window);
+            const end = start + width;
+            if (start <= offsetX && offsetX <= end) {
+              ++count;
+            }
           }
-        }
 
-        if (count > 0) {
-          violations.push(constraintViolation);
+          if (count > 0) {
+            violations.push(constraintResult);
+          }
         }
       }
 

--- a/src/components/timeline/ConstraintViolations.svelte
+++ b/src/components/timeline/ConstraintViolations.svelte
@@ -82,7 +82,7 @@
   function onMousemove(e: MouseEvent | undefined): void {
     if (e) {
       const { offsetX } = e;
-      const violations = [];
+      const constraintResultsWithViolations: ConstraintResult[] = [];
 
       for (const constraintResult of constraintResults || []) {
         for (const constraintViolation of constraintResult.violations || []) {
@@ -98,18 +98,18 @@
           }
 
           if (count > 0) {
-            violations.push(constraintResult);
+            constraintResultsWithViolations.push(constraintResult);
           }
         }
       }
 
-      dispatch('mouseOver', { constraintViolations: violations, e });
+      dispatch('mouseOver', { constraintResults: constraintResultsWithViolations, e });
     }
   }
 
   function onMouseout(e: MouseEvent | undefined): void {
     if (e) {
-      dispatch('mouseOver', { constraintViolations: [], e });
+      dispatch('mouseOver', { constraintResults: [], e });
     }
   }
 </script>

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -14,7 +14,7 @@
     ActivityDirectivesMap,
   } from '../../types/activity';
   import type { User } from '../../types/app';
-  import type { ConstraintViolation } from '../../types/constraint';
+  import type { ConstraintResult } from '../../types/constraint';
   import type { Resource, SimulationDataset, Span, SpanId, SpanUtilityMaps, SpansMap } from '../../types/simulation';
   import type {
     Axis,
@@ -46,7 +46,7 @@
   export let activityDirectivesByView: ActivityDirectivesByView = { byLayerId: {}, byTimelineId: {} };
   export let activityDirectivesMap: ActivityDirectivesMap = {};
   export let autoAdjustHeight: boolean = false;
-  export let constraintViolations: ConstraintViolation[] = [];
+  export let constraintResults: ConstraintResult[] = [];
   export let dpr: number = 0;
   export let drawHeight: number = 0;
   export let drawWidth: number = 0;
@@ -93,7 +93,7 @@
   let mouseDownActivityDirectivesByLayer: Record<number, ActivityDirective[]> = {};
   let mouseDownSpansByLayer: Record<number, Span[]> = {};
   let mouseOverActivityDirectivesByLayer: Record<number, ActivityDirective[]> = {};
-  let mouseOverConstraintViolations: ConstraintViolation[] = []; // For this row.
+  let mouseOverConstraintViolations: ConstraintResult[] = []; // For this row.
   let mouseOverPointsByLayer: Record<number, Point[]> = {};
   let mouseOverSpansByLayer: Record<number, Span[]> = {};
   let mouseOverGapsByLayer: Record<number, Point[]> = {};
@@ -267,7 +267,7 @@
         {#if drawWidth > 0}
           <RowXAxisTicks {drawHeight} {xScaleView} {xTicksView} />
           <ConstraintViolations
-            {constraintViolations}
+            {constraintResults}
             {drawHeight}
             {drawWidth}
             {mousemove}

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -93,7 +93,7 @@
   let mouseDownActivityDirectivesByLayer: Record<number, ActivityDirective[]> = {};
   let mouseDownSpansByLayer: Record<number, Span[]> = {};
   let mouseOverActivityDirectivesByLayer: Record<number, ActivityDirective[]> = {};
-  let mouseOverConstraintViolations: ConstraintResult[] = []; // For this row.
+  let mouseOverConstraintResults: ConstraintResult[] = []; // For this row.
   let mouseOverPointsByLayer: Record<number, Point[]> = {};
   let mouseOverSpansByLayer: Record<number, Span[]> = {};
   let mouseOverGapsByLayer: Record<number, Point[]> = {};
@@ -175,18 +175,18 @@
     const { layerId } = detail;
 
     mouseOverActivityDirectivesByLayer[layerId] = detail?.activityDirectives ?? [];
-    mouseOverConstraintViolations = detail?.constraintViolations ?? mouseOverConstraintViolations;
+    mouseOverConstraintResults = detail?.constraintResults ?? mouseOverConstraintResults;
     mouseOverPointsByLayer[layerId] = detail?.points ?? [];
     mouseOverSpansByLayer[layerId] = detail?.spans ?? [];
     mouseOverGapsByLayer[layerId] = detail?.gaps ?? mouseOverGapsByLayer[layerId] ?? [];
 
     const activityDirectives = Object.values(mouseOverActivityDirectivesByLayer).flat();
-    const constraintViolations = mouseOverConstraintViolations;
+    const constraintResults = mouseOverConstraintResults;
     const points = Object.values(mouseOverPointsByLayer).flat();
     const spans = Object.values(mouseOverSpansByLayer).flat();
     const gaps = Object.values(mouseOverGapsByLayer).flat();
 
-    dispatch('mouseOver', { ...detail, activityDirectives, constraintViolations, gaps, points, spans });
+    dispatch('mouseOver', { ...detail, activityDirectives, constraintResults, gaps, points, spans });
   }
 
   function onUpdateRowHeightDrag(event: CustomEvent<{ newHeight: number }>) {

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -5,7 +5,7 @@
   import { SOURCES, TRIGGERS, dndzone } from 'svelte-dnd-action';
   import type { ActivityDirectiveId, ActivityDirectivesByView, ActivityDirectivesMap } from '../../types/activity';
   import type { User } from '../../types/app';
-  import type { ConstraintViolation } from '../../types/constraint';
+  import type { ConstraintResult } from '../../types/constraint';
   import type {
     Resource,
     Simulation,
@@ -46,7 +46,7 @@
 
   export let activityDirectivesByView: ActivityDirectivesByView = { byLayerId: {}, byTimelineId: {} };
   export let activityDirectivesMap: ActivityDirectivesMap = {};
-  export let constraintViolations: ConstraintViolation[] = [];
+  export let constraintResults: ConstraintResult[] = [];
   export let hasUpdateDirectivePermission: boolean = false;
   export let hasUpdateSimulationPermission: boolean = false;
   export let maxTimeRange: TimeRange = { end: 0, start: 0 };
@@ -260,7 +260,7 @@
       activityDirectives={timeline && activityDirectivesByView?.byTimelineId[timeline.id]
         ? activityDirectivesByView.byTimelineId[timeline.id]
         : []}
-      {constraintViolations}
+      {constraintResults}
       {cursorEnabled}
       drawHeight={timelineHistogramDrawHeight}
       {drawWidth}
@@ -278,7 +278,7 @@
   </div>
   <div bind:this={xAxisDiv} class="x-axis" style="height: {xAxisDrawHeight}px">
     <TimelineXAxis
-      {constraintViolations}
+      {constraintResults}
       drawHeight={xAxisDrawHeight}
       {drawWidth}
       marginLeft={timeline?.marginLeft}
@@ -318,7 +318,7 @@
         {activityDirectivesByView}
         {activityDirectivesMap}
         autoAdjustHeight={row.autoAdjustHeight}
-        {constraintViolations}
+        {constraintResults}
         {dpr}
         drawHeight={row.height}
         {drawWidth}

--- a/src/components/timeline/TimelineHistogram.svelte
+++ b/src/components/timeline/TimelineHistogram.svelte
@@ -6,7 +6,7 @@
   import { select, type Selection } from 'd3-selection';
   import { createEventDispatcher } from 'svelte';
   import type { ActivityDirective } from '../../types/activity';
-  import type { ConstraintViolation } from '../../types/constraint';
+  import type { ConstraintResult } from '../../types/constraint';
   import type { SimulationDataset, Span } from '../../types/simulation';
   import type { MouseOver, TimeRange } from '../../types/timeline';
   import { clamp } from '../../utilities/generic';
@@ -14,7 +14,7 @@
   import { tooltip } from '../../utilities/tooltip';
 
   export let activityDirectives: ActivityDirective[] = [];
-  export let constraintViolations: ConstraintViolation[] = [];
+  export let constraintResults: ConstraintResult[] = [];
   export let cursorEnabled: boolean = true;
   export let drawHeight: number = 40;
   export let drawWidth: number = 0;
@@ -169,7 +169,7 @@
   // Update histograms if xScaleMax, activities, or constraint violation changes
   $: if (
     xScaleMax &&
-    (activityDirectives || constraintViolations) &&
+    (activityDirectives || constraintResults) &&
     windowMin !== undefined &&
     windowMax !== undefined &&
     windowMin - windowMax > 0
@@ -223,17 +223,19 @@
 
     // Compute constraint violations histogram
     constraintViolationsToRender = [];
-    constraintViolations.forEach(violation => {
-      violation.windows.forEach(w => {
-        if (xScaleMax !== null) {
-          const xStart = xScaleMax(w.start);
-          const xEnd = xScaleMax(w.end);
-          const clampedStart = xStart < 0 ? 0 : xStart;
-          const clampedEnd = xEnd > drawWidth ? drawWidth : xEnd;
-          const width = clampedEnd - clampedStart;
-          const clampedWidth = width <= 0 ? 5 : width;
-          constraintViolationsToRender.push({ width: clampedWidth, x: clampedStart });
-        }
+    constraintResults.forEach(constraintResult => {
+      constraintResult.violations.forEach(violation => {
+        violation.windows.forEach(window => {
+          if (xScaleMax !== null) {
+            const xStart = xScaleMax(window.start);
+            const xEnd = xScaleMax(window.end);
+            const clampedStart = xStart < 0 ? 0 : xStart;
+            const clampedEnd = xEnd > drawWidth ? drawWidth : xEnd;
+            const width = clampedEnd - clampedStart;
+            const clampedWidth = width <= 0 ? 5 : width;
+            constraintViolationsToRender.push({ width: clampedWidth, x: clampedStart });
+          }
+        });
       });
     });
   }

--- a/src/components/timeline/TimelinePanel.svelte
+++ b/src/components/timeline/TimelinePanel.svelte
@@ -7,7 +7,7 @@
     selectActivity,
     selectedActivityDirectiveId,
   } from '../../stores/activities';
-  import { visibleConstraintViolations } from '../../stores/constraints';
+  import { visibleConstraintResults } from '../../stores/constraints';
   import { maxTimeRange, plan, planId, viewTimeRange } from '../../stores/plan';
   import {
     resourcesByViewLayerId,
@@ -153,7 +153,7 @@
     <Timeline
       activityDirectivesByView={$activityDirectivesByView}
       activityDirectivesMap={$activityDirectivesMap}
-      constraintViolations={$visibleConstraintViolations}
+      constraintResults={$visibleConstraintResults}
       {hasUpdateDirectivePermission}
       {hasUpdateSimulationPermission}
       maxTimeRange={$maxTimeRange}

--- a/src/components/timeline/Tooltip.svelte
+++ b/src/components/timeline/Tooltip.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { select } from 'd3-selection';
   import type { ActivityDirective } from '../../types/activity';
-  import type { ConstraintViolation } from '../../types/constraint';
+  import type { ConstraintResult } from '../../types/constraint';
   import type { Span } from '../../types/simulation';
   import type { LinePoint, MouseOver, Point, XRangePoint } from '../../types/timeline';
   import { getDoyTime } from '../../utilities/time';
@@ -11,7 +11,7 @@
   export let mouseOver: MouseOver | null;
 
   let activityDirectives: ActivityDirective[] = [];
-  let constraintViolations: ConstraintViolation[] = [];
+  let constraintViolations: ConstraintResult[] = [];
   let points: Point[] = [];
   let gaps: Point[] = [];
   let spans: Span[] = [];
@@ -114,7 +114,7 @@
       tooltipText = `${tooltipText}<hr>`;
     }
 
-    constraintViolations.forEach((constraintViolation: ConstraintViolation, i: number) => {
+    constraintViolations.forEach((constraintViolation: ConstraintResult, i: number) => {
       const text = textForConstraintViolation(constraintViolation);
       tooltipText = `${tooltipText} ${text}`;
 
@@ -178,7 +178,7 @@
     `;
   }
 
-  function textForConstraintViolation(constraintViolation: ConstraintViolation): string {
+  function textForConstraintViolation(constraintViolation: ConstraintResult): string {
     const { constraintName } = constraintViolation;
     return `
       <div>

--- a/src/components/timeline/Tooltip.svelte
+++ b/src/components/timeline/Tooltip.svelte
@@ -11,7 +11,7 @@
   export let mouseOver: MouseOver | null;
 
   let activityDirectives: ActivityDirective[] = [];
-  let constraintViolations: ConstraintResult[] = [];
+  let constraintResults: ConstraintResult[] = [];
   let points: Point[] = [];
   let gaps: Point[] = [];
   let spans: Span[] = [];
@@ -23,7 +23,7 @@
   function onMouseOver(event: MouseOver | undefined) {
     if (event) {
       activityDirectives = event?.activityDirectives ?? [];
-      constraintViolations = event?.constraintViolations ?? [];
+      constraintResults = event?.constraintResults ?? [];
       gaps = event?.gaps ?? [];
       points = event?.points ?? [];
       spans = event?.spans ?? [];
@@ -39,7 +39,7 @@
   function show(event: MouseEvent): void {
     const showTooltip =
       activityDirectives.length > 0 ||
-      constraintViolations.length > 0 ||
+      constraintResults.length > 0 ||
       points.length > 0 ||
       spans.length > 0 ||
       gaps.length > 0;
@@ -92,7 +92,7 @@
     if (gaps.length) {
       // For now we render a single static "No Value" message for any number of gaps,
       // as long as there aren't other data points to render at the same location
-      if (!points.length && !constraintViolations.length && !activityDirectives.length && !spans.length) {
+      if (!points.length && !constraintResults.length && !activityDirectives.length && !spans.length) {
         return `
           <div>
             No Value
@@ -110,20 +110,20 @@
       }
     });
 
-    if (constraintViolations.length && activityDirectives.length) {
+    if (constraintResults.length && activityDirectives.length) {
       tooltipText = `${tooltipText}<hr>`;
     }
 
-    constraintViolations.forEach((constraintViolation: ConstraintResult, i: number) => {
-      const text = textForConstraintViolation(constraintViolation);
+    constraintResults.forEach((constraintResult: ConstraintResult, i: number) => {
+      const text = textForConstraintViolation(constraintResult);
       tooltipText = `${tooltipText} ${text}`;
 
-      if (i !== constraintViolations.length - 1) {
+      if (i !== constraintResults.length - 1) {
         tooltipText = `${tooltipText}<hr>`;
       }
     });
 
-    if (points.length && (constraintViolations.length || activityDirectives.length)) {
+    if (points.length && (constraintResults.length || activityDirectives.length)) {
       tooltipText = `${tooltipText}<hr>`;
     }
 
@@ -143,7 +143,7 @@
       }
     });
 
-    if (spans.length && (points.length || constraintViolations.length || activityDirectives.length)) {
+    if (spans.length && (points.length || constraintResults.length || activityDirectives.length)) {
       tooltipText = `${tooltipText}<hr>`;
     }
 

--- a/src/components/timeline/XAxis.svelte
+++ b/src/components/timeline/XAxis.svelte
@@ -2,12 +2,12 @@
 
 <script lang="ts">
   import type { ScaleTime } from 'd3-scale';
-  import type { ConstraintViolation } from '../../types/constraint';
+  import type { ConstraintResult } from '../../types/constraint';
   import type { TimeRange, XAxisTick } from '../../types/timeline';
   import ConstraintViolations from './ConstraintViolations.svelte';
   import RowXAxisTicks from './RowXAxisTicks.svelte';
 
-  export let constraintViolations: ConstraintViolation[] = [];
+  export let constraintResults: ConstraintResult[] = [];
   export let drawHeight: number = 70;
   export let drawWidth: number = 0;
   export let marginLeft: number = 50;
@@ -42,7 +42,7 @@
     </g>
     <g transform="translate(0, {violationsOffset})">
       <ConstraintViolations
-        {constraintViolations}
+        {constraintResults}
         mousemove={undefined}
         mouseout={undefined}
         {drawHeight}

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -337,7 +337,6 @@
       >
         <VerticalCollapseIcon />
         <svelte:fragment slot="metadata">
-          <!-- TODO: is there a better way to compute the count of violations, pre-compute them in the store? -->
           <div>Constraint violations: {$constraintResults.filter(result => result.violations.length).length}</div>
         </svelte:fragment>
       </PlanNavButton>

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -27,7 +27,7 @@
     resetActivityStores,
     selectActivity,
   } from '../../../stores/activities';
-  import { checkConstraintsStatus, constraintViolations, resetConstraintStores } from '../../../stores/constraints';
+  import { checkConstraintsStatus, constraintResults, resetConstraintStores } from '../../../stores/constraints';
   import {
     allErrors,
     anchorValidationErrors,
@@ -337,7 +337,8 @@
       >
         <VerticalCollapseIcon />
         <svelte:fragment slot="metadata">
-          <div>Constraint violations: {$constraintViolations.length}</div>
+          <!-- TODO: is there a better way to compute the count of violations, pre-compute them in the store? -->
+          <div>Constraint violations: {$constraintResults.filter(result => result.violations.length).length}</div>
         </svelte:fragment>
       </PlanNavButton>
       <PlanNavButton

--- a/src/stores/constraints.ts
+++ b/src/stores/constraints.ts
@@ -66,6 +66,11 @@ export const visibleConstraintResults: Readable<ConstraintResult[]> = derived(
     $constraintResults.filter(constraintResult => $constraintVisibilityMap[constraintResult.constraintId]),
 );
 
+export const constraintResultMap: Readable<Record<Constraint['id'], ConstraintResult>> = derived(
+  [constraintResults],
+  ([$constraintResults]) => keyBy($constraintResults, 'constraintId'),
+);
+
 /* Helper Functions. */
 
 export function setConstraintVisibility(constraintId: Constraint['id'], visible: boolean) {

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -23,20 +23,16 @@ export type ConstraintInsertInput = Omit<
 
 export type ConstraintType = 'model' | 'plan';
 
-export type ConstraintViolationAssociations = {
-  activityInstanceIds: number[];
-  resourceIds: string[];
-};
-
 export type ConstraintViolation = {
-  associations: ConstraintViolationAssociations;
-  constraintId: Constraint['id'];
-  constraintName: Constraint['name'];
-  gaps: TimeRange[];
-  type: ConstraintType;
+  activityInstanceIds: number[];
   windows: TimeRange[];
 };
 
-export type ConstraintViolationsMap = Record<Constraint['id'], ConstraintViolation[]>;
-
-export type ConstraintVisibilityMap = Record<Constraint['id'], boolean>;
+export type ConstraintResult = {
+  constraintId: Constraint['id'];
+  constraintName: Constraint['name'];
+  gaps: TimeRange[];
+  resourceIds: string[];
+  type: ConstraintType;
+  violations: ConstraintViolation[];
+};

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -1,6 +1,6 @@
 import type { Selection } from 'd3-selection';
 import type { ActivityDirective } from './activity';
-import type { ConstraintViolation } from './constraint';
+import type { ConstraintResult } from './constraint';
 import type { Span } from './simulation';
 
 export interface ActivityLayer extends Layer {
@@ -91,7 +91,7 @@ export type MouseDown = {
 
 export type MouseOver = {
   activityDirectives?: ActivityDirective[];
-  constraintViolations?: ConstraintViolation[];
+  constraintViolations?: ConstraintResult[];
   e: MouseEvent;
   gaps?: Point[];
   layerId: number;

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -91,7 +91,7 @@ export type MouseDown = {
 
 export type MouseOver = {
   activityDirectives?: ActivityDirective[];
-  constraintViolations?: ConstraintResult[];
+  constraintResults?: ConstraintResult[];
   e: MouseEvent;
   gaps?: Point[];
   layerId: number;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -3,7 +3,7 @@ import { base } from '$app/paths';
 import type { CommandDictionary as AmpcsCommandDictionary } from '@nasa-jpl/aerie-ampcs';
 import { get } from 'svelte/store';
 import { activityDirectivesMap, selectedActivityDirectiveId } from '../stores/activities';
-import { checkConstraintsStatus, constraintViolationsResponse } from '../stores/constraints';
+import { checkConstraintsStatus, constraintResultsResponse } from '../stores/constraints';
 import { catchError, catchSchedulingError } from '../stores/errors';
 import {
   createExpansionRuleError,
@@ -34,7 +34,7 @@ import type {
 import type { ActivityMetadata } from '../types/activity-metadata';
 import type { BaseUser, User, UserRole } from '../types/app';
 import type { ReqAuthResponse, ReqLogoutResponse, ReqSessionResponse } from '../types/auth';
-import type { Constraint, ConstraintInsertInput, ConstraintViolation } from '../types/constraint';
+import type { Constraint, ConstraintInsertInput, ConstraintResult } from '../types/constraint';
 import type {
   ExpansionRule,
   ExpansionRuleInsertInput,
@@ -239,18 +239,17 @@ const effects = {
       const currentPlan = get(plan);
       if (currentPlan !== null) {
         const { id: planId } = currentPlan;
-        const data = await reqHasura<{ violations: ConstraintViolation[] }>(
+        const data = await reqHasura<ConstraintResult[]>(
           gql.CHECK_CONSTRAINTS,
           {
             planId,
           },
           user,
         );
-        const { checkConstraintsResponse } = data;
-        if (checkConstraintsResponse != null) {
-          const { violations } = checkConstraintsResponse;
 
-          constraintViolationsResponse.set(violations);
+        const { constraintResults } = data;
+        if (constraintResults != null) {
+          constraintResultsResponse.set(constraintResults);
           checkConstraintsStatus.set(Status.Complete);
           showSuccessToast('Check Constraints Complete');
         } else {

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -16,8 +16,18 @@ const gql = {
 
   CHECK_CONSTRAINTS: `#graphql
     query CheckConstraints($planId: Int!) {
-      checkConstraintsResponse: constraintViolations(planId: $planId) {
-        violations
+      constraintResults: constraintViolations(planId: $planId) {
+        constraintId
+        constraintName
+        resourceIds
+        type
+        violations {
+          activityInstanceIds
+          windows {
+            end
+            start
+          }
+        }
       }
     }
   `,


### PR DESCRIPTION
Resolves #797 
Depends on https://github.com/NASA-AMMOS/aerie/pull/1026

This refactors the UI constraint violation logic to use the new schema specified from the backend. The gist of the change is:

Previously we received a list of `ConstraintViolations` that would include all of the associated constraint information alongside the violation windows:

```
export type ConstraintViolationAssociations = {
  activityInstanceIds: number[];
  resourceIds: string[];
};

export type ConstraintViolation = {
  associations: ConstraintViolationAssociations;
  constraintId: Constraint['id'];
  constraintName: Constraint['name'];
  gaps: TimeRange[];
  type: ConstraintType;
  windows: TimeRange[];
};
```

Whereas now, for each constraint evaluated, we receive a top level `ConstraintResult` object that specifies the common information about the constraint, and then contains a list of `Violations` containing a list of windows.

```
export type ConstraintViolation = {
  activityInstanceIds: number[];
  windows: TimeRange[];
};

export type ConstraintResult = {
  constraintId: Constraint['id'];
  constraintName: Constraint['name'];
  gaps: TimeRange[];
  resourceIds: string[];
  type: ConstraintType;
  violations: ConstraintViolation[];
};
```

This work should effectively be transparent from the UI, and constraints/violations should behave exactly the same as before. The majority of the work was to go through the app and where we previously would refer to a `ConstraintViolation` we now have a `ConstraintResult`. And all logic that pulls the windows from violations was updated to look one level deeper.