### PR TITLE
Always display select/unselect all buttons on layer filters

### DIFF
--- a/src/components/timeline/form/TimelineEditorLayerFilter.svelte
+++ b/src/components/timeline/form/TimelineEditorLayerFilter.svelte
@@ -90,36 +90,36 @@
     <div class="filter-search-icon" slot="left"><SearchIcon /></div>
   </Input>
   <Menu hideAfterClick={false} bind:this={filterMenu} placement="bottom-start" on:hide={() => (filterString = '')}>
-    <MenuHeader title={menuTitle} />
-    <div class="body st-typography-body">
-      {#if filteredValues.length}
-        <div class="values">
-          {#each filteredValues as item}
-            <button
-              class="value st-button tertiary st-typography-body"
-              on:click={() => toggleItem(item)}
-              class:active={selectedValuesMap[item]}
-            >
-              {item}
-            </button>
-          {/each}
-        </div>
-        <div class="list-buttons">
-          {#if filterString}
-            <button class="st-button secondary list-button" on:click={selectFilteredValues}>
-              Select {filteredValues.length}
-              {#if filteredValues.length === 1}
-                {layer.chartType === 'activity' ? 'activity' : 'resource'}
-              {:else}
-                {layer.chartType === 'activity' ? 'activities' : 'resources'}
-              {/if}
-            </button>
+    <div class="menu-content">
+      <MenuHeader title={menuTitle} />
+      <div class="body st-typography-body">
+        {#if filteredValues.length}
+          <div class="values">
+            {#each filteredValues as item}
+              <button
+                class="value st-button tertiary st-typography-body"
+                on:click={() => toggleItem(item)}
+                class:active={selectedValuesMap[item]}
+              >
+                {item}
+              </button>
+            {/each}
+          </div>
+        {:else}
+          <div class="st-typography-label empty-state">No items matching filter</div>
+        {/if}
+      </div>
+      <div class="list-buttons menu-border-top">
+        <button class="st-button secondary list-button" on:click={selectFilteredValues}>
+          Select {filteredValues.length}
+          {#if filteredValues.length === 1}
+            {layer.chartType === 'activity' ? 'activity' : 'resource'}
+          {:else}
+            {layer.chartType === 'activity' ? 'activities' : 'resources'}
           {/if}
-          <button class="st-button secondary list-button" on:click={unselectFilteredValues}>Unselect all</button>
-        </div>
-      {:else}
-        <div class="st-typography-label empty-state">No items matching filter</div>
-      {/if}
+        </button>
+        <button class="st-button secondary list-button" on:click={unselectFilteredValues}>Unselect all</button>
+      </div>
     </div>
   </Menu>
 </div>
@@ -139,11 +139,16 @@
     display: flex;
   }
 
+  .menu-content {
+    display: grid;
+    grid-template-rows: min-content 1fr min-content;
+    max-height: 360px;
+  }
+
   .body {
     cursor: auto;
     display: grid;
     gap: 8px;
-    max-height: 376px;
     overflow: auto;
     text-align: left;
   }
@@ -176,14 +181,15 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-    margin-bottom: 8px;
-  }
-
-  .list-button {
-    margin: 0px 8px;
+    padding: 8px;
+    width: 100%;
   }
 
   .empty-state {
     margin: 8px;
+  }
+
+  .menu-border-top {
+    border-top: 1px solid var(--st-gray-20);
   }
 </style>


### PR DESCRIPTION
Resolves #592 #591

This PR makes it so that when selecting filter options to be included in a timeline row, we make a "select all" and "unselect all" option always visible, regardless of whether filter text has been supplied.

We originally specified to move these buttons to the top of the filter list, and stack them side-by-side. But depending on the length of the resource names, we don't necessarily have much width to work with and the side-by-side approach seemed like it could be cramped. As @joswig pointed out in a comment on #592, another option here is to keep the buttons at the bottom, but just make them fixed so they're always visible. I do think this works a bit better in this context and doesn't steal too much vertical space from the list items themselves. Happy to discuss if anyone disagrees or thinks there's a better approach here? 

![2023-10-27 15 23 48](https://github.com/NASA-AMMOS/aerie-ui/assets/888818/4278a19b-090e-4540-b13a-a0fb6ecae943)