### PR TITLE
Sort Start Offset column chronologically

### DIFF
--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -17,7 +17,7 @@
   import type { User } from '../../types/app';
   import type { ViewGridSection, ViewTable } from '../../types/view';
   import { filterEmpty } from '../../utilities/generic';
-  import { getActivityDirectiveStartTimeMs, getDoyTime } from '../../utilities/time';
+  import { getActivityDirectiveStartTimeMs, getDoyTime, getUnixEpochTimeFromInterval } from '../../utilities/time';
   import { tooltip } from '../../utilities/tooltip';
   import GridMenu from '../menus/GridMenu.svelte';
   import type DataGrid from '../ui/DataGrid/DataGrid.svelte';
@@ -147,6 +147,15 @@
       sortable: true,
     },
     start_offset: {
+      comparator: (valueA: string, valueB: string) => {
+        if ($plan) {
+          return (
+            getUnixEpochTimeFromInterval($plan.start_time, valueA) -
+            getUnixEpochTimeFromInterval($plan.start_time, valueB)
+          );
+        }
+        return valueA.localeCompare(valueB);
+      },
       field: 'start_offset',
       filter: 'text',
       headerName: 'Start Offset',


### PR DESCRIPTION
Closes [#880](https://github.com/NASA-AMMOS/aerie-ui/issues/880)

Use numeric comparison for time offset column

<img width="319" alt="Screenshot 2023-08-31 at 9 22 36 PM" src="https://github.com/NASA-AMMOS/aerie-ui/assets/5984211/09b9a696-499c-4190-8459-40d0d1633456">
