### PR TITLE
Added support for showing and accessing custom helpers

### DIFF
--- a/src/components/menus/ExtensionMenu.svelte
+++ b/src/components/menus/ExtensionMenu.svelte
@@ -27,6 +27,7 @@
     } else if (description?.length < DESCRIPTION_MAX_LENGTH) {
       return description;
     }
+
     return '';
   }
 

--- a/src/components/menus/ExtensionMenu.svelte
+++ b/src/components/menus/ExtensionMenu.svelte
@@ -1,0 +1,88 @@
+<svelte:options accessors={true} immutable={true} />
+
+<script lang="ts">
+  import SettingsIcon from '@nasa-jpl/stellar/icons/settings.svg?component';
+  import { createEventDispatcher } from 'svelte';
+  import type { User } from '../../types/app';
+  import type { Extension } from '../../types/extension';
+  import { permissionHandler } from '../../utilities/permissionHandler';
+  import PlanNavButton from '../plan/PlanNavButton.svelte';
+  import MenuItem from './MenuItem.svelte';
+
+  export let extensions: Extension[];
+  export let title: string;
+  export let user: User | null;
+
+  const DESCRIPTION_MAX_LENGTH = 50;
+  const dispatch = createEventDispatcher();
+
+  function callExtension(extension: Extension) {
+    dispatch('callExtension', extension);
+  }
+
+  function formatDescription(description: string): string {
+    // Truncate the description at DESCRIPTION_MAX_LENGTH and add ellipsis.
+    if (description !== null && description.length > DESCRIPTION_MAX_LENGTH) {
+      return `${description.substring(0, Math.min(description.length, DESCRIPTION_MAX_LENGTH))}...`;
+    } else if (description?.length < DESCRIPTION_MAX_LENGTH) {
+      return description;
+    }
+    return '';
+  }
+
+  function hasExtensionPermission(extension: Extension): boolean {
+    for (const extensionRole of extension.extension_roles) {
+      if (user?.activeRole === extensionRole.role) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+</script>
+
+{#if extensions.length > 0}
+  <div class="extension-menu st-typography-medium">
+    <PlanNavButton {title} menuTitle="Extensions">
+      <SettingsIcon />
+      <div class="st-typography-medium" slot="menu">
+        {#each extensions as extension}
+          <MenuItem
+            on:click={() => callExtension(extension)}
+            use={[
+              [
+                permissionHandler,
+                {
+                  hasPermission: hasExtensionPermission(extension),
+                  permissionError: 'You do not have permission to call this extension',
+                },
+              ],
+            ]}
+          >
+            <div class="extension-menu--menu-item">
+              {extension.label}
+              <span class="st-typography-label">{formatDescription(extension.description)}</span>
+            </div>
+          </MenuItem>
+        {/each}
+      </div>
+    </PlanNavButton>
+  </div>
+{/if}
+
+<style>
+  .extension-menu {
+    --aerie-menu-item-template-columns: auto;
+    align-items: center;
+    cursor: pointer;
+    display: grid;
+    height: inherit;
+    justify-content: center;
+    position: relative;
+  }
+
+  .extension-menu--menu-item {
+    display: flex;
+    flex-direction: column;
+  }
+</style>

--- a/src/routes/extensions/+server.ts
+++ b/src/routes/extensions/+server.ts
@@ -1,0 +1,22 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import type { ExtensionResponse } from '../../types/extension';
+import { reqExtension } from '../../utilities/requests';
+
+/**
+ * Used to proxy requests from the UI to an external extension. This avoids any CORS errors we might
+ * encounter by calling a tool that may or may not be external to Aerie.
+ */
+export const POST: RequestHandler = async event => {
+  const { url, ...body } = await event.request.json();
+  const response = await reqExtension(url, body, event.locals.user);
+
+  if (isExtensionResponse(response)) {
+    return json(response);
+  }
+
+  return json({ message: response, success: false });
+};
+
+function isExtensionResponse(result: any): result is ExtensionResponse {
+  return 'message' in result && 'success' in result;
+}

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -348,6 +348,7 @@
       simulationDatasetId: $simulationDatasetId,
       url: event.detail.url,
     };
+
     effects.callExtension(event.detail, payload, data.user);
   }
 

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -15,6 +15,7 @@
   import Console from '../../../components/console/Console.svelte';
   import ConsoleSection from '../../../components/console/ConsoleSection.svelte';
   import ConsoleTab from '../../../components/console/ConsoleTab.svelte';
+  import ExtensionMenu from '../../../components/menus/ExtensionMenu.svelte';
   import PlanMenu from '../../../components/menus/PlanMenu.svelte';
   import ViewMenu from '../../../components/menus/ViewMenu.svelte';
   import PlanMergeRequestsStatusButton from '../../../components/plan/PlanMergeRequestsStatusButton.svelte';
@@ -31,6 +32,7 @@
     activityDirectivesMap,
     resetActivityStores,
     selectActivity,
+    selectedActivityDirectiveId,
   } from '../../../stores/activities';
   import { checkConstraintsStatus, constraintResults, resetConstraintStores } from '../../../stores/constraints';
   import {
@@ -87,6 +89,7 @@
     viewUpdateGrid,
   } from '../../../stores/views';
   import type { ActivityDirective } from '../../../types/activity';
+  import type { Extension } from '../../../types/extension';
   import type { PlanSnapshot } from '../../../types/plan-snapshot';
   import type { View, ViewSaveEvent, ViewToggleEvent } from '../../../types/view';
   import effects from '../../../utilities/effects';
@@ -338,6 +341,16 @@
     }
   }
 
