### PR TITLE
Catch failed requests from custom extension endpoints

### DIFF
--- a/src/routes/extensions/+server.ts
+++ b/src/routes/extensions/+server.ts
@@ -7,14 +7,22 @@ import { reqExtension } from '../../utilities/requests';
  * encounter by calling a tool that may or may not be external to Aerie.
  */
 export const POST: RequestHandler = async event => {
-  const { url, ...body } = await event.request.json();
-  const response = await reqExtension(url, body, event.locals.user);
+  try {
+    const { url, ...body } = await event.request.json();
+    const response = await reqExtension(url, body, event.locals.user);
 
-  if (isExtensionResponse(response)) {
-    return json(response);
+    if (isExtensionResponse(response)) {
+      return json(response);
+    }
+
+    return json({ message: response, success: false });
+  } catch (e) {
+    console.log(e);
+    return json({
+      message: `${(e as Error).message}\n${(e as Error).cause}`,
+      success: false,
+    });
   }
-
-  return json({ message: response, success: false });
 };
 
 function isExtensionResponse(result: any): result is ExtensionResponse {


### PR DESCRIPTION
If you specify the URL of an extension to be something that doesn't actually exist, currently the UI will display "Internal Server Error".

This PR just catches the actual error (i.e. 404 in this case) and passes it along to the UI so that users can see that the error is ideally not the UI's fault.