### PR TITLE
Return Constraint Compilation Errors

### DIFF
--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -36,3 +36,20 @@ export type ConstraintResult = {
   type: ConstraintType;
   violations: ConstraintViolation[];
 };
+
+export type ConstraintResponse = {
+  errors: UserCodeError[];
+  results: ConstraintResult;
+  success: boolean;
+};
+
+export type UserCodeError = {
+  location: CodeLocation;
+  message: string;
+  stack: string;
+};
+
+export type CodeLocation = {
+  column: number;
+  line: number;
+};

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -26,16 +26,31 @@ const gql = {
 
   CHECK_CONSTRAINTS: `#graphql
     query CheckConstraints($planId: Int!) {
-      constraintResults: constraintViolations(planId: $planId) {
-        constraintId
-        constraintName
-        resourceIds
-        type
-        violations {
-          activityInstanceIds
-          windows {
+      constraintResponses: constraintViolations(planId: $planId) {
+        success
+        results {
+          constraintId
+          constraintName
+          resourceIds
+          type
+          gaps {
             end
             start
+          }
+          violations {
+            activityInstanceIds
+            windows {
+              end
+              start
+            }
+          }
+        }
+        errors {
+          message
+          stack
+          location {
+            column
+            line
           }
         }
       }


### PR DESCRIPTION
Currently, if a constraint compilation error occurs, the server swallows it, making it difficult for users to develop constraints in Aerie. This is because users cannot see why the constraint is not running or where the error is located.

This PR changes this behavior and will display compilation errors in the UI console. This will allow users to quickly identify and fix compilation errors, improving their constraint development experience.

Additionally, this PR updates the gql call to support receiving errors or results per constraint. This will be used in a future PR to stop the Merlin server from short-circuiting and not running the full list of constraints.