### PR TITLE
Add simulation snapshot panel interactions

### DIFF
--- a/src/components/console/Console.svelte
+++ b/src/components/console/Console.svelte
@@ -3,20 +3,21 @@
 <script lang="ts">
   import ChevronDownIcon from '@nasa-jpl/stellar/icons/chevron_down.svg?component';
   import ChevronUpIcon from '@nasa-jpl/stellar/icons/chevron_up.svg?component';
+  import { createEventDispatcher } from 'svelte';
   import Tabs from '../ui/Tabs/Tabs.svelte';
   import ConsoleDragHandle from './ConsoleDragHandle.svelte';
 
   const consoleHeaderHeight: number = 36;
+  const dispatch = createEventDispatcher();
 
   let consoleHeight: number = 0;
   let consoleHeightString: string;
-  let consolePositionString: string;
   let isOpen: boolean = false;
   let previousConsoleHeight: number = 300;
 
   $: {
     consoleHeightString = `${consoleHeight + consoleHeaderHeight}px`;
-    consolePositionString = `${-consoleHeight}px`;
+    dispatch('resize', consoleHeightString);
   }
 
   function onSelectTab() {
@@ -44,12 +45,7 @@
 </script>
 
 <div class="console-container">
-  <div
-    class="console-expand-container"
-    class:expanded={isOpen}
-    style:height={consoleHeightString}
-    style:top={consolePositionString}
-  >
+  <div class="console-expand-container" class:expanded={isOpen} style:height={consoleHeightString}>
     {#if isOpen}
       <ConsoleDragHandle maxHeight="75%" rowHeight={consoleHeight} on:updateRowHeight={onUpdateRowHeight} />
     {/if}

--- a/src/components/modals/CreatePlanSnapshotModal.svelte
+++ b/src/components/modals/CreatePlanSnapshotModal.svelte
@@ -101,6 +101,6 @@
 
 <style>
   .description {
-    padding: 0px 16px 0;
+    padding: 0px 16px;
   }
 </style>

--- a/src/components/modals/RestorePlanSnapshotModal.svelte
+++ b/src/components/modals/RestorePlanSnapshotModal.svelte
@@ -74,6 +74,7 @@
 <style>
   .message {
     font-weight: 500;
+    padding: 0px 16px;
   }
 
   input[type='checkbox'],

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -3,11 +3,13 @@
 <script lang="ts">
   import { SearchParameters } from '../../enums/searchParameters';
   import { planSnapshotId, planSnapshotsWithSimulations } from '../../stores/planSnapshots';
+  import { simulationDataset, simulationDatasetId } from '../../stores/simulation';
   import type { User } from '../../types/app';
   import type { Plan } from '../../types/plan';
+  import type { PlanSnapshot as PlanSnapshotType } from '../../types/plan-snapshot';
   import type { PlanTagsInsertInput, Tag, TagsChangeEvent } from '../../types/tags';
   import effects from '../../utilities/effects';
-  import { setQueryParam } from '../../utilities/generic';
+  import { removeQueryParam, setQueryParam } from '../../utilities/generic';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
   import { getShortISOForDate } from '../../utilities/time';
@@ -15,6 +17,7 @@
   import Collapse from '../Collapse.svelte';
   import Input from '../form/Input.svelte';
   import CardList from '../ui/CardList.svelte';
+  import FilterToggleButton from '../ui/FilterToggleButton.svelte';
   import TagsInput from '../ui/Tags/TagsInput.svelte';
   import PlanSnapshot from './PlanSnapshot.svelte';
 
@@ -24,6 +27,8 @@
   export let user: User | null;
 
   let hasPermission: boolean = false;
+  let filteredPlanSnapshots: PlanSnapshotType[] = [];
+  let isFilteredBySimulation: boolean = false;
   let permissionError = 'You do not have permission to edit this plan.';
 
   $: {
@@ -32,6 +37,14 @@
     } else {
       hasPermission = false;
     }
+  }
+
+  $: if (isFilteredBySimulation && $simulationDataset != null) {
+    filteredPlanSnapshots = $planSnapshotsWithSimulations.filter(
+      planSnapshot => planSnapshot.revision === $simulationDataset?.plan_revision,
+    );
+  } else {
+    filteredPlanSnapshots = $planSnapshotsWithSimulations;
   }
 
   async function onTagsInputChange(event: TagsChangeEvent) {
@@ -58,6 +71,10 @@
     if (plan) {
       effects.createPlanSnapshot(plan, user);
     }
+  }
+
+  function onToggleFilter() {
+    isFilteredBySimulation = !isFilteredBySimulation;
   }
 </script>
 
@@ -153,19 +170,41 @@
     </fieldset>
     <fieldset>
       <Collapse title="Snapshots" padContent={false}>
-        <button class="st-button secondary" slot="right" on:click={onCreatePlanSnapshot}>Take Snapshot</button>
+        <div class="buttons" slot="right">
+          {#if $simulationDatasetId >= 0}
+            <FilterToggleButton
+              label="Snapshot"
+              offTooltipContent="Filter snapshots by selected simulation"
+              onTooltipContent="Remove filter"
+              isOn={isFilteredBySimulation}
+              on:toggle={onToggleFilter}
+            />
+          {/if}
+          <button class="st-button secondary" on:click={onCreatePlanSnapshot}>Take Snapshot</button>
+        </div>
         <div style="margin-top: 8px">
           <CardList>
-            {#each $planSnapshotsWithSimulations as planSnapshot (planSnapshot.snapshot_id)}
+            {#each filteredPlanSnapshots as planSnapshot (planSnapshot.snapshot_id)}
               <PlanSnapshot
                 activePlanSnapshotId={$planSnapshotId}
                 {planSnapshot}
-                on:click={() => setQueryParam(SearchParameters.SNAPSHOT_ID, `${planSnapshot.snapshot_id}`, 'PUSH')}
+                on:click={() => {
+                  setQueryParam(SearchParameters.SNAPSHOT_ID, `${planSnapshot.snapshot_id}`, 'PUSH');
+                  $planSnapshotId = planSnapshot.snapshot_id;
+
+                  if (planSnapshot.simulation?.id != null) {
+                    setQueryParam(SearchParameters.SIMULATION_DATASET_ID, `${planSnapshot.simulation?.id}`, 'PUSH');
+                    $simulationDatasetId = planSnapshot.simulation?.id;
+                  } else {
+                    removeQueryParam(SearchParameters.SIMULATION_DATASET_ID);
+                    $simulationDatasetId = -1;
+                  }
+                }}
                 on:restore={() => effects.restorePlanSnapshot(planSnapshot, user)}
                 on:delete={() => effects.deletePlanSnapshot(planSnapshot, user)}
               />
             {/each}
-            {#if $planSnapshotsWithSimulations.length < 1}
+            {#if filteredPlanSnapshots.length < 1}
               <div class="st-typography-label">No Plan Snapshots Found</div>
             {/if}
           </CardList>
@@ -178,5 +217,10 @@
 <style>
   .plan-form fieldset:last-child {
     padding-bottom: 16px;
+  }
+
+  .buttons {
+    column-gap: 4px;
+    display: flex;
   }
 </style>

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -195,6 +195,8 @@
                   if (planSnapshot.simulation?.id != null) {
                     setQueryParam(SearchParameters.SIMULATION_DATASET_ID, `${planSnapshot.simulation?.id}`, 'PUSH');
                     $simulationDatasetId = planSnapshot.simulation?.id;
+
+                    viewTogglePanel({ state: true, type: 'left', update: { leftComponentTop: 'SimulationPanel' } });
                   } else {
                     removeQueryParam(SearchParameters.SIMULATION_DATASET_ID);
                     $simulationDatasetId = -1;

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -4,6 +4,7 @@
   import { SearchParameters } from '../../enums/searchParameters';
   import { planSnapshotId, planSnapshotsWithSimulations } from '../../stores/planSnapshots';
   import { simulationDataset, simulationDatasetId } from '../../stores/simulation';
+  import { viewTogglePanel } from '../../stores/views';
   import type { User } from '../../types/app';
   import type { Plan } from '../../types/plan';
   import type { PlanSnapshot as PlanSnapshotType } from '../../types/plan-snapshot';

--- a/src/components/plan/PlanMergeReview.test.ts
+++ b/src/components/plan/PlanMergeReview.test.ts
@@ -61,7 +61,7 @@ const mockInitialPlan: Plan = {
   parent_plan: null,
   revision: 3,
   scheduling_specifications: [{ id: 1 }],
-  simulations: [{ simulation_datasets: [{ id: 1 }] }],
+  simulations: [{ simulation_datasets: [{ id: 1, plan_revision: 3 }] }],
   start_time: '2023-02-16T00:00:00',
   start_time_doy: '2023-047T00:00:00',
   tags: [],

--- a/src/components/plan/PlanSnapshotBar.svelte
+++ b/src/components/plan/PlanSnapshotBar.svelte
@@ -1,0 +1,51 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import type { PlanSnapshot } from '../../types/plan-snapshot';
+
+  export let snapshot: PlanSnapshot;
+  export let numOfDirectives: number;
+
+  const dispatch = createEventDispatcher();
+</script>
+
+<div class="snapshot-bar">
+  <div class="info">
+    <div>Preview of plan snapshot</div>
+    <div class="snapshot-name">{snapshot.snapshot_name}</div>
+    <div>{numOfDirectives} directive{numOfDirectives !== 1 ? 's' : ''}</div>
+  </div>
+
+  <div class="buttons">
+    <button class="st-button" on:click|stopPropagation={() => dispatch('restore', snapshot)}>Restore Snapshot</button>
+    <button class="st-button secondary" on:click={() => dispatch('close')}>Close Preview</button>
+  </div>
+</div>
+
+<style>
+  .snapshot-bar {
+    align-items: center;
+    background-color: var(--st-primary-10, #e6e6ff);
+    border-bottom: 1px solid var(--st-primary-30, #a1a4fc);
+    display: flex;
+    justify-content: space-between;
+    padding: 10px 16px;
+  }
+
+  .snapshot-bar .info {
+    align-items: center;
+    color: var(--st-primary-90, #1a237e);
+    column-gap: 10px;
+    display: flex;
+    display: flex;
+    font-weight: 500;
+  }
+
+  .snapshot-bar .info .snapshot-name {
+    background-color: #fff;
+    border: 1px solid var(--st-primary-30, #a1a4fc);
+    border-radius: 16px;
+    padding: 4px 12px;
+  }
+</style>

--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -45,6 +45,7 @@
   import PanelHeaderActions from '../ui/PanelHeaderActions.svelte';
   import SimulationHistoryDataset from './SimulationHistoryDataset.svelte';
   import SimulationTemplateInput from './SimulationTemplateInput.svelte';
+  import { viewTogglePanel } from '../../stores/views';
 
   export let gridSection: ViewGridSection;
   export let user: User | null;
@@ -398,6 +399,7 @@
                 on:click={() => {
                   simulationDatasetId.set(simDataset.id);
                   setQueryParam(SearchParameters.SIMULATION_DATASET_ID, `${$simulationDatasetId}`);
+                  viewTogglePanel({ state: true, type: 'right', update: { rightComponentTop: 'PlanMetadataPanel' } });
                 }}
                 on:cancel={onCancelSimulation}
               />

--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -39,6 +39,7 @@
   import GridMenu from '../menus/GridMenu.svelte';
   import Parameters from '../parameters/Parameters.svelte';
   import DatePickerActionButton from '../ui/DatePicker/DatePickerActionButton.svelte';
+  import FilterToggleButton from '../ui/FilterToggleButton.svelte';
   import Panel from '../ui/Panel.svelte';
   import PanelHeaderActionButton from '../ui/PanelHeaderActionButton.svelte';
   import PanelHeaderActions from '../ui/PanelHeaderActions.svelte';
@@ -55,6 +56,7 @@
   let formParameters: FormParameter[] = [];
   let hasRunPermission: boolean = false;
   let hasUpdatePermission: boolean = false;
+  let isFilteredBySnapshot: boolean = false;
   let numOfUserChanges: number = 0;
   let startTimeDoy: string;
   let startTimeDoyField: FieldStore<string>;
@@ -105,6 +107,16 @@
         );
       }
     });
+  }
+
+  $: isFilteredBySnapshot = $planSnapshot !== null;
+
+  $: if (isFilteredBySnapshot) {
+    filteredSimulationDatasets = $simulationDatasetsPlan.filter(
+      simulationDataset => simulationDataset.plan_revision === $planSnapshot?.revision,
+    );
+  } else {
+    filteredSimulationDatasets = $simulationDatasetsPlan;
   }
 
   $: if ($simulationDatasetsPlan?.length) {
@@ -211,6 +223,10 @@
         user,
       );
     }
+  }
+
+  function onToggleFilter() {
+    isFilteredBySnapshot = !isFilteredBySnapshot;
   }
 
   function updateStartTime(doyString: string) {
@@ -369,6 +385,17 @@
 
     <fieldset>
       <Collapse title="Simulation History" padContent={false}>
+        <svelte:fragment slot="right">
+          {#if $planSnapshot}
+            <FilterToggleButton
+              label="Simulation"
+              offTooltipContent="Filter simulations by selected snapshot"
+              onTooltipContent="Remove filter"
+              isOn={isFilteredBySnapshot}
+              on:toggle={onToggleFilter}
+            />
+          {/if}
+        </svelte:fragment>
         <div class="simulation-history">
           {#if !filteredSimulationDatasets || !filteredSimulationDatasets.length}
             <div>No Simulation Datasets</div>

--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -113,22 +113,10 @@
 
   $: if (isFilteredBySnapshot) {
     filteredSimulationDatasets = $simulationDatasetsPlan.filter(
-      simulationDataset => simulationDataset.plan_revision === $planSnapshot?.revision,
+      simulationDataset => $planSnapshot === null || simulationDataset.plan_revision === $planSnapshot?.revision,
     );
   } else {
     filteredSimulationDatasets = $simulationDatasetsPlan;
-  }
-
-  $: if ($simulationDatasetsPlan?.length) {
-    if ($planSnapshot) {
-      filteredSimulationDatasets = $simulationDatasetsPlan.filter(
-        simulationDataset => simulationDataset.plan_revision === $planSnapshot?.revision,
-      );
-    } else {
-      filteredSimulationDatasets = $simulationDatasetsPlan;
-    }
-  } else {
-    filteredSimulationDatasets = [];
   }
 
   async function onChangeFormParameters(event: CustomEvent<FormParameter>) {

--- a/src/components/ui/FilterToggleButton.svelte
+++ b/src/components/ui/FilterToggleButton.svelte
@@ -1,0 +1,73 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import CloseIcon from '@nasa-jpl/stellar/icons/close.svg?component';
+  import FilterIcon from '@nasa-jpl/stellar/icons/filter.svg?component';
+  import { createEventDispatcher } from 'svelte';
+  import { tooltip } from '../../utilities/tooltip';
+
+  export let isOn: boolean = false;
+  export let label: string = '';
+  export let offTooltipContent: string = '';
+  export let onTooltipContent: string = '';
+  export let tooltipPlacement: string = 'top';
+
+  const dispatch = createEventDispatcher();
+
+  function onClick() {
+    dispatch('toggle');
+  }
+</script>
+
+<button
+  class="st-button filter-button"
+  class:toggled={isOn}
+  on:click|stopPropagation={onClick}
+  use:tooltip={{ content: isOn ? onTooltipContent : offTooltipContent, placement: tooltipPlacement }}
+>
+  <div class="icons">
+    <FilterIcon />
+    <div class="hovered"><CloseIcon /></div>
+  </div>
+  <span>{label}</span>
+</button>
+
+<style>
+  .filter-button {
+    align-content: center;
+    background-color: var(--st-gray-15, #f1f2f3);
+    border-radius: 8px;
+    color: var(--st-gray-60, #545f64);
+    column-gap: 4px;
+    display: grid;
+    grid-template-columns: auto auto;
+    padding: 4px;
+    vertical-align: middle;
+  }
+
+  .filter-button .icons :global(*) {
+    align-self: center;
+    display: flex;
+  }
+
+  .filter-button .icons .hovered {
+    display: none;
+  }
+
+  .toggled {
+    background-color: var(--st-primary-10, #e6e6ff);
+    color: var(--st-primary-90, #1d0ebe);
+  }
+
+  .toggled:hover {
+    background-color: var(--st-primary-20, #c4c6ff);
+  }
+
+  .toggled:hover .icons > :global(svg) {
+    display: none;
+  }
+
+  .toggled:hover .icons .hovered {
+    display: inline;
+  }
+</style>

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -19,12 +19,14 @@
   import ViewMenu from '../../../components/menus/ViewMenu.svelte';
   import PlanMergeRequestsStatusButton from '../../../components/plan/PlanMergeRequestsStatusButton.svelte';
   import PlanNavButton from '../../../components/plan/PlanNavButton.svelte';
+  import PlanSnapshotBar from '../../../components/plan/PlanSnapshotBar.svelte';
   import CssGrid from '../../../components/ui/CssGrid.svelte';
   import PlanGrid from '../../../components/ui/PlanGrid.svelte';
   import ProgressLinear from '../../../components/ui/ProgressLinear.svelte';
   import { SearchParameters } from '../../../enums/searchParameters';
   import {
     activityDirectives,
+    activityDirectivesList,
     activityDirectivesMap,
     resetActivityStores,
     selectActivity,
@@ -253,6 +255,18 @@
     clearSchedulingErrors();
   }
 
+  function onCloseSnapshotPreview() {
+    $planSnapshotId = null;
+    $simulationDatasetId = -1;
+    removeQueryParam(SearchParameters.SNAPSHOT_ID);
+    removeQueryParam(SearchParameters.SIMULATION_DATASET_ID, 'PUSH');
+  }
+
+  function onConsoleResize(event: CustomEvent<string>) {
+    const { detail } = event;
+    consoleHeightString = detail;
+  }
+
   function onKeydown(event: KeyboardEvent): void {
     if (isSaveEvent(event)) {
       event.preventDefault();
@@ -280,6 +294,11 @@
         resetOriginalView();
       }
     }
+  }
+
+  function onRestoreSnapshot(event: CustomEvent<PlanSnapshot>) {
+    const { detail: planSnapshot } = event;
+    effects.restorePlanSnapshot(planSnapshot, data.user);
   }
 
   async function onSaveView(event: CustomEvent<ViewSaveEvent>) {
@@ -460,7 +479,14 @@
       />
     </svelte:fragment>
   </Nav>
-
+  {#if $planSnapshot}
+    <PlanSnapshotBar
+      numOfDirectives={$activityDirectivesList.length}
+      snapshot={$planSnapshot}
+      on:close={onCloseSnapshotPreview}
+      on:restore={onRestoreSnapshot}
+    />
+  {/if}
   <PlanGrid
     {...$view?.definition.plan.grid}
     user={data.user}

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -249,6 +249,11 @@
     closeActiveModal();
   });
 
+  function clearSnapshot() {
+    $planSnapshotId = null;
+    $simulationDatasetId = data.initialPlan.simulations[0]?.simulation_datasets[0]?.id ?? -1;
+  }
+
   function onClearAllErrors() {
     clearAllErrors();
   }
@@ -258,8 +263,7 @@
   }
 
   function onCloseSnapshotPreview() {
-    $planSnapshotId = null;
-    $simulationDatasetId = data.initialPlan.simulations[0]?.simulation_datasets[0]?.id ?? -1;
+    clearSnapshot();
     removeQueryParam(SearchParameters.SNAPSHOT_ID);
     removeQueryParam(SearchParameters.SIMULATION_DATASET_ID, 'PUSH');
   }
@@ -298,9 +302,11 @@
     }
   }
 
-  function onRestoreSnapshot(event: CustomEvent<PlanSnapshot>) {
+  async function onRestoreSnapshot(event: CustomEvent<PlanSnapshot>) {
     const { detail: planSnapshot } = event;
-    effects.restorePlanSnapshot(planSnapshot, data.user);
+    await effects.restorePlanSnapshot(planSnapshot, data.user);
+
+    clearSnapshot();
   }
 
   async function onSaveView(event: CustomEvent<ViewSaveEvent>) {

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -142,7 +142,7 @@
     const querySimulationDatasetId = $page.url.searchParams.get(SearchParameters.SIMULATION_DATASET_ID);
     if (querySimulationDatasetId) {
       $simulationDatasetId = parseInt(querySimulationDatasetId);
-    } else {
+    } else if (data.initialPlanSnapshotId === null) {
       $simulationDatasetId = data.initialPlan.simulations[0]?.simulation_datasets[0]?.id ?? -1;
     }
 
@@ -200,7 +200,7 @@
   }
 
   $: if ($plan && $simulationDataset !== undefined) {
-    if ($simulationDataset !== null) {
+    if ($simulationDataset !== null && $simulationDatasetId !== -1) {
       const datasetId = $simulationDataset.dataset_id;
       const startTimeYmd = $simulationDataset?.simulation_start_time ?? $plan.start_time;
       effects.getResources(datasetId, startTimeYmd, data.user).then(newResources => ($resources = newResources));

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -86,7 +86,7 @@
   import type { ActivityDirective } from '../../../types/activity';
   import type { ViewSaveEvent, ViewToggleEvent } from '../../../types/view';
   import effects from '../../../utilities/effects';
-  import { removeQueryParam } from '../../../utilities/generic';
+  import { getSearchParameterNumber, removeQueryParam, setQueryParam } from '../../../utilities/generic';
   import { isSaveEvent } from '../../../utilities/keyboardEvents';
   import { closeActiveModal, showPlanLockedModal } from '../../../utilities/modal';
   import { featurePermissions } from '../../../utilities/permissions';
@@ -138,7 +138,6 @@
     const querySimulationDatasetId = $page.url.searchParams.get(SearchParameters.SIMULATION_DATASET_ID);
     if (querySimulationDatasetId) {
       $simulationDatasetId = parseInt(querySimulationDatasetId);
-      removeQueryParam(SearchParameters.SIMULATION_DATASET_ID);
     } else {
       $simulationDatasetId = data.initialPlan.simulations[0]?.simulation_datasets[0]?.id ?? -1;
     }
@@ -167,6 +166,18 @@
         planSnapshotActivityDirectives = directives;
       }
     });
+
+    const currentPlanSnapshotSimulation = data.initialPlan.simulations[0]?.simulation_datasets.find(simulation => {
+      return simulation.id === getSearchParameterNumber(SearchParameters.SIMULATION_DATASET_ID);
+    });
+    const latestPlanSnapshotSimulation = data.initialPlan.simulations[0]?.simulation_datasets.find(simulation => {
+      return simulation.plan_revision === $planSnapshot?.revision;
+    });
+
+    if (!currentPlanSnapshotSimulation && latestPlanSnapshotSimulation) {
+      $simulationDatasetId = latestPlanSnapshotSimulation.id;
+      setQueryParam(SearchParameters.SIMULATION_DATASET_ID, `${$simulationDatasetId}`);
+    }
   }
 
   $: if (data.initialView) {

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -171,14 +171,14 @@
       }
     });
 
-    const currentPlanSnapshotSimulation = data.initialPlan.simulations[0]?.simulation_datasets.find(simulation => {
+    const currentPlanSimulation = data.initialPlan.simulations[0]?.simulation_datasets.find(simulation => {
       return simulation.id === getSearchParameterNumber(SearchParameters.SIMULATION_DATASET_ID);
     });
     const latestPlanSnapshotSimulation = data.initialPlan.simulations[0]?.simulation_datasets.find(simulation => {
       return simulation.plan_revision === $planSnapshot?.revision;
     });
 
-    if (!currentPlanSnapshotSimulation && latestPlanSnapshotSimulation) {
+    if (!currentPlanSimulation && latestPlanSnapshotSimulation) {
       $simulationDatasetId = latestPlanSnapshotSimulation.id;
       setQueryParam(SearchParameters.SIMULATION_DATASET_ID, `${$simulationDatasetId}`);
     }
@@ -259,7 +259,7 @@
 
   function onCloseSnapshotPreview() {
     $planSnapshotId = null;
-    $simulationDatasetId = -1;
+    $simulationDatasetId = data.initialPlan.simulations[0]?.simulation_datasets[0]?.id ?? -1;
     removeQueryParam(SearchParameters.SNAPSHOT_ID);
     removeQueryParam(SearchParameters.SIMULATION_DATASET_ID, 'PUSH');
   }

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -86,6 +86,7 @@
     viewUpdateGrid,
   } from '../../../stores/views';
   import type { ActivityDirective } from '../../../types/activity';
+  import type { PlanSnapshot } from '../../../types/plan-snapshot';
   import type { ViewSaveEvent, ViewToggleEvent } from '../../../types/view';
   import effects from '../../../utilities/effects';
   import { getSearchParameterNumber, removeQueryParam, setQueryParam } from '../../../utilities/generic';
@@ -110,6 +111,7 @@
   export let data: PageData;
 
   let compactNavMode = false;
+  let consoleHeightString = '36px';
   let hasCreateViewPermission: boolean = false;
   let hasUpdateViewPermission: boolean = false;
   let hasExpandPermission: boolean = false;
@@ -351,7 +353,12 @@
 
 <PageTitle subTitle={data.initialPlan.name} title="Plans" />
 
-<CssGrid class="plan-container" rows="var(--nav-header-height) auto 36px">
+<CssGrid
+  class="plan-container"
+  rows={$planSnapshot
+    ? `var(--nav-header-height) min-content auto ${consoleHeightString}`
+    : `var(--nav-header-height) auto ${consoleHeightString}`}
+>
   <Nav user={data.user}>
     <div slot="title">
       <PlanMenu plan={data.initialPlan} user={data.user} />
@@ -496,7 +503,7 @@
     on:changeRightRowSizes={onChangeRightRowSizes}
   />
 
-  <Console>
+  <Console on:resize={onConsoleResize}>
     <svelte:fragment slot="console-tabs">
       <div class="console-tabs">
         <div>

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -251,7 +251,7 @@
 
   function clearSnapshot() {
     $planSnapshotId = null;
-    $simulationDatasetId = data.initialPlan.simulations[0]?.simulation_datasets[0]?.id ?? -1;
+    $simulationDatasetId = $simulationDatasetLatest?.id ?? -1;
   }
 
   function onClearAllErrors() {

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -87,7 +87,7 @@ export type PlanSchema = {
   parent_plan: Pick<PlanSchema, 'id' | 'name'> | null;
   revision: number;
   scheduling_specifications: Pick<SchedulingSpec, 'id'>[];
-  simulations: [{ simulation_datasets: [{ id: number }] }];
+  simulations: [{ simulation_datasets: [{ id: number; plan_revision: number }] }];
   start_time: string;
   tags: { tag: Tag }[];
   updated_at: string;

--- a/src/utilities/generic.ts
+++ b/src/utilities/generic.ts
@@ -188,7 +188,7 @@ export function convertToQuery(gql: string): string {
 /**
  * Removes a query param from the current URL.
  */
-export function removeQueryParam(key: SearchParameters): void {
+export function removeQueryParam(key: SearchParameters, mode: 'PUSH' | 'REPLACE' = 'REPLACE'): void {
   if (!browser) {
     return;
   }
@@ -210,7 +210,11 @@ export function removeQueryParam(key: SearchParameters): void {
     path = `${path}${hash}`;
   }
 
-  history.replaceState({ path }, '', path);
+  if (mode === 'REPLACE') {
+    history.replaceState({ path }, '', path);
+  } else {
+    history.pushState({ path }, '', path);
+  }
 }
 
 /**


### PR DESCRIPTION
resolves #878

To test:
1. Create a plan and add some directives
2. Run a simulation
3. Change some simulation arguments
4. Run another simulation
5. Create a snapshot
6. Add more directives
7. Run another simulation
8. Create another snapshot
9. Open the Simulation and Plan Metadata panels
10. Verify that clicking on a snapshot displays the snapshot bar at the top
11. Verify that clicking on different snapshots automatically filters out the relevant past simulations
12. Verify that the "Simulation" button is toggleable
![Screenshot 2023-10-02 at 11 26 40 AM](https://github.com/NASA-AMMOS/aerie-ui/assets/5290214/3bba6b2f-3e4a-4f0a-befa-235462aa8b56)
13. Verify that the "Snapshot" button is off by default and is toggleable also
![Screenshot 2023-10-02 at 11 28 21 AM](https://github.com/NASA-AMMOS/aerie-ui/assets/5290214/bcbfd17b-ce0a-4530-a8b1-fe5cb88aac74)
14. Verify that the "Snapshot" filter button filters the snapshot list by what is relevant to the selected simulation dataset