### PR TITLE
View subscription refactor and bug fixes

### DIFF
--- a/src/components/context-menu/ContextMenu.svelte
+++ b/src/components/context-menu/ContextMenu.svelte
@@ -65,11 +65,12 @@
   function onKeyDown(event: KeyboardEvent) {
     if (event.key === 'Escape') {
       hide(true);
+      event.stopPropagation();
     }
   }
 </script>
 
-<svelte:body on:click={() => hide(true)} on:keydown={onKeyDown} />
+<svelte:body on:click={() => hide(true)} on:keydown|capture={onKeyDown} />
 
 {#if shown}
   <!-- svelte-ignore a11y-mouse-events-have-key-events -->

--- a/src/components/context-menu/ContextMenu.svelte
+++ b/src/components/context-menu/ContextMenu.svelte
@@ -63,7 +63,7 @@
   }
 
   function onKeyDown(event: KeyboardEvent) {
-    if (event.key === 'Escape') {
+    if (shown && event.key === 'Escape') {
       hide(true);
       event.stopPropagation();
     }

--- a/src/components/modals/SavedViewsModal.svelte
+++ b/src/components/modals/SavedViewsModal.svelte
@@ -5,7 +5,7 @@
   import { SearchParameters } from '../../enums/searchParameters';
   import { initializeView, view, views } from '../../stores/views';
   import type { User } from '../../types/app';
-  import type { View } from '../../types/view';
+  import type { ViewSlim } from '../../types/view';
   import effects from '../../utilities/effects';
   import { setQueryParam } from '../../utilities/generic';
   import Tab from '../ui/Tabs/Tab.svelte';
@@ -22,12 +22,12 @@
 
   const dispatch = createEventDispatcher();
 
-  let userViews: View[] = [];
+  let userViews: ViewSlim[] = [];
 
-  $: userViews = $views.filter((view: View) => view.owner === user?.id);
+  $: userViews = $views.filter((view: ViewSlim) => view.owner === user?.id);
 
   async function deleteView({ detail: viewId }: CustomEvent<number>) {
-    const matchingView = userViews.find(v => v.id === viewId);
+    const matchingView = $views.find(v => v.id === viewId);
     if (matchingView) {
       const success = await effects.deleteView(matchingView, user);
 
@@ -40,7 +40,7 @@
   }
 
   async function deleteViews({ detail: viewIds }: CustomEvent<number[]>) {
-    const matchingViews = userViews.filter(v => viewIds.some(viewId => viewId === v.id));
+    const matchingViews = $views.filter(v => viewIds.some(viewId => viewId === v.id));
     const success = await effects.deleteViews(matchingViews, user);
 
     if (success) {

--- a/src/components/view/ViewsTable.svelte
+++ b/src/components/view/ViewsTable.svelte
@@ -5,21 +5,21 @@
   import { createEventDispatcher } from 'svelte';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef } from '../../types/data-grid';
-  import type { View } from '../../types/view';
+  import type { View, ViewSlim } from '../../types/view';
   import { featurePermissions } from '../../utilities/permissions';
   import { downloadView as downloadViewUtil } from '../../utilities/view';
   import BulkActionDataGrid from '../ui/DataGrid/BulkActionDataGrid.svelte';
   import DataGridActions from '../ui/DataGrid/DataGridActions.svelte';
 
-  export let views: View[] = [];
+  export let views: ViewSlim[] = [];
   export let user: User | null;
 
   type CellRendererParams = {
-    deleteView: (view: View) => void;
-    downloadView: (view: View) => void;
-    openView: (view: View) => void;
+    deleteView: (view: ViewSlim) => void;
+    downloadView: (view: ViewSlim) => void;
+    openView: (view: ViewSlim) => void;
   };
-  type ViewCellRendererParams = ICellRendererParams<View> & CellRendererParams;
+  type ViewCellRendererParams = ICellRendererParams<ViewSlim> & CellRendererParams;
 
   const dispatch = createEventDispatcher();
   const baseColumnDefs: DataGridColumnDef[] = [
@@ -104,20 +104,20 @@
     },
   ];
 
-  function deleteView({ id: viewId }: View) {
+  function deleteView({ id: viewId }: ViewSlim) {
     dispatch('deleteView', viewId);
   }
 
-  function deleteViews({ detail: views }: CustomEvent<View[]>) {
+  function deleteViews({ detail: views }: CustomEvent<ViewSlim[]>) {
     const viewIds = views.map(({ id }) => id);
     dispatch('deleteViews', viewIds);
   }
 
-  function hasDeletePermission(user: User | null, view: View) {
+  function hasDeletePermission(user: User | null, view: ViewSlim) {
     return featurePermissions.view.canDelete(user, view);
   }
 
-  function openView({ id: viewId }: Partial<View>) {
+  function openView({ id: viewId }: Partial<ViewSlim>) {
     dispatch('openView', viewId);
   }
 </script>

--- a/src/components/view/ViewsTable.svelte
+++ b/src/components/view/ViewsTable.svelte
@@ -7,7 +7,6 @@
   import type { DataGridColumnDef } from '../../types/data-grid';
   import type { View, ViewSlim } from '../../types/view';
   import { featurePermissions } from '../../utilities/permissions';
-  import { downloadView as downloadViewUtil } from '../../utilities/view';
   import BulkActionDataGrid from '../ui/DataGrid/BulkActionDataGrid.svelte';
   import DataGridActions from '../ui/DataGrid/DataGridActions.svelte';
 
@@ -91,7 +90,7 @@
       },
       cellRendererParams: {
         deleteView,
-        downloadView: downloadViewUtil,
+        downloadView,
         openView,
       } as CellRendererParams,
       field: 'actions',
@@ -106,6 +105,10 @@
 
   function deleteView({ id: viewId }: ViewSlim) {
     dispatch('deleteView', viewId);
+  }
+
+  function downloadView({ id: viewId }: ViewSlim) {
+    dispatch('downloadView', viewId);
   }
 
   function deleteViews({ detail: views }: CustomEvent<ViewSlim[]>) {

--- a/src/stores/views.ts
+++ b/src/stores/views.ts
@@ -1,6 +1,6 @@
 import { isEqual } from 'lodash-es';
 import { derived, get, writable, type Writable } from 'svelte/store';
-import type { View, ViewGrid, ViewTable, ViewToggleEvent } from '../types/view';
+import type { View, ViewGrid, ViewSlim, ViewTable, ViewToggleEvent } from '../types/view';
 import { getTarget } from '../utilities/generic';
 import gql from '../utilities/gql';
 import { TimelineInteractionMode, TimelineLockStatus } from '../utilities/timeline';
@@ -9,7 +9,7 @@ import { gqlSubscribable } from './subscribable';
 
 /* Subscriptions. */
 
-export const views = gqlSubscribable<View[]>(gql.SUB_VIEWS, {}, [], null);
+export const views = gqlSubscribable<ViewSlim[]>(gql.SUB_VIEWS, {}, [], null);
 
 /* Writeable. */
 

--- a/src/types/view.ts
+++ b/src/types/view.ts
@@ -92,3 +92,5 @@ export type View = {
   owner: UserId;
   updated_at: string;
 };
+
+export type ViewSlim = Omit<View, 'definition'>;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -2203,8 +2203,8 @@ const effects = {
   async deleteViews(views: ViewSlim[], user: User | null): Promise<boolean> {
     try {
       const hasPermission = views.reduce((previousValue, view) => {
-        return previousValue || queryPermissions.DELETE_VIEWS(user, view);
-      }, false);
+        return previousValue && queryPermissions.DELETE_VIEWS(user, view);
+      }, true);
       if (!hasPermission) {
         throwPermissionError('delete one or all of these views');
       }

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -2098,7 +2098,6 @@ const gql = {
     subscription SubViews {
       views: view {
         created_at
-        definition
         id
         name
         owner

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -19,7 +19,7 @@ import type { SchedulingCondition, SchedulingGoal } from '../types/scheduling';
 import type { UserSequence } from '../types/sequencing';
 import type { Simulation, SimulationTemplate } from '../types/simulation';
 import type { Tag } from '../types/tags';
-import type { View } from '../types/view';
+import type { View, ViewSlim } from '../types/view';
 import { showFailureToast } from './toast';
 
 export const ADMIN_ROLE = 'aerie_admin';
@@ -506,10 +506,10 @@ const queryPermissions = {
   DELETE_USER_SEQUENCE: (user: User | null, sequence: AssetWithOwner<UserSequence>): boolean => {
     return isUserAdmin(user) || (getPermission(['delete_user_sequence_by_pk'], user) && isUserOwner(user, sequence));
   },
-  DELETE_VIEW: (user: User | null, view: View): boolean => {
+  DELETE_VIEW: (user: User | null, view: ViewSlim): boolean => {
     return isUserAdmin(user) || (getPermission(['delete_view_by_pk'], user) && isUserOwner(user, view));
   },
-  DELETE_VIEWS: (user: User | null, view: View): boolean => {
+  DELETE_VIEWS: (user: User | null, view: ViewSlim): boolean => {
     return isUserAdmin(user) || (getPermission(['delete_view'], user) && isUserOwner(user, view));
   },
   DUPLICATE_PLAN: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
@@ -870,7 +870,7 @@ interface FeaturePermissions {
   simulation: RunnableCRUDPermission<AssetWithOwner<Simulation>>;
   simulationTemplates: PlanSimulationTemplateCRUDPermission;
   tags: CRUDPermission<Tag>;
-  view: CRUDPermission<View>;
+  view: CRUDPermission<ViewSlim>;
 }
 
 const featurePermissions: FeaturePermissions = {


### PR DESCRIPTION
Partially addresses #1012 by resolving the underlying performance issue with the view subscription. Previously the view subscription included view definitions but this PR removes definitions from the subscription and instead fetches the full view on demand. This PR also fixes:
- A small UI issue related to context menu escaping closing the open view modal
- Issue deleting views as an admin where fix was to not rely on the `userViews` list since the admin might not be the owner of the view but could still have delete permissions (which will be checked downstream anyway).