### PR TITLE
Utilize svelte `base` for importing files during runtime to allow for proxied deployment configurations

### DIFF
--- a/src/components/ui/MonacoEditor.svelte
+++ b/src/components/ui/MonacoEditor.svelte
@@ -1,6 +1,7 @@
 <svelte:options accessors={true} immutable={true} />
 
 <script lang="ts">
+  import { base } from '$app/paths';
   import type {
     CancellationToken,
     editor as Editor,
@@ -78,7 +79,7 @@
         if (label === 'typescript' || label === 'javascript') {
           // Force the worker to be loaded in the classic style, served directly out of static
           // https://thethoughtfulkoala.com/posts/2021/07/10/vite-js-classic-web-worker.html
-          return new Worker(new URL('ts.worker.js', location.origin), { type: 'classic' });
+          return new Worker(`${base}/ts.worker.js`, { type: 'classic' });
         }
         return new editorWorker();
       },


### PR DESCRIPTION
resolves #948 

To test:
1. Change in `svelte.config.js` the `base` field to be "/aerie"
2. Open the network dev tool
3. Then navigate to `http://localhost:3000/aerie/scheduling`
4. Verify that `ts.worker.js` is successfully downloaded into the UI