### PR TITLE
Basic Chart/Point Drawing Optimizations

### DIFF
--- a/src/components/timeline/LayerLine.svelte
+++ b/src/components/timeline/LayerLine.svelte
@@ -122,7 +122,7 @@
         const y = yScale(point.y);
         quadtree.add({ id: point.id, x, y });
         visiblePointsById[point.id] = point;
-        ctx.drawImage(offscreenPoint, x - pointRadius, y - pointRadius);
+        ctx.drawImage(offscreenPoint, x - pointRadius, y - pointRadius, pointRadius * 2, pointRadius * 2);
       }
     }
   }
@@ -193,13 +193,18 @@
   }
 
   function generateOffscreenPoint(lineColor: string, radius: number): OffscreenCanvas | null {
-    const tempCanvas = new OffscreenCanvas(radius * 2, radius * 2);
+    if (!radius) {
+      return null;
+    }
+
+    const tempCanvas = new OffscreenCanvas(radius * 2 * dpr, radius * 2 * dpr);
     const tempCtx = tempCanvas.getContext('2d');
 
     if (!tempCtx) {
       return null;
     }
 
+    tempCtx.resetTransform();
     tempCtx.scale(dpr, dpr);
     tempCtx.fillStyle = lineColor;
 

--- a/src/components/timeline/LayerLine.svelte
+++ b/src/components/timeline/LayerLine.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
   import { quadtree as d3Quadtree, type Quadtree } from 'd3-quadtree';
-  import type { ScaleTime } from 'd3-scale';
+  import type { ScaleLinear, ScaleTime } from 'd3-scale';
   import { curveLinear, line as d3Line } from 'd3-shape';
   import { createEventDispatcher, onMount, tick } from 'svelte';
   import type { Resource } from '../../types/simulation';
@@ -34,6 +34,8 @@
   let mounted: boolean = false;
   let quadtree: Quadtree<QuadtreePoint>;
   let visiblePointsById: Record<number, LinePoint> = {};
+  let yScale: ScaleLinear<number, number, never>;
+  let drawPointsRequest: number;
 
   $: canvasHeightDpr = drawHeight * dpr;
   $: canvasWidthDpr = drawWidth * dpr;
@@ -61,6 +63,7 @@
   $: onMousemove(mousemove);
   $: onMouseout(mouseout);
   $: points = resourcesToLinePoints(resources, pointRadius);
+  $: offscreenPoint = ctx && generateOffscreenPoint(lineColor, pointRadius);
 
   onMount(() => {
     if (canvas) {
@@ -71,6 +74,7 @@
 
   async function draw(): Promise<void> {
     if (ctx && xScaleView) {
+      window.cancelAnimationFrame(drawPointsRequest);
       await tick();
 
       ctx.resetTransform();
@@ -79,21 +83,10 @@
 
       const [yAxis] = yAxes.filter(axis => yAxisId === axis.id);
       const domain = yAxis?.scaleDomain || [];
-      const yScale = getYScale(domain, drawHeight);
+      yScale = getYScale(domain, drawHeight);
 
-      quadtree = d3Quadtree<QuadtreePoint>()
-        .x(p => p.x)
-        .y(p => p.y)
-        .extent([
-          [0, 0],
-          [drawWidth, drawHeight],
-        ]);
-      visiblePointsById = {};
-
-      const fill = lineColor;
-      ctx.fillStyle = fill;
       ctx.lineWidth = lineWidth;
-      ctx.strokeStyle = fill;
+      ctx.strokeStyle = lineColor;
 
       const line = d3Line<LinePoint>()
         .x(d => (xScaleView as ScaleTime<number, number, never>)(d.x))
@@ -105,19 +98,31 @@
       ctx.stroke();
       ctx.closePath();
 
-      for (const point of points) {
-        const { id, radius } = point;
+      drawPointsRequest = window.requestAnimationFrame(() => drawPoints());
+    }
+  }
 
-        if (point.x >= viewTimeRange.start && point.x <= viewTimeRange.end) {
-          const x = (xScaleView as ScaleTime<number, number, never>)(point.x);
-          const y = yScale(point.y);
-          quadtree.add({ id, x, y });
-          visiblePointsById[id] = point;
+  function drawPoints() {
+    quadtree = d3Quadtree<QuadtreePoint>()
+      .x(p => p.x)
+      .y(p => p.y)
+      .extent([
+        [0, 0],
+        [drawWidth, drawHeight],
+      ]);
+    visiblePointsById = {};
 
-          const circle = new Path2D();
-          circle.arc(x, y, radius, 0, 2 * Math.PI);
-          ctx.fill(circle);
-        }
+    if (!ctx || !offscreenPoint) {
+      return;
+    }
+
+    for (const point of points) {
+      if (point.x >= viewTimeRange.start && point.x <= viewTimeRange.end) {
+        const x = (xScaleView as ScaleTime<number, number, never>)(point.x);
+        const y = yScale(point.y);
+        quadtree.add({ id: point.id, x, y });
+        visiblePointsById[point.id] = point;
+        ctx.drawImage(offscreenPoint, x - pointRadius, y - pointRadius);
       }
     }
   }
@@ -185,6 +190,24 @@
     }
 
     return points;
+  }
+
+  function generateOffscreenPoint(lineColor: string, radius: number): OffscreenCanvas | null {
+    const tempCanvas = new OffscreenCanvas(radius * 2, radius * 2);
+    const tempCtx = tempCanvas.getContext('2d');
+
+    if (!tempCtx) {
+      return null;
+    }
+
+    tempCtx.scale(dpr, dpr);
+    tempCtx.fillStyle = lineColor;
+
+    const circle = new Path2D();
+    circle.arc(radius, radius, radius, 0, 2 * Math.PI);
+    tempCtx.fill(circle);
+
+    return tempCanvas;
   }
 </script>
 


### PR DESCRIPTION
This PR does a couple things that I feel like are low-hanging fruit optimizations, and pretty "safe", i.e. shouldn't present any noticeable change relative to the current functionality. I'm interested to see after merging these in with @AaronPlave's zoom work what our baseline performance is, and then see where we need to go from there.

- Render the data points to an offscreen canvas and then copy them as image data as needed. This should be quite faster than redrawing new arc paths every time.
- Splits rendering the line and points into two separate frames. This has two advantages:
  1) Rendering the lines and points across separate frames means we give the main thread a chance to unblock in-between
  2) If we get several immediate requests to redraw the line, we can cancel the existing requests to draw the points and only draw them once at the end. Effectively debouncing them. If we want I think we could be even more aggressive about this, i.e. delay drawing the points until after 50ms pass from the original draw request.
