### PR TITLE
Do not hide bottom row border when row has auto height

### DIFF
--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -217,7 +217,12 @@
   }
 </script>
 
-<div class="row-root" class:active-row={$selectedRow ? $selectedRow.id === id : false} class:expanded>
+<div
+  class="row-root"
+  class:active-row={$selectedRow ? $selectedRow.id === id : false}
+  class:expanded
+  class:auto-height={autoAdjustHeight}
+>
   <div class="row-content">
     <!-- Row Header. -->
     <RowHeader
@@ -450,7 +455,7 @@
     position: relative;
   }
 
-  .row-root.expanded {
+  .row-root.expanded:not(.auto-height) {
     border-bottom: none;
   }
 


### PR DESCRIPTION
Closes #996 

To test: 
1. Open a timeline and create multiple rows
2. Set the row resize mode in the timeline editor to "auto"
3. Expand and collapse that row and ensure it still has a gray bottom border.