### PR TITLE
Fix Activity Preset Update Failing

### DIFF
--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -251,7 +251,6 @@
     } = event;
     if (activityDirective.applied_preset) {
       await effects.updateActivityPreset(
-        activityDirective.applied_preset.preset_id,
         {
           ...activityDirective.applied_preset.preset_applied,
           arguments: getDisplayedArguments(),

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -97,7 +97,7 @@ export type ActivityPresetInsertInput = Pick<
   'arguments' | 'associated_activity_type' | 'model_id' | 'name'
 >;
 
-export type ActivityPresetSetInput = PartialWith<ActivityPreset, 'owner'>;
+export type ActivityPresetSetInput = PartialWith<ActivityPreset, 'id' | 'owner'>;
 
 export type AnchorValidationStatus = {
   activity_id: ActivityDirectiveId;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -3793,20 +3793,18 @@ const effects = {
     }
   },
 
-  async updateActivityPreset(
-    id: ActivityPresetId,
-    updatedActivityPreset: ActivityPresetSetInput,
-    user: User | null,
-  ): Promise<void> {
+  async updateActivityPreset(updatedActivityPreset: ActivityPresetSetInput, user: User | null): Promise<void> {
     try {
       if (!queryPermissions.UPDATE_ACTIVITY_PRESET(user, updatedActivityPreset)) {
         throwPermissionError('update this activity preset');
       }
-      const { id: _id, ...restOfPresetPayload } = updatedActivityPreset;
+
+      const { id, ...restOfPresetPayload } = updatedActivityPreset;
       const { update_activity_presets_by_pk } = await reqHasura<ActivityPreset>(
         gql.UPDATE_ACTIVITY_PRESET,
         {
           activityPresetSetInput: restOfPresetPayload,
+          id,
         },
         user,
       );


### PR DESCRIPTION
Closes #1018 

Passes the preset id into the update request. Additionally, removes the `id` argument from `updateActivityPreset`, as it is unused in favor of the id in the `updatedActivityPreset` argument.