### PR TITLE
Feature/add active role to extension

### DIFF
--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -21,6 +21,7 @@ export async function reqExtension(
 ): Promise<ExtensionResponse> {
   const headers: HeadersInit = {
     Authorization: `Bearer ${user?.token ?? ''}`,
+    'x-hasura-role': (user as User)?.activeRole ?? '',
     ...{ 'Content-Type': 'application/json' },
   };
   const options: RequestInit = {


### PR DESCRIPTION
Adds the active role header to the extension API call so the external tool can infer the user's Aerie role.