+  async function onCallExtension(event: CustomEvent<Extension>) {
+    const payload = {
+      planId: $planId,
+      selectedActivityDirectiveId: $selectedActivityDirectiveId,
+      simulationDatasetId: $simulationDatasetId,
+      url: event.detail.url,
+    };
+    effects.callExtension(event.detail, payload, data.user);
+  }
+
   async function onSaveView(event: CustomEvent<ViewSaveEvent>) {
     const { detail } = event;
     const { definition, id, name, owner } = detail;
@@ -516,6 +529,12 @@
       >
         <CalendarIcon />
       </PlanNavButton>
+      <ExtensionMenu
+        extensions={data.extensions}
+        title={!compactNavMode ? 'Extensions' : ''}
+        user={data.user}
+        on:callExtension={onCallExtension}
+      />
       <ViewMenu
         hasCreatePermission={hasCreateViewPermission}
         hasUpdatePermission={hasUpdateViewPermission}

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -50,8 +50,10 @@ export const load: PageLoad = async ({ parent, params, url }) => {
       const initialPlanTags = await effects.getPlanTags(initialPlan.id, user);
       const initialView = await effects.getView(url.searchParams, user, initialActivityTypes, initialResourceTypes);
       const initialPlanSnapshotId = getSearchParameterNumber(SearchParameters.SNAPSHOT_ID, url.searchParams);
+      const extensions = await effects.getExtensions(user);
 
       return {
+        extensions,
         initialActivityTypes,
         initialPlan,
         initialPlanSnapshotId,

--- a/src/types/extension.ts
+++ b/src/types/extension.ts
@@ -1,0 +1,28 @@
+export type Extension = {
+  description: string;
+  extension_roles: ExtensionRole[];
+  id: number;
+  label: string;
+  updated_at: string;
+  url: string;
+};
+
+export type ExtensionPayload = {
+  gateway?: string;
+  hasura?: string;
+  planId: number;
+  selectedActivityDirectiveId: number | null;
+  simulationDatasetId: number | null;
+};
+
+export type ExtensionResponse = {
+  message: string;
+  success: boolean;
+  url: string;
+};
+
+export type ExtensionRole = {
+  extension_id: number;
+  id: number;
+  role: string;
+};

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -798,6 +798,23 @@ const gql = {
     }
   `,
 
+  GET_EXTENSIONS: `#graphql
+    query GetExtensions {
+      extensions {
+        description
+        extension_roles {
+          extension_id
+          id
+          role
+        }
+        id
+        label
+        updated_at
+        url
+      }
+    }
+  `,
+
   GET_MODELS: `#graphql
     query GetModels {
       models: mission_model {

--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -1,9 +1,49 @@
 import { browser } from '$app/environment';
 import { env } from '$env/dynamic/public';
 import type { BaseUser, User } from '../types/app';
+import type { ExtensionPayload, ExtensionResponse } from '../types/extension';
 import type { QueryVariables } from '../types/subscribable';
 import { logout } from '../utilities/login';
 import { INVALID_JWT } from '../utilities/permissions';
+
+/**
+ * Used to make calls to application external to Aerie.
+ *
+ * @param url The external URL to call.
+ * @param payload The JSON payload that is serialized as the body of the request.
+ * @param user The user information serialized as a bearer token.
+ * @returns
+ */
+export async function reqExtension(
+  url: string,
+  payload: ExtensionPayload | (ExtensionPayload & Record<'url', string>),
+  user: BaseUser | User | null,
+): Promise<ExtensionResponse> {
+  const headers: HeadersInit = {
+    Authorization: `Bearer ${user?.token ?? ''}`,
+    ...{ 'Content-Type': 'application/json' },
+  };
+  const options: RequestInit = {
+    headers,
+    method: 'POST',
+  };
+
+  if (payload !== null) {
+    options.body = JSON.stringify({
+      ...payload,
+      gateway: browser ? env.PUBLIC_GATEWAY_CLIENT_URL : env.PUBLIC_GATEWAY_SERVER_URL,
+      hasura: browser ? env.PUBLIC_HASURA_CLIENT_URL : env.PUBLIC_HASURA_SERVER_URL,
+    });
+  }
+
+  const response = await fetch(`${url}`, options);
+
+  if (!response.ok) {
+    throw new Error(response.statusText);
+  }
+
+  return await response.json();
+}
 
 /**
  * Function to make HTTP requests to the Aerie Gateway.


### PR DESCRIPTION
This PR adds support for custom helpers we're calling extensions. [Here](https://github.com/NASA-AMMOS/aerie/issues/1153) is the associated backend issue.

There's still one open question, I'm not sure how to handle the case of when no extensions are defined. Right now I'm hiding the button, but there's a case to always show it as well. I think one concern that @joswig had was that some implementations may never even use this feature, so it might be nice if it's hidden if there aren't any defined.

- [Backend PR](https://github.com/NASA-AMMOS/aerie/pull/1179)
- [Documentation PR](https://github.com/NASA-AMMOS/aerie-docs/pull/87)

<img width="1083" alt="Screenshot 2023-10-04 at 6 02 00 AM" src="https://github.com/NASA-AMMOS/aerie-ui/assets/3433719/d5723ab1-47fb-47e3-a43f-75c53463b33b">

