### PR TITLE
Fixes the number of directives displayed associated with snapshot

### DIFF
--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -240,9 +240,7 @@
 
   $: {
     $activityDirectivesMap =
-      $planSnapshotId !== null && planSnapshotActivityDirectives.length > 0
-        ? keyBy(planSnapshotActivityDirectives, 'id')
-        : keyBy($activityDirectives, 'id');
+      $planSnapshotId !== null ? keyBy(planSnapshotActivityDirectives, 'id') : keyBy($activityDirectives, 'id');
   }
 
   $: if ($plan && $planLocked) {

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -28,7 +28,6 @@
   import { SearchParameters } from '../../../enums/searchParameters';
   import {
     activityDirectives,
-    activityDirectivesList,
     activityDirectivesMap,
     resetActivityStores,
     selectActivity,
@@ -551,7 +550,7 @@
   </Nav>
   {#if $planSnapshot}
     <PlanSnapshotBar
-      numOfDirectives={$activityDirectivesList.length}
+      numOfDirectives={planSnapshotActivityDirectives.length}
       snapshot={$planSnapshot}
       on:close={onCloseSnapshotPreview}
       on:restore={onRestoreSnapshot}


### PR DESCRIPTION
Currently if you select a snapshot that didn't have any activities associated to it, the displayed number of directives in the plan snapshot bar will display the total directives that exist in the latest revision. This fix ensures that if no directives were present at the time of the snapshot creation, the displayed number of directives will display "0".

To test:
1. Create plan
2. Before adding directives, create a snapshot
3. After a snapshot is created, then add a few
4. Create another snapshot
5. Repeat steps 3-4 as many times as you want, but make sure you mentally keep track of how many directives exist during the creation of a snapshot
6. Open the plan metadata panel and select the very first snapshot
7. Verify that the plan snapshot bar at the top correctly displays "0 directives"
8. Click the other snapshots and verify that each one correctly displays the number of directives