### PR TITLE
Add resource name to plot tooltips

### DIFF
--- a/src/components/timeline/Tooltip.svelte
+++ b/src/components/timeline/Tooltip.svelte
@@ -195,6 +195,8 @@
       <div>
         Id: ${id}
         <br>
+        Resource Name: ${point.name}
+        <br>
         Time: ${getDoyTime(new Date(x))}
         <br>
         Value: ${y}
@@ -224,6 +226,8 @@
     return `
       <div>
         Id: ${id}
+        <br>
+        Resource Name: ${point.name}
         <br>
         Start: ${getDoyTime(new Date(x))}
         <br>


### PR DESCRIPTION
Resolves https://github.com/NASA-AMMOS/aerie-ui/issues/252

To test:
- Verify resource plots now have their resource name in the tooltip