### PR TITLE
Prevent non-activities from being dragged onto an activity layer

### DIFF
--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -148,7 +148,11 @@
         const unixEpochTime = xScaleView.invert(offsetX).getTime();
         const start_time = getDoyTime(new Date(unixEpochTime));
         const activityTypeName = e.dataTransfer.getData('activityTypeName');
-        effects.createActivityDirective({}, start_time, activityTypeName, activityTypeName, {}, user);
+
+        // Only allow creating an activity if we have an actual activity in the drag data.
+        if (activityTypeName) {
+          effects.createActivityDirective({}, start_time, activityTypeName, activityTypeName, {}, user);
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes https://github.com/NASA-AMMOS/aerie-ui/issues/568

To test:
- Verify that you can only drag activities from the activity type list onto an activity layer to create a directive