### PR TITLE
Fix tag filtering in tables

### DIFF
--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -21,7 +21,7 @@
   import { tooltip } from '../../utilities/tooltip';
   import GridMenu from '../menus/GridMenu.svelte';
   import type DataGrid from '../ui/DataGrid/DataGrid.svelte';
-  import { tagsCellRenderer } from '../ui/DataGrid/DataGridTagsCellRenderer';
+  import { tagsCellRenderer, tagsFilterValueGetter } from '../ui/DataGrid/DataGridTags';
   import Panel from '../ui/Panel.svelte';
   import ActivityDirectivesTable from './ActivityDirectivesTable.svelte';
   import ActivityTableMenu from './ActivityTableMenu.svelte';
@@ -159,6 +159,7 @@
       cellRenderer: tagsCellRenderer,
       field: 'tags',
       filter: 'text',
+      filterValueGetter: tagsFilterValueGetter,
       headerName: 'Tags',
       resizable: true,
       sortable: false,

--- a/src/components/constraints/Constraints.svelte
+++ b/src/components/constraints/Constraints.svelte
@@ -17,7 +17,7 @@
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
   import DataGridActions from '../ui/DataGrid/DataGridActions.svelte';
-  import { tagsCellRenderer } from '../ui/DataGrid/DataGridTagsCellRenderer';
+  import { tagsCellRenderer, tagsFilterValueGetter } from '../ui/DataGrid/DataGridTags';
   import SingleActionDataGrid from '../ui/DataGrid/SingleActionDataGrid.svelte';
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
@@ -92,6 +92,7 @@
       cellRenderer: tagsCellRenderer,
       field: 'tags',
       filter: 'text',
+      filterValueGetter: tagsFilterValueGetter,
       headerName: 'Tags',
       resizable: true,
       sortable: false,

--- a/src/components/expansion/ExpansionRules.svelte
+++ b/src/components/expansion/ExpansionRules.svelte
@@ -17,7 +17,7 @@
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
   import DataGridActions from '../ui/DataGrid/DataGridActions.svelte';
-  import { tagsCellRenderer } from '../ui/DataGrid/DataGridTagsCellRenderer';
+  import { tagsCellRenderer, tagsFilterValueGetter } from '../ui/DataGrid/DataGridTags';
   import SingleActionDataGrid from '../ui/DataGrid/SingleActionDataGrid.svelte';
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
@@ -74,6 +74,7 @@
       cellRenderer: tagsCellRenderer,
       field: 'tags',
       filter: 'text',
+      filterValueGetter: tagsFilterValueGetter,
       headerName: 'Tags',
       resizable: true,
       sortable: false,

--- a/src/components/scheduling/goals/SchedulingGoals.svelte
+++ b/src/components/scheduling/goals/SchedulingGoals.svelte
@@ -15,7 +15,7 @@
   import { featurePermissions } from '../../../utilities/permissions';
   import Input from '../../form/Input.svelte';
   import DataGridActions from '../../ui/DataGrid/DataGridActions.svelte';
-  import { tagsCellRenderer } from '../../ui/DataGrid/DataGridTagsCellRenderer';
+  import { tagsCellRenderer, tagsFilterValueGetter } from '../../ui/DataGrid/DataGridTags';
   import SingleActionDataGrid from '../../ui/DataGrid/SingleActionDataGrid.svelte';
   import Panel from '../../ui/Panel.svelte';
   import SectionTitle from '../../ui/SectionTitle.svelte';
@@ -54,6 +54,7 @@
         cellRenderer: tagsCellRenderer,
         field: 'tags',
         filter: 'text',
+        filterValueGetter: tagsFilterValueGetter,
         headerName: 'Tags',
         resizable: true,
         sortable: false,

--- a/src/components/ui/DataGrid/DataGridTags.ts
+++ b/src/components/ui/DataGrid/DataGridTags.ts
@@ -1,8 +1,12 @@
-import type { ICellRendererParams } from 'ag-grid-community';
+import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
 import type { Tag } from '../../../types/tags';
 import TagChip from '../Tags/Tag.svelte';
 
-export function tagsCellRenderer(params?: ICellRendererParams<{ tags: { tag: Tag }[] }>) {
+type AssetWithTags<T = any> = T & {
+  tags: { tag: Tag }[];
+};
+
+export function tagsCellRenderer<T>(params?: ICellRendererParams<AssetWithTags<T>>) {
   if (params && params.data && params.data.tags) {
     const tagsDiv = document.createElement('div');
     tagsDiv.className = 'tags-cell';
@@ -17,4 +21,8 @@ export function tagsCellRenderer(params?: ICellRendererParams<{ tags: { tag: Tag
     });
     return tagsDiv;
   }
+}
+
+export function tagsFilterValueGetter<T>(params: ValueGetterParams<AssetWithTags<T>>) {
+  return params.data?.tags.map(({ tag }) => tag.name).join(', ') ?? '';
 }

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -15,7 +15,7 @@
   import AlertError from '../../components/ui/AlertError.svelte';
   import CssGrid from '../../components/ui/CssGrid.svelte';
   import DataGridActions from '../../components/ui/DataGrid/DataGridActions.svelte';
-  import { tagsCellRenderer } from '../../components/ui/DataGrid/DataGridTagsCellRenderer';
+  import { tagsCellRenderer, tagsFilterValueGetter } from '../../components/ui/DataGrid/DataGridTags';
   import SingleActionDataGrid from '../../components/ui/DataGrid/SingleActionDataGrid.svelte';
   import Panel from '../../components/ui/Panel.svelte';
   import SectionTitle from '../../components/ui/SectionTitle.svelte';
@@ -114,6 +114,7 @@
       cellRenderer: tagsCellRenderer,
       field: 'tags',
       filter: 'text',
+      filterValueGetter: tagsFilterValueGetter,
       headerName: 'Tags',
       resizable: true,
       sortable: false,


### PR DESCRIPTION
resolves #868 

This adds a filter function for any table that displays tags.

To test:

1. Create a plan with some tags
2. Create another plan with some different and some common tags as the first
3. In the plans table, verify that filtering by certain tag strings actually filters the table
4. In one of the plans, add some directives
5. To some of the directives added, add some tags
6. In the directives table, verify that filtering by tags actually filters out the activities correctly