### PR TITLE
Custom Worker - Warning when use of identifiers. 

### DIFF
--- a/src/workers/customCodes.ts
+++ b/src/workers/customCodes.ts
@@ -26,6 +26,7 @@ export const CustomErrorCodes = {
     MAX_RELATIVE: -14,
     UNBALANCED: -9,
     UNCAUGHT_ARG: -3,
+    UNCHECK_ARG: -15,
   },
   /**
    * InvalidAbsoluteTime error code and message.
@@ -185,5 +186,15 @@ Suggestion: ${balancedTime}`,
    */
   UncaughtArgumentType: (): ErrorCode => {
     return { id: CustomErrorCodes.Type.UNCAUGHT_ARG, message: `Error: Command Argument Type Mismatch` };
+  },
+  /**
+   * uncheckable warning code and message.
+   */
+  UncheckableArgumentType: (): ErrorCode => {
+    return {
+      id: CustomErrorCodes.Type.UNCHECK_ARG,
+      message: `Warning: Not able to evaluate and validate identifier.
+Suggestion: Use literals when you can`,
+    };
   },
 };

--- a/src/workers/workerHelpers.ts
+++ b/src/workers/workerHelpers.ts
@@ -188,6 +188,29 @@ export function findNextChildOfKind(
 }
 
 /**
+ * Checks if a TypeScript AST node is a literal (string, number, boolean).
+ *
+ * @param {ts.Node} node - The TypeScript AST node to check.
+ * @returns {boolean} `true` if the node is a literal (string, number, boolean), `false` otherwise.
+ *
+ * @example
+ * const node = ... // some TypeScript AST node
+ * const result = isLiteral(node);
+ * console.log(result);  // Outputs: true or false
+ */
+function isLiteral(node: tsc.Node): boolean {
+  switch (node.kind) {
+    case tsc.SyntaxKind.StringLiteral:
+    case tsc.SyntaxKind.NumericLiteral:
+    case tsc.SyntaxKind.TrueKeyword:
+    case tsc.SyntaxKind.FalseKeyword:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
  * Removes quotation marks from the input string.
  *
  * @param {string} input - The string from which to remove quotation marks.
@@ -399,6 +422,16 @@ export function validateArguments(
   // ignore specific eDSL local and parameter values
   if (arg_val.startsWith('locals.') || arg_val.startsWith('parameters.')) {
     return false;
+  }
+
+  // ignore identifier as we need literals to do the checks
+  if (!isLiteral(argumentNode)) {
+    return makeDiagnostic(
+      CustomErrorCodes.UncheckableArgumentType(),
+      sourceFile,
+      argumentNode,
+      tsc.DiagnosticCategory.Warning,
+    );
   }
 
   let validation_resp: ValidationReturn;


### PR DESCRIPTION
Closes #897 
During expansion logic, I observed that when the user attempts to utilize the activity's parameters as command arguments, the custom worker throws an error. This occurs because it endeavors to assess the value of the parameters, which haven't been defined yet.

Unfortunately, the custom worker lacks the capability to evaluate identifiers without compiling the user code at runtime, which is not a viable option.

To address this, I have implemented a warning in case this situation arises.

ex.
previous
```ts
let temp = 100
C.PREHEAT_OVEN(temp) #ERROR
```

now
```ts
C.PREHEAT_OVEN(temp) #warning Not able to evaluate identifiers
```