### PR TITLE
Store active role in cookie instead of token

### DIFF
--- a/src/routes/auth/changeRole/+server.ts
+++ b/src/routes/auth/changeRole/+server.ts
@@ -1,32 +1,10 @@
 import { base } from '$app/paths';
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
-import jwtDecode from 'jwt-decode';
-import type { BaseUser, ParsedUserToken } from '../../../types/app';
-import type { ChangeUserRoleRequestBody, ReqAuthResponse } from '../../../types/auth';
-import effects from '../../../utilities/effects';
+import type { ChangeUserRoleRequestBody } from '../../../types/auth';
 
 export const POST: RequestHandler = async event => {
   const body: ChangeUserRoleRequestBody = await event.request.json();
   const { role } = body;
-  const { locals } = event;
-  const { user } = locals;
-
-  try {
-    const authResponse: ReqAuthResponse = await effects.changeUserRole(role, user);
-    const { message, success, token: newToken } = authResponse;
-
-    if (success && newToken) {
-      const decodedToken: ParsedUserToken = jwtDecode(newToken);
-      const user: BaseUser = { id: decodedToken.username, token: newToken };
-      const userStr = JSON.stringify(user);
-      const userCookie = Buffer.from(userStr).toString('base64');
-
-      return json({ success: true, user }, { headers: { 'set-cookie': `user=${userCookie}; Path=${base}/` } });
-    } else {
-      return json({ message, success: false });
-    }
-  } catch (e) {
-    return json({ message: (e as Error).message, success: false });
-  }
+  return json({ success: true }, { headers: { 'set-cookie': `activeRole=${role}; Path=${base}/` } });
 };

--- a/src/routes/auth/logout/+server.ts
+++ b/src/routes/auth/logout/+server.ts
@@ -5,6 +5,10 @@ import { json } from '@sveltejs/kit';
 export const POST: RequestHandler = async () => {
   return json(
     { message: 'Logout successful', success: true },
-    { headers: { 'set-cookie': `user=deleted; path=${base}/; expires=Thu, 01 Jan 1970 00:00:00 GMT` } },
+    {
+      headers: {
+        'set-cookie': `activeRole=deleted; path=${base}/,user=deleted; path=${base}/; expires=Thu, 01 Jan 1970 00:00:00 GMT`,
+      },
+    },
   );
 };

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -17,7 +17,6 @@ export type User = BaseUser & {
 };
 
 export type ParsedUserToken = {
-  activeRole: UserRole;
   exp: number;
   'https://hasura.io/jwt/claims': {
     'x-hasura-allowed-roles': UserRole[];

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -32,7 +32,7 @@ import type {
   ActivityTypeExpansionRules,
 } from '../types/activity';
 import type { ActivityMetadata } from '../types/activity-metadata';
-import type { BaseUser, User, UserRole } from '../types/app';
+import type { BaseUser, User } from '../types/app';
 import type { ReqAuthResponse, ReqSessionResponse } from '../types/auth';
 import type { Constraint, ConstraintInsertInput, ConstraintResult } from '../types/constraint';
 import type {
@@ -216,20 +216,6 @@ const effects = {
     } catch (e) {
       catchError('Template Unable To Be Applied To Simulation', e as Error);
       showFailureToast('Template Application Failed');
-    }
-  },
-
-  async changeUserRole(role: UserRole, user: User | null): Promise<ReqAuthResponse> {
-    try {
-      const data = await reqGateway<ReqAuthResponse>('/auth/changeRole', 'POST', JSON.stringify({ role }), user, false);
-      return data;
-    } catch (e) {
-      catchError(e as Error);
-      return {
-        message: 'An unexpected error occurred',
-        success: false,
-        token: null,
-      };
     }
   },
 


### PR DESCRIPTION
When discussing the change role endpoint in the Gateway with @mattdailis, he pointed out we don't really need it and can just store the active role in a cookie like we do with the user. This greatly simplifies the Gateway API, and makes it easier to maintain. We still get security because Hasura automatically does the role check via the `x-hasura-role` header.

To test:
- Make sure changing the active role still works

Gateway PR: https://github.com/NASA-AMMOS/aerie-gateway/pull/44