### PR TITLE
Implement Quick Fix Popover

### DIFF
--- a/src/components/expansion/ExpansionLogicEditor.svelte
+++ b/src/components/expansion/ExpansionLogicEditor.svelte
@@ -6,6 +6,7 @@
   import type { User } from '../../types/app';
   import type { Monaco, TypeScriptFile } from '../../types/monaco';
   import effects from '../../utilities/effects';
+  import { sequenceProvideCodeActions } from '../../utilities/monacoHelper';
   import MonacoEditor from '../ui/MonacoEditor.svelte';
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
@@ -101,6 +102,7 @@
       bind:monaco
       bind:model={editorModel}
       automaticLayout={true}
+      actionProvider={sequenceProvideCodeActions}
       fixedOverflowWidgets={true}
       language="typescript"
       lineNumbers="on"

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -8,6 +8,7 @@
   import type { User } from '../../types/app';
   import type { Monaco, TypeScriptFile } from '../../types/monaco';
   import effects from '../../utilities/effects';
+  import { sequenceProvideCodeActions } from '../../utilities/monacoHelper';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
   import MonacoEditor from '../ui/MonacoEditor.svelte';
@@ -113,6 +114,7 @@
         bind:monaco
         bind:model={sequenceEditorModel}
         automaticLayout={true}
+        actionProvider={sequenceProvideCodeActions}
         fixedOverflowWidgets={true}
         language="typescript"
         lineNumbers="on"

--- a/src/utilities/monacoHelper.ts
+++ b/src/utilities/monacoHelper.ts
@@ -1,0 +1,56 @@
+import type { CancellationToken, editor as Editor, languages, Range } from 'monaco-editor/esm/vs/editor/editor.api';
+import { CustomErrorCodes } from '../workers/customCodes';
+
+export const sequenceProvideCodeActions = (
+  model: Editor.ITextModel,
+  _range: Range,
+  context: languages.CodeActionContext,
+  _token: CancellationToken,
+): languages.ProviderResult<languages.CodeActionList> => {
+  // create quick-action to convert unbalanced time to balanced time.
+  const codeActions = context.markers
+    .filter(error => error.code === String(CustomErrorCodes.Type.UNBALANCED))
+    .map(unbalancedTime => {
+      const match = unbalancedTime.message.match(/Suggestion:\s*(.*)/);
+      if (match) {
+        const extractSuggestedTime = match[1].replace(/\s+/g, '');
+        return generateQuickFixAction('Convert Unbalanced Time', extractSuggestedTime, unbalancedTime, model);
+      }
+      return undefined; // Return undefined when the match fails
+    })
+    .filter(action => action !== undefined) as languages.CodeAction[]; // Filter out undefined values
+
+  // Add custom code actions like unit conversion or time conversion
+  return {
+    actions: codeActions,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    dispose: () => {},
+  };
+};
+
+function generateQuickFixAction(
+  title: string,
+  replaceText: string,
+  diagnostics: Editor.IMarkerData,
+  model: Editor.ITextModel,
+): languages.CodeAction {
+  return {
+    diagnostics: [diagnostics],
+    edit: {
+      // Define the edits needed to fix the issue
+      edits: [
+        {
+          resource: model.uri,
+          textEdit: {
+            range: diagnostics,
+            text: replaceText,
+          },
+          versionId: model.getVersionId(),
+        },
+      ],
+    },
+    isPreferred: true,
+    kind: 'quickfix',
+    title: title,
+  };
+}

--- a/src/workers/customCodes.ts
+++ b/src/workers/customCodes.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sort-keys */
 /**
  * Represents an error code with an ID and a message.
  */
