### PR TITLE
Fix local time display

### DIFF
--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -122,19 +122,18 @@
       // Format fine and coarse time based off duration
       const doyTimestamp = getDoyTime(date, true);
       let formattedDateUTC = doyTimestamp;
-      let formattedDateLocal = date.toISOString();
-      formattedDateLocal = formattedDateLocal.slice(0, formattedDateLocal.length - 1);
+      let formattedDateLocal = date.toLocaleString();
       if (xScaleViewDuration > durationYear * tickCount) {
         formattedDateUTC = doyTimestamp.slice(0, 4);
-        formattedDateLocal = formattedDateLocal.slice(0, 4);
+        formattedDateLocal = date.getFullYear().toString();
         labelWidth = 28;
       } else if (xScaleViewDuration > durationMonth * tickCount) {
         formattedDateUTC = doyTimestamp.slice(0, 8);
-        formattedDateLocal = formattedDateLocal.slice(0, 7);
+        formattedDateLocal = date.toLocaleDateString();
         labelWidth = 50;
       } else if (xScaleViewDuration > durationWeek) {
         formattedDateUTC = doyTimestamp.slice(0, 8);
-        formattedDateLocal = formattedDateLocal.slice(0, 10);
+        formattedDateLocal = date.toLocaleDateString();
         labelWidth = 58;
       }
       return { date, formattedDateLocal, formattedDateUTC, hideLabel: false };


### PR DESCRIPTION
The #977 PR did not properly implement local time display. This PR implements proper local time display.

To test:
1. Create a plan with a many year duration.
2. The time labels (UTC and your local time) should both display in the correct formats.
3. Zoom in significantly
4. The time labels should show full UTC and local times in the correct formats.