### PR TITLE
include description with snapshot creation

### DIFF
--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -933,16 +933,12 @@ const effects = {
   ): Promise<void> {
     const data = await reqHasura<{ snapshot_id: number }>(
       gql.CREATE_PLAN_SNAPSHOT,
-      { plan_id: planId, /* snapshot_description: description, */ snapshot_name: name },
+      { description, plan_id: planId, snapshot_name: name },
       user,
     );
     const { createSnapshot } = data;
     if (createSnapshot != null) {
       const { snapshot_id } = createSnapshot;
-      // TODO this will soon be part of create plan snapshot
-      const updates = { description };
-      await reqHasura(gql.UPDATE_PLAN_SNAPSHOT, { planSnapshot: updates, snapshot_id }, user);
-
       // Associate tags with the snapshot
       const newPlanSnapshotTags: PlanSnapshotTagsInsertInput[] =
         tags?.map(({ id: tag_id }) => ({

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -202,8 +202,8 @@ const gql = {
   `,
 
   CREATE_PLAN_SNAPSHOT: `#graphql
-    mutation CreatePlanSnapshot($plan_id: Int!, $snapshot_name: String!) {
-      createSnapshot: create_snapshot(args: { _plan_id: $plan_id, _snapshot_name: $snapshot_name } ) {
+    mutation CreatePlanSnapshot($plan_id: Int!, $snapshot_name: String!, $description: String!) {
+      createSnapshot: create_snapshot(args: { _plan_id: $plan_id, _snapshot_name: $snapshot_name, _description: $description } ) {
         snapshot_id
       }
     }


### PR DESCRIPTION
Resolves #964 

To test:

1. Open a plan
2. Open browser developer tools
3. Open the "Plan Metadata" view
4. Create a new plan snap show and include a description
5. Check that snapshot created by 4 includes the description
6. Confirm that there was a single graphql request to create the request (disregard any requests to add tags)


https://github.com/NASA-AMMOS/aerie-ui/assets/5984211/a9fd5d0c-620a-4a41-8410-7be4df537093