@@ -10,12 +11,28 @@ export type ErrorCode = {
  * Contains custom error code definitions along with their error messages.
  */
 export const CustomErrorCodes = {
+  Type: {
+    INVALID_ABSOLUTE: -1,
+    INVALID_ARGUMENT: -8,
+    INVALID_ENUM: -6,
+    INVALID_EPOCH: -2,
+    INVALID_INT: -4,
+    INVALID_NUMBER: -10,
+    INVALID_RANGE: -7,
+    INVALID_RELATIVE: -11,
+    INVALID_UNSIGN_INTEGER: -5,
+    MAX_ABSOLUTE: -12,
+    MAX_EPOCH: -13,
+    MAX_RELATIVE: -14,
+    UNBALANCED: -9,
+    UNCAUGHT_ARG: -3,
+  },
   /**
    * InvalidAbsoluteTime error code and message.
    */
   InvalidAbsoluteTime: (): ErrorCode => {
     return {
-      id: -1,
+      id: CustomErrorCodes.Type.INVALID_ABSOLUTE,
       message: `Time Error: Incorrectly formatted absolute time string.
 Received : Malformed Absolute time.
 Expected: YYYY-DOYThh:mm:ss[.sss]`,
@@ -27,7 +44,7 @@ Expected: YYYY-DOYThh:mm:ss[.sss]`,
    */
   InvalidArgumentCount: (argName: string, repeatArgCount: number, min: number, max: number): ErrorCode => {
     return {
-      id: -8,
+      id: CustomErrorCodes.Type.INVALID_ARGUMENT,
       message: `Argument Count Error: The provided arguments for '${argName}' is outside the valid range.
 Received: ${repeatArgCount} repeating arguments.
 Expected: Repetition within the range of [${min}, ${max}]]`,
@@ -39,7 +56,7 @@ Expected: Repetition within the range of [${min}, ${max}]]`,
    */
   InvalidEnum: (argName: string, argValue: string, expectedValue: string): ErrorCode => {
     return {
-      id: -6,
+      id: CustomErrorCodes.Type.INVALID_ENUM,
       message: `ENUM Error: '${argName}' Unexpected ENUM argument.
 Received: ${argValue}
 Expected: ${expectedValue}`,
@@ -51,7 +68,7 @@ Expected: ${expectedValue}`,
    */
   InvalidEpochTime: (): ErrorCode => {
     return {
-      id: -2,
+      id: CustomErrorCodes.Type.INVALID_EPOCH,
       message: `Time Error: Incorrectly formatted duration string.
 Received: A malformed duration.
 Expected: [+/-]hh:mm:ss[.sss] or [+/-]DDDThh:mm:ss[.sss]`,
@@ -63,7 +80,7 @@ Expected: [+/-]hh:mm:ss[.sss] or [+/-]DDDThh:mm:ss[.sss]`,
    */
   InvalidInteger: (argName: string, argValue: string): ErrorCode => {
     return {
-      id: -4,
+      id: CustomErrorCodes.Type.INVALID_INT,
       message: `Number Error: '${argName}' is not a integer.
 Received: ${argValue}
 Expected: An integer.`,
@@ -75,7 +92,7 @@ Expected: An integer.`,
    */
   InvalidNumber: (argName: string, argValue: string): ErrorCode => {
     return {
-      id: -4,
+      id: CustomErrorCodes.Type.INVALID_NUMBER,
       message: `Number Error: '${argName}' Invalid Argument Type
 Received: ${argValue}
 Expected: A valid number.`,
@@ -87,7 +104,7 @@ Expected: A valid number.`,
    */
   InvalidRange: (argName: string, argValue: number, min: number, max: number): ErrorCode => {
     return {
-      id: -7,
+      id: CustomErrorCodes.Type.INVALID_RANGE,
       message: `Range Error: '${argName}' Out of Bounds.
 Received: ${argValue}
 Expected: A number within the range of [${min}, ${max}]].`,
@@ -99,7 +116,7 @@ Expected: A number within the range of [${min}, ${max}]].`,
    */
   InvalidRelativeTime: (): ErrorCode => {
     return {
-      id: -2,
+      id: CustomErrorCodes.Type.INVALID_RELATIVE,
       message: `Time Error: Incorrectly formatted duration string.
 Received: A malformed duration.
 Expected: hh:mm:ss[.sss]`,
@@ -111,7 +128,7 @@ Expected: hh:mm:ss[.sss]`,
    */
   InvalidUnsignedInteger: (argName: string, argValue: string): ErrorCode => {
     return {
-      id: -5,
+      id: CustomErrorCodes.Type.INVALID_UNSIGN_INTEGER,
       message: `Number Error: '${argName}' is not unsigned.
 Received: ${argValue}
 Expected: A signed value`,
@@ -123,7 +140,7 @@ Expected: A signed value`,
    */
   MaxAbsoluteTime: (balancedTime: string): ErrorCode => {
     return {
-      id: -1,
+      id: CustomErrorCodes.Type.MAX_ABSOLUTE,
       message: `Time Error: Maximum time reached
   Received: Balanced time - ${balancedTime}.
   Expected: ${balancedTime} <= 9999-365T23:59:59.999`,
@@ -135,7 +152,7 @@ Expected: A signed value`,
    */
   MaxEpochTime: (balancedTime: string): ErrorCode => {
     return {
-      id: -2,
+      id: CustomErrorCodes.Type.MAX_EPOCH,
       message: `Time Error: Maximum time reached.
 Received: Balanced time - ${balancedTime}.
 Expected: ${balancedTime} <= 365T23:59:59.999`,
@@ -147,7 +164,7 @@ Expected: ${balancedTime} <= 365T23:59:59.999`,
    */
   MaxRelativeTime: (balancedTime: string): ErrorCode => {
     return {
-      id: -2,
+      id: CustomErrorCodes.Type.MAX_RELATIVE,
       message: `Time Error: Maximum time reached.
   Received: Balanced time - ${balancedTime}.
   Expected: ${balancedTime} <= 23:59:59.999`,
@@ -158,15 +175,15 @@ Expected: ${balancedTime} <= 365T23:59:59.999`,
    */
   UnbalancedTime: (balancedTime: string): ErrorCode => {
     return {
-      id: -9,
+      id: CustomErrorCodes.Type.UNBALANCED,
       message: `Time Warning: Unbalanced time used.
-Suggestion: Change time to ${balancedTime}`,
+Suggestion: ${balancedTime}`,
     };
   },
   /**
    * UncaughtArgumentType error code and message.
    */
   UncaughtArgumentType: (): ErrorCode => {
-    return { id: -3, message: `Error: Command Argument Type Mismatch` };
+    return { id: CustomErrorCodes.Type.UNCAUGHT_ARG, message: `Error: Command Argument Type Mismatch` };
   },
 };

--- a/src/workers/diagnostics/timeDiagnostics.ts
+++ b/src/workers/diagnostics/timeDiagnostics.ts
@@ -320,15 +320,21 @@ function balanceDuration(
 
   const balancedTime = `${DD}${HH}:${MM}:${SS}.${sss}`;
 
-  if (regex.source === HMS_EPOCH_REGEX.source && days > 365) {
-    return { error: CustomErrorCodes.MaxEpochTime(balancedTime) };
+  if (regex.source === HMS_EPOCH_REGEX.source) {
+    if (days > 365) {
+      return { error: CustomErrorCodes.MaxEpochTime(balancedTime) };
+    } else {
+      return { warning: CustomErrorCodes.UnbalancedTime(`E\`${balancedTime}\``) };
+    }
   }
 
-  if (regex.source === HMS_RELATIVE_REGEX.source && days !== 0) {
-    return { error: CustomErrorCodes.MaxRelativeTime(balancedTime) };
+  if (regex.source === HMS_RELATIVE_REGEX.source) {
+    if (days !== 0) {
+      return { error: CustomErrorCodes.MaxRelativeTime(balancedTime) };
+    }
+    return { warning: CustomErrorCodes.UnbalancedTime(`R\`${balancedTime}\``) };
   }
-
-  return { warning: CustomErrorCodes.UnbalancedTime(balancedTime) };
+  return { error: undefined, warning: undefined };
 }
 
 function balanceAbsolute(


### PR DESCRIPTION
Closes #824 

In this PR, I have Implemented an infrastructure that introduces the ability to create Monaco Editor "Quick Fix" actions. This infrastructure lays the foundation for users to invoke specific actions to address issues within the editor seamlessly.

An illustrative example of this feature's potential lies in the implementation of a "Quick Fix" action designed to rectify unbalanced times. While the eDSL already handles the conversion of these times during SeqJSON generation, users now have the option to resolve these issues preemptively, prior to the generation process.

This infrastructure offers extensibility for the future, paving the way for the introduction of additional actions. Examples of prospective actions include unit conversions (e.g., deg to rad, minutes to hours, etc.).
