### PR TITLE
Add ability to create a new snapshot before restoring a snapshot

### DIFF
--- a/src/components/modals/RestorePlanSnapshotModal.svelte
+++ b/src/components/modals/RestorePlanSnapshotModal.svelte
@@ -7,23 +7,37 @@
   import ModalContent from './ModalContent.svelte';
   import ModalFooter from './ModalFooter.svelte';
   import ModalHeader from './ModalHeader.svelte';
+  import { tags } from '../../stores/tags';
+  import type { Tag, TagsChangeEvent } from '../../types/tags';
+  import effects from '../../utilities/effects';
+  import TagsInput from '../ui/Tags/TagsInput.svelte';
+  import type { User } from '../../types/app';
 
-  export let height: number = 270;
+  export let height: number | string = 'unset';
   export let width: number = 280;
   export let numOfActivities: number;
   export let snapshot: PlanSnapshot;
+  export let user: User | null = null;
 
   const dispatch = createEventDispatcher();
 
   let shouldCreateSnapshot: boolean = false;
   let newSnapshotName: string = '';
+  let snapshotDescription: string = '';
+  let snapshotTags: Tag[] = [];
   let restoreButtonDisabled: boolean = true;
 
   $: restoreButtonDisabled = shouldCreateSnapshot && newSnapshotName === '';
 
   function restore() {
     if (!restoreButtonDisabled) {
-      dispatch('restore', { name: newSnapshotName, snapshot });
+      dispatch('restore', {
+        description: snapshotDescription,
+        name: newSnapshotName,
+        shouldCreateSnapshot,
+        snapshot,
+        tags: snapshotTags,
+      });
     }
   }
 
@@ -34,20 +48,35 @@
       restore();
     }
   }
+
+  async function onTagsInputChange(event: TagsChangeEvent) {
+    const {
+      detail: { tag, type },
+    } = event;
+    if (type === 'remove') {
+      snapshotTags = snapshotTags.filter(t => t.name !== tag.name);
+    } else if (type === 'create' || type === 'select') {
+      let tagsToAdd: Tag[] = [tag];
+      if (type === 'create') {
+        tagsToAdd = (await effects.createTags([{ color: tag.color, name: tag.name }], user)) || [];
+      }
+      snapshotTags = snapshotTags.concat(tagsToAdd);
+    }
+  }
 </script>
 
 <svelte:window on:keydown={onKeydown} />
 
 <Modal {height} {width}>
   <ModalHeader on:close>Restore Snapshot</ModalHeader>
-  <ModalContent style=" display: flex; flex-direction: column; gap: 8px; padding:8px 0 0 ;">
+  <ModalContent style=" display: flex; flex-direction: column; gap: 8px; padding:8px 0 16px;">
     <div class="message">
       Restore {numOfActivities} activity directives from "{snapshot.snapshot_name}"
     </div>
     <fieldset>
       <label>
-        <span class="create-label">Create </span>
         <input type="checkbox" bind:checked={shouldCreateSnapshot} />
+        <span class="create-label">Take snapshot prior to restoring</span>
       </label>
     </fieldset>
     {#if shouldCreateSnapshot}
@@ -62,6 +91,19 @@
           required
           type="text"
         />
+      </fieldset>
+      <fieldset>
+        <label for="description">Description</label>
+        <textarea
+          bind:value={snapshotDescription}
+          placeholder="Notes about this snapshot"
+          class="st-input w-100"
+          name="description"
+        />
+      </fieldset>
+      <fieldset>
+        <label for="plan-duration">Tags</label>
+        <TagsInput options={$tags} selected={snapshotTags} on:change={onTagsInputChange} />
       </fieldset>
     {/if}
   </ModalContent>

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -311,9 +311,11 @@
   async function onRestoreSnapshot(event: CustomEvent<PlanSnapshot>) {
     const { detail: planSnapshot } = event;
     if ($plan) {
-      await effects.restorePlanSnapshot(planSnapshot, $plan, data.user);
+      const success = await effects.restorePlanSnapshot(planSnapshot, $plan, data.user);
 
-      clearSnapshot();
+      if (success) {
+        clearSnapshot();
+      }
     }
   }
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -891,8 +891,7 @@ const effects = {
   },
 
   /**
-   * This function will eventually go away once the backend is able to create a snapshot
-   * with a description and tags in one go
+   * This helper function is for handling the creation of a snapshot and associating tags in one go
    *
    * @param planId
    * @param name

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -512,11 +512,11 @@ export async function showRestorePlanSnapshotModal(
   user: User | null,
 ): Promise<
   ModalElementValue<{
-    description?: string;
-    name?: string;
+    description: string;
+    name: string;
     shouldCreateSnapshot: boolean;
     snapshot: PlanSnapshot;
-    tags?: Tag[];
+    tags: Tag[];
   }>
 > {
   return new Promise(resolve => {
@@ -541,11 +541,11 @@ export async function showRestorePlanSnapshotModal(
           'restore',
           (
             e: CustomEvent<{
-              description?: string;
-              name?: string;
+              description: string;
+              name: string;
               shouldCreateSnapshot: boolean;
               snapshot: PlanSnapshot;
-              tags?: Tag[];
+              tags: Tag[];
             }>,
           ) => {
             target.replaceChildren();

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -509,14 +509,23 @@ export async function showPlanMergeRequestsModal(
 export async function showRestorePlanSnapshotModal(
   snapshot: PlanSnapshot,
   numOfActivities: number,
-): Promise<ModalElementValue<{ name?: string; plan: Plan; snapshot: PlanSnapshot }>> {
+  user: User | null,
+): Promise<
+  ModalElementValue<{
+    description?: string;
+    name?: string;
+    shouldCreateSnapshot: boolean;
+    snapshot: PlanSnapshot;
+    tags?: Tag[];
+  }>
+> {
   return new Promise(resolve => {
     if (browser) {
       const target: ModalElement | null = document.querySelector('#svelte-modal');
 
       if (target) {
         const restorePlanSnapshotModal = new RestorePlanSnapshotModal({
-          props: { numOfActivities, snapshot },
+          props: { numOfActivities, snapshot, user },
           target,
         });
         target.resolve = resolve;
@@ -530,7 +539,15 @@ export async function showRestorePlanSnapshotModal(
 
         restorePlanSnapshotModal.$on(
           'restore',
-          (e: CustomEvent<{ name?: string; plan: Plan; snapshot: PlanSnapshot }>) => {
+          (
+            e: CustomEvent<{
+              description?: string;
+              name?: string;
+              shouldCreateSnapshot: boolean;
+              snapshot: PlanSnapshot;
+              tags?: Tag[];
+            }>,
+          ) => {
             target.replaceChildren();
             target.resolve = null;
             resolve({ confirm: true, value: e.detail });


### PR DESCRIPTION
Resolves #919 

This fully implements the feature to take a new snapshot before restoring a snapshot.

To test:
1. Create a plan with some activities
2. Create a snapshot of that plan
3. Add/remove activities
4. View the preview of the snapshot that you took in step 2
5. Click the "Restore Snapshot" button in the snapshot bar
6. Check the "Take snapshot prior to restoring" checkbox
7. Input new snapshot information
8. Click "Restore"
9. Verify that a new snapshot with the information provided was created as well as the intended snapshot is restored