### PR TITLE
Remove reset text from value source badge if disabled

### DIFF
--- a/src/components/parameters/ParameterBaseBoolean.svelte
+++ b/src/components/parameters/ParameterBaseBoolean.svelte
@@ -33,6 +33,7 @@
       use:useActions={use}
     />
     <ParameterBaseRightAdornments
+      {disabled}
       hidden={hideRightAdornments}
       slot="right"
       {formParameter}

--- a/src/components/parameters/ParameterBaseDuration.svelte
+++ b/src/components/parameters/ParameterBaseDuration.svelte
@@ -50,6 +50,7 @@
     />
 
     <ParameterBaseRightAdornments
+      {disabled}
       slot="right"
       {formParameter}
       additionalErrors={durationStringFormatError ? [durationStringFormatError] : []}

--- a/src/components/parameters/ParameterBaseNumber.svelte
+++ b/src/components/parameters/ParameterBaseNumber.svelte
@@ -35,6 +35,7 @@
       on:change={() => dispatch('change', formParameter)}
     />
     <ParameterBaseRightAdornments
+      {disabled}
       hidden={hideRightAdornments}
       slot="right"
       {formParameter}

--- a/src/components/parameters/ParameterBasePath.svelte
+++ b/src/components/parameters/ParameterBasePath.svelte
@@ -8,6 +8,7 @@
   import ParameterBaseRightAdornments from './ParameterBaseRightAdornments.svelte';
   import ParameterName from './ParameterName.svelte';
 
+  export let disabled: boolean = false;
   export let formParameter: FormParameter;
   export let hideRightAdornments: boolean = false;
   export let labelColumnWidth: number = 200;
@@ -46,6 +47,7 @@
         type="text"
       />
       <ParameterBaseRightAdornments
+        {disabled}
         hidden={hideRightAdornments}
         slot="right"
         {formParameter}

--- a/src/components/parameters/ParameterBaseRightAdornments.svelte
+++ b/src/components/parameters/ParameterBaseRightAdornments.svelte
@@ -6,6 +6,7 @@
   import InputErrorBadge from './InputErrorBadge.svelte';
   import ValueSourceBadge from './ValueSourceBadge.svelte';
 
+  export let disabled: boolean = false;
   export let formParameter: FormParameter;
   export let additionalErrors: string[] = [];
   export let hidden: boolean = false;
@@ -25,7 +26,7 @@
 
 <div class="parameter-base-right-adornment" {hidden}>
   {#if !hideValueSource}
-    <ValueSourceBadge source={formParameter.valueSource} {parameterType} {use} on:reset />
+    <ValueSourceBadge {disabled} source={formParameter.valueSource} {parameterType} {use} on:reset />
   {/if}
   {#if errors.length > 0 && !hideError}
     <InputErrorBadge {errors} />

--- a/src/components/parameters/ParameterBaseString.svelte
+++ b/src/components/parameters/ParameterBaseString.svelte
@@ -35,6 +35,7 @@
       on:change={() => dispatch('change', formParameter)}
     />
     <ParameterBaseRightAdornments
+      {disabled}
       hidden={hideRightAdornments}
       slot="right"
       {formParameter}

--- a/src/components/parameters/ParameterBaseVariant.svelte
+++ b/src/components/parameters/ParameterBaseVariant.svelte
@@ -41,6 +41,7 @@
       {/each}
     </select>
     <ParameterBaseRightAdornments
+      {disabled}
       hidden={hideRightAdornments}
       {formParameter}
       {parameterType}

--- a/src/components/parameters/ParameterRecSeries.svelte
+++ b/src/components/parameters/ParameterRecSeries.svelte
@@ -102,6 +102,7 @@
           <PlusIcon />
         </button>
         <ParameterBaseRightAdornments
+          {disabled}
           hidden={hideRightAdornments}
           {formParameter}
           {parameterType}

--- a/src/components/parameters/ParameterRecStruct.svelte
+++ b/src/components/parameters/ParameterRecStruct.svelte
@@ -68,6 +68,7 @@
     </div>
     <div class="right" slot="right">
       <ParameterBaseRightAdornments
+        {disabled}
         hidden={hideRightAdornments}
         {formParameter}
         {parameterType}

--- a/src/components/parameters/ValueSourceBadge.svelte
+++ b/src/components/parameters/ValueSourceBadge.svelte
@@ -8,6 +8,7 @@
   import { tooltip } from '../../utilities/tooltip';
   import { useActions, type ActionArray } from '../../utilities/useActions';
 
+  export let disabled: boolean = false;
   export let source: ValueSource;
   export let parameterType: ParameterType = 'activity';
   export let use: ActionArray = [];
@@ -15,6 +16,7 @@
   const dispatch = createEventDispatcher();
 
   let tooltipContent: string = '';
+  let tooltipContentModifiedReset: string = '';
 
   $: dotClasses = classNames('value-source-badge-dot st-typography-body', {
     'value-source-badge-dot--mission': source === 'mission',
@@ -26,13 +28,14 @@
     switch (source) {
       case 'user on model':
       case 'user on preset':
+        tooltipContentModifiedReset = `<div class="value-source-tooltip-modified-reset">
+                                          <span>Reset to ${source === 'user on preset' ? presetText : 'Model'}</span>
+                                          <div>${isMacOs() ? '⌘' : 'CTRL'} Click</div>
+                                       </div>`;
         tooltipContent = `<div class="value-source-tooltip-modified">
-                          <span>Modified</span>
-                          <div class="value-source-tooltip-modified-reset">
-                            <span>Reset to ${source === 'user on preset' ? presetText : 'Model'}</span>
-                            <div>${isMacOs() ? '⌘' : 'CTRL'} Click</div>
-                          </div>
-                        </div>`;
+                            <span>Modified</span>
+                            ${disabled ? '' : tooltipContentModifiedReset}
+                          </div>`;
         break;
       case 'preset':
         tooltipContent = `${presetText} Value`;
@@ -44,7 +47,7 @@
   }
 
   function onClick(event: MouseEvent) {
-    if (isMetaOrCtrlPressed(event)) {
+    if (isMetaOrCtrlPressed(event) && !disabled) {
       dispatch('reset');
     }
   }
@@ -93,18 +96,16 @@
   :global(.value-source-tooltip-modified) {
     align-items: center;
     color: var(--st-gray-10);
-    column-gap: 2rem;
-    display: grid;
-    grid-template-columns: auto auto;
-    justify-content: space-between;
+    display: flex;
+    gap: 2rem;
+    justify-content: center;
   }
 
   :global(.value-source-tooltip-modified .value-source-tooltip-modified-reset) {
     align-items: center;
-    column-gap: 0.3rem;
-    display: grid;
+    display: flex;
     font-weight: 200;
-    grid-template-columns: auto auto;
+    gap: 0.3rem;
   }
 
   :global(.value-source-tooltip-modified .value-source-tooltip-modified-reset > div) {


### PR DESCRIPTION
Fixes https://github.com/NASA-AMMOS/aerie-ui/issues/670

* We only need to show the reset text if the parameter is enabled

Test:
- Make sure the reset set text is not included on parameters on the plan merge review page