### PR TITLE
Debounce parameter form number inputs

### DIFF
--- a/src/components/parameters/ParameterBaseNumber.svelte
+++ b/src/components/parameters/ParameterBaseNumber.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { debounce } from 'lodash-es';
   import { createEventDispatcher } from 'svelte';
   import type { FormParameter, ParameterType } from '../../types/parameter';
   import { useActions, type ActionArray } from '../../utilities/useActions';
@@ -20,7 +21,16 @@
 
   const dispatch = createEventDispatcher();
 
+  let debouncedOnChange = debounce(onChange, 350, {
+    leading: true,
+    trailing: true,
+  });
+
   $: columns = `calc(${labelColumnWidth}px - ${level * levelPadding}px) auto`;
+
+  function onChange() {
+    dispatch('change', formParameter);
+  }
 </script>
 
 <div class="parameter-base-number" style="grid-template-columns: {columns}">
@@ -33,7 +43,7 @@
       {disabled}
       type="number"
       use:useActions={use}
-      on:change={() => dispatch('change', formParameter)}
+      on:change={debouncedOnChange}
     />
     <div class="parameter-right" slot="right">
       <ParameterUnits unit={formParameter.schema?.metadata?.unit?.value} />


### PR DESCRIPTION
Chips away at #939 but does not provide any general solution. This PR adds a debounce to parameter form number inputs to prevent serious performance degradation when user holds an arrow key to change the number in an input. This does not however address larger concerns of input lag/staleness/focus behavior. 

To test:
1. Make a plan with activities
2. Click on an activity with numerical params, try banananation ParameterTest to really assess worst case performance.
3. Spam number input changes with up and down arrow keys
4. The updates should only come at the beginning and end of the sequence of changes.