### PR TITLE
Show Success Toast when Constraints Successfully Update

### DIFF
--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -3382,7 +3382,7 @@ const effects = {
         ...(description && { description }),
       };
       const data = await reqHasura(gql.UPDATE_CONSTRAINT, { constraint, id }, user);
-      if (data.update_activity_directive_by_pk != null) {
+      if (data.updateConstraint != null) {
         showSuccessToast('Constraint Updated Successfully');
       } else {
         throw Error(`Unable to update constraint with ID: "${id}"`);


### PR DESCRIPTION
Closes #870.

There UI was mistakenly checking for an `update_activity_directive_by_pk` field in the returned `data` to verify if updating the constraint succeeded. This caused it to always display the `failed` Toast. It now checks for the correct `updateConstraint` field.