### PR TITLE
Set plan readme state when snapshot is selected

### DIFF
--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -202,6 +202,7 @@
                 on:click={() => {
                   setQueryParam(SearchParameters.SNAPSHOT_ID, `${planSnapshot.snapshot_id}`, 'PUSH');
                   $planSnapshotId = planSnapshot.snapshot_id;
+                  $planReadOnly = true;
 
                   if (planSnapshot.simulation?.id != null) {
                     setQueryParam(SearchParameters.SIMULATION_DATASET_ID, `${planSnapshot.simulation?.id}`, 'PUSH');

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -165,6 +165,7 @@
   }
   $: if (data.initialPlanSnapshotId !== null) {
     $planSnapshotId = data.initialPlanSnapshotId;
+    $planReadOnly = true;
   }
   $: if ($planSnapshot !== null) {
     effects.getPlanSnapshotActivityDirectives($planSnapshot, data.user).then(directives => {
@@ -253,6 +254,7 @@
 
   function clearSnapshot() {
     $planSnapshotId = null;
+    $planReadOnly = false;
     $simulationDatasetId = $simulationDatasetLatest?.id ?? -1;
   }
 


### PR DESCRIPTION
If a snapshot is currently being viewed, the plan should be in `readonly` mode