### PR TITLE
Fix miscalculated parameter padding

### DIFF
--- a/src/components/Collapse.svelte
+++ b/src/components/Collapse.svelte
@@ -123,14 +123,20 @@
   }
 
   .content {
-    display: none;
+    display: flex;
     flex-direction: column;
     gap: 4px;
+    height: 0;
     margin-left: 32px;
+    overflow: hidden;
+    visibility: hidden;
+    width: 0;
   }
 
   .expanded {
-    display: flex;
+    height: auto;
+    visibility: visible;
+    width: auto;
   }
 
   .left {


### PR DESCRIPTION
Currently the parameter input is incorrectly calculating the padding needed because the `Collapse` component has a CSS property of `display:none` which doesn't affect layout. This results in a `0` padding calculation.
![Screenshot 2023-08-16 at 11 52 44 AM](https://github.com/NASA-AMMOS/aerie-ui/assets/5290214/766f08f6-83a2-4ff5-9f18-4aca0a5e1bb9)

To test:
1. Create a plan using the bananation model
2. Run the simulation
3. In the Simulation panel, expand the "initialConditions" argument
4. Verify that the up/down arrows for the number inputs do not overlap over the source color dot
