### PR TITLE
feat: add ability to react to action/function permissions

### DIFF
--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -113,9 +113,9 @@
   };
 
   async function applyPresetToActivity(activityPreset: ActivityPreset | null, numOfUserChanges: number) {
-    if (activityPreset === null && activityDirective.applied_preset) {
+    if (activityPreset === null && activityDirective.applied_preset && $plan) {
       await effects.removePresetFromActivityDirective(
-        activityDirective.plan_id,
+        $plan,
         activityDirective.id,
         activityDirective.applied_preset.preset_id,
         user,

--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -10,7 +10,7 @@
     ActivityDirective,
     ActivityDirectiveId,
     ActivityDirectivesMap,
-    ActivityPresetId,
+    ActivityPreset,
     ActivityPresetInsertInput,
     ActivityType,
   } from '../../types/activity';
@@ -112,22 +112,16 @@
     }
   };
 
-  async function applyPresetToActivity(presetId: number | null, numOfUserChanges: number) {
-    if (presetId === null && activityDirective.applied_preset) {
+  async function applyPresetToActivity(activityPreset: ActivityPreset | null, numOfUserChanges: number) {
+    if (activityPreset === null && activityDirective.applied_preset) {
       await effects.removePresetFromActivityDirective(
         activityDirective.plan_id,
         activityDirective.id,
         activityDirective.applied_preset.preset_id,
         user,
       );
-    } else if (presetId !== null) {
-      await effects.applyPresetToActivity(
-        presetId,
-        activityDirective.id,
-        activityDirective.plan_id,
-        numOfUserChanges,
-        user,
-      );
+    } else if (activityPreset !== null && $plan !== null) {
+      await effects.applyPresetToActivity(activityPreset, activityDirective.id, $plan, numOfUserChanges, user);
     }
   }
 
@@ -135,18 +129,24 @@
     editingActivityName = true;
   }
   function updateAnchor({ detail: anchorId }: CustomEvent<ActivityDirectiveId>) {
-    const { id, plan_id } = activityDirective;
-    effects.updateActivityDirective(plan_id, id, { anchor_id: anchorId }, user);
+    const { id } = activityDirective;
+    if ($plan) {
+      effects.updateActivityDirective($plan, id, { anchor_id: anchorId }, user);
+    }
   }
 
   function updateAnchorEdge({ detail: isStart }: CustomEvent<boolean>) {
-    const { id, plan_id } = activityDirective;
-    effects.updateActivityDirective(plan_id, id, { anchored_to_start: isStart }, user);
+    const { id } = activityDirective;
+    if ($plan) {
+      effects.updateActivityDirective($plan, id, { anchored_to_start: isStart }, user);
+    }
   }
 
   function updateStartOffset({ detail: offset }: CustomEvent<string>) {
-    const { id, plan_id } = activityDirective;
-    effects.updateActivityDirective(plan_id, id, { start_offset: offset }, user);
+    const { id } = activityDirective;
+    if ($plan) {
+      effects.updateActivityDirective($plan, id, { start_offset: offset }, user);
+    }
   }
 
   async function onActivityNameKeyup(event: KeyboardEvent) {
@@ -158,42 +158,48 @@
     }
   }
 
-  async function onApplyPresetToActivity(event: CustomEvent<number | null>) {
-    const { detail: presetId } = event;
-    await applyPresetToActivity(presetId, numOfUserChanges);
+  async function onApplyPresetToActivity(event: CustomEvent<ActivityPreset | null>) {
+    const { detail: selectedPreset } = event;
+    await applyPresetToActivity(selectedPreset, numOfUserChanges);
   }
 
   function onChangeFormParameters(event: CustomEvent<FormParameter>) {
     const { detail: formParameter } = event;
-    const { arguments: argumentsMap, id, plan_id } = activityDirective;
+    const { arguments: argumentsMap, id } = activityDirective;
     const newArguments = getArguments(argumentsMap, formParameter);
-    effects.updateActivityDirective(plan_id, id, { arguments: newArguments }, user);
+    if ($plan) {
+      effects.updateActivityDirective($plan, id, { arguments: newArguments }, user);
+    }
   }
 
   function onResetFormParameters(event: CustomEvent<FormParameter>) {
     const { detail: formParameter } = event;
-    const { arguments: argumentsMap, id, plan_id } = activityDirective;
+    const { arguments: argumentsMap, id } = activityDirective;
     const newArguments = getArguments(argumentsMap, {
       ...formParameter,
       value: activityDirective.applied_preset
         ? activityDirective.applied_preset.preset_applied.arguments[formParameter.name]
         : null,
     });
-    effects.updateActivityDirective(plan_id, id, { arguments: newArguments }, user);
+    if ($plan) {
+      effects.updateActivityDirective($plan, id, { arguments: newArguments }, user);
+    }
   }
 
   function onChangeActivityMetadata(event: CustomEvent<{ key: string; value: any }>) {
     const { detail } = event;
     const { key, value } = detail;
-    const { id, metadata, plan_id } = activityDirective;
+    const { id, metadata } = activityDirective;
     const newActivityMetadata = getActivityMetadata(metadata, key, value);
-    effects.updateActivityDirective(plan_id, id, { metadata: newActivityMetadata }, user);
+    if ($plan) {
+      effects.updateActivityDirective($plan, id, { metadata: newActivityMetadata }, user);
+    }
   }
 
-  async function onDeletePreset(event: CustomEvent<ActivityPresetId>) {
-    const { detail: id } = event;
+  async function onDeletePreset(event: CustomEvent<ActivityPreset>) {
+    const { detail: deletedActivityPreset } = event;
     if ($plan) {
-      await effects.deleteActivityPreset(id, $plan.model.name, user);
+      await effects.deleteActivityPreset(deletedActivityPreset, $plan.model.name, user);
     }
   }
 
@@ -201,15 +207,15 @@
     const {
       detail: { name },
     } = event;
-    const id = await effects.createActivityPreset(
+    const createdActivityPreset = await effects.createActivityPreset(
       activityDirective.arguments,
       activityDirective.type,
       name,
       modelId,
       user,
     );
-    if (id !== null) {
-      await applyPresetToActivity(id, 0);
+    if (createdActivityPreset !== null) {
+      await applyPresetToActivity(createdActivityPreset, 0);
     }
   }
 
@@ -220,6 +226,7 @@
       await effects.updateActivityPreset(
         activityDirective.applied_preset.preset_id,
         {
+          ...activityDirective.applied_preset.preset_applied,
           arguments: activityDirective.arguments,
           name,
         },
@@ -231,8 +238,10 @@
   async function onUpdateActivityName() {
     if ($activityNameField.dirty) {
       if ($activityNameField.value) {
-        const { id, plan_id } = activityDirective;
-        effects.updateActivityDirective(plan_id, id, { name: $activityNameField.value }, user);
+        const { id } = activityDirective;
+        if ($plan) {
+          effects.updateActivityDirective($plan, id, { name: $activityNameField.value }, user);
+        }
       } else {
         resetActivityName();
       }
@@ -242,10 +251,12 @@
 
   function onUpdateStartTime() {
     if ($startTimeDoyField.valid && startTimeDoy !== $startTimeDoyField.value) {
-      const { id, plan_id } = activityDirective;
+      const { id } = activityDirective;
       const planStartTimeDoy = getDoyTime(new Date(planStartTimeYmd));
       const start_offset = getIntervalFromDoyRange(planStartTimeDoy, $startTimeDoyField.value);
-      effects.updateActivityDirective(plan_id, id, { start_offset }, user);
+      if ($plan) {
+        effects.updateActivityDirective($plan, id, { start_offset }, user);
+      }
     }
   }
 
@@ -272,8 +283,10 @@
   function resetActivityName() {
     const initialValue = $activityNameField.initialValue;
     activityNameField.reset(initialValue);
-    const { id, plan_id } = activityDirective;
-    effects.updateActivityDirective(plan_id, id, { name: initialValue }, user);
+    const { id } = activityDirective;
+    if ($plan) {
+      effects.updateActivityDirective($plan, id, { name: initialValue }, user);
+    }
   }
 
   async function validateArguments(newArguments: ArgumentsMap | null): Promise<void> {

--- a/src/components/activity/ActivityDirectivesTable.svelte
+++ b/src/components/activity/ActivityDirectivesTable.svelte
@@ -70,10 +70,10 @@
     completeColumnDefs = [...(columnDefs ?? []), activityActionColumnDef];
   }
 
-  async function deleteActivityDirective({ id, plan_id }: ActivityDirective) {
-    if (!isDeletingDirective) {
+  async function deleteActivityDirective({ id }: ActivityDirective) {
+    if (!isDeletingDirective && plan !== null) {
       isDeletingDirective = true;
-      await effects.deleteActivityDirective(plan_id, id, user);
+      await effects.deleteActivityDirective(id, plan, user);
       isDeletingDirective = false;
     }
   }
@@ -82,7 +82,7 @@
     if (!isDeletingDirective && plan !== null) {
       isDeletingDirective = true;
       const ids = activities.map(({ id }) => id);
-      await effects.deleteActivityDirectives(plan.id, ids, user);
+      await effects.deleteActivityDirectives(ids, plan, user);
       isDeletingDirective = false;
     }
   }

--- a/src/components/activity/ActivityFormPanel.svelte
+++ b/src/components/activity/ActivityFormPanel.svelte
@@ -83,8 +83,8 @@
             permissionError: deletePermissionError,
           }}
           on:click|stopPropagation={() => {
-            if ($selectedActivityDirective !== null && hasDeletePermission) {
-              effects.deleteActivityDirective($selectedActivityDirective.plan_id, $selectedActivityDirective.id, user);
+            if ($selectedActivityDirective !== null && $plan !== null && hasDeletePermission) {
+              effects.deleteActivityDirective($selectedActivityDirective.id, $plan, user);
             }
           }}
           use:tooltip={{ content: 'Delete Activity', disabled: !hasDeletePermission, placement: 'top' }}

--- a/src/components/activity/ActivityPresetInput.svelte
+++ b/src/components/activity/ActivityPresetInput.svelte
@@ -45,18 +45,19 @@
   $: if (activityDirective != null) {
     activityPresets.setVariables({ activityTypeName: activityDirective.type, modelId });
   }
-  $: options = $activityPresets.map((activityPreset: ActivityPreset) => ({
-    display: activityPreset.name,
-    hasSelectPermission: hasAssignPermission,
-    value: activityPreset.id,
-  }));
   $: if (plan !== null) {
-    hasAssignPermission = featurePermissions.activityPresets.canAssign(user, plan);
-    // because we also assign after preset creation, we must include both checks here as part of the creation permission check
-    hasCreatePermission =
-      featurePermissions.activityPresets.canCreate(user, plan) &&
-      featurePermissions.activityPresets.canAssign(user, plan) &&
-      !$planReadOnly;
+    options = $activityPresets.map((activityPreset: ActivityPreset) => ({
+      display: activityPreset.name,
+      hasSelectPermission: featurePermissions.activityPresets.canAssign(
+        user,
+        plan as Plan,
+        (plan as Plan).model,
+        activityPreset,
+      ),
+      value: activityPreset.id,
+    }));
+
+    hasCreatePermission = featurePermissions.activityPresets.canCreate(user, plan) && !$planReadOnly;
 
     const selectedPreset = $activityPresets.find(
       activityPreset => activityPreset.id === activityDirective?.applied_preset?.preset_id,
@@ -68,8 +69,10 @@
   }
 
   function onDeletePreset(event: CustomEvent<DropdownOptionValue>) {
-    const { detail: presetId } = event;
-    dispatch('deletePreset', presetId);
+    const { detail: activityPresetId } = event;
+    const deletedActivityPreset = $activityPresets.find(activityPreset => activityPreset.id === activityPresetId);
+
+    dispatch('deletePreset', deletedActivityPreset);
   }
 
   function onSaveNewPreset(event: CustomEvent<string>) {
@@ -84,7 +87,9 @@
 
   function onSelectPreset(event: CustomEvent<SelectedDropdownOptionValue>) {
     const { detail: activityPresetId } = event;
-    dispatch('applyPreset', activityPresetId);
+    const selectedActivityPreset = $activityPresets.find(activityPreset => activityPreset.id === activityPresetId);
+
+    dispatch('applyPreset', selectedActivityPreset ?? null);
   }
 </script>
 

--- a/src/components/activity/ActivityPresetInput.svelte
+++ b/src/components/activity/ActivityPresetInput.svelte
@@ -57,6 +57,7 @@
       value: activityPreset.id,
     }));
 
+    hasAssignPermission = featurePermissions.activityPresets.canUnassign(user, plan) && !$planReadOnly;
     hasCreatePermission = featurePermissions.activityPresets.canCreate(user, plan) && !$planReadOnly;
 
     const selectedPreset = $activityPresets.find(

--- a/src/components/activity/ActivityTypesPanel.svelte
+++ b/src/components/activity/ActivityTypesPanel.svelte
@@ -31,7 +31,7 @@
   async function createActivityDirectiveAtPlanStart(activityType: ActivityType) {
     if ($plan !== null) {
       const { start_time_doy } = $plan;
-      effects.createActivityDirective({}, start_time_doy, activityType.name, activityType.name, {}, user);
+      effects.createActivityDirective({}, start_time_doy, activityType.name, activityType.name, {}, $plan, user);
     }
   }
 

--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -37,7 +37,7 @@
   export let mode: 'create' | 'edit' = 'create';
   export let user: User | null;
 
-  const permissionError = 'You do not have permission to edit this constraint.';
+  const permissionError = `You do not have permission to ${mode === 'edit' ? 'edit this' : 'create a'} constraint.`;
 
   let constraintDefinition: string = initialConstraintDefinition;
   let constraintDescription: string = initialConstraintDescription;
@@ -174,11 +174,12 @@
       if (mode === 'create') {
         const newConstraintId = await effects.createConstraint(
           constraintDefinition,
-          constraintModelId,
+          constraintModelId ? initialModelMap[constraintModelId] : null,
           constraintName,
-          constraintPlanId,
+          constraintPlanId ? initialPlanMap[constraintPlanId] : null,
           user,
           constraintDescription,
+          initialPlans,
         );
 
         if (newConstraintId !== null) {
@@ -194,10 +195,11 @@
         await effects.updateConstraint(
           constraintId,
           constraintDefinition,
-          constraintModelId,
+          constraintModelId ? initialModelMap[constraintModelId] : null,
           constraintName,
-          constraintPlanId,
+          constraintPlanId ? initialPlanMap[constraintPlanId] : null,
           user,
+          initialPlans,
           constraintDescription,
         );
 

--- a/src/components/constraints/ConstraintListItem.svelte
+++ b/src/components/constraints/ConstraintListItem.svelte
@@ -9,6 +9,7 @@
   import { createEventDispatcher } from 'svelte';
   import type { User } from '../../types/app';
   import type { Constraint, ConstraintResult } from '../../types/constraint';
+  import type { Plan } from '../../types/plan';
   import effects from '../../utilities/effects';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { tooltip } from '../../utilities/tooltip';
@@ -18,12 +19,13 @@
   import ConstraintViolationButton from './ConstraintViolationButton.svelte';
 
   export let constraint: Constraint;
+  export let constraintResult: ConstraintResult;
   export let hasDeletePermission: boolean = false;
   export let hasEditPermission: boolean = false;
+  export let plan: Plan | null;
   export let totalViolationCount: number = 0;
-  export let constraintResult: ConstraintResult;
-  export let visible: boolean = true;
   export let user: User | null;
+  export let visible: boolean = true;
 
   const dispatch = createEventDispatcher();
 
@@ -106,7 +108,7 @@
       </ContextMenuItem>
       <ContextMenuHeader>Modify</ContextMenuHeader>
       <ContextMenuItem
-        on:click={() => effects.deleteConstraint(constraint, user)}
+        on:click={() => plan && effects.deleteConstraint(constraint, plan, user)}
         use={[
           [
             permissionHandler,

--- a/src/components/constraints/ConstraintsPanel.svelte
+++ b/src/components/constraints/ConstraintsPanel.svelte
@@ -164,12 +164,14 @@
     <PanelHeaderActions status={$checkConstraintsStatus}>
       <PanelHeaderActionButton
         title="Check Constraints"
-        on:click={() => effects.checkConstraints(user)}
+        on:click={() => $plan && effects.checkConstraints($plan, user)}
         use={[
           [
             permissionHandler,
             {
-              hasPermission: $plan ? featurePermissions.constraints.canCheck(user, $plan) && !$planReadOnly : false,
+              hasPermission: $plan
+                ? featurePermissions.constraints.canCheck(user, $plan, $plan.model) && !$planReadOnly
+                : false,
               permissionError: $planReadOnly
                 ? PlanStatusMessages.READ_ONLY
                 : 'You do not have permission to run constraint checks',
@@ -276,12 +278,13 @@
         {#each filteredConstraints as constraint}
           <ConstraintListItem
             {constraint}
+            constraintResult={filteredConstraintResultMap[constraint.id]}
             hasDeletePermission={$plan ? featurePermissions.constraints.canDelete(user, $plan) : false}
             hasEditPermission={$plan ? featurePermissions.constraints.canUpdate(user, $plan) : false}
-            visible={$constraintVisibilityMap[constraint.id]}
-            constraintResult={filteredConstraintResultMap[constraint.id]}
+            plan={$plan}
             totalViolationCount={$constraintResultMap[constraint.id]?.violations?.length || 0}
             {user}
+            visible={$constraintVisibilityMap[constraint.id]}
             on:toggleVisibility={toggleVisibility}
           />
         {/each}

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -72,7 +72,7 @@
   $: if (user !== null && $plan !== null) {
     hasCreatePermission = featurePermissions.expansionSequences.canCreate(user) && !$planReadOnly;
     hasDeletePermission = featurePermissions.expansionSequences.canDelete(user, $plan) && !$planReadOnly;
-    hasExpandPermission = featurePermissions.expansionSequences.canExpand(user, $plan) && !$planReadOnly;
+    hasExpandPermission = featurePermissions.expansionSequences.canExpand(user, $plan, $plan.model) && !$planReadOnly;
   }
   $: {
     columnDefs = [
@@ -156,8 +156,8 @@
           ],
         ]}
         on:click={() => {
-          if ($selectedExpansionSetId) {
-            effects.expand($selectedExpansionSetId, $simulationDatasetId, user);
+          if ($selectedExpansionSetId && $plan) {
+            effects.expand($selectedExpansionSetId, $simulationDatasetId, $plan, $plan.model, user);
           }
         }}
       />

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -9,7 +9,7 @@
   import { commandDictionaries } from '../../stores/sequencing';
   import { tags } from '../../stores/tags';
   import type { User, UserId } from '../../types/app';
-  import type { ExpansionRule, ExpansionRuleInsertInput } from '../../types/expansion';
+  import type { ExpansionRule, ExpansionRuleInsertInput, ExpansionRuleSetInput } from '../../types/expansion';
   import type { ExpansionRuleTagsInsertInput, Tag, TagsChangeEvent } from '../../types/tags';
   import effects from '../../utilities/effects';
   import { isSaveEvent } from '../../utilities/keyboardEvents';
@@ -171,8 +171,8 @@
           }
         }
       } else if (mode === 'edit') {
-        if (ruleId !== null) {
-          const updatedRule: Partial<ExpansionRule> = {
+        if (ruleId !== null && ruleCreatedAt !== null && ruleTags !== null) {
+          const updatedRule: ExpansionRuleSetInput = {
             ...(hasAuthoringPermission && ruleActivityType !== null ? { activity_type: ruleActivityType } : {}),
             ...(hasAuthoringPermission && ruleDictionaryId !== null
               ? { authoring_command_dict_id: ruleDictionaryId }
@@ -181,6 +181,7 @@
             ...(ruleDescription !== null ? { description: ruleDescription } : {}),
             expansion_logic: ruleLogic,
             name: ruleName,
+            owner: ruleOwner,
           };
           const updated_at = await effects.updateExpansionRule(ruleId, updatedRule, user);
           if (updated_at !== null) {

--- a/src/components/menus/PlanMenu.svelte
+++ b/src/components/menus/PlanMenu.svelte
@@ -22,7 +22,7 @@
   export let user: User | null;
 
   let hasCreateMergeRequestPermission: boolean = false;
-  let hasCreatPlanBranchPermission: boolean = false;
+  let hasCreatePlanBranchPermission: boolean = false;
   let hasCreateSnapshotPermission: boolean = false;
   let planMenu: Menu;
 
@@ -37,7 +37,7 @@
         plan.model,
       ) && !$planReadOnly
     : false;
-  $: hasCreatPlanBranchPermission =
+  $: hasCreatePlanBranchPermission =
     featurePermissions.planBranch.canCreateBranch(user, plan, plan.model) && !$planReadOnly;
   $: hasCreateSnapshotPermission = featurePermissions.planSnapshot.canCreate(user, plan, plan.model) && !$planReadOnly;
 
@@ -82,10 +82,10 @@
           [
             permissionHandler,
             {
-              hasPermission: hasCreateMergeRequestPermission,
+              hasPermission: hasCreatePlanBranchPermission,
               permissionError: $planReadOnly
                 ? PlanStatusMessages.READ_ONLY
-                : 'You do not have permission to create a merge request',
+                : 'You do not have permission to create a plan branch',
             },
           ],
         ]}
@@ -104,10 +104,10 @@
             [
               permissionHandler,
               {
-                hasPermission: hasCreatPlanBranchPermission,
+                hasPermission: hasCreateMergeRequestPermission,
                 permissionError: $planReadOnly
                   ? PlanStatusMessages.READ_ONLY
-                  : 'You do not have permission to create a plan branch',
+                  : 'You do not have permission to create a merge request',
               },
             ],
           ]}

--- a/src/components/menus/PlanMenu.svelte
+++ b/src/components/menus/PlanMenu.svelte
@@ -26,9 +26,20 @@
   let hasCreateSnapshotPermission: boolean = false;
   let planMenu: Menu;
 
-  $: hasCreateMergeRequestPermission = featurePermissions.planBranch.canCreateRequest(user, plan) && !$planReadOnly;
-  $: hasCreatPlanBranchPermission = featurePermissions.planBranch.canCreateBranch(user) && !$planReadOnly;
-  $: hasCreateSnapshotPermission = featurePermissions.planSnapshot.canCreate(user, plan) && !$planReadOnly;
+  $: hasCreateMergeRequestPermission = plan.parent_plan
+    ? featurePermissions.planBranch.canCreateRequest(
+        user,
+        plan,
+        {
+          ...plan.parent_plan,
+          model_id: plan.model_id,
+        },
+        plan.model,
+      ) && !$planReadOnly
+    : false;
+  $: hasCreatPlanBranchPermission =
+    featurePermissions.planBranch.canCreateBranch(user, plan, plan.model) && !$planReadOnly;
+  $: hasCreateSnapshotPermission = featurePermissions.planSnapshot.canCreate(user, plan, plan.model) && !$planReadOnly;
 
   function createMergePlanBranchRequest() {
     effects.createPlanBranchRequest(plan, 'merge', user);

--- a/src/components/menus/ViewMenu.svelte
+++ b/src/components/menus/ViewMenu.svelte
@@ -48,7 +48,7 @@
 
   function editView() {
     if ($view && user) {
-      dispatch('editView', { definition: $view.definition, owner: user.id });
+      dispatch('editView', $view);
     }
   }
 
@@ -66,7 +66,7 @@
 
   function saveView() {
     if ($view && user && $view.owner === user.id && !saveViewDisabled) {
-      dispatch('saveView', { definition: $view.definition, id: $view.id, name: $view.name });
+      dispatch('saveView', { definition: $view.definition, id: $view.id, name: $view.name, owner: $view.owner });
     }
   }
 

--- a/src/components/modals/PlanBranchRequestModal.svelte
+++ b/src/components/modals/PlanBranchRequestModal.svelte
@@ -4,7 +4,7 @@
   import BranchIcon from '@nasa-jpl/stellar/icons/branch.svg?component';
   import MergeIcon from '@nasa-jpl/stellar/icons/merge.svg?component';
   import { createEventDispatcher } from 'svelte';
-  import type { Plan, PlanBranchRequestAction, PlanSchema } from '../../types/plan';
+  import type { Plan, PlanBranchRequestAction, PlanForMerging } from '../../types/plan';
   import Modal from './Modal.svelte';
   import ModalContent from './ModalContent.svelte';
   import ModalFooter from './ModalFooter.svelte';
@@ -21,12 +21,22 @@
   let actionButtonText: string = '';
   let createButtonDisabled: boolean = true;
   let modalHeader: string = '';
-  let planList: Pick<PlanSchema, 'id' | 'name'>[] = [];
+  let planList: PlanForMerging[] = [];
+  let selectedPlan: PlanForMerging | null = null;
   let selectedPlanId: number | null = null;
 
   $: createButtonDisabled = selectedPlanId === null;
   $: selectedPlanId = plan?.parent_plan?.id ?? null;
-  $: planList = plan.parent_plan ? [plan.parent_plan] : [];
+  $: selectedPlan = planList.find(({ id }) => id === selectedPlanId) ?? null;
+  $: planList = plan.parent_plan
+    ? [
+        {
+          ...plan.parent_plan,
+          model: plan.model,
+          model_id: plan.model_id,
+        },
+      ]
+    : [];
   $: if (action === 'merge') {
     modalHeader = 'Merge Request';
     actionHeader = 'Merge to';
@@ -40,9 +50,9 @@
   function create() {
     if (!createButtonDisabled) {
       if (action === 'merge') {
-        dispatch('create', { source_plan_id: plan.id, target_plan_id: selectedPlanId });
+        dispatch('create', { source_plan: plan, target_plan: selectedPlan });
       } else {
-        dispatch('create', { source_plan_id: selectedPlanId, target_plan_id: plan.id });
+        dispatch('create', { source_plan: selectedPlan, target_plan: plan });
       }
     }
   }

--- a/src/components/modals/PlanMergeRequestsModal.svelte
+++ b/src/components/modals/PlanMergeRequestsModal.svelte
@@ -78,13 +78,23 @@
     if (planMergeRequest.type === 'incoming') {
       planMergeRequest.pending = true;
       filteredPlanMergeRequests = [...filteredPlanMergeRequests];
-      const success = await effects.planMergeBegin(planMergeRequest.id, user);
+      const success = await effects.planMergeBegin(
+        planMergeRequest.id,
+        planMergeRequest.plan_snapshot_supplying_changes.plan,
+        planMergeRequest.plan_receiving_changes,
+        user,
+      );
       if (success) {
         dispatch('close');
         goto(`${base}/plans/${planMergeRequest.plan_receiving_changes.id}/merge`);
       }
     } else if (planMergeRequest.type === 'outgoing') {
-      await effects.planMergeRequestWithdraw(planMergeRequest.id, user);
+      await effects.planMergeRequestWithdraw(
+        planMergeRequest.id,
+        planMergeRequest.plan_snapshot_supplying_changes.plan,
+        planMergeRequest.plan_receiving_changes,
+        user,
+      );
     }
 
     planMergeRequest.pending = false;
@@ -109,9 +119,16 @@
       return featurePermissions.planBranch.canDeleteRequest(
         user,
         planMergeRequest.plan_snapshot_supplying_changes.plan,
+        planMergeRequest.plan_receiving_changes,
+        planMergeRequest.plan_snapshot_supplying_changes.plan.model,
       );
     }
-    return featurePermissions.planBranch.canReviewRequest(user, planMergeRequest.plan_receiving_changes);
+    return featurePermissions.planBranch.canReviewRequest(
+      user,
+      planMergeRequest.plan_snapshot_supplying_changes.plan,
+      planMergeRequest.plan_receiving_changes,
+      planMergeRequest.plan_snapshot_supplying_changes.plan.model,
+    );
   }
 </script>
 

--- a/src/components/modals/SavedViewsModal.svelte
+++ b/src/components/modals/SavedViewsModal.svelte
@@ -40,7 +40,8 @@
   }
 
   async function deleteViews({ detail: viewIds }: CustomEvent<number[]>) {
-    const success = await effects.deleteViews(viewIds, user);
+    const matchingViews = userViews.filter(v => viewIds.some(viewId => viewId === v.id));
+    const success = await effects.deleteViews(matchingViews, user);
 
     if (success) {
       if ($view && viewIds.includes($view.id)) {

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -214,7 +214,7 @@
                     $simulationDatasetId = -1;
                   }
                 }}
-                on:restore={() => effects.restorePlanSnapshot(planSnapshot, user)}
+                on:restore={() => plan && effects.restorePlanSnapshot(planSnapshot, plan, user)}
                 on:delete={() => effects.deletePlanSnapshot(planSnapshot, user)}
               />
             {/each}

--- a/src/components/plan/PlanMergeReview.test.ts
+++ b/src/components/plan/PlanMergeReview.test.ts
@@ -3,6 +3,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest
 import { activityMetadataDefinitions } from '../../stores/activities';
 import { activityTypes } from '../../stores/plan';
 import type { User } from '../../types/app';
+import type { Model } from '../../types/model';
 import type {
   Plan,
   PlanMergeConflictingActivity,
@@ -17,13 +18,23 @@ vi.mock('$env/dynamic/public', () => import.meta.env); // https://github.com/sve
 const mockMergeRequest: PlanMergeRequestSchema = {
   id: 1,
   plan_receiving_changes: {
+    collaborators: [],
     id: 1,
+    model: {
+      owner: 'unknown',
+    } as Model,
+    model_id: 1,
     name: 'Demo Plan',
     owner: 'unknown',
   },
   plan_snapshot_supplying_changes: {
     plan: {
+      collaborators: [],
       id: 2,
+      model: {
+        owner: 'unknown',
+      } as Model,
+      model_id: 1,
       name: 'Branch 1',
       owner: 'unknown',
     },
@@ -75,6 +86,7 @@ const user: User = {
   defaultRole: ADMIN_ROLE,
   id: 'foo',
   permissibleQueries: {},
+  rolePermissions: {},
   token: '',
 };
 

--- a/src/components/scheduling/Scheduling.svelte
+++ b/src/components/scheduling/Scheduling.svelte
@@ -36,25 +36,37 @@
   }
 
   async function deleteCondition(condition: SchedulingCondition) {
-    const success = await effects.deleteSchedulingCondition(condition, user);
+    const { scheduling_specification_conditions } = condition;
+    const specification_id = scheduling_specification_conditions[0].specification_id;
+    const plan = plans?.find(plan => plan.scheduling_specifications[0]?.id === specification_id);
 
-    if (success) {
-      schedulingConditions.filterValueById(condition.id);
+    if (plan) {
+      const success = await effects.deleteSchedulingCondition(condition, plan, user);
 
-      if (condition.id === selectedCondition?.id) {
-        selectedCondition = null;
+      if (success) {
+        schedulingConditions.filterValueById(condition.id);
+
+        if (condition.id === selectedCondition?.id) {
+          selectedCondition = null;
+        }
       }
     }
   }
 
   async function deleteGoal(goal: SchedulingGoalSlim) {
-    const success = await effects.deleteSchedulingGoal(goal, user);
+    const { scheduling_specification_goal } = goal;
+    const specification_id = scheduling_specification_goal.specification_id;
+    const plan = plans?.find(plan => plan.scheduling_specifications[0]?.id === specification_id);
 
-    if (success) {
-      schedulingGoals.filterValueById(goal.id);
+    if (plan) {
+      const success = await effects.deleteSchedulingGoal(goal, plan, user);
 
-      if (goal.id === selectedGoal?.id) {
-        selectedGoal = null;
+      if (success) {
+        schedulingGoals.filterValueById(goal.id);
+
+        if (goal.id === selectedGoal?.id) {
+          selectedGoal = null;
+        }
       }
     }
   }

--- a/src/components/scheduling/SchedulingConditionsPanel.svelte
+++ b/src/components/scheduling/SchedulingConditionsPanel.svelte
@@ -87,10 +87,11 @@
       {:else}
         {#each filteredSchedulingSpecConditions as specCondition (specCondition.condition.id)}
           <SchedulingCondition
-            enabled={specCondition.enabled}
             condition={specCondition.condition}
+            enabled={specCondition.enabled}
             {hasDeletePermission}
             {hasEditPermission}
+            plan={$plan}
             specificationId={specCondition.specification_id}
             permissionError={$planReadOnly
               ? PlanStatusMessages.READ_ONLY

--- a/src/components/scheduling/SchedulingGoalsPanel.svelte
+++ b/src/components/scheduling/SchedulingGoalsPanel.svelte
@@ -26,6 +26,7 @@
   let activeElement: HTMLElement;
   let filterText: string = '';
   let filteredSchedulingSpecGoals: SchedulingSpecGoal[] = [];
+  let hasAnalyzePermission: boolean = false;
   let hasCreatePermission: boolean = false;
   let hasDeletePermission: boolean = false;
   let hasGoalEditPermission: boolean = false;
@@ -38,13 +39,13 @@
     return includesName;
   });
 
-  $: hasAnalyzePermission = featurePermissions.schedulingGoals.canAnalyze(user) && !$planReadOnly;
   $: if ($plan) {
+    hasAnalyzePermission = featurePermissions.schedulingGoals.canAnalyze(user, $plan, $plan.model) && !$planReadOnly;
     hasCreatePermission = featurePermissions.schedulingGoals.canCreate(user, $plan) && !$planReadOnly;
     hasDeletePermission = featurePermissions.schedulingGoals.canDelete(user, $plan) && !$planReadOnly;
     hasGoalEditPermission = featurePermissions.schedulingGoals.canUpdate(user, $plan) && !$planReadOnly;
     hasSpecEditPermission = featurePermissions.schedulingGoals.canUpdateSpecification(user, $plan) && !$planReadOnly;
-    hasRunPermission = featurePermissions.schedulingGoals.canRun(user, $plan) && !$planReadOnly;
+    hasRunPermission = featurePermissions.schedulingGoals.canRun(user, $plan, $plan.model) && !$planReadOnly;
   }
 
   // Manually keep focus as scheduling goal elements are re-ordered.
@@ -67,7 +68,7 @@
     <PanelHeaderActions status={$schedulingStatus}>
       <PanelHeaderActionButton
         title="Analyze"
-        on:click={() => effects.schedule(true, user)}
+        on:click={() => effects.schedule(true, $plan, user)}
         disabled={!$enableScheduling}
         use={[
           [
@@ -85,7 +86,7 @@
       </PanelHeaderActionButton>
       <PanelHeaderActionButton
         title="Schedule"
-        on:click={() => effects.schedule(false, user)}
+        on:click={() => effects.schedule(false, $plan, user)}
         disabled={!$enableScheduling}
         use={[
           [
@@ -135,6 +136,7 @@
             {hasSpecEditPermission}
             goal={specGoal.goal}
             priority={specGoal.priority}
+            plan={$plan}
             simulateAfter={specGoal.simulate_after}
             specificationId={specGoal.specification_id}
             {user}

--- a/src/components/scheduling/conditions/SchedulingCondition.svelte
+++ b/src/components/scheduling/conditions/SchedulingCondition.svelte
@@ -3,6 +3,7 @@
 <script lang="ts">
   import { base } from '$app/paths';
   import type { User } from '../../../types/app';
+  import type { Plan } from '../../../types/plan';
   import type { SchedulingCondition } from '../../../types/scheduling';
   import effects from '../../../utilities/effects';
   import { permissionHandler } from '../../../utilities/permissionHandler';
@@ -11,10 +12,11 @@
   import ContextMenuItem from '../../context-menu/ContextMenuItem.svelte';
   import Input from '../../form/Input.svelte';
 
-  export let enabled: boolean;
   export let condition: SchedulingCondition;
+  export let enabled: boolean;
   export let hasDeletePermission: boolean = false;
   export let hasEditPermission: boolean = false;
+  export let plan: Plan | null;
   export let permissionError: string = '';
   export let specificationId: number;
   export let user: User | null;
@@ -56,7 +58,7 @@
       </ContextMenuItem>
       <ContextMenuHeader>Modify</ContextMenuHeader>
       <ContextMenuItem
-        on:click={() => effects.deleteSchedulingCondition(condition, user)}
+        on:click={() => plan && effects.deleteSchedulingCondition(condition, plan, user)}
         use={[
           [
             permissionHandler,

--- a/src/components/scheduling/goals/SchedulingGoal.svelte
+++ b/src/components/scheduling/goals/SchedulingGoal.svelte
@@ -5,6 +5,7 @@
   import CaretDownFillIcon from 'bootstrap-icons/icons/caret-down-fill.svg?component';
   import CaretUpFillIcon from 'bootstrap-icons/icons/caret-up-fill.svg?component';
   import type { User } from '../../../types/app';
+  import type { Plan } from '../../../types/plan';
   import type { SchedulingGoalSlim } from '../../../types/scheduling';
   import effects from '../../../utilities/effects';
   import { permissionHandler } from '../../../utilities/permissionHandler';
@@ -18,6 +19,7 @@
 
   export let enabled: boolean;
   export let goal: SchedulingGoalSlim;
+  export let plan: Plan | null;
   export let priority: number;
   export let specificationId: number;
   export let simulateAfter: boolean = true;
@@ -41,7 +43,9 @@
   }
 
   function updatePriority(priority: number) {
-    effects.updateSchedulingSpecGoal(goal.id, specificationId, { priority }, user);
+    if (plan) {
+      effects.updateSchedulingSpecGoal(goal.id, specificationId, { priority }, plan, user);
+    }
   }
 
   function onKeyDown(e: KeyboardEvent) {
@@ -108,7 +112,8 @@
             bind:checked={enabled}
             style:cursor="pointer"
             type="checkbox"
-            on:change={() => effects.updateSchedulingSpecGoal(goal.id, specificationId, { enabled }, user)}
+            on:change={() =>
+              plan && effects.updateSchedulingSpecGoal(goal.id, specificationId, { enabled }, plan, user)}
             use:permissionHandler={{
               hasPermission: hasSpecEditPermission,
               permissionError,
@@ -138,7 +143,7 @@
       </ContextMenuItem>
       <ContextMenuHeader>Modify</ContextMenuHeader>
       <ContextMenuItem
-        on:click={() => effects.deleteSchedulingGoal(goal, user)}
+        on:click={() => plan && effects.deleteSchedulingGoal(goal, plan, user)}
         use={[
           [
             permissionHandler,
@@ -167,7 +172,9 @@
           role="none"
           on:click|stopPropagation={() => {
             simulateGoal = !simulateGoal;
-            effects.updateSchedulingSpecGoal(goal.id, specificationId, { simulate_after: simulateGoal }, user);
+            if (plan) {
+              effects.updateSchedulingSpecGoal(goal.id, specificationId, { simulate_after: simulateGoal }, plan, user);
+            }
           }}
         >
           <input bind:checked={simulateGoal} style:cursor="pointer" type="checkbox" /> Simulate After

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte.test.ts
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte.test.ts
@@ -58,6 +58,7 @@ describe('Scheduling Goal Form component', () => {
         defaultRole: ADMIN_ROLE,
         id: 'foo',
         permissibleQueries: {},
+        rolePermissions: {},
         token: '',
       },
     });

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -118,7 +118,7 @@
             definition: sequenceDefinition,
             name: sequenceName,
           };
-          const updated_at = await effects.updateUserSequence(sequenceId, updatedSequence, user);
+          const updated_at = await effects.updateUserSequence(sequenceId, updatedSequence, sequenceOwner, user);
           if (updated_at !== null) {
             sequenceUpdatedAt = updated_at;
           }

--- a/src/components/simulation/SimulationTemplateInput.svelte
+++ b/src/components/simulation/SimulationTemplateInput.svelte
@@ -57,7 +57,10 @@
 
   function onDeleteTemplate(event: CustomEvent<DropdownOptionValue>) {
     const { detail: templateId } = event;
-    dispatch('deleteTemplate', templateId);
+    const deletedSimulationTemplate = $simulationTemplates.find(
+      simulationTemplate => simulationTemplate.id === templateId,
+    );
+    dispatch('deleteTemplate', deletedSimulationTemplate);
   }
 
   function onSaveNewTemplate(event: CustomEvent<string>) {

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -10,6 +10,7 @@
   import SpanHashMarksSVG from '../../assets/span-hash-marks.svg?raw';
   import type { ActivityDirective, ActivityDirectiveId, ActivityDirectivesMap } from '../../types/activity';
   import type { User } from '../../types/app';
+  import type { Plan } from '../../types/plan';
   import type { SimulationDataset, Span, SpanId, SpansMap, SpanUtilityMaps } from '../../types/simulation';
   import type {
     ActivityLayerFilter,
@@ -58,7 +59,7 @@
   export let mouseout: MouseEvent | undefined;
   export let mouseup: MouseEvent | undefined;
   export let planEndTimeDoy: string;
-  export let planId: number;
+  export let plan: Plan | null = null;
   export let planStartTimeYmd: string;
   export let selectedActivityDirectiveId: ActivityDirectiveId | null = null;
   export let selectedSpanId: SpanId | null = null;
@@ -214,9 +215,9 @@
 
   function dragActivityEnd(): void {
     if (dragActivityDirectiveActive !== null && dragStartX !== null && dragCurrentX !== null) {
-      if (dragStartX !== dragCurrentX) {
+      if (dragStartX !== dragCurrentX && plan) {
         const start_offset = getIntervalUnixEpochTime(planStartTimeMs, dragCurrentX);
-        effects.updateActivityDirective(planId, dragActivityDirectiveActive.id, { start_offset }, user);
+        effects.updateActivityDirective(plan, dragActivityDirectiveActive.id, { start_offset }, user);
       }
 
       dragActivityDirectiveActive = null;

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -15,6 +15,7 @@
   } from '../../types/activity';
   import type { User } from '../../types/app';
   import type { ConstraintResult } from '../../types/constraint';
+  import type { Plan } from '../../types/plan';
   import type { Resource, SimulationDataset, Span, SpanId, SpanUtilityMaps, SpansMap } from '../../types/simulation';
   import type {
     Axis,
@@ -58,7 +59,7 @@
   export let name: string = '';
   export let marginLeft: number = 50;
   export let planEndTimeDoy: string;
-  export let planId: number;
+  export let plan: Plan | null = null;
   export let planStartTimeYmd: string;
   export let resourcesByViewLayerId: Record<number, Resource[]> = {};
   export let rowDragMoveDisabled = true;
@@ -150,8 +151,8 @@
         const activityTypeName = e.dataTransfer.getData('activityTypeName');
 
         // Only allow creating an activity if we have an actual activity in the drag data.
-        if (activityTypeName) {
-          effects.createActivityDirective({}, start_time, activityTypeName, activityTypeName, {}, user);
+        if (activityTypeName && plan) {
+          effects.createActivityDirective({}, start_time, activityTypeName, activityTypeName, {}, plan, user);
         }
       }
     }
@@ -305,7 +306,7 @@
             {mouseout}
             {mouseup}
             {planEndTimeDoy}
-            {planId}
+            {plan}
             {planStartTimeYmd}
             {selectedActivityDirectiveId}
             {selectedSpanId}

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -6,6 +6,7 @@
   import type { ActivityDirectiveId, ActivityDirectivesByView, ActivityDirectivesMap } from '../../types/activity';
   import type { User } from '../../types/app';
   import type { ConstraintResult } from '../../types/constraint';
+  import type { Plan } from '../../types/plan';
   import type {
     Resource,
     Simulation,
@@ -51,7 +52,7 @@
   export let hasUpdateSimulationPermission: boolean = false;
   export let maxTimeRange: TimeRange = { end: 0, start: 0 };
   export let planEndTimeDoy: string;
-  export let planId: number;
+  export let plan: Plan | null = null;
   export let planStartTimeYmd: string;
   export let resourcesByViewLayerId: Record<number, Resource[]> = {};
   export let selectedActivityDirectiveId: ActivityDirectiveId | null = null;
@@ -330,7 +331,7 @@
         name={row.name}
         marginLeft={timeline?.marginLeft}
         {planEndTimeDoy}
-        {planId}
+        {plan}
         {planStartTimeYmd}
         {resourcesByViewLayerId}
         {rowDragMoveDisabled}
@@ -381,6 +382,7 @@
     {simulationDataset}
     {spansMap}
     {spanUtilityMaps}
+    {plan}
     {planStartTimeYmd}
     verticalGuides={timeline?.verticalGuides ?? []}
     {xScaleView}

--- a/src/components/timeline/TimelineContextMenu.svelte
+++ b/src/components/timeline/TimelineContextMenu.svelte
@@ -8,6 +8,7 @@
   import { view, viewUpdateGrid } from '../../stores/views';
   import type { ActivityDirective, ActivityDirectivesMap } from '../../types/activity';
   import type { User } from '../../types/app';
+  import type { Plan } from '../../types/plan';
   import type { Simulation, SimulationDataset, Span, SpanUtilityMaps, SpansMap } from '../../types/simulation';
   import type { MouseOver, VerticalGuide } from '../../types/timeline';
   import { getAllSpansForActivityDirective, getSpanRootParent } from '../../utilities/activities';
@@ -27,6 +28,7 @@
   export let simulationDataset: SimulationDataset | null = null;
   export let spansMap: SpansMap;
   export let spanUtilityMaps: SpanUtilityMaps;
+  export let plan: Plan | null = null;
   export let planStartTimeYmd: string;
   export let contextMenu: MouseOver | null;
   export let verticalGuides: VerticalGuide[];
@@ -87,19 +89,19 @@
   }
 
   function updateSimulationStartTime(date: Date | null) {
-    if (simulation !== null && date !== null) {
+    if (simulation !== null && date !== null && plan !== null) {
       const doyString = getDoyTime(date, false);
       const newSimulation: Simulation = { ...simulation, simulation_start_time: doyString };
-      effects.updateSimulation(newSimulation, user);
+      effects.updateSimulation(plan, newSimulation, user);
       switchToSimulation();
     }
   }
 
   function updateSimulationEndTime(date: Date | null) {
-    if (simulation !== null && date !== null) {
+    if (simulation !== null && date !== null && plan !== null) {
       const doyString = getDoyTime(date, false);
       const newSimulation: Simulation = { ...simulation, simulation_end_time: doyString };
-      effects.updateSimulation(newSimulation, user);
+      effects.updateSimulation(plan, newSimulation, user);
       switchToSimulation();
     }
   }

--- a/src/components/timeline/TimelinePanel.svelte
+++ b/src/components/timeline/TimelinePanel.svelte
@@ -8,7 +8,7 @@
     selectedActivityDirectiveId,
   } from '../../stores/activities';
   import { visibleConstraintResults } from '../../stores/constraints';
-  import { maxTimeRange, plan, planId, planReadOnly, viewTimeRange } from '../../stores/plan';
+  import { maxTimeRange, plan, planReadOnly, viewTimeRange } from '../../stores/plan';
   import {
     resourcesByViewLayerId,
     selectedSpanId,
@@ -48,7 +48,9 @@
 
   function deleteActivityDirective(event: CustomEvent<ActivityDirectiveId>) {
     const { detail: activityDirectiveId } = event;
-    effects.deleteActivityDirective($planId, activityDirectiveId, user);
+    if ($plan) {
+      effects.deleteActivityDirective(activityDirectiveId, $plan, user);
+    }
   }
 
   function openSelectedActivityPanel(event: CustomEvent) {
@@ -159,7 +161,7 @@
       {hasUpdateSimulationPermission}
       maxTimeRange={$maxTimeRange}
       planEndTimeDoy={$plan?.end_time_doy ?? ''}
-      planId={$planId}
+      plan={$plan}
       planStartTimeYmd={$plan?.start_time ?? ''}
       {timeline}
       {timelineDirectiveVisibilityToggles}

--- a/src/components/ui/EditableDropdown.svelte
+++ b/src/components/ui/EditableDropdown.svelte
@@ -131,6 +131,7 @@
   {error}
   {options}
   {placeholder}
+  {planReadOnly}
   {searchPlaceholder}
   {selectedOptionValue}
   {settingsIconTooltip}

--- a/src/components/ui/SearchableDropdown.svelte
+++ b/src/components/ui/SearchableDropdown.svelte
@@ -19,6 +19,7 @@
   import Menu from '../menus/Menu.svelte';
   import MenuHeader from '../menus/MenuHeader.svelte';
   import MenuItem from '../menus/MenuItem.svelte';
+  import { PlanStatusMessages } from '../../enums/planStatusMessages';
 
   interface PlaceholderOption extends Omit<DropdownOption, 'value'> {
     value: null;
@@ -33,6 +34,7 @@
   export let maxListHeight: string = '300px';
   export let updatePermissionError: string = 'You do not have permission to update this';
   export let placeholder: string = '';
+  export let planReadOnly: boolean = false;
   export let selectedOptionValue: SelectedDropdownOptionValue | undefined = undefined;
   export let showPlaceholderOption: boolean = true;
   export let searchPlaceholder: string = 'Search Items';
@@ -109,8 +111,8 @@
     role="textbox"
     aria-label={selectedOption?.display ?? placeholder}
     use:permissionHandler={{
-      hasPermission: hasUpdatePermission,
-      permissionError: updatePermissionError,
+      hasPermission: hasUpdatePermission && !planReadOnly,
+      permissionError: planReadOnly ? PlanStatusMessages.READ_ONLY : updatePermissionError,
     }}
     use:tooltip={{ content: error, placement: 'top' }}
   >
@@ -118,7 +120,7 @@
     <button
       use:tooltip={{
         content: settingsIconTooltip,
-        disabled: !hasUpdatePermission,
+        disabled: !hasUpdatePermission && planReadOnly,
         placement: settingsIconTooltipPlacement,
       }}
       class="icon st-button settings-icon"

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -9,12 +9,14 @@ import { ADMIN_ROLE } from './utilities/permissions';
 export const handle: Handle = async ({ event, resolve }) => {
   if (!isLoginEnabled()) {
     const permissibleQueries = await effects.getUserQueries(null);
+    const rolePermissions = await effects.getRolePermissions(null);
     event.locals.user = {
       activeRole: ADMIN_ROLE,
       allowedRoles: [ADMIN_ROLE],
       defaultRole: ADMIN_ROLE,
       id: 'unknown',
       permissibleQueries,
+      rolePermissions,
       token: '',
     };
   } else {
@@ -39,12 +41,15 @@ export const handle: Handle = async ({ event, resolve }) => {
           allowedRoles,
           defaultRole,
           permissibleQueries: null,
+          rolePermissions: null,
         };
         const permissibleQueries = await effects.getUserQueries(user);
 
+        const rolePermissions = await effects.getRolePermissions(user);
         event.locals.user = {
           ...user,
           permissibleQueries,
+          rolePermissions,
         };
       } else {
         event.locals.user = null;

--- a/src/routes/expansion/sets/new/+page.svelte
+++ b/src/routes/expansion/sets/new/+page.svelte
@@ -7,4 +7,4 @@
   export let data: PageData;
 </script>
 
-<ExpansionSetForm mode="create" user={data.user} />
+<ExpansionSetForm mode="create" user={data.user} plans={data.initialPlans} />

--- a/src/routes/expansion/sets/new/+page.ts
+++ b/src/routes/expansion/sets/new/+page.ts
@@ -1,5 +1,6 @@
 import { base } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
+import effects from '../../../../utilities/effects';
 import { shouldRedirectToLogin } from '../../../../utilities/login';
 import type { PageLoad } from './$types';
 
@@ -10,5 +11,7 @@ export const load: PageLoad = async ({ parent }) => {
     throw redirect(302, `${base}/login`);
   }
 
-  return { user };
+  const { plans: initialPlans } = await effects.getPlansAndModels(user);
+
+  return { initialPlans, user };
 };

--- a/src/routes/tags/+page.svelte
+++ b/src/routes/tags/+page.svelte
@@ -205,6 +205,7 @@
     const tag = {
       color: $colorField.value,
       name: $nameField.value,
+      owner: selectedTag.owner,
     };
     const updatedTag = await effects.updateTag(selectedTag.id, tag, user);
     if (updatedTag) {

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -1,6 +1,6 @@
 import type { ActivityDeletionAction } from '../utilities/activities';
 import type { ActivityMetadata } from './activity-metadata';
-import type { UserId } from './app';
+import type { PartialWith, UserId } from './app';
 import type { ExpansionRuleSlim } from './expansion';
 import type { ArgumentsMap, ParametersMap } from './parameter';
 import type { ValueSchema } from './schema';
@@ -79,14 +79,12 @@ export type ActivityPreset = {
   owner: UserId;
 };
 
-export type ActivityPresetInsertInput = {
-  arguments: ArgumentsMap;
-  associated_activity_type: string;
-  model_id: number;
-  name: string;
-};
+export type ActivityPresetInsertInput = Pick<
+  ActivityPreset,
+  'arguments' | 'associated_activity_type' | 'model_id' | 'name'
+>;
 
-export type ActivityPresetSetInput = Partial<ActivityPresetInsertInput>;
+export type ActivityPresetSetInput = PartialWith<ActivityPreset, 'owner'>;
 
 export type AnchorValidationStatus = {
   activity_id: ActivityDirectiveId;

--- a/src/types/app.ts
+++ b/src/types/app.ts
@@ -1,4 +1,4 @@
-import type { PermissibleQueriesMap } from './permissions';
+import type { PermissibleQueriesMap, RolePermissionsMap } from './permissions';
 
 export type UserId = string | null;
 
@@ -14,6 +14,7 @@ export type User = BaseUser & {
   allowedRoles: UserRole[];
   defaultRole: UserRole;
   permissibleQueries: PermissibleQueriesMap | null;
+  rolePermissions: RolePermissionsMap | null;
 };
 
 export type ParsedUserToken = {
@@ -34,3 +35,5 @@ export type Version = {
   date: string;
   name: string;
 };
+
+export type PartialWith<T, K extends keyof T> = Partial<T> & Pick<T, K>;

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -1,4 +1,4 @@
-import type { UserId } from './app';
+import type { PartialWith, UserId } from './app';
 import type { SeqJson } from './sequencing';
 import type { SpanId } from './simulation';
 import type { Tag } from './tags';
@@ -24,6 +24,7 @@ export type ExpansionRuleInsertInput = Omit<
   ExpansionRuleSlim,
   'created_at' | 'id' | 'updated_at' | 'updated_by' | 'owner' | 'tags'
 >;
+export type ExpansionRuleSetInput = PartialWith<ExpansionRule, 'owner'>;
 
 export type ExpansionSequenceToActivityInsertInput = {
   seq_id: string;

--- a/src/types/permissions.ts
+++ b/src/types/permissions.ts
@@ -1,9 +1,12 @@
-import type { User, UserId } from './app';
+import type { User, UserId, UserRole } from './app';
+import type { Model } from './model';
 import type { Plan } from './plan';
 
 export type AssetWithOwner<T = any> = Partial<T> & {
   owner: UserId;
 };
+
+export type ModelWithOwner = Pick<Model, 'id' | 'owner'>;
 
 export type PermissibleQueriesMap = Record<string, true>;
 
@@ -27,20 +30,32 @@ export type PermissionCheck<T = AssetWithOwner> =
   | CreatePermissionCheck
   | UpdatePermissionCheck<T>;
 
+export type PlanWithOwners = Pick<Plan, 'id' | 'owner' | 'collaborators' | 'model_id'>;
+
 export type ReadPermissionCheck<T = AssetWithOwner> = (user: User | null, asset?: T) => boolean;
 
 export type CreatePermissionCheck = (user: User | null) => boolean;
 
 export type UpdatePermissionCheck<T = AssetWithOwner> = (user: User | null, asset: T) => boolean;
 
-export type PlanAssetReadPermissionCheck = (user: User | null) => boolean;
+export type RolePermission =
+  | 'NO_CHECK'
+  | 'OWNER'
+  | 'MISSION_MODEL_OWNER'
+  | 'PLAN_OWNER'
+  | 'PLAN_COLLABORATOR'
+  | 'PLAN_OWNER_COLLABORATOR'
+  | 'PLAN_OWNER_SOURCE'
+  | 'PLAN_COLLABORATOR_SOURCE'
+  | 'PLAN_OWNER_COLLABORATOR_SOURCE'
+  | 'PLAN_OWNER_TARGET'
+  | 'PLAN_COLLABORATOR_TARGET'
+  | 'PLAN_OWNER_COLLABORATOR_TARGET';
 
-export type PlanAssetCreatePermissionCheck = (user: User | null, plan: PlanWithOwners) => boolean;
+export type RolePermissionResponse = {
+  action_permissions: Record<string, RolePermission>;
+  function_permissions: Record<string, RolePermission>;
+  role: UserRole;
+};
 
-export type PlanAssetUpdatePermissionCheck<T = AssetWithOwner> = (
-  user: User | null,
-  plan: PlanWithOwners,
-  asset?: T,
-) => boolean;
-
-export type PlanWithOwners = Pick<Plan, 'id' | 'owner' | 'collaborators'>;
+export type RolePermissionsMap = Record<string, RolePermission>;

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -51,19 +51,15 @@ export type PlanMergeRequest = PlanMergeRequestSchema & { pending: boolean; type
 
 export type PlanMergeRequestStatus = 'accepted' | 'in-progress' | 'pending' | 'rejected' | 'withdrawn';
 
+export type PlanForMerging = Pick<PlanSchema, 'id' | 'name' | 'owner' | 'collaborators' | 'model_id'> & {
+  model: Pick<Model, 'id' | 'name' | 'owner' | 'version'>;
+};
+
 export type PlanMergeRequestSchema = {
   id: number;
-  plan_receiving_changes: {
-    id: number;
-    name: string;
-    owner: UserId;
-  };
+  plan_receiving_changes: PlanForMerging;
   plan_snapshot_supplying_changes: {
-    plan: {
-      id: number;
-      name: string;
-      owner: UserId;
-    };
+    plan: PlanForMerging;
     snapshot_id: number;
   };
   requester_username: string;
@@ -84,7 +80,7 @@ export type PlanSchema = {
   model_id: number;
   name: string;
   owner: UserId;
-  parent_plan: Pick<PlanSchema, 'id' | 'name'> | null;
+  parent_plan: Pick<PlanSchema, 'id' | 'name' | 'owner' | 'collaborators'> | null;
   revision: number;
   scheduling_specifications: Pick<SchedulingSpec, 'id'>[];
   simulations: [{ simulation_datasets: [{ id: number; plan_revision: number }] }];

--- a/src/types/tags.ts
+++ b/src/types/tags.ts
@@ -43,6 +43,6 @@ export type TagsMap = Record<Tag['id'], Tag>;
 
 export type TagsInsertInput = Pick<Tag, 'color' | 'name'>;
 
-export type TagsSetInput = Pick<Tag, 'color' | 'name'>;
+export type TagsSetInput = Pick<Tag, 'color' | 'name' | 'owner'>;
 
 export type TagsChangeEvent = CustomEvent<{ tag: Tag; type: 'select' | 'create' | 'remove' }>;

--- a/src/utilities/effects.test.ts
+++ b/src/utilities/effects.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as Errors from '../stores/errors';
 import type { User } from '../types/app';
+import type { Model } from '../types/model';
 import type { Plan } from '../types/plan';
 import effects from './effects';
 import * as Modals from './modal';
@@ -116,6 +117,7 @@ const user: User = {
     view: true,
     withdraw_merge_request: true,
   },
+  rolePermissions: {},
   token: '',
 };
 
@@ -140,7 +142,32 @@ describe('Handle modal and requests in effects', () => {
       vi.spyOn(Modals, 'showConfirmModal').mockResolvedValueOnce({ confirm: true });
       vi.spyOn(Errors, 'catchError').mockImplementationOnce(catchErrorSpy);
 
-      await effects.applyPresetToActivity(1, 2, 3, 4, user);
+      await effects.applyPresetToActivity(
+        {
+          arguments: {},
+          associated_activity_type: 'foo',
+          id: 1,
+          model_id: 1,
+          name: 'Foo preset',
+          owner: 'test',
+        },
+        2,
+        {
+          collaborators: [
+            {
+              collaborator: 'test',
+            },
+          ],
+          id: 3,
+          model: {
+            id: 1,
+            owner: 'test',
+          } as Model,
+          owner: 'test',
+        } as Plan,
+        4,
+        user,
+      );
 
       expect(catchErrorSpy).toHaveBeenCalledWith(
         'Preset Unable To Be Applied To Activity',
@@ -151,9 +178,6 @@ describe('Handle modal and requests in effects', () => {
 
   describe('applyTemplateToSimulation', () => {
     it('should correctly handle null responses', async () => {
-      mockPlanStore.plan.set({
-        id: 1,
-      } as Plan);
       vi.spyOn(Requests, 'reqHasura').mockResolvedValue({
         updateSimulation: null,
       });
@@ -176,6 +200,10 @@ describe('Handle modal and requests in effects', () => {
           simulation_start_time: '',
           template: null,
         },
+        {
+          id: 1,
+          owner: 'test',
+        } as Plan,
         3,
         user,
       );
@@ -196,7 +224,13 @@ describe('Handle modal and requests in effects', () => {
       vi.spyOn(Modals, 'showConfirmModal').mockResolvedValueOnce({ confirm: true });
       vi.spyOn(Errors, 'catchError').mockImplementationOnce(catchErrorSpy);
 
-      await effects.checkConstraints(user);
+      await effects.checkConstraints(
+        {
+          id: 1,
+          owner: 'test',
+        } as Plan,
+        user,
+      );
 
       expect(catchErrorSpy).toHaveBeenCalledWith(
         'Check Constraints Failed',
@@ -213,7 +247,18 @@ describe('Handle modal and requests in effects', () => {
 
       vi.spyOn(Errors, 'catchError').mockImplementationOnce(catchErrorSpy);
 
-      await effects.createActivityDirective({}, '2020-100T00:00:00', '', 'foo', {}, user);
+      await effects.createActivityDirective(
+        {},
+        '2020-100T00:00:00',
+        '',
+        'foo',
+        {},
+        {
+          id: 1,
+          owner: 'test',
+        } as Plan,
+        user,
+      );
 
       expect(catchErrorSpy).toHaveBeenCalledWith(
         'Activity Directive Create Failed',

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -3377,19 +3377,19 @@ const effects = {
   },
 
   async removePresetFromActivityDirective(
-    plan_id: number,
+    plan: Plan,
     activity_directive_id: ActivityDirectiveId,
     preset_id: ActivityPresetId,
     user: User | null,
   ): Promise<boolean> {
     try {
-      if (!queryPermissions.DELETE_PRESET_TO_DIRECTIVE(user)) {
+      if (!queryPermissions.DELETE_PRESET_TO_DIRECTIVE(user, plan)) {
         throwPermissionError('remove the preset from this activity directive');
       }
 
       const data = await reqHasura<{ preset_id: number }>(
         gql.DELETE_PRESET_TO_DIRECTIVE,
-        { activity_directive_id, plan_id, preset_id },
+        { activity_directive_id, plan_id: plan.id, preset_id },
         user,
       );
       if (data.delete_preset_to_directive_by_pk != null) {

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -839,6 +839,7 @@ const gql = {
           id
           jar_id
           name
+          owner
           parameters {
             parameters
           }
@@ -850,6 +851,10 @@ const gql = {
         parent_plan {
           id
           name
+          owner
+          collaborators {
+            collaborator
+          }
         }
         revision
         scheduling_specifications {
@@ -1024,6 +1029,16 @@ const gql = {
       resource_types: resource_type(where: { model_id: { _eq: $model_id } }, order_by: { name: asc }, limit: $limit) {
         name
         schema
+      }
+    }
+  `,
+
+  GET_ROLE_PERMISSIONS: `#graphql
+    query GetRolePermissions {
+      rolePermissions: user_role_permission {
+        role
+        action_permissions
+        function_permissions
       }
     }
   `,
@@ -1345,8 +1360,11 @@ const gql = {
         applied_preset {
           preset_id
           preset_applied {
-            name
             arguments
+            associated_activity_type
+            id
+            name
+            owner
           }
         }
         arguments
@@ -1594,14 +1612,32 @@ const gql = {
         id
         plan_receiving_changes {
           id
+          model: mission_model {
+            id
+            name
+            owner
+            version
+          }
           name
           owner
+          collaborators {
+            collaborator
+          }
         }
         plan_snapshot_supplying_changes {
           plan {
             id
+            model: mission_model {
+              id
+              name
+              owner
+              version
+            }
             name
             owner
+            collaborators {
+              collaborator
+            }
           }
           snapshot_id
         }
@@ -1618,14 +1654,32 @@ const gql = {
         id
         plan_receiving_changes {
           id
+          model: mission_model {
+            id
+            name
+            owner
+            version
+          }
           name
           owner
+          collaborators {
+            collaborator
+          }
         }
         plan_snapshot_supplying_changes {
           plan {
             id
+            model: mission_model {
+              id
+              name
+              owner
+              version
+            }
             name
             owner
+            collaborators {
+              collaborator
+            }
           }
           snapshot_id
         }
@@ -1641,14 +1695,32 @@ const gql = {
         id
         plan_receiving_changes {
           id
+          model: mission_model {
+            id
+            name
+            owner
+            version
+          }
           name
           owner
+          collaborators {
+            collaborator
+          }
         }
         plan_snapshot_supplying_changes {
           plan {
             id
+            model: mission_model {
+              id
+              name
+              owner
+              version
+            }
             name
             owner
+            collaborators {
+              collaborator
+            }
           }
           snapshot_id
         }

--- a/src/utilities/login.test.ts
+++ b/src/utilities/login.test.ts
@@ -39,6 +39,7 @@ describe('login util functions', () => {
           defaultRole: 'user',
           id: 'foo',
           permissibleQueries: {},
+          rolePermissions: {},
           token: 'foo',
         }),
       ).toEqual(true);
@@ -52,6 +53,7 @@ describe('login util functions', () => {
           permissibleQueries: {
             constraints: true,
           },
+          rolePermissions: {},
           token: 'foo',
         }),
       ).toEqual(false);
@@ -68,6 +70,7 @@ describe('login util functions', () => {
           defaultRole: 'user',
           id: 'foo',
           permissibleQueries: {},
+          rolePermissions: {},
           token: 'foo',
         }),
       ).toEqual(false);
@@ -81,6 +84,7 @@ describe('login util functions', () => {
           permissibleQueries: {
             constraints: true,
           },
+          rolePermissions: {},
           token: 'foo',
         }),
       ).toEqual(false);

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -19,7 +19,13 @@ import type { ActivityDirectiveDeletionMap, ActivityDirectiveId } from '../types
 import type { User } from '../types/app';
 import type { ExpansionSequence } from '../types/expansion';
 import type { ModalElement, ModalElementValue } from '../types/modal';
-import type { Plan, PlanBranchRequestAction, PlanMergeRequestStatus, PlanMergeRequestTypeFilter } from '../types/plan';
+import type {
+  Plan,
+  PlanBranchRequestAction,
+  PlanForMerging,
+  PlanMergeRequestStatus,
+  PlanMergeRequestTypeFilter,
+} from '../types/plan';
 import type { PlanSnapshot } from '../types/plan-snapshot';
 import type { Tag } from '../types/tags';
 import type { ViewDefinition } from '../types/view';
@@ -402,7 +408,12 @@ export async function showExpansionSequenceModal(
 export async function showPlanBranchRequestModal(
   plan: Plan,
   action: PlanBranchRequestAction,
-): Promise<ModalElementValue<{ source_plan_id: number; target_plan_id: number }>> {
+): Promise<
+  ModalElementValue<{
+    source_plan: PlanForMerging;
+    target_plan: PlanForMerging;
+  }>
+> {
   return new Promise(resolve => {
     if (browser) {
       const target: ModalElement | null = document.querySelector('#svelte-modal');
@@ -418,12 +429,20 @@ export async function showPlanBranchRequestModal(
           planModal.$destroy();
         });
 
-        planModal.$on('create', (e: CustomEvent<{ source_plan_id: number; target_plan_id: number }>) => {
-          target.replaceChildren();
-          target.resolve = null;
-          resolve({ confirm: true, value: e.detail });
-          planModal.$destroy();
-        });
+        planModal.$on(
+          'create',
+          (
+            e: CustomEvent<{
+              source_plan: PlanForMerging;
+              target_plan: PlanForMerging;
+            }>,
+          ) => {
+            target.replaceChildren();
+            target.resolve = null;
+            resolve({ confirm: true, value: e.detail });
+            planModal.$destroy();
+          },
+        );
       }
     } else {
       resolve({ confirm: false });

--- a/src/utilities/permissions.test.ts
+++ b/src/utilities/permissions.test.ts
@@ -19,6 +19,7 @@ describe('hasNoAuthorization', () => {
         defaultRole: 'user',
         id: 'foo',
         permissibleQueries: {},
+        rolePermissions: {},
         token: '',
       }),
     ).toEqual(true);
@@ -32,6 +33,7 @@ describe('hasNoAuthorization', () => {
         permissibleQueries: {
           constraint: true,
         },
+        rolePermissions: {},
         token: '',
       }),
     ).toEqual(false);
@@ -58,6 +60,7 @@ describe('Check roles', () => {
         permissibleQueries: {
           constraint: true,
         },
+        rolePermissions: {},
         token: '',
       }),
     ).toEqual(false);
@@ -69,6 +72,7 @@ describe('Check roles', () => {
         defaultRole: 'user',
         id: 'foo',
         permissibleQueries: {},
+        rolePermissions: {},
         token: '',
       }),
     ).toEqual(true);
@@ -85,6 +89,7 @@ describe('Check roles', () => {
           permissibleQueries: {
             constraint: true,
           },
+          rolePermissions: {},
           token: '',
         },
         {
@@ -101,6 +106,7 @@ describe('Check roles', () => {
           defaultRole: 'user',
           id: 'foo',
           permissibleQueries: {},
+          rolePermissions: {},
           token: '',
         },
         {
@@ -121,6 +127,7 @@ describe('Check roles', () => {
           permissibleQueries: {
             constraint: true,
           },
+          rolePermissions: {},
           token: '',
         },
         {
@@ -139,6 +146,7 @@ describe('Check roles', () => {
           defaultRole: 'user',
           id: 'foo',
           permissibleQueries: {},
+          rolePermissions: {},
           token: '',
         },
         {
@@ -161,11 +169,13 @@ describe('Check roles', () => {
           permissibleQueries: {
             constraint: true,
           },
+          rolePermissions: {},
           token: '',
         },
         {
           collaborators: [{ collaborator: 'foo' }],
           id: 1,
+          model_id: 1,
           owner: 'bar',
         },
       ),
@@ -179,11 +189,13 @@ describe('Check roles', () => {
           defaultRole: 'user',
           id: 'foo',
           permissibleQueries: {},
+          rolePermissions: {},
           token: '',
         },
         {
           collaborators: [{ collaborator: 'foo' }],
           id: 1,
+          model_id: 1,
           owner: 'bar',
         },
       ),

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -278,51 +278,56 @@ const queryPermissions = {
     preset: ActivityPreset,
   ): boolean => {
     const queries = ['apply_preset_to_activity'];
-    return getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model, preset);
+    return (
+      isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model, preset))
+    );
   },
   CHECK_CONSTRAINTS: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
     const queries = ['constraintViolations'];
-    return getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model);
+    return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
   CREATE_ACTIVITY_DIRECTIVE: (user: User | null, plan: PlanWithOwners): boolean => {
     const queries = ['insert_activity_directive_one'];
-    return getPermission(queries, user) && (isPlanOwner(user, plan) || isPlanCollaborator(user, plan));
+    return (
+      isUserAdmin(user) || (getPermission(queries, user) && (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
+    );
   },
   CREATE_ACTIVITY_DIRECTIVE_TAGS: (user: User | null): boolean => {
-    return getPermission(['insert_activity_directive_tags'], user);
+    return isUserAdmin(user) || getPermission(['insert_activity_directive_tags'], user);
   },
   CREATE_ACTIVITY_PRESET: (user: User | null): boolean => {
-    return getPermission(['insert_activity_presets_one'], user);
+    return isUserAdmin(user) || getPermission(['insert_activity_presets_one'], user);
   },
   CREATE_COMMAND_DICTIONARY: (user: User | null): boolean => {
-    return getPermission(['uploadDictionary'], user);
+    return isUserAdmin(user) || getPermission(['uploadDictionary'], user);
   },
   CREATE_CONSTRAINT: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
-      getPermission(['insert_constraint_one'], user) && (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+      isUserAdmin(user) ||
+      (getPermission(['insert_constraint_one'], user) && (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
   CREATE_CONSTRAINT_TAGS: (user: User | null): boolean => {
-    return getPermission(['insert_constraint_tags'], user);
+    return isUserAdmin(user) || getPermission(['insert_constraint_tags'], user);
   },
   CREATE_EXPANSION_RULE: (user: User | null): boolean => {
-    return getPermission(['insert_expansion_rule_one'], user);
+    return isUserAdmin(user) || getPermission(['insert_expansion_rule_one'], user);
   },
   CREATE_EXPANSION_RULE_TAGS: (user: User | null): boolean => {
-    return getPermission(['insert_expansion_rule_tags'], user);
+    return isUserAdmin(user) || getPermission(['insert_expansion_rule_tags'], user);
   },
   CREATE_EXPANSION_SEQUENCE: (user: User | null): boolean => {
-    return getPermission(['insert_sequence_one'], user);
+    return isUserAdmin(user) || getPermission(['insert_sequence_one'], user);
   },
   CREATE_EXPANSION_SET: (user: User | null, plans: PlanWithOwners[], model: ModelWithOwner): boolean => {
     const queries = ['createExpansionSet'];
-    return getPermission(queries, user) && getRoleModelPermission(queries, user, plans, model);
+    return isUserAdmin(user) || (getPermission(queries, user) && getRoleModelPermission(queries, user, plans, model));
   },
   CREATE_MODEL: (user: User | null): boolean => {
-    return getPermission(['insert_mission_model_one'], user);
+    return isUserAdmin(user) || getPermission(['insert_mission_model_one'], user);
   },
   CREATE_PLAN: (user: User | null): boolean => {
-    return getPermission(['insert_plan_one'], user);
+    return isUserAdmin(user) || getPermission(['insert_plan_one'], user);
   },
   CREATE_PLAN_MERGE_REQUEST: (
     user: User | null,
@@ -331,56 +336,64 @@ const queryPermissions = {
     model: ModelWithOwner,
   ): boolean => {
     const queries = ['create_merge_request'];
-    return getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model);
+    return (
+      isUserAdmin(user) ||
+      (getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model))
+    );
   },
   CREATE_PLAN_SNAPSHOT: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
     const queries = ['create_snapshot'];
-    return getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model);
+    return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
   CREATE_PLAN_SNAPSHOT_TAGS: (user: User | null): boolean => {
-    return getPermission(['insert_plan_snapshot_tags'], user);
+    return isUserAdmin(user) || getPermission(['insert_plan_snapshot_tags'], user);
   },
   CREATE_PLAN_TAGS: (user: User | null): boolean => {
-    return getPermission(['insert_plan_tags'], user);
+    return isUserAdmin(user) || getPermission(['insert_plan_tags'], user);
   },
   CREATE_SCHEDULING_CONDITION: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
-      getPermission(['insert_scheduling_condition_one'], user) &&
-      (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+      isUserAdmin(user) ||
+      (getPermission(['insert_scheduling_condition_one'], user) &&
+        (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
   CREATE_SCHEDULING_GOAL: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
-      getPermission(['insert_scheduling_goal_one'], user) && (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+      isUserAdmin(user) ||
+      (getPermission(['insert_scheduling_goal_one'], user) &&
+        (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
   CREATE_SCHEDULING_GOAL_TAGS: (user: User | null): boolean => {
-    return getPermission(['insert_scheduling_goal_tags'], user);
+    return isUserAdmin(user) || getPermission(['insert_scheduling_goal_tags'], user);
   },
   CREATE_SCHEDULING_SPEC: (user: User | null): boolean => {
-    return getPermission(['insert_scheduling_specification_one'], user);
+    return isUserAdmin(user) || getPermission(['insert_scheduling_specification_one'], user);
   },
   CREATE_SCHEDULING_SPEC_CONDITION: (user: User | null): boolean => {
-    return getPermission(['insert_scheduling_specification_conditions_one'], user);
+    return isUserAdmin(user) || getPermission(['insert_scheduling_specification_conditions_one'], user);
   },
   CREATE_SCHEDULING_SPEC_GOAL: (user: User | null): boolean => {
-    return getPermission(['insert_scheduling_specification_goals_one'], user);
+    return isUserAdmin(user) || getPermission(['insert_scheduling_specification_goals_one'], user);
   },
   CREATE_SIMULATION_TEMPLATE: (user: User | null): boolean => {
-    return getPermission(['insert_simulation_template_one'], user);
+    return isUserAdmin(user) || getPermission(['insert_simulation_template_one'], user);
   },
   CREATE_TAGS: (user: User | null): boolean => {
-    return getPermission(['insert_tags'], user);
+    return isUserAdmin(user) || getPermission(['insert_tags'], user);
   },
   CREATE_USER_SEQUENCE: (user: User | null): boolean => {
-    return getPermission(['insert_user_sequence_one'], user);
+    return isUserAdmin(user) || getPermission(['insert_user_sequence_one'], user);
   },
   CREATE_VIEW: (user: User | null): boolean => {
-    return getPermission(['insert_view_one'], user);
+    return isUserAdmin(user) || getPermission(['insert_view_one'], user);
   },
   DELETE_ACTIVITY_DIRECTIVES: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
-      getPermission(['delete_activity_directive'], user) && (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+      isUserAdmin(user) ||
+      (getPermission(['delete_activity_directive'], user) &&
+        (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
   DELETE_ACTIVITY_DIRECTIVES_REANCHOR_PLAN_START: (
@@ -389,7 +402,7 @@ const queryPermissions = {
     model: ModelWithOwner,
   ): boolean => {
     const queries = ['delete_activity_by_pk_reanchor_plan_start_bulk'];
-    return getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model);
+    return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
   DELETE_ACTIVITY_DIRECTIVES_REANCHOR_TO_ANCHOR: (
     user: User | null,
@@ -397,123 +410,136 @@ const queryPermissions = {
     model: ModelWithOwner,
   ): boolean => {
     const queries = ['delete_activity_by_pk_reanchor_to_anchor_bulk'];
-    return getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model);
+    return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
   DELETE_ACTIVITY_DIRECTIVES_SUBTREE: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
     const queries = ['delete_activity_by_pk_delete_subtree_bulk'];
-    return getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model);
+    return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
   DELETE_ACTIVITY_DIRECTIVE_TAGS: (user: User | null): boolean => {
-    return getPermission(['delete_activity_directive_tags'], user);
+    return isUserAdmin(user) || getPermission(['delete_activity_directive_tags'], user);
   },
   DELETE_ACTIVITY_PRESET: (user: User | null, preset: AssetWithOwner<ActivityPreset>): boolean => {
-    return getPermission(['delete_activity_presets_by_pk'], user) && isUserOwner(user, preset);
+    return isUserAdmin(user) || (getPermission(['delete_activity_presets_by_pk'], user) && isUserOwner(user, preset));
   },
   DELETE_COMMAND_DICTIONARY: (user: User | null): boolean => {
-    return getPermission(['delete_command_dictionary_by_pk'], user);
+    return isUserAdmin(user) || getPermission(['delete_command_dictionary_by_pk'], user);
   },
   DELETE_CONSTRAINT: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
-      getPermission(['delete_constraint_by_pk'], user) && (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+      isUserAdmin(user) ||
+      (getPermission(['delete_constraint_by_pk'], user) && (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
   DELETE_CONSTRAINT_TAGS: (user: User | null): boolean => {
-    return getPermission(['delete_constraint_tags'], user);
+    return isUserAdmin(user) || getPermission(['delete_constraint_tags'], user);
   },
   DELETE_EXPANSION_RULE: (user: User | null, expansionRule: AssetWithOwner<ExpansionRule>): boolean => {
-    return getPermission(['delete_expansion_rule_by_pk'], user) && isUserOwner(user, expansionRule);
+    return (
+      isUserAdmin(user) || (getPermission(['delete_expansion_rule_by_pk'], user) && isUserOwner(user, expansionRule))
+    );
   },
   DELETE_EXPANSION_RULE_TAGS: (user: User | null): boolean => {
-    return getPermission(['delete_expansion_rule_tags'], user);
+    return isUserAdmin(user) || getPermission(['delete_expansion_rule_tags'], user);
   },
   DELETE_EXPANSION_SEQUENCE: (user: User | null): boolean => {
-    return getPermission(['delete_sequence_by_pk'], user);
+    return isUserAdmin(user) || getPermission(['delete_sequence_by_pk'], user);
   },
   DELETE_EXPANSION_SEQUENCE_TO_ACTIVITY: (user: User | null): boolean => {
-    return getPermission(['delete_sequence_to_simulated_activity_by_pk'], user);
+    return isUserAdmin(user) || getPermission(['delete_sequence_to_simulated_activity_by_pk'], user);
   },
   DELETE_EXPANSION_SET: (user: User | null, expansionSet: AssetWithOwner<ExpansionSet>): boolean => {
-    return getPermission(['delete_expansion_set_by_pk'], user) && isUserOwner(user, expansionSet);
+    return (
+      isUserAdmin(user) || (getPermission(['delete_expansion_set_by_pk'], user) && isUserOwner(user, expansionSet))
+    );
   },
   DELETE_MODEL: (user: User | null): boolean => {
-    return getPermission(['delete_mission_model_by_pk'], user);
+    return isUserAdmin(user) || getPermission(['delete_mission_model_by_pk'], user);
   },
   DELETE_PLAN: (user: User | null, plan: PlanWithOwners): boolean => {
-    return getPermission(['delete_plan_by_pk', 'delete_scheduling_specification'], user) && isPlanOwner(user, plan);
+    return (
+      isUserAdmin(user) ||
+      (getPermission(['delete_plan_by_pk', 'delete_scheduling_specification'], user) && isPlanOwner(user, plan))
+    );
   },
   DELETE_PLAN_SNAPSHOT: (user: User | null): boolean => {
     return getPermission(['delete_plan_snapshot_by_pk'], user) && isUserAdmin(user);
   },
   DELETE_PLAN_TAGS: (user: User | null): boolean => {
-    return getPermission(['delete_plan_tags'], user);
+    return isUserAdmin(user) || getPermission(['delete_plan_tags'], user);
   },
   DELETE_PRESET_TO_DIRECTIVE: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
-      getPermission(['delete_preset_to_directive_by_pk'], user) &&
-      (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+      isUserAdmin(user) ||
+      (getPermission(['delete_preset_to_directive_by_pk'], user) &&
+        (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
   DELETE_SCHEDULING_CONDITION: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
-      getPermission(['delete_scheduling_condition_by_pk'], user) &&
-      (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+      isUserAdmin(user) ||
+      (getPermission(['delete_scheduling_condition_by_pk'], user) &&
+        (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
   DELETE_SCHEDULING_GOAL: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
-      getPermission(['delete_scheduling_goal_by_pk'], user) &&
-      (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+      isUserAdmin(user) ||
+      (getPermission(['delete_scheduling_goal_by_pk'], user) &&
+        (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
   DELETE_SCHEDULING_GOAL_TAGS: (user: User | null): boolean => {
-    return getPermission(['delete_scheduling_goal_tags'], user);
+    return isUserAdmin(user) || getPermission(['delete_scheduling_goal_tags'], user);
   },
   DELETE_SCHEDULING_SPEC_GOAL: (user: User | null): boolean => {
-    return getPermission(['delete_scheduling_specification_goals_by_pk'], user);
+    return isUserAdmin(user) || getPermission(['delete_scheduling_specification_goals_by_pk'], user);
   },
   DELETE_SIMULATION_TEMPLATE: (user: User | null, template: SimulationTemplate): boolean => {
-    return getPermission(['delete_simulation_template_by_pk'], user) && isUserOwner(user, template);
+    return (
+      isUserAdmin(user) || (getPermission(['delete_simulation_template_by_pk'], user) && isUserOwner(user, template))
+    );
   },
   DELETE_TAGS: (user: User | null, tag: Tag): boolean => {
-    return getPermission(['delete_tags_by_pk'], user) && isUserOwner(user, tag);
+    return isUserAdmin(user) || (getPermission(['delete_tags_by_pk'], user) && isUserOwner(user, tag));
   },
   DELETE_USER_SEQUENCE: (user: User | null, sequence: AssetWithOwner<UserSequence>): boolean => {
-    return getPermission(['delete_user_sequence_by_pk'], user) && isUserOwner(user, sequence);
+    return isUserAdmin(user) || (getPermission(['delete_user_sequence_by_pk'], user) && isUserOwner(user, sequence));
   },
   DELETE_VIEW: (user: User | null, view: View): boolean => {
-    return getPermission(['delete_view_by_pk'], user) && isUserOwner(user, view);
+    return isUserAdmin(user) || (getPermission(['delete_view_by_pk'], user) && isUserOwner(user, view));
   },
   DELETE_VIEWS: (user: User | null, view: View): boolean => {
-    return getPermission(['delete_view'], user) && isUserOwner(user, view);
+    return isUserAdmin(user) || (getPermission(['delete_view'], user) && isUserOwner(user, view));
   },
   DUPLICATE_PLAN: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
     const queries = ['duplicate_plan'];
-    return getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model);
+    return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
   EXPAND: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
     const queries = ['expandAllActivities'];
-    return getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model);
+    return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
   GET_EXPANSION_RUNS: (user: User | null): boolean => {
-    return getPermission(['expansion_run'], user);
+    return isUserAdmin(user) || getPermission(['expansion_run'], user);
   },
   GET_EXPANSION_SEQUENCE_ID: (user: User | null): boolean => {
-    return getPermission(['sequence_to_simulated_activity_by_pk'], user);
+    return isUserAdmin(user) || getPermission(['sequence_to_simulated_activity_by_pk'], user);
   },
   GET_PLAN: (user: User | null): boolean => {
-    return getPermission(['plan_by_pk'], user);
+    return isUserAdmin(user) || getPermission(['plan_by_pk'], user);
   },
   GET_PLANS_AND_MODELS: (user: User | null): boolean => {
-    return getPermission(['mission_model'], user);
+    return isUserAdmin(user) || getPermission(['mission_model'], user);
   },
   GET_PLAN_SNAPSHOT: (user: User | null): boolean => {
-    return getPermission(['plan_snapshot_by_pk'], user);
+    return isUserAdmin(user) || getPermission(['plan_snapshot_by_pk'], user);
   },
   INITIAL_SIMULATION_UPDATE: (user: User | null): boolean => {
-    return getPermission(['update_simulation'], user);
+    return isUserAdmin(user) || getPermission(['update_simulation'], user);
   },
   INSERT_EXPANSION_SEQUENCE_TO_ACTIVITY: (user: User | null): boolean => {
-    return getPermission(['insert_sequence_to_simulated_activity_one'], user);
+    return isUserAdmin(user) || getPermission(['insert_sequence_to_simulated_activity_one'], user);
   },
   PLAN_MERGE_BEGIN: (
     user: User | null,
@@ -522,7 +548,10 @@ const queryPermissions = {
     model: ModelWithOwner,
   ): boolean => {
     const queries = ['begin_merge'];
-    return getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model);
+    return (
+      isUserAdmin(user) ||
+      (getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model))
+    );
   },
   PLAN_MERGE_CANCEL: (
     user: User | null,
@@ -531,7 +560,10 @@ const queryPermissions = {
     model: ModelWithOwner,
   ): boolean => {
     const queries = ['cancel_merge'];
-    return getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model);
+    return (
+      isUserAdmin(user) ||
+      (getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model))
+    );
   },
   PLAN_MERGE_COMMIT: (
     user: User | null,
@@ -540,7 +572,10 @@ const queryPermissions = {
     model: ModelWithOwner,
   ): boolean => {
     const queries = ['commit_merge'];
-    return getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model);
+    return (
+      isUserAdmin(user) ||
+      (getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model))
+    );
   },
   PLAN_MERGE_DENY: (
     user: User | null,
@@ -549,7 +584,10 @@ const queryPermissions = {
     model: ModelWithOwner,
   ): boolean => {
     const queries = ['deny_merge'];
-    return getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model);
+    return (
+      isUserAdmin(user) ||
+      (getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model))
+    );
   },
   PLAN_MERGE_REQUEST_WITHDRAW: (
     user: User | null,
@@ -558,7 +596,10 @@ const queryPermissions = {
     model: ModelWithOwner,
   ): boolean => {
     const queries = ['withdraw_merge_request'];
-    return getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model);
+    return (
+      isUserAdmin(user) ||
+      (getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model))
+    );
   },
   PLAN_MERGE_RESOLVE_ALL_CONFLICTS: (
     user: User | null,
@@ -567,7 +608,10 @@ const queryPermissions = {
     model: ModelWithOwner,
   ): boolean => {
     const queries = ['set_resolution_bulk'];
-    return getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model);
+    return (
+      isUserAdmin(user) ||
+      (getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model))
+    );
   },
   PLAN_MERGE_RESOLVE_CONFLICT: (
     user: User | null,
@@ -576,122 +620,134 @@ const queryPermissions = {
     model: ModelWithOwner,
   ): boolean => {
     const queries = ['set_resolution'];
-    return getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model);
+    return (
+      isUserAdmin(user) ||
+      (getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model))
+    );
   },
   RESTORE_PLAN_SNAPSHOT: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
     const queries = ['restore_from_snapshot'];
-    return getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model);
+    return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
   SCHEDULE: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
     const queries = ['schedule'];
-    return getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model);
+    return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
   SIMULATE: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
     const queries = ['simulate'];
-    return getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model);
+    return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
   SUB_ACTIVITY_PRESETS: (user: User | null): boolean => {
-    return getPermission(['activity_presets'], user);
+    return isUserAdmin(user) || getPermission(['activity_presets'], user);
   },
   SUB_CONSTRAINTS_ALL: (user: User | null): boolean => {
-    return getPermission(['constraint'], user);
+    return isUserAdmin(user) || getPermission(['constraint'], user);
   },
   SUB_EXPANSION_RULES: (user: User | null): boolean => {
-    return getPermission(['expansion_rule'], user);
+    return isUserAdmin(user) || getPermission(['expansion_rule'], user);
   },
   SUB_EXPANSION_SETS: (user: User | null): boolean => {
-    return getPermission(['expansion_set'], user);
+    return isUserAdmin(user) || getPermission(['expansion_set'], user);
   },
   SUB_PLAN_SNAPSHOTS: (user: User | null): boolean => {
-    return getPermission(['plan_snapshot'], user);
+    return isUserAdmin(user) || getPermission(['plan_snapshot'], user);
   },
   SUB_PLAN_SNAPSHOT_ACTIVITY_DIRECTIVES: (user: User | null): boolean => {
-    return getPermission(['plan_snapshot_activities'], user);
+    return isUserAdmin(user) || getPermission(['plan_snapshot_activities'], user);
   },
   SUB_SIMULATION: (user: User | null): boolean => {
-    return getPermission(['simulation'], user);
+    return isUserAdmin(user) || getPermission(['simulation'], user);
   },
   SUB_SIMULATION_TEMPLATES: (user: User | null): boolean => {
-    return getPermission(['simulation_template'], user);
+    return isUserAdmin(user) || getPermission(['simulation_template'], user);
   },
   SUB_TAGS: (user: User | null): boolean => {
-    return getPermission(['tag'], user);
+    return isUserAdmin(user) || getPermission(['tag'], user);
   },
   SUB_USER_SEQUENCES: (user: User | null): boolean => {
-    return getPermission(['user_sequence'], user);
+    return isUserAdmin(user) || getPermission(['user_sequence'], user);
   },
   SUB_VIEWS: (user: User | null): boolean => {
-    return getPermission(['view'], user);
+    return isUserAdmin(user) || getPermission(['view'], user);
   },
   UPDATE_ACTIVITY_DIRECTIVE: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
-      getPermission(['update_activity_directive_by_pk'], user) &&
-      (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+      isUserAdmin(user) ||
+      (getPermission(['update_activity_directive_by_pk'], user) &&
+        (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
   UPDATE_ACTIVITY_PRESET: (user: User | null, preset: AssetWithOwner<ActivityPreset>): boolean => {
-    return getPermission(['update_activity_presets_by_pk'], user) && isUserOwner(user, preset);
+    return isUserAdmin(user) || (getPermission(['update_activity_presets_by_pk'], user) && isUserOwner(user, preset));
   },
   UPDATE_CONSTRAINT: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
-      getPermission(['update_constraint_by_pk'], user) && (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+      isUserAdmin(user) ||
+      (getPermission(['update_constraint_by_pk'], user) && (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
   UPDATE_EXPANSION_RULE: (user: User | null, expansionRule: AssetWithOwner<ExpansionRule>): boolean => {
-    return getPermission(['update_expansion_rule_by_pk'], user) && isUserOwner(user, expansionRule);
+    return (
+      isUserAdmin(user) || (getPermission(['update_expansion_rule_by_pk'], user) && isUserOwner(user, expansionRule))
+    );
   },
   UPDATE_PLAN: (user: User | null, plan: PlanWithOwners): boolean => {
-    return getPermission(['update_plan_by_pk'], user) && isPlanOwner(user, plan);
+    return isUserAdmin(user) || (getPermission(['update_plan_by_pk'], user) && isPlanOwner(user, plan));
   },
   UPDATE_PLAN_SNAPSHOT: (user: User | null): boolean => {
     return getPermission(['update_plan_snapshot_by_pk'], user);
   },
   UPDATE_SCHEDULING_CONDITION: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
-      getPermission(['update_scheduling_condition_by_pk'], user) &&
-      (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+      isUserAdmin(user) ||
+      (getPermission(['update_scheduling_condition_by_pk'], user) &&
+        (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
   UPDATE_SCHEDULING_GOAL: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
-      getPermission(['update_scheduling_goal_by_pk'], user) &&
-      (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+      isUserAdmin(user) ||
+      (getPermission(['update_scheduling_goal_by_pk'], user) &&
+        (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
   UPDATE_SCHEDULING_SPEC: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
-      getPermission(['update_scheduling_specification_by_pk'], user) &&
-      (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+      isUserAdmin(user) ||
+      (getPermission(['update_scheduling_specification_by_pk'], user) &&
+        (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
   UPDATE_SCHEDULING_SPEC_CONDITION_ID: (user: User | null): boolean => {
-    return getPermission(['update_scheduling_specification_conditions_by_pk'], user);
+    return isUserAdmin(user) || getPermission(['update_scheduling_specification_conditions_by_pk'], user);
   },
   UPDATE_SCHEDULING_SPEC_GOAL: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
-      getPermission(['update_scheduling_specification_goals_by_pk'], user) &&
-      (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+      isUserAdmin(user) ||
+      (getPermission(['update_scheduling_specification_goals_by_pk'], user) &&
+        (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
   UPDATE_SIMULATION: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
-      getPermission(['update_simulation_by_pk'], user) && (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+      isUserAdmin(user) ||
+      (getPermission(['update_simulation_by_pk'], user) && (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
   UPDATE_SIMULATION_DATASET: (user: User | null): boolean => {
-    return getPermission(['update_simulation_dataset_by_pk'], user);
+    return isUserAdmin(user) || getPermission(['update_simulation_dataset_by_pk'], user);
   },
   UPDATE_SIMULATION_TEMPLATE: (user: User | null, plan: PlanWithOwners): boolean => {
-    return getPermission(['update_simulation_template_by_pk'], user) && isUserOwner(user, plan);
+    return isUserAdmin(user) || (getPermission(['update_simulation_template_by_pk'], user) && isUserOwner(user, plan));
   },
   UPDATE_TAG: (user: User | null, tag: AssetWithOwner<Tag>): boolean => {
-    return getPermission(['update_tags_by_pk'], user) && isUserOwner(user, tag);
+    return isUserAdmin(user) || (getPermission(['update_tags_by_pk'], user) && isUserOwner(user, tag));
   },
   UPDATE_USER_SEQUENCE: (user: User | null, sequence: AssetWithOwner<UserSequence>): boolean => {
-    return getPermission(['update_user_sequence_by_pk'], user) && isUserOwner(user, sequence);
+    return isUserAdmin(user) || (getPermission(['update_user_sequence_by_pk'], user) && isUserOwner(user, sequence));
   },
   UPDATE_VIEW: (user: User | null, view: AssetWithOwner<View>): boolean => {
-    return getPermission(['update_view_by_pk'], user) && isUserOwner(user, view);
+    return isUserAdmin(user) || (getPermission(['update_view_by_pk'], user) && isUserOwner(user, view));
   },
 };
 
@@ -812,142 +868,132 @@ interface FeaturePermissions {
 
 const featurePermissions: FeaturePermissions = {
   activityDirective: {
-    canCreate: (user, plan) => isUserAdmin(user) || queryPermissions.CREATE_ACTIVITY_DIRECTIVE(user, plan),
-    canDelete: (user, plan) => isUserAdmin(user) || queryPermissions.DELETE_ACTIVITY_DIRECTIVES(user, plan),
-    canRead: user => isUserAdmin(user) || queryPermissions.GET_PLAN(user),
-    canUpdate: (user, plan) => isUserAdmin(user) || queryPermissions.UPDATE_ACTIVITY_DIRECTIVE(user, plan),
+    canCreate: (user, plan) => queryPermissions.CREATE_ACTIVITY_DIRECTIVE(user, plan),
+    canDelete: (user, plan) => queryPermissions.DELETE_ACTIVITY_DIRECTIVES(user, plan),
+    canRead: user => queryPermissions.GET_PLAN(user),
+    canUpdate: (user, plan) => queryPermissions.UPDATE_ACTIVITY_DIRECTIVE(user, plan),
   },
   activityPresets: {
-    canAssign: (user, plan, model, preset) =>
-      isUserAdmin(user) || queryPermissions.APPLY_PRESET_TO_ACTIVITY(user, plan, model, preset),
-    canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_ACTIVITY_PRESET(user),
-    canDelete: (user, _plan, preset) => isUserAdmin(user) || queryPermissions.DELETE_ACTIVITY_PRESET(user, preset),
-    canRead: user => isUserAdmin(user) || queryPermissions.SUB_ACTIVITY_PRESETS(user),
-    canUnassign: (user, plan) => isUserAdmin(user) || queryPermissions.DELETE_PRESET_TO_DIRECTIVE(user, plan),
-    canUpdate: (user, _plan, preset) => isUserAdmin(user) || queryPermissions.UPDATE_ACTIVITY_PRESET(user, preset),
+    canAssign: (user, plan, model, preset) => queryPermissions.APPLY_PRESET_TO_ACTIVITY(user, plan, model, preset),
+    canCreate: user => queryPermissions.CREATE_ACTIVITY_PRESET(user),
+    canDelete: (user, _plan, preset) => queryPermissions.DELETE_ACTIVITY_PRESET(user, preset),
+    canRead: user => queryPermissions.SUB_ACTIVITY_PRESETS(user),
+    canUnassign: (user, plan) => queryPermissions.DELETE_PRESET_TO_DIRECTIVE(user, plan),
+    canUpdate: (user, _plan, preset) => queryPermissions.UPDATE_ACTIVITY_PRESET(user, preset),
   },
   commandDictionary: {
-    canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_COMMAND_DICTIONARY(user),
-    canDelete: user => isUserAdmin(user) || queryPermissions.DELETE_COMMAND_DICTIONARY(user),
+    canCreate: user => queryPermissions.CREATE_COMMAND_DICTIONARY(user),
+    canDelete: user => queryPermissions.DELETE_COMMAND_DICTIONARY(user),
     canRead: () => false, // Not implemented
     canUpdate: () => false, // Not implemented
   },
   constraints: {
-    canCheck: (user, plan, model) => isUserAdmin(user) || queryPermissions.CHECK_CONSTRAINTS(user, plan, model),
-    canCreate: (user, plan) => isUserAdmin(user) || queryPermissions.CREATE_CONSTRAINT(user, plan),
-    canDelete: (user, plan) => isUserAdmin(user) || queryPermissions.DELETE_CONSTRAINT(user, plan),
-    canRead: user => isUserAdmin(user) || queryPermissions.SUB_CONSTRAINTS_ALL(user),
-    canUpdate: (user, plan) => isUserAdmin(user) || queryPermissions.UPDATE_CONSTRAINT(user, plan),
+    canCheck: (user, plan, model) => queryPermissions.CHECK_CONSTRAINTS(user, plan, model),
+    canCreate: (user, plan) => queryPermissions.CREATE_CONSTRAINT(user, plan),
+    canDelete: (user, plan) => queryPermissions.DELETE_CONSTRAINT(user, plan),
+    canRead: user => queryPermissions.SUB_CONSTRAINTS_ALL(user),
+    canUpdate: (user, plan) => queryPermissions.UPDATE_CONSTRAINT(user, plan),
   },
   expansionRules: {
-    canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_EXPANSION_RULE(user),
-    canDelete: (user, expansionRule) =>
-      isUserAdmin(user) || queryPermissions.DELETE_EXPANSION_RULE(user, expansionRule),
-    canRead: user => isUserAdmin(user) || queryPermissions.SUB_EXPANSION_RULES(user),
-    canUpdate: (user, expansionRule) =>
-      isUserAdmin(user) || queryPermissions.UPDATE_EXPANSION_RULE(user, expansionRule),
+    canCreate: user => queryPermissions.CREATE_EXPANSION_RULE(user),
+    canDelete: (user, expansionRule) => queryPermissions.DELETE_EXPANSION_RULE(user, expansionRule),
+    canRead: user => queryPermissions.SUB_EXPANSION_RULES(user),
+    canUpdate: (user, expansionRule) => queryPermissions.UPDATE_EXPANSION_RULE(user, expansionRule),
   },
   expansionSequences: {
-    canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_EXPANSION_SEQUENCE(user),
-    canDelete: user => isUserAdmin(user) || queryPermissions.DELETE_EXPANSION_SEQUENCE(user),
-    canExpand: (user, plan, model) => isUserAdmin(user) || queryPermissions.EXPAND(user, plan, model),
-    canRead: user => isUserAdmin(user) || queryPermissions.GET_EXPANSION_SEQUENCE_ID(user),
+    canCreate: user => queryPermissions.CREATE_EXPANSION_SEQUENCE(user),
+    canDelete: user => queryPermissions.DELETE_EXPANSION_SEQUENCE(user),
+    canExpand: (user, plan, model) => queryPermissions.EXPAND(user, plan, model),
+    canRead: user => queryPermissions.GET_EXPANSION_SEQUENCE_ID(user),
     canUpdate: () => false, // this is not a feature,
   },
   expansionSets: {
-    canCreate: (user, plans, model) => isUserAdmin(user) || queryPermissions.CREATE_EXPANSION_SET(user, plans, model),
-    canDelete: (user, expansionSet) => isUserAdmin(user) || queryPermissions.DELETE_EXPANSION_SET(user, expansionSet),
-    canRead: user => isUserAdmin(user) || queryPermissions.SUB_EXPANSION_SETS(user),
+    canCreate: (user, plans, model) => queryPermissions.CREATE_EXPANSION_SET(user, plans, model),
+    canDelete: (user, expansionSet) => queryPermissions.DELETE_EXPANSION_SET(user, expansionSet),
+    canRead: user => queryPermissions.SUB_EXPANSION_SETS(user),
     canUpdate: () => false, // no feature to update expansion sets exists
   },
   model: {
-    canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_MODEL(user),
-    canDelete: user => isUserAdmin(user) || queryPermissions.DELETE_MODEL(user),
-    canRead: user => isUserAdmin(user) || queryPermissions.GET_PLANS_AND_MODELS(user),
+    canCreate: user => queryPermissions.CREATE_MODEL(user),
+    canDelete: user => queryPermissions.DELETE_MODEL(user),
+    canRead: user => queryPermissions.GET_PLANS_AND_MODELS(user),
     canUpdate: () => false, // no feature to update models exists
   },
   plan: {
-    canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_PLAN(user),
-    canDelete: (user, plan) => isUserAdmin(user) || queryPermissions.DELETE_PLAN(user, plan),
-    canRead: user => isUserAdmin(user) || queryPermissions.GET_PLAN(user),
-    canUpdate: (user, plan) => isUserAdmin(user) || queryPermissions.UPDATE_PLAN(user, plan),
+    canCreate: user => queryPermissions.CREATE_PLAN(user),
+    canDelete: (user, plan) => queryPermissions.DELETE_PLAN(user, plan),
+    canRead: user => queryPermissions.GET_PLAN(user),
+    canUpdate: (user, plan) => queryPermissions.UPDATE_PLAN(user, plan),
   },
   planBranch: {
-    canCreateBranch: (user, plan, model) => isUserAdmin(user) || queryPermissions.DUPLICATE_PLAN(user, plan, model),
+    canCreateBranch: (user, plan, model) => queryPermissions.DUPLICATE_PLAN(user, plan, model),
     canCreateRequest: (user, sourcePlan, targetPlan, model) =>
-      isUserAdmin(user) || queryPermissions.CREATE_PLAN_MERGE_REQUEST(user, sourcePlan, targetPlan, model),
+      queryPermissions.CREATE_PLAN_MERGE_REQUEST(user, sourcePlan, targetPlan, model),
     canDeleteRequest: (user, sourcePlan, targetPlan, model) =>
-      isUserAdmin(user) || queryPermissions.PLAN_MERGE_REQUEST_WITHDRAW(user, sourcePlan, targetPlan, model),
+      queryPermissions.PLAN_MERGE_REQUEST_WITHDRAW(user, sourcePlan, targetPlan, model),
     canReviewRequest: (user, sourcePlan, targetPlan, model) =>
-      isUserAdmin(user) ||
-      (queryPermissions.PLAN_MERGE_BEGIN(user, sourcePlan, targetPlan, model) &&
-        queryPermissions.PLAN_MERGE_CANCEL(user, sourcePlan, targetPlan, model) &&
-        queryPermissions.PLAN_MERGE_COMMIT(user, sourcePlan, targetPlan, model) &&
-        queryPermissions.PLAN_MERGE_DENY(user, sourcePlan, targetPlan, model) &&
-        queryPermissions.PLAN_MERGE_RESOLVE_CONFLICT(user, sourcePlan, targetPlan, model) &&
-        queryPermissions.PLAN_MERGE_RESOLVE_ALL_CONFLICTS(user, sourcePlan, targetPlan, model)),
+      queryPermissions.PLAN_MERGE_BEGIN(user, sourcePlan, targetPlan, model) &&
+      queryPermissions.PLAN_MERGE_CANCEL(user, sourcePlan, targetPlan, model) &&
+      queryPermissions.PLAN_MERGE_COMMIT(user, sourcePlan, targetPlan, model) &&
+      queryPermissions.PLAN_MERGE_DENY(user, sourcePlan, targetPlan, model) &&
+      queryPermissions.PLAN_MERGE_RESOLVE_CONFLICT(user, sourcePlan, targetPlan, model) &&
+      queryPermissions.PLAN_MERGE_RESOLVE_ALL_CONFLICTS(user, sourcePlan, targetPlan, model),
   },
   planSnapshot: {
-    canCreate: (user, plan, model) => isUserAdmin(user) || queryPermissions.CREATE_PLAN_SNAPSHOT(user, plan, model),
-    canDelete: user => isUserAdmin(user) || queryPermissions.DELETE_PLAN_SNAPSHOT(user),
-    canRead: user =>
-      isUserAdmin(user) || (queryPermissions.GET_PLAN_SNAPSHOT(user) && queryPermissions.SUB_PLAN_SNAPSHOTS(user)),
-    canRestore: (user, plan, model) => isUserAdmin(user) || queryPermissions.RESTORE_PLAN_SNAPSHOT(user, plan, model),
+    canCreate: (user, plan, model) => queryPermissions.CREATE_PLAN_SNAPSHOT(user, plan, model),
+    canDelete: user => queryPermissions.DELETE_PLAN_SNAPSHOT(user),
+    canRead: user => queryPermissions.GET_PLAN_SNAPSHOT(user) && queryPermissions.SUB_PLAN_SNAPSHOTS(user),
+    canRestore: (user, plan, model) => queryPermissions.RESTORE_PLAN_SNAPSHOT(user, plan, model),
     canUpdate: () => false, // no feature to update snapshots exists,
   },
   schedulingConditions: {
-    canCreate: (user, plan) => isUserAdmin(user) || queryPermissions.CREATE_SCHEDULING_CONDITION(user, plan),
-    canDelete: (user, plan) => isUserAdmin(user) || queryPermissions.DELETE_SCHEDULING_CONDITION(user, plan),
+    canCreate: (user, plan) => queryPermissions.CREATE_SCHEDULING_CONDITION(user, plan),
+    canDelete: (user, plan) => queryPermissions.DELETE_SCHEDULING_CONDITION(user, plan),
     canRead: () => false,
-    canUpdate: (user, plan) => isUserAdmin(user) || queryPermissions.UPDATE_SCHEDULING_CONDITION(user, plan),
+    canUpdate: (user, plan) => queryPermissions.UPDATE_SCHEDULING_CONDITION(user, plan),
   },
   schedulingGoals: {
     canAnalyze: (user, plan, model) =>
-      isUserAdmin(user) ||
-      (queryPermissions.UPDATE_SCHEDULING_SPEC(user, plan) && queryPermissions.SCHEDULE(user, plan, model)),
-    canCreate: (user, plan) => isUserAdmin(user) || queryPermissions.CREATE_SCHEDULING_GOAL(user, plan),
-    canDelete: (user, plan) => isUserAdmin(user) || queryPermissions.DELETE_SCHEDULING_GOAL(user, plan),
+      queryPermissions.UPDATE_SCHEDULING_SPEC(user, plan) && queryPermissions.SCHEDULE(user, plan, model),
+    canCreate: (user, plan) => queryPermissions.CREATE_SCHEDULING_GOAL(user, plan),
+    canDelete: (user, plan) => queryPermissions.DELETE_SCHEDULING_GOAL(user, plan),
     canRead: () => false,
     canRun: (user, plan, model) =>
-      isUserAdmin(user) ||
-      (queryPermissions.UPDATE_SCHEDULING_SPEC(user, plan) && queryPermissions.SCHEDULE(user, plan, model)),
-    canUpdate: (user, plan) => isUserAdmin(user) || queryPermissions.UPDATE_SCHEDULING_GOAL(user, plan),
-    canUpdateSpecification: (user, plan) =>
-      isUserAdmin(user) || queryPermissions.UPDATE_SCHEDULING_SPEC_GOAL(user, plan),
+      queryPermissions.UPDATE_SCHEDULING_SPEC(user, plan) && queryPermissions.SCHEDULE(user, plan, model),
+    canUpdate: (user, plan) => queryPermissions.UPDATE_SCHEDULING_GOAL(user, plan),
+    canUpdateSpecification: (user, plan) => queryPermissions.UPDATE_SCHEDULING_SPEC_GOAL(user, plan),
   },
   sequences: {
-    canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_USER_SEQUENCE(user),
-    canDelete: (user, sequence) => isUserAdmin(user) || queryPermissions.DELETE_USER_SEQUENCE(user, sequence),
-    canRead: user => isUserAdmin(user) || queryPermissions.SUB_USER_SEQUENCES(user),
-    canUpdate: (user, sequence) => isUserAdmin(user) || queryPermissions.UPDATE_USER_SEQUENCE(user, sequence),
+    canCreate: user => queryPermissions.CREATE_USER_SEQUENCE(user),
+    canDelete: (user, sequence) => queryPermissions.DELETE_USER_SEQUENCE(user, sequence),
+    canRead: user => queryPermissions.SUB_USER_SEQUENCES(user),
+    canUpdate: (user, sequence) => queryPermissions.UPDATE_USER_SEQUENCE(user, sequence),
   },
   simulation: {
     canCreate: () => false, // no feature to create a simulation exists
     canDelete: () => false, // no feature to delete a simulation exists
-    canRead: user => isUserAdmin(user) || queryPermissions.SUB_SIMULATION(user),
-    canRun: (user, plan, model) => isUserAdmin(user) || queryPermissions.SIMULATE(user, plan, model),
-    canUpdate: (user, plan) => isUserAdmin(user) || queryPermissions.UPDATE_SIMULATION(user, plan),
+    canRead: user => queryPermissions.SUB_SIMULATION(user),
+    canRun: (user, plan, model) => queryPermissions.SIMULATE(user, plan, model),
+    canUpdate: (user, plan) => queryPermissions.UPDATE_SIMULATION(user, plan),
   },
   simulationTemplates: {
-    canAssign: (user, plan) => isUserAdmin(user) || queryPermissions.UPDATE_SIMULATION(user, plan),
-    canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_SIMULATION_TEMPLATE(user),
-    canDelete: (user, _plan, template) =>
-      isUserAdmin(user) || queryPermissions.DELETE_SIMULATION_TEMPLATE(user, template),
-    canRead: user => isUserAdmin(user) || queryPermissions.SUB_SIMULATION_TEMPLATES(user),
-    canUpdate: (user, plan) => isUserAdmin(user) || queryPermissions.UPDATE_SIMULATION_TEMPLATE(user, plan),
+    canAssign: (user, plan) => queryPermissions.UPDATE_SIMULATION(user, plan),
+    canCreate: user => queryPermissions.CREATE_SIMULATION_TEMPLATE(user),
+    canDelete: (user, _plan, template) => queryPermissions.DELETE_SIMULATION_TEMPLATE(user, template),
+    canRead: user => queryPermissions.SUB_SIMULATION_TEMPLATES(user),
+    canUpdate: (user, plan) => queryPermissions.UPDATE_SIMULATION_TEMPLATE(user, plan),
   },
   tags: {
-    canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_TAGS(user),
-    canDelete: (user, tag) => isUserAdmin(user) || queryPermissions.DELETE_TAGS(user, tag),
-    canRead: user => isUserAdmin(user) || queryPermissions.SUB_TAGS(user),
-    canUpdate: (user, tag) => isUserAdmin(user) || queryPermissions.UPDATE_TAG(user, tag),
+    canCreate: user => queryPermissions.CREATE_TAGS(user),
+    canDelete: (user, tag) => queryPermissions.DELETE_TAGS(user, tag),
+    canRead: user => queryPermissions.SUB_TAGS(user),
+    canUpdate: (user, tag) => queryPermissions.UPDATE_TAG(user, tag),
   },
   view: {
-    canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_VIEW(user),
-    canDelete: (user, view) =>
-      isUserAdmin(user) || (queryPermissions.DELETE_VIEW(user, view) && queryPermissions.DELETE_VIEWS(user, view)),
-    canRead: user => isUserAdmin(user) || queryPermissions.SUB_VIEWS(user),
-    canUpdate: (user, view) => isUserAdmin(user) || queryPermissions.UPDATE_VIEW(user, view),
+    canCreate: user => queryPermissions.CREATE_VIEW(user),
+    canDelete: (user, view) => queryPermissions.DELETE_VIEW(user, view) && queryPermissions.DELETE_VIEWS(user, view),
+    canRead: user => queryPermissions.SUB_VIEWS(user),
+    canUpdate: (user, view) => queryPermissions.UPDATE_VIEW(user, view),
   },
 };
 

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -447,8 +447,11 @@ const queryPermissions = {
   DELETE_PLAN_TAGS: (user: User | null): boolean => {
     return getPermission(['delete_plan_tags'], user);
   },
-  DELETE_PRESET_TO_DIRECTIVE: (user: User | null): boolean => {
-    return getPermission(['delete_preset_to_directive_by_pk'], user);
+  DELETE_PRESET_TO_DIRECTIVE: (user: User | null, plan: PlanWithOwners): boolean => {
+    return (
+      getPermission(['delete_preset_to_directive_by_pk'], user) &&
+      (isPlanOwner(user, plan) || isPlanCollaborator(user, plan))
+    );
   },
   DELETE_SCHEDULING_CONDITION: (user: User | null, plan: PlanWithOwners): boolean => {
     return (
@@ -749,6 +752,7 @@ interface PlanActivityPresetsCRUDPermission
   extends Omit<PlanAssetCRUDPermission<ActivityPreset>, 'canDelete' | 'canUpdate'> {
   canAssign: RolePlanPermissionCheckWithAsset<ActivityPreset>;
   canDelete: (user: User | null, plan: PlanWithOwners, asset: ActivityPreset) => boolean;
+  canUnassign: (user: User | null, plan: PlanWithOwners) => boolean;
   canUpdate: (user: User | null, plan: PlanWithOwners, asset: ActivityPreset) => boolean;
 }
 
@@ -819,6 +823,7 @@ const featurePermissions: FeaturePermissions = {
     canCreate: user => isUserAdmin(user) || queryPermissions.CREATE_ACTIVITY_PRESET(user),
     canDelete: (user, _plan, preset) => isUserAdmin(user) || queryPermissions.DELETE_ACTIVITY_PRESET(user, preset),
     canRead: user => isUserAdmin(user) || queryPermissions.SUB_ACTIVITY_PRESETS(user),
+    canUnassign: (user, plan) => isUserAdmin(user) || queryPermissions.DELETE_PRESET_TO_DIRECTIVE(user, plan),
     canUpdate: (user, _plan, preset) => isUserAdmin(user) || queryPermissions.UPDATE_ACTIVITY_PRESET(user, preset),
   },
   commandDictionary: {


### PR DESCRIPTION
resolves #860 

This one is a pretty big one to test out. On top of making sure that everything still works as it currently does, one ideally would test that the new checks mentioned [here (expand the blue boxes to see full list)](https://nasa-ammos.github.io/aerie-docs/deployment/advanced-permissions/#action-and-function-permissions) work as expected. 

An example for testing would be:
1. Create a plan with a certain user
2. Go into the [plan_collaborators](http://localhost:8080/console/data/AerieMerlin/schema/public/tables/plan_collaborators/browse) table in hasura
3. Insert a new row containing the id of the plan you created in step 1 and add a different user id from the one you used to  create said plan
4. Add some activities to the plan and verify that you can still run a simulation
5. Now go to the [user_role_permissions](http://localhost:8080/console/data/AerieMerlin/schema/metadata/tables/user_role_permission/browse) table
6. Edit the `user` row by changing the `simulate` value under the `action_permissions` column to `"PLAN_OWNER"`
7. Log out and log back in as the user id of the collaborator you inserted in step 3 and switch to the `user` role
8. Navigate to the plan and add a new activity
9. Verify that you are no longer able to run a simulation