### PR TITLE
Avoid fetching `id` from the `extension_roles` table

### DIFF
--- a/src/types/extension.ts
+++ b/src/types/extension.ts
@@ -23,6 +23,5 @@ export type ExtensionResponse = {
 
 export type ExtensionRole = {
   extension_id: number;
-  id: number;
   role: string;
 };

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -804,7 +804,6 @@ const gql = {
         description
         extension_roles {
           extension_id
-          id
           role
         }
         id


### PR DESCRIPTION
This PR has the UI no longer fetch the `id` column from `extension_roles`. While this is technically a sister PR to https://github.com/NASA-AMMOS/aerie/pull/1202, from what I can tell this column is not used in the UI currently, meaning it can be merged before https://github.com/NASA-AMMOS/aerie/pull/1202.
