### PR TITLE
Filter external resources by simulation

### DIFF
--- a/src/components/context-menu/ContextMenu.svelte
+++ b/src/components/context-menu/ContextMenu.svelte
@@ -48,7 +48,7 @@
       }
     }
     if (y > window.innerHeight - rect.height) {
-      y = Math.max(y - rect.height, 8);
+      y = Math.max(window.innerHeight - rect.height, 8);
     }
   }
 

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -218,7 +218,7 @@
 
   $: if ($plan) {
     effects
-      .getResourcesExternal($plan.id, $plan.start_time, data.user)
+      .getResourcesExternal($plan.id, $simulationDatasetId ?? null, $plan.start_time, data.user)
       .then(newResources => ($externalResources = newResources));
   }
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -2766,9 +2766,26 @@ const effects = {
     }
   },
 
-  async getResourcesExternal(planId: number, startTimeYmd: string, user: User | null): Promise<Resource[]> {
+  async getResourcesExternal(
+    planId: number,
+    simulationDatasetId: number | null,
+    startTimeYmd: string,
+    user: User | null,
+  ): Promise<Resource[]> {
     try {
-      const data = await reqHasura<PlanDataset[]>(gql.GET_PROFILES_EXTERNAL, { planId }, user);
+      const data = await reqHasura<PlanDataset[]>(
+        gql.GET_PROFILES_EXTERNAL,
+        {
+          planId,
+          simulationDatasetFilter:
+            simulationDatasetId === null
+              ? {
+                  _is_null: true,
+                }
+              : { _eq: simulationDatasetId },
+        },
+        user,
+      );
       const { plan_dataset: plan_datasets } = data;
       if (plan_datasets != null) {
         let resources: Resource[] = [];

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1036,8 +1036,8 @@ const gql = {
   `,
 
   GET_PROFILES_EXTERNAL: `#graphql
-    query GetProfilesExternal($planId: Int!) {
-      plan_dataset(where: { plan_id: { _eq: $planId } }) {
+    query GetProfilesExternal($planId: Int!, $simulationDatasetFilter: Int_comparison_exp) {
+      plan_dataset(where: { plan_id: { _eq: $planId }, simulation_dataset_id: $simulationDatasetFilter }) {
         dataset {
           profiles {
             dataset_id


### PR DESCRIPTION
resolves #933 

To test:
1. Create a banananation plan and add some directives and create a plan snapshot
2. Make some changes to the directives and run a simulation
4. Change some simulation parameters and run it again
6. Open hasura's api
7. Enter this mutation query ([for reference](https://nasa-ammos.github.io/aerie-docs/planning/external-datasets/#create-an-external-dataset-with-real-and-discrete-profiles)) and fill in the plan id and one of the simulations that you created
```
mutation AddExternalDataset(
  $planId: Int!,
  $simulationDatasetId: Int,
  $datasetStart: String!,
  $profileSet: ProfileSet!) {
    addExternalDataset(
      planId: $planId,
      simulationDatasetId: $simulationDatasetId,
      datasetStart: $datasetStart,
      profileSet: $profileSet) {
      datasetId
    }
}
```
with a payload of
```
{
  "planId": YOUR_PLAN_ID,
  "datasetStart": "2023-274T00:00:00",
  "simulationDatasetId": SIMULATION_DATASET_ID,
  "profileSet": {
    "batteryEnergy": {
      "type": "real",
      "schema": {
        "type": "struct",
        "items": {
          "rate": { "type": "real" },
          "initial": { "type": "real" }
        }
      },
      "segments": [
        { "duration": 30000000, "dynamics": { "initial": 50, "rate": -0.5 } },
        { "duration": 30000000, "dynamics": { "initial": 35, "rate": -0.1 } }
      ]
    },
    "awake": {
      "type": "discrete",
      "schema": { "type": "boolean" },
      "segments": [
        { "duration": 30000000, "dynamics": true },
        { "duration": 30000000, "dynamics": false }
      ]
    }
  }
}
```
8. Open the Simulations panel and click between the existing simulations
9. Verify that the external dataset that you have selected is only visible when you have the corresponding simulation dataset selected.