### PR TITLE
Fix setting vertical guide color from timeline editor

### DIFF
--- a/src/components/timeline/form/TimelineEditorPanel.svelte
+++ b/src/components/timeline/form/TimelineEditorPanel.svelte
@@ -267,7 +267,7 @@
       }
       return guide;
     });
-    viewUpdateRow('verticalGuides', newVerticalGuides);
+    viewUpdateTimeline('verticalGuides', newVerticalGuides, $selectedTimelineId);
   }
 
   function handleUpdateHorizontalGuideLabel(event: Event, horizontalGuide: HorizontalGuide) {


### PR DESCRIPTION
Fixes https://github.com/NASA-AMMOS/aerie-ui/issues/867
Bug introduced in https://github.com/NASA-AMMOS/aerie-ui/pull/285

* Incorrect function was used; vertical guides are on the timeline, not the row

To test:
- Add a vertical guide to a plan and change the color, make sure the color changes