### PR TITLE
Initial pass at adding a toggle to show mode changes as a line chart

### DIFF
--- a/src/components/timeline/LayerLine.svelte
+++ b/src/components/timeline/LayerLine.svelte
@@ -83,7 +83,7 @@
 
       const [yAxis] = yAxes.filter(axis => yAxisId === axis.id);
       const domain = yAxis?.scaleDomain || [];
-      yScale = getYScale(domain, drawHeight);
+      const yScale = getYScale(domain, drawHeight) as ScaleLinear<number, number>;
 
       ctx.lineWidth = lineWidth;
       ctx.strokeStyle = lineColor;

--- a/src/components/timeline/LayerLine.svelte
+++ b/src/components/timeline/LayerLine.svelte
@@ -23,7 +23,7 @@
   export let mouseout: MouseEvent | undefined;
   export let pointRadius: number = 2;
   export let resources: Resource[] = [];
-  export let showStateLineChart: boolean = false;
+  export let showAsLinePlot: boolean = false;
   export let viewTimeRange: TimeRange = { end: 0, start: 0 };
   export let xScaleView: ScaleTime<number, number> | null = null;
   export let yAxes: Axis[] = [];
@@ -54,7 +54,7 @@
     typeof lineWidth === 'number' &&
     typeof pointRadius === 'number' &&
     mounted &&
-    showStateLineChart !== undefined &&
+    showAsLinePlot !== undefined &&
     points &&
     viewTimeRange &&
     xScaleView &&
@@ -99,7 +99,7 @@
       ctx.strokeStyle = lineColor;
       let line;
 
-      if (showStateLineChart) {
+      if (showAsLinePlot) {
         const domain = Array.from(scaleDomain);
         const yScale = scalePoint()
           .domain(domain.filter(filterEmpty))
@@ -214,7 +214,7 @@
             y,
           });
         }
-      } else if (schema.type === 'string') {
+      } else if (schema.type === 'string' || schema.type === 'variant') {
         for (let i = 0; i < values.length; ++i) {
           const value = values[i];
           const { x } = value;

--- a/src/components/timeline/LayerLine.svelte
+++ b/src/components/timeline/LayerLine.svelte
@@ -2,12 +2,13 @@
 
 <script lang="ts">
   import { quadtree as d3Quadtree, type Quadtree } from 'd3-quadtree';
-  import type { ScaleLinear, ScaleTime } from 'd3-scale';
+  import { scalePoint, type ScaleLinear, type ScaleTime } from 'd3-scale';
   import { curveLinear, line as d3Line } from 'd3-shape';
   import { createEventDispatcher, onMount, tick } from 'svelte';
   import type { Resource } from '../../types/simulation';
   import type { Axis, LinePoint, QuadtreePoint, ResourceLayerFilter, TimeRange } from '../../types/timeline';
-  import { getYScale, searchQuadtreePoint } from '../../utilities/timeline';
+  import { filterEmpty } from '../../utilities/generic';
+  import { CANVAS_PADDING_Y, getYScale, searchQuadtreePoint } from '../../utilities/timeline';
 
   export let contextmenu: MouseEvent | undefined;
   export let dpr: number = 1;
@@ -22,6 +23,7 @@
   export let mouseout: MouseEvent | undefined;
   export let pointRadius: number = 2;
   export let resources: Resource[] = [];
+  export let showStateLineChart: boolean = false;
   export let viewTimeRange: TimeRange = { end: 0, start: 0 };
   export let xScaleView: ScaleTime<number, number> | null = null;
   export let yAxes: Axis[] = [];
@@ -33,6 +35,7 @@
   let ctx: CanvasRenderingContext2D | null;
   let mounted: boolean = false;
   let quadtree: Quadtree<QuadtreePoint>;
+  let scaleDomain: Set<string> = new Set();
   let visiblePointsById: Record<number, LinePoint> = {};
   let yScale: ScaleLinear<number, number, never>;
   let drawPointsRequest: number;
@@ -47,10 +50,11 @@
     dpr &&
     // TODO swap filter out for resources which are recomputed when the view changes (i.e. filter changes)
     filter &&
-    lineColor &&
+    lineColor !== undefined &&
     typeof lineWidth === 'number' &&
     typeof pointRadius === 'number' &&
     mounted &&
+    showStateLineChart !== undefined &&
     points &&
     viewTimeRange &&
     xScaleView &&
@@ -82,17 +86,41 @@
       ctx.clearRect(0, 0, drawWidth, drawHeight);
 
       const [yAxis] = yAxes.filter(axis => yAxisId === axis.id);
-      const domain = yAxis?.scaleDomain || [];
-      const yScale = getYScale(domain, drawHeight) as ScaleLinear<number, number>;
+
+      quadtree = d3Quadtree<QuadtreePoint>()
+        .x(p => p.x)
+        .y(p => p.y)
+        .extent([
+          [0, 0],
+          [drawWidth, drawHeight],
+        ]);
 
       ctx.lineWidth = lineWidth;
       ctx.strokeStyle = lineColor;
+      let line;
 
-      const line = d3Line<LinePoint>()
-        .x(d => (xScaleView as ScaleTime<number, number, never>)(d.x))
-        .y(d => yScale(d.y))
-        .defined(d => d.y !== null) // Skip any gaps in resource data instead of interpolating
-        .curve(curveLinear);
+      if (showStateLineChart) {
+        const domain = Array.from(scaleDomain);
+        const yScale = scalePoint()
+          .domain(domain.filter(filterEmpty))
+          .range([drawHeight - CANVAS_PADDING_Y, CANVAS_PADDING_Y]);
+
+        line = d3Line<LinePoint>()
+          .x(d => (xScaleView as ScaleTime<number, number, never>)(d.x))
+          .y(d => yScale(d.y.toString()) as number)
+          .defined(d => d.y !== null) // Skip any gaps in resource data instead of interpolating
+          .curve(curveLinear);
+      } else {
+        const domain = yAxis?.scaleDomain || [];
+        const yScale = getYScale(domain, drawHeight) as ScaleLinear<number, number>;
+
+        line = d3Line<LinePoint>()
+          .x(d => (xScaleView as ScaleTime<number, number, never>)(d.x))
+          .y(d => yScale(d.y))
+          .defined(d => d.y !== null) // Skip any gaps in resource data instead of interpolating
+          .curve(curveLinear);
+      }
+
       ctx.beginPath();
       line.context(ctx)(points);
       ctx.stroke();
@@ -181,6 +209,21 @@
             id: id++,
             name,
             radius,
+            type: 'line',
+            x,
+            y,
+          });
+        }
+      } else if (schema.type === 'string') {
+        for (let i = 0; i < values.length; ++i) {
+          const value = values[i];
+          const { x } = value;
+          const y = value.y as number;
+          scaleDomain.add(value.y as string);
+          points.push({
+            id: id++,
+            name,
+            radius: radius,
             type: 'line',
             x,
             y,

--- a/src/components/timeline/LayerXRange.svelte
+++ b/src/components/timeline/LayerXRange.svelte
@@ -66,7 +66,6 @@
 
   $: canvasHeightDpr = drawHeight * dpr;
   $: canvasWidthDpr = drawWidth * dpr;
-  // If the user wants to see the stateLineChart, split this layer in half horizontally.
   $: if (
     canvasHeightDpr &&
     canvasWidthDpr &&

--- a/src/components/timeline/LayerXRange.svelte
+++ b/src/components/timeline/LayerXRange.svelte
@@ -76,7 +76,7 @@
   });
 
   async function draw(): Promise<void> {
-    if (ctx !== null && xScaleView) {
+    if (ctx && xScaleView) {
       await tick();
 
       ctx.resetTransform();
@@ -230,9 +230,8 @@
   function onMousemove(e: MouseEvent | undefined): void {
     if (e) {
       const { offsetX: x, offsetY: y } = e;
-      let points = searchQuadtreeRect<XRangePoint>(quadtree, x, y, drawHeight, maxXWidth, visiblePointsById);
+      const points = searchQuadtreeRect<XRangePoint>(quadtree, x, y, drawHeight, maxXWidth, visiblePointsById);
 
-      // The user will only hover one part of the layer at a time so only dispatch the set of points they're hovering.
       dispatch('mouseOver', { e, layerId: id, points });
     }
   }

--- a/src/components/timeline/LayerXRange.svelte
+++ b/src/components/timeline/LayerXRange.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
   import { quadtree as d3Quadtree, type Quadtree } from 'd3-quadtree';
-  import { scaleOrdinal, scalePoint, type ScaleTime } from 'd3-scale';
+  import { scaleOrdinal, type ScaleTime } from 'd3-scale';
   import {
     schemeAccent,
     schemeCategory10,
@@ -15,21 +15,11 @@
     schemeSet3,
     schemeTableau10,
   } from 'd3-scale-chromatic';
-  import { curveLinear, line as d3Line } from 'd3-shape';
   import { createEventDispatcher, onMount, tick } from 'svelte';
   import type { Resource } from '../../types/simulation';
-  import type {
-    Axis,
-    LinePoint,
-    QuadtreePoint,
-    QuadtreeRect,
-    ResourceLayerFilter,
-    TimeRange,
-    XRangeLayerColorScheme,
-    XRangePoint,
-  } from '../../types/timeline';
-  import { clamp, filterEmpty } from '../../utilities/generic';
-  import { CANVAS_PADDING_Y, searchQuadtreePoint, searchQuadtreeRect } from '../../utilities/timeline';
+  import type { QuadtreeRect, ResourceLayerFilter, XRangeLayerColorScheme, XRangePoint } from '../../types/timeline';
+  import { clamp } from '../../utilities/generic';
+  import { searchQuadtreeRect } from '../../utilities/timeline';
 
   export let contextmenu: MouseEvent | undefined;
   export let colorScheme: XRangeLayerColorScheme = 'schemeAccent';
@@ -42,11 +32,7 @@
   export let mouseout: MouseEvent | undefined;
   export let opacity: number = 0.8;
   export let resources: Resource[] = [];
-  export let viewTimeRange: TimeRange = { end: 0, start: 0 };
   export let xScaleView: ScaleTime<number, number> | null = null;
-  export let showStateLineChart: boolean = false;
-  export const yAxes: Axis[] = [];
-  export const yAxisId: number | null = null;
 
   const dispatch = createEventDispatcher();
   const textMeasurementCache: Record<string, { textHeight: number; textWidth: number }> = {};
@@ -57,12 +43,8 @@
   let maxXWidth: number;
   let mounted: boolean = false;
   let points: XRangePoint[] = [];
-  let pointRadius: number = 2;
   let quadtree: Quadtree<QuadtreeRect>;
-  let quadtreePoints: Quadtree<QuadtreePoint>;
-  let scaleDomain: Set<string> = new Set();
   let visiblePointsById: Record<number, XRangePoint> = {};
-  let visibleLinePointsById: Record<number, LinePoint> = {};
 
   $: canvasHeightDpr = drawHeight * dpr;
   $: canvasWidthDpr = drawWidth * dpr;
@@ -84,7 +66,6 @@
   $: onContextMenu(contextmenu);
   $: onMousemove(mousemove);
   $: onMouseout(mouseout);
-  $: linePoints = resourcesToLinePoints(resources);
   $: points = resourcesToXRangePoints(resources);
 
   onMount(() => {
@@ -103,105 +84,77 @@
       ctx.clearRect(0, 0, drawWidth, drawHeight);
       ctx.globalAlpha = opacity;
 
-      if (showStateLineChart) {
-        const fill = '';
-        ctx.fillStyle = fill;
-        ctx.lineWidth = 1;
-        ctx.strokeStyle = fill;
+      quadtree = d3Quadtree<QuadtreeRect>()
+        .x(p => p.x)
+        .y(p => p.y)
+        .extent([
+          [0, 0],
+          [drawWidth, drawHeight],
+        ]);
+      visiblePointsById = {};
 
-        const domain = Array.from(scaleDomain);
-        const yScale = scalePoint()
-          .domain(domain.filter(filterEmpty))
-          .range([drawHeight - CANVAS_PADDING_Y, CANVAS_PADDING_Y]);
-        quadtreePoints = d3Quadtree<QuadtreePoint>()
-          .x(p => p.x)
-          .y(p => p.y)
-          .extent([
-            [0, 0],
-            [drawWidth, drawHeight],
-          ]);
-        visibleLinePointsById = {};
+      maxXWidth = Number.MIN_SAFE_INTEGER;
+      const colorScale = getColorScale();
 
-        const line = d3Line<LinePoint>()
-          .x(d => (xScaleView as ScaleTime<number, number, never>)(d.x))
-          .y(d => yScale(d.y.toString()) as number)
-          .defined(d => d.y !== null) // Skip any gaps in resource data instead of interpolating
-          .curve(curveLinear);
-        ctx.beginPath();
-        line.context(ctx)(linePoints);
-        ctx.stroke();
-        ctx.closePath();
-
-        for (const point of linePoints) {
-          const { id, radius } = point;
-
-          if (point.x >= viewTimeRange.start && point.x <= viewTimeRange.end) {
-            const x = (xScaleView as ScaleTime<number, number, never>)(point.x);
-            const y = yScale(point.y.toString()) as number;
-            quadtreePoints.add({ id, x, y });
-            visibleLinePointsById[id] = point;
-
-            const circle = new Path2D();
-            circle.arc(x, y, radius, 0, 2 * Math.PI);
-            ctx.fill(circle);
-          }
+      for (let i = 0; i < points.length; ++i) {
+        const point = points[i];
+        if (point.is_gap) {
+          continue;
         }
-      } else {
-        quadtree = d3Quadtree<QuadtreeRect>()
-          .x(p => p.x)
-          .y(p => p.y)
-          .extent([
-            [0, 0],
-            [drawWidth, drawHeight],
-          ]);
-        visiblePointsById = {};
 
-        maxXWidth = Number.MIN_SAFE_INTEGER;
-        const colorScale = getColorScale();
+        // Scan to the next point with a different label than the current point.
+        let j = i + 1;
+        let nextPoint = points[j];
+        while (nextPoint && nextPoint.label.text === point.label.text && nextPoint.is_gap === point.is_gap) {
+          j = j + 1;
+          nextPoint = points[j];
+        }
+        i = j - 1; // Minus since the loop auto increments i at the end of the block.
 
-        for (let i = 0; i < points.length; ++i) {
-          const point = points[i];
-          if (point.is_gap) {
-            continue;
+        const xStart = clamp(xScaleView(point.x), 0, drawWidth);
+        const xEnd = clamp(xScaleView(nextPoint ? nextPoint.x : points[i].x), 0, drawWidth);
+
+        const xWidth = xEnd - xStart;
+        const y = 0;
+
+        if (xWidth > 0) {
+          const { id } = point;
+          visiblePointsById[id] = point;
+
+          const labelText = point.label.text;
+          ctx.fillStyle = colorScale(labelText);
+          const rect = new Path2D();
+          rect.rect(xStart, y, xWidth, drawHeight);
+          ctx.fill(rect);
+
+          quadtree.add({
+            height: drawHeight,
+            id,
+            width: xWidth,
+            x: xStart,
+            y,
+          });
+
+          if (xWidth > maxXWidth) {
+            maxXWidth = xWidth;
           }
 
-          // Scan to the next point with a different label than the current point.
-          let j = i + 1;
-          let nextPoint = points[j];
-          while (nextPoint && nextPoint.label.text === point.label.text && nextPoint.is_gap === point.is_gap) {
-            j = j + 1;
-            nextPoint = points[j];
-          }
-          i = j - 1; // Minus since the loop auto increments i at the end of the block.
+          const { textHeight, textWidth } = setLabelContext(point);
+          if (textWidth < xWidth) {
+            ctx.fillText(labelText, xStart + xWidth / 2 - textWidth / 2, drawHeight / 2 + textHeight / 2, textWidth);
+          } else {
+            const extraLabelPadding = 10;
+            let newLabelText = labelText;
+            let newTextWidth = textWidth;
 
-          const xStart = clamp(xScaleView(point.x), 0, drawWidth);
-          const xEnd = clamp(xScaleView(nextPoint ? nextPoint.x : points[i].x), 0, drawWidth);
-
-          const xWidth = xEnd - xStart;
-          const y = 0;
-
-          if (xWidth > 0) {
-            const { id } = point;
-            visiblePointsById[id] = point;
-
-            const labelText = point.label.text;
-            ctx.fillStyle = colorScale(labelText);
-            const rect = new Path2D();
-            rect.rect(xStart, y, xWidth, drawHeight);
-            ctx.fill(rect);
-
-            quadtree.add({
-              height: drawHeight,
-              id,
-              width: xWidth,
-              x: xStart,
-              y,
-            });
-
-            if (xWidth > maxXWidth) {
-              maxXWidth = xWidth;
+            // Remove characters from label until it is small enough to fit in x-range point.
+            while (newTextWidth > 0 && newTextWidth > xWidth - extraLabelPadding) {
+              newLabelText = newLabelText.slice(0, -1);
+              const textMeasurement = measureText(newLabelText);
+              newTextWidth = textMeasurement.textWidth;
             }
 
+<<<<<<< HEAD
             // Only draw if text will be visible
             if (newTextWidth > 0) {
               ctx.fillText(
@@ -211,6 +164,14 @@
                 newTextWidth,
               );
             }
+=======
+            ctx.fillText(
+              `${newLabelText}...`,
+              xStart + xWidth / 2 - newTextWidth / 2,
+              drawHeight / 2 + textHeight / 2,
+              newTextWidth,
+            );
+>>>>>>> ebee5695 (Moved state mode changes out of LayerXRange and into LayerLine)
           }
         }
       }
@@ -269,14 +230,7 @@
   function onMousemove(e: MouseEvent | undefined): void {
     if (e) {
       const { offsetX: x, offsetY: y } = e;
-      let points: LinePoint[] | XRangePoint[];
-
-      // Only check if the user is hovering the line chart if it's showing.
-      if (showStateLineChart) {
-        points = searchQuadtreePoint<LinePoint>(quadtreePoints, x, y, pointRadius, visibleLinePointsById);
-      } else {
-        points = searchQuadtreeRect<XRangePoint>(quadtree, x, y, drawHeight, maxXWidth, visiblePointsById);
-      }
+      let points = searchQuadtreeRect<XRangePoint>(quadtree, x, y, drawHeight, maxXWidth, visiblePointsById);
 
       // The user will only hover one part of the layer at a time so only dispatch the set of points they're hovering.
       dispatch('mouseOver', { e, layerId: id, points });
@@ -287,31 +241,6 @@
     if (e) {
       dispatch('mouseOver', { e, layerId: id, points: [] });
     }
-  }
-
-  function resourcesToLinePoints(resources: Resource[]): LinePoint[] {
-    const points: LinePoint[] = [];
-
-    for (const resource of resources) {
-      const { name, values } = resource;
-
-      for (let i = 0; i < values.length; ++i) {
-        const value = values[i];
-        const { x } = value;
-        const y = value.y as number;
-        scaleDomain.add(value.y as string);
-        points.push({
-          id: id++,
-          name,
-          radius: pointRadius,
-          type: 'line',
-          x,
-          y,
-        });
-      }
-    }
-
-    return points;
   }
 
   function resourcesToXRangePoints(resources: Resource[]): XRangePoint[] {

--- a/src/components/timeline/LayerXRange.svelte
+++ b/src/components/timeline/LayerXRange.svelte
@@ -143,7 +143,7 @@
           if (textWidth < xWidth) {
             ctx.fillText(labelText, xStart + xWidth / 2 - textWidth / 2, drawHeight / 2 + textHeight / 2, textWidth);
           } else {
-            const extraLabelPadding = 10;
+            const extraLabelPadding = 8;
             let newLabelText = labelText;
             let newTextWidth = textWidth;
 
@@ -154,7 +154,6 @@
               newTextWidth = textMeasurement.textWidth;
             }
 
-<<<<<<< HEAD
             // Only draw if text will be visible
             if (newTextWidth > 0) {
               ctx.fillText(
@@ -164,14 +163,6 @@
                 newTextWidth,
               );
             }
-=======
-            ctx.fillText(
-              `${newLabelText}...`,
-              xStart + xWidth / 2 - newTextWidth / 2,
-              drawHeight / 2 + textHeight / 2,
-              newTextWidth,
-            );
->>>>>>> ebee5695 (Moved state mode changes out of LayerXRange and into LayerLine)
           }
         }
       }

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -31,7 +31,12 @@
   import effects from '../../utilities/effects';
   import { classNames } from '../../utilities/generic';
   import { getDoyTime } from '../../utilities/time';
-  import { getYAxesWithScaleDomains, TimelineInteractionMode, type TimelineLockStatus } from '../../utilities/timeline';
+  import {
+    getYAxesWithScaleDomains,
+    isXRangeLayer,
+    TimelineInteractionMode,
+    type TimelineLockStatus,
+  } from '../../utilities/timeline';
   import ConstraintViolations from './ConstraintViolations.svelte';
   import LayerActivity from './LayerActivity.svelte';
   import LayerGaps from './LayerGaps.svelte';
@@ -415,23 +420,42 @@
               on:contextMenu
             />
           {/if}
-          {#if layer.chartType === 'x-range'}
-            <LayerXRange
-              {...layer}
-              {contextmenu}
-              {dpr}
-              drawHeight={computedDrawHeight}
-              {drawWidth}
-              filter={layer.filter.resource}
-              {mousemove}
-              {mouseout}
-              resources={resourcesByViewLayerId[layer.id] ?? []}
-              {viewTimeRange}
-              {xScaleView}
-              yAxes={yAxesWithScaleDomains}
-              on:mouseOver={onMouseOver}
-              on:contextMenu
-            />
+          {#if isXRangeLayer(layer)}
+            {#if layer.showStateLineChart === true}
+              <LayerLine
+                {...layer}
+                {contextmenu}
+                {dpr}
+                drawHeight={computedDrawHeight}
+                {drawWidth}
+                filter={layer.filter.resource}
+                {mousemove}
+                {mouseout}
+                resources={resourcesByViewLayerId[layer.id] ?? []}
+                {viewTimeRange}
+                {xScaleView}
+                yAxes={yAxesWithScaleDomains}
+                on:mouseOver={onMouseOver}
+                on:contextMenu
+              />
+            {:else}
+              <LayerXRange
+                {...layer}
+                {contextmenu}
+                {dpr}
+                drawHeight={computedDrawHeight}
+                {drawWidth}
+                filter={layer.filter.resource}
+                {mousemove}
+                {mouseout}
+                resources={resourcesByViewLayerId[layer.id] ?? []}
+                {viewTimeRange}
+                {xScaleView}
+                yAxes={yAxesWithScaleDomains}
+                on:mouseOver={onMouseOver}
+                on:contextMenu
+              />
+            {/if}
           {/if}
         {/each}
       </div>

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -421,7 +421,7 @@
             />
           {/if}
           {#if isXRangeLayer(layer)}
-            {#if layer.showStateLineChart === true}
+            {#if layer.showAsLinePlot === true}
               <LayerLine
                 {...layer}
                 {contextmenu}

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -426,7 +426,9 @@
               {mousemove}
               {mouseout}
               resources={resourcesByViewLayerId[layer.id] ?? []}
+              {viewTimeRange}
               {xScaleView}
+              yAxes={yAxesWithScaleDomains}
               on:mouseOver={onMouseOver}
               on:contextMenu
             />

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -449,9 +449,7 @@
                 {mousemove}
                 {mouseout}
                 resources={resourcesByViewLayerId[layer.id] ?? []}
-                {viewTimeRange}
                 {xScaleView}
-                yAxes={yAxesWithScaleDomains}
                 on:mouseOver={onMouseOver}
                 on:contextMenu
               />

--- a/src/components/timeline/RowYAxes.svelte
+++ b/src/components/timeline/RowYAxes.svelte
@@ -40,12 +40,12 @@
        * but for now we're just setting the Y axes dynamically based on the data.
        */
       const xRangeLayers = layers.filter(layer => layer.chartType === 'x-range');
-      const xRangeAxisG = gSelection.append('g').attr('class', axisClass);
-      xRangeAxisG.selectAll('*').remove();
       let i = 0;
 
       for (const layer of xRangeLayers) {
         const resources = resourcesByViewLayerId[layer.id];
+        const xRangeAxisG = gSelection.append('g').attr('class', axisClass);
+        xRangeAxisG.selectAll('*').remove();
 
         if ((layer as XRangeLayer).showAsLinePlot && resources && resources.length > 0) {
           let domain: string[] = [];

--- a/src/components/timeline/RowYAxes.svelte
+++ b/src/components/timeline/RowYAxes.svelte
@@ -18,6 +18,7 @@
   const dispatch = createEventDispatcher();
 
   let g: SVGGElement;
+  let xRangeAxisDrawn: boolean;
 
   $: if (drawHeight && g && yAxes && resourcesByViewLayerId && layers) {
     draw();
@@ -33,16 +34,18 @@
       let marginWidth = 0;
       const axisClass = 'y-axis';
       gSelection.selectAll(`.${axisClass}`).remove();
+      // TODO: Use this flag to only draw the xRange axis once, can be removed when the TODO below is resolved.
+      xRangeAxisDrawn = false;
 
       for (let i = 0; i < yAxes.length; ++i) {
         const axis = yAxes[i];
         const xRangeLayers = layers.filter(layer => layer.yAxisId === axis.id && layer.chartType === 'x-range');
-        const axisG = gSelection.append('g').attr('class', axisClass);
-        axisG.selectAll('*').remove();
 
-        if (xRangeLayers.length === 1) {
+        if (xRangeLayers.length === 1 && !xRangeAxisDrawn) {
           const layer = xRangeLayers[0] as XRangeLayer;
           const resources = resourcesByViewLayerId[layer.id];
+          const xRangeAxisG = gSelection.append('g').attr('class', axisClass);
+          xRangeAxisG.selectAll('*').remove();
 
           /**
            * TODO: This is a temporary solution to showing state mode changes as a line chart.
@@ -69,87 +72,96 @@
             const axisMargin = 2;
             const startPosition = -(totalWidth + axisMargin * i);
             marginWidth += i > 0 ? axisMargin : 0;
-            axisG.attr('transform', `translate(${startPosition}, 0)`);
-            axisG.style('color', axis.color);
+            xRangeAxisG.attr('transform', `translate(${startPosition}, 0)`);
+            xRangeAxisG.style('color', axis.color);
+            xRangeAxisG.call(axisLeft);
+            xRangeAxisG.call(g => g.select('.domain').remove());
+
+            totalWidth += getBoundingClientRectWidth(xRangeAxisG.node());
+            xRangeAxisDrawn = true;
+          }
+        }
+
+        const axisG = gSelection.append('g').attr('class', axisClass);
+        axisG.selectAll('*').remove();
+
+        // Get color for axis by examining associated layers. If more than one layer is associated,
+        // use the default axis color, otherwise use the color from the layer.
+        // TODO we don't expose y-axis color and this refactor would elimate need to store it in view.
+        // That is unless we want to allow user override of this behavior?
+        let color = axis.color;
+        const yAxisLayers = layers.filter(layer => layer.yAxisId === axis.id && layer.chartType === 'line');
+        if (yAxisLayers.length === 1) {
+          color = (yAxisLayers[0] as LineLayer).lineColor;
+        }
+
+        // TODO deprecate these view properties?
+        // const labelColor = axis.label?.color || 'black';
+        // const labelFontFace = axis.label?.fontFace || 'sans-serif';
+        // const labelFontSize = axis.label?.fontSize || 12;
+        // const labelText = axis.label.text;
+        const tickCount = axis.tickCount || 1;
+        if (
+          tickCount > 0 &&
+          axis.scaleDomain &&
+          axis.scaleDomain.length === 2 &&
+          typeof axis.scaleDomain[0] === 'number' &&
+          typeof axis.scaleDomain[1] === 'number'
+        ) {
+          const domain = axis.scaleDomain;
+          const scale = getYScale(domain, drawHeight);
+          const axisLeft = d3AxisLeft(scale)
+            .tickSizeInner(0)
+            .tickSizeOuter(0)
+            .ticks(tickCount)
+            .tickFormat(n => {
+              // Format -1 to 1 as normal numbers instead of <number>m (milli) which d3
+              // does out of the box to align with various standards but which can be
+              // commonly confused for M (million).
+              const number = n as number;
+              if (number > -1 && number < 1) {
+                return d3Format('.2r')(n);
+              }
+              return d3Format('~s')(n);
+            })
+            .tickPadding(2);
+
+          const axisMargin = 2;
+          const startPosition = -(totalWidth + axisMargin * i);
+          marginWidth += i > 0 ? axisMargin : 0;
+          axisG.attr('transform', `translate(${startPosition}, 0)`);
+          axisG.style('color', color);
+          if (domain.length === 2 && domain[0] !== null && domain[1] !== null) {
             axisG.call(axisLeft);
             axisG.call(g => g.select('.domain').remove());
           }
-        } else {
-          // Get color for axis by examining associated layers. If more than one layer is associated,
-          // use the default axis color, otherwise use the color from the layer.
-          // TODO we don't expose y-axis color and this refactor would elimate need to store it in view.
-          // That is unless we want to allow user override of this behavior?
-          let color = axis.color;
-          const yAxisLayers = layers.filter(layer => layer.yAxisId === axis.id && layer.chartType === 'line');
-          if (yAxisLayers.length === 1) {
-            color = (yAxisLayers[0] as LineLayer).lineColor;
-          }
-
-          // TODO deprecate these view properties?
-          // const labelColor = axis.label?.color || 'black';
-          // const labelFontFace = axis.label?.fontFace || 'sans-serif';
-          // const labelFontSize = axis.label?.fontSize || 12;
-          // const labelText = axis.label.text;
-          const tickCount = axis.tickCount || 1;
-          if (
-            tickCount > 0 &&
-            axis.scaleDomain &&
-            axis.scaleDomain.length === 2 &&
-            typeof axis.scaleDomain[0] === 'number' &&
-            typeof axis.scaleDomain[1] === 'number'
-          ) {
-            const domain = axis.scaleDomain;
-            const scale = getYScale(domain, drawHeight);
-            const axisLeft = d3AxisLeft(scale)
-              .tickSizeInner(0)
-              .tickSizeOuter(0)
-              .ticks(tickCount)
-              .tickFormat(n => {
-                // Format -1 to 1 as normal numbers instead of <number>m (milli) which d3
-                // does out of the box to align with various standards but which can be
-                // commonly confused for M (million).
-                const number = n as number;
-                if (number > -1 && number < 1) {
-                  return d3Format('.2r')(n);
-                }
-                return d3Format('~s')(n);
-              })
-              .tickPadding(2);
-
-            const axisMargin = 2;
-            const startPosition = -(totalWidth + axisMargin * i);
-            marginWidth += i > 0 ? axisMargin : 0;
-            axisG.attr('transform', `translate(${startPosition}, 0)`);
-            axisG.style('color', color);
-            if (domain.length === 2 && domain[0] !== null && domain[1] !== null) {
-              axisG.call(axisLeft);
-              axisG.call(g => g.select('.domain').remove());
-            }
-          }
-
-          // Draw separator
-          axisG
-            .append('line')
-            .attr('x1', 2)
-            .attr('y1', 0)
-            .attr('x2', 2)
-            .attr('y2', drawHeight)
-            .style('stroke', '#EBECEC')
-            .style('stroke-width', 2);
         }
 
-        const axisGElement: SVGGElement | null = axisG.node();
-        if (axisGElement !== null) {
-          // TODO might be able to save minor perf by getting bounding rect of entire
-          // container instead of each individual axis?
-          totalWidth += axisGElement.getBoundingClientRect().width;
-        }
+        // Draw separator
+        axisG
+          .append('line')
+          .attr('x1', 2)
+          .attr('y1', 0)
+          .attr('x2', 2)
+          .attr('y2', drawHeight)
+          .style('stroke', '#EBECEC')
+          .style('stroke-width', 2);
+
+        totalWidth += getBoundingClientRectWidth(axisG.node());
       }
 
       totalWidth += marginWidth;
       // Dispatch the width so the RowHeader can recalculate the label width.
       dispatch('updateYAxesWidth', totalWidth);
     }
+  }
+
+  function getBoundingClientRectWidth(axisG: SVGGElement | null): number {
+    if (axisG !== null) {
+      return axisG.getBoundingClientRect().width + 4;
+    }
+
+    return 0;
   }
 </script>
 

--- a/src/components/timeline/RowYAxes.svelte
+++ b/src/components/timeline/RowYAxes.svelte
@@ -1,13 +1,13 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import { axisLeft as d3AxisLeft } from 'd3-axis';
+  import { axisLeft as d3AxisLeft, type AxisScale } from 'd3-axis';
   import { format as d3Format } from 'd3-format';
   import { select } from 'd3-selection';
   import { createEventDispatcher, tick } from 'svelte';
   import type { Resource } from '../../types/simulation';
-  import type { Axis, Layer, LineLayer } from '../../types/timeline';
-  import { getYScale } from '../../utilities/timeline';
+  import type { Axis, Layer, LineLayer, XRangeLayer } from '../../types/timeline';
+  import { getOrdinalYScale, getYScale } from '../../utilities/timeline';
 
   export let drawHeight: number = 0;
   export let drawWidth: number = 0;
@@ -36,69 +36,106 @@
 
       for (let i = 0; i < yAxes.length; ++i) {
         const axis = yAxes[i];
-
-        // Get color for axis by examining associated layers. If more than one layer is associated,
-        // use the default axis color, otherwise use the color from the layer.
-        // TODO we don't expose y-axis color and this refactor would elimate need to store it in view.
-        // That is unless we want to allow user override of this behavior?
-        let color = axis.color;
-        const yAxisLayers = layers.filter(layer => layer.yAxisId === axis.id && layer.chartType === 'line');
-        if (yAxisLayers.length === 1) {
-          color = (yAxisLayers[0] as LineLayer).lineColor;
-        }
-
-        // TODO deprecate these view properties?
-        // const labelColor = axis.label?.color || 'black';
-        // const labelFontFace = axis.label?.fontFace || 'sans-serif';
-        // const labelFontSize = axis.label?.fontSize || 12;
-        // const labelText = axis.label.text;
-        const tickCount = axis.tickCount || 1;
+        const xRangeLayers = layers.filter(layer => layer.yAxisId === axis.id && layer.chartType === 'x-range');
         const axisG = gSelection.append('g').attr('class', axisClass);
         axisG.selectAll('*').remove();
-        if (
-          tickCount > 0 &&
-          axis.scaleDomain &&
-          axis.scaleDomain.length === 2 &&
-          typeof axis.scaleDomain[0] === 'number' &&
-          typeof axis.scaleDomain[1] === 'number'
-        ) {
-          const domain = axis.scaleDomain;
-          const scale = getYScale(domain, drawHeight);
-          const axisLeft = d3AxisLeft(scale)
-            .tickSizeInner(0)
-            .tickSizeOuter(0)
-            .ticks(tickCount)
-            .tickFormat(n => {
-              // Format -1 to 1 as normal numbers instead of <number>m (milli) which d3
-              // does out of the box to align with various standards but which can be
-              // commonly confused for M (million).
-              const number = n as number;
-              if (number > -1 && number < 1) {
-                return d3Format('.2r')(n);
-              }
-              return d3Format('~s')(n);
-            })
-            .tickPadding(2);
 
-          const axisMargin = 2;
-          const startPosition = -(totalWidth + axisMargin * i);
-          marginWidth += i > 0 ? axisMargin : 0;
-          axisG.attr('transform', `translate(${startPosition}, 0)`);
-          axisG.style('color', color);
-          if (domain.length === 2 && domain[0] !== null && domain[1] !== null) {
+        if (xRangeLayers.length === 1) {
+          const layer = xRangeLayers[0] as XRangeLayer;
+          const resources = resourcesByViewLayerId[layer.id];
+
+          /**
+           * TODO: This is a temporary solution to showing state mode changes as a line chart.
+           * The correct way to do this would be generating a Y axes when the user toggles the line chart,
+           * but for now we're just setting the Y axes dynamically based on the data.
+           */
+          if (layer.showStateLineChart && resources && resources.length > 0) {
+            let domain: string[] = [];
+
+            // Get all the unique ordinal values of the chart.
+            for (const value of resources[0].values) {
+              if (domain.indexOf(value.y as string) === -1) {
+                domain.push(value.y as string);
+              }
+            }
+
+            const scale = getOrdinalYScale(domain, drawHeight);
+            // Don't do any special formatting here because we're dealing with strings.
+            const axisLeft = d3AxisLeft(scale as AxisScale<string>)
+              .tickSizeInner(0)
+              .tickSizeOuter(0)
+              .ticks(domain.length)
+              .tickPadding(2);
+            const axisMargin = 2;
+            const startPosition = -(totalWidth + axisMargin * i);
+            marginWidth += i > 0 ? axisMargin : 0;
+            axisG.attr('transform', `translate(${startPosition}, 0)`);
+            axisG.style('color', axis.color);
             axisG.call(axisLeft);
             axisG.call(g => g.select('.domain').remove());
           }
+        } else {
+          // Get color for axis by examining associated layers. If more than one layer is associated,
+          // use the default axis color, otherwise use the color from the layer.
+          // TODO we don't expose y-axis color and this refactor would elimate need to store it in view.
+          // That is unless we want to allow user override of this behavior?
+          let color = axis.color;
+          const yAxisLayers = layers.filter(layer => layer.yAxisId === axis.id && layer.chartType === 'line');
+          if (yAxisLayers.length === 1) {
+            color = (yAxisLayers[0] as LineLayer).lineColor;
+          }
 
-          // Draw separator
-          axisG
-            .append('line')
-            .attr('x1', 2)
-            .attr('y1', 0)
-            .attr('x2', 2)
-            .attr('y2', drawHeight)
-            .style('stroke', '#EBECEC')
-            .style('stroke-width', 2);
+          // TODO deprecate these view properties?
+          // const labelColor = axis.label?.color || 'black';
+          // const labelFontFace = axis.label?.fontFace || 'sans-serif';
+          // const labelFontSize = axis.label?.fontSize || 12;
+          // const labelText = axis.label.text;
+          const tickCount = axis.tickCount || 1;
+          if (
+            tickCount > 0 &&
+            axis.scaleDomain &&
+            axis.scaleDomain.length === 2 &&
+            typeof axis.scaleDomain[0] === 'number' &&
+            typeof axis.scaleDomain[1] === 'number'
+          ) {
+            const domain = axis.scaleDomain;
+            const scale = getYScale(domain, drawHeight);
+            const axisLeft = d3AxisLeft(scale)
+              .tickSizeInner(0)
+              .tickSizeOuter(0)
+              .ticks(tickCount)
+              .tickFormat(n => {
+                // Format -1 to 1 as normal numbers instead of <number>m (milli) which d3
+                // does out of the box to align with various standards but which can be
+                // commonly confused for M (million).
+                const number = n as number;
+                if (number > -1 && number < 1) {
+                  return d3Format('.2r')(n);
+                }
+                return d3Format('~s')(n);
+              })
+              .tickPadding(2);
+
+            const axisMargin = 2;
+            const startPosition = -(totalWidth + axisMargin * i);
+            marginWidth += i > 0 ? axisMargin : 0;
+            axisG.attr('transform', `translate(${startPosition}, 0)`);
+            axisG.style('color', color);
+            if (domain.length === 2 && domain[0] !== null && domain[1] !== null) {
+              axisG.call(axisLeft);
+              axisG.call(g => g.select('.domain').remove());
+            }
+
+            // Draw separator
+            axisG
+              .append('line')
+              .attr('x1', 2)
+              .attr('y1', 0)
+              .attr('x2', 2)
+              .attr('y2', drawHeight)
+              .style('stroke', '#EBECEC')
+              .style('stroke-width', 2);
+          }
         }
 
         const axisGElement: SVGGElement | null = axisG.node();
@@ -108,6 +145,7 @@
           totalWidth += axisGElement.getBoundingClientRect().width;
         }
       }
+
       totalWidth += marginWidth;
       if (totalWidth > 0 && drawWidth !== totalWidth) {
         dispatch('updateYAxesWidth', totalWidth);

--- a/src/components/timeline/RowYAxes.svelte
+++ b/src/components/timeline/RowYAxes.svelte
@@ -146,8 +146,9 @@
         }
       }
 
+      totalWidth += marginWidth;
       // Dispatch the width so the RowHeader can recalculate the label width.
-      dispatch('updateYAxesWidth', totalWidth + marginWidth);
+      dispatch('updateYAxesWidth', totalWidth);
     }
   }
 </script>

--- a/src/components/timeline/RowYAxes.svelte
+++ b/src/components/timeline/RowYAxes.svelte
@@ -18,7 +18,6 @@
   const dispatch = createEventDispatcher();
 
   let g: SVGGElement;
-  let xRangeAxisDrawn: boolean;
 
   $: if (drawHeight && g && yAxes && resourcesByViewLayerId && layers) {
     draw();
@@ -34,25 +33,21 @@
       let marginWidth = 0;
       const axisClass = 'y-axis';
       gSelection.selectAll(`.${axisClass}`).remove();
-      // TODO: Use this flag to only draw the xRange axis once, can be removed when the TODO below is resolved.
-      xRangeAxisDrawn = false;
 
       for (let i = 0; i < yAxes.length; ++i) {
         const axis = yAxes[i];
         const xRangeLayers = layers.filter(layer => layer.yAxisId === axis.id && layer.chartType === 'x-range');
+        const xRangeAxisG = gSelection.append('g').attr('class', axisClass);
+        xRangeAxisG.selectAll('*').remove();
 
-        if (xRangeLayers.length === 1 && !xRangeAxisDrawn) {
-          const layer = xRangeLayers[0] as XRangeLayer;
+        for (const layer of xRangeLayers) {
           const resources = resourcesByViewLayerId[layer.id];
-          const xRangeAxisG = gSelection.append('g').attr('class', axisClass);
-          xRangeAxisG.selectAll('*').remove();
-
           /**
            * TODO: This is a temporary solution to showing state mode changes as a line chart.
            * The correct way to do this would be generating a Y axes when the user toggles the line chart,
            * but for now we're just setting the Y axes dynamically based on the data.
            */
-          if (layer.showAsLinePlot && resources && resources.length > 0) {
+          if ((layer as XRangeLayer).showAsLinePlot && resources && resources.length > 0) {
             let domain: string[] = [];
 
             // Get all the unique ordinal values of the chart.
@@ -78,7 +73,6 @@
             xRangeAxisG.call(g => g.select('.domain').remove());
 
             totalWidth += getBoundingClientRectWidth(xRangeAxisG.node());
-            xRangeAxisDrawn = true;
           }
         }
 

--- a/src/components/timeline/RowYAxes.svelte
+++ b/src/components/timeline/RowYAxes.svelte
@@ -49,7 +49,7 @@
            * The correct way to do this would be generating a Y axes when the user toggles the line chart,
            * but for now we're just setting the Y axes dynamically based on the data.
            */
-          if (layer.showStateLineChart && resources && resources.length > 0) {
+          if (layer.showAsLinePlot && resources && resources.length > 0) {
             let domain: string[] = [];
 
             // Get all the unique ordinal values of the chart.

--- a/src/components/timeline/RowYAxes.svelte
+++ b/src/components/timeline/RowYAxes.svelte
@@ -125,17 +125,17 @@
               axisG.call(axisLeft);
               axisG.call(g => g.select('.domain').remove());
             }
-
-            // Draw separator
-            axisG
-              .append('line')
-              .attr('x1', 2)
-              .attr('y1', 0)
-              .attr('x2', 2)
-              .attr('y2', drawHeight)
-              .style('stroke', '#EBECEC')
-              .style('stroke-width', 2);
           }
+
+          // Draw separator
+          axisG
+            .append('line')
+            .attr('x1', 2)
+            .attr('y1', 0)
+            .attr('x2', 2)
+            .attr('y2', drawHeight)
+            .style('stroke', '#EBECEC')
+            .style('stroke-width', 2);
         }
 
         const axisGElement: SVGGElement | null = axisG.node();
@@ -146,10 +146,8 @@
         }
       }
 
-      totalWidth += marginWidth;
-      if (totalWidth > 0 && drawWidth !== totalWidth) {
-        dispatch('updateYAxesWidth', totalWidth);
-      }
+      // Dispatch the width so the RowHeader can recalculate the label width.
+      dispatch('updateYAxesWidth', totalWidth + marginWidth);
     }
   }
 </script>

--- a/src/components/timeline/form/TimelineEditorLayerSettings.svelte
+++ b/src/components/timeline/form/TimelineEditorLayerSettings.svelte
@@ -159,6 +159,17 @@
             on:input={onInput}
           />
         </Input>
+        <Input layout="inline">
+          <label for="showStateLineChart">Show State Changes</label>
+          <input
+            style:width="max-content"
+            checked={layerAsXRange.showStateLineChart}
+            id="showStateLineChart"
+            name="showStateLineChart"
+            on:change={onInput}
+            type="checkbox"
+          />
+        </Input>
       {/if}
       <Input layout="inline">
         <label for="id">Layer ID</label>

--- a/src/components/timeline/form/TimelineEditorLayerSettings.svelte
+++ b/src/components/timeline/form/TimelineEditorLayerSettings.svelte
@@ -160,12 +160,12 @@
           />
         </Input>
         <Input layout="inline">
-          <label for="showStateLineChart">Show State Changes</label>
+          <label for="showAsLinePlot">Show As Line Plot</label>
           <input
             style:width="max-content"
-            checked={layerAsXRange.showStateLineChart}
-            id="showStateLineChart"
-            name="showStateLineChart"
+            checked={layerAsXRange.showAsLinePlot}
+            id="showAsLinePlot"
+            name="showAsLinePlot"
             on:change={onInput}
             type="checkbox"
           />

--- a/src/schemas/ui-view-schema.json
+++ b/src/schemas/ui-view-schema.json
@@ -405,6 +405,9 @@
                               "opacity": {
                                 "type": "number"
                               },
+                              "showStateLineChart": {
+                                "type": "boolean"
+                              },
                               "yAxisId": {
                                 "$ref": "#/definitions/yAxisId"
                               }

--- a/src/schemas/ui-view-schema.json
+++ b/src/schemas/ui-view-schema.json
@@ -405,7 +405,7 @@
                               "opacity": {
                                 "type": "number"
                               },
-                              "showStateLineChart": {
+                              "showAsLinePlot": {
                                 "type": "boolean"
                               },
                               "yAxisId": {

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -196,6 +196,7 @@ export type XRangeLayerColorScheme =
 export interface XRangeLayer extends Layer {
   colorScheme: XRangeLayerColorScheme;
   opacity: number;
+  showStateLineChart: boolean;
 }
 
 export interface XRangePoint extends Point {

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -196,7 +196,7 @@ export type XRangeLayerColorScheme =
 export interface XRangeLayer extends Layer {
   colorScheme: XRangeLayerColorScheme;
   opacity: number;
-  showStateLineChart: boolean;
+  showAsLinePlot: boolean;
 }
 
 export interface XRangePoint extends Point {

--- a/src/utilities/generic.ts
+++ b/src/utilities/generic.ts
@@ -95,10 +95,21 @@ export function getTarget(event: Event) {
 
   if (target.tagName === 'INPUT') {
     const input = target as HTMLInputElement;
-    const { name, type, value: valueAsString, valueAsNumber } = input;
-    const value = type === 'number' ? valueAsNumber : valueAsString;
+    const { name, type, value: valueAsString, valueAsNumber, checked } = input;
+    let convertedValue;
 
-    return { name, value };
+    switch (type) {
+      case 'number':
+        convertedValue = valueAsNumber;
+        break;
+      case 'checkbox':
+        convertedValue = checked;
+        break;
+      default:
+        convertedValue = valueAsString;
+    }
+
+    return { name, value: convertedValue };
   } else if (target.tagName === 'SELECT') {
     const select = target as HTMLSelectElement;
     const type = select.getAttribute('data-type') ?? 'text';

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -1,6 +1,6 @@
 import { bisector, tickStep } from 'd3-array';
 import type { Quadtree, QuadtreeInternalNode, QuadtreeLeaf } from 'd3-quadtree';
-import { scaleLinear, scaleTime, type ScaleLinear, type ScaleTime } from 'd3-scale';
+import { scaleLinear, scalePoint, scaleTime, type ScaleLinear, type ScalePoint, type ScaleTime } from 'd3-scale';
 import {
   timeHour,
   timeInterval,
@@ -137,6 +137,12 @@ export function getXScale(domain: Date[], width: number): ScaleTime<number, numb
   return scaleTime()
     .domain(domain)
     .range([CANVAS_PADDING_X, width - CANVAS_PADDING_X]);
+}
+
+export function getOrdinalYScale(domain: (string | null)[], height: number): ScalePoint<string> {
+  return scalePoint()
+    .domain(domain as string[])
+    .range([height - CANVAS_PADDING_Y, CANVAS_PADDING_Y]);
 }
 
 export function getYScale(domain: (number | null)[], height: number): ScaleLinear<number, number> {
@@ -355,7 +361,11 @@ export function createHorizontalGuide(
       if (firstAxis.scaleDomain.length === 2) {
         if (firstAxis.scaleDomain[0] !== null && firstAxis.scaleDomain[1] !== null) {
           // Default y value to the middle of the domain
-          y = (firstAxis.scaleDomain[1] + firstAxis.scaleDomain[0]) / 2;
+          if (typeof firstAxis.scaleDomain[0] === 'number' && typeof firstAxis.scaleDomain[1] === 'number') {
+            y = (firstAxis.scaleDomain[1] + firstAxis.scaleDomain[0]) / 2;
+          } else {
+            // TODO: Figure out how to place a horizontal guide on a categorical axis
+          }
         }
       }
     }
@@ -494,6 +504,7 @@ export function createTimelineXRangeLayer(
     id,
     name: '',
     opacity: 0.8,
+    showStateLineChart: false,
     yAxisId,
     ...args,
   };
@@ -589,6 +600,25 @@ export function getYAxisBounds(
   }
 
   return scaleDomain as number[];
+}
+
+/**
+ * Checks if the domain is categorical (list of strings).
+ * @param values
+ * @returns True if the domain is categorical.
+ */
+export function isDomainCategorical(values: (number | string | null)[]): boolean {
+  if (values === null || values.length === 0) {
+    return false;
+  }
+
+  for (const value of values) {
+    if (typeof value === 'number') {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 /**

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -151,6 +151,10 @@ export function getYScale(domain: (number | null)[], height: number): ScaleLinea
     .range([height - CANVAS_PADDING_Y, CANVAS_PADDING_Y]);
 }
 
+export function isXRangeLayer(layer: Layer): layer is XRangeLayer {
+  return layer.chartType === 'x-range';
+}
+
 function isQuadtreeLeaf<T>(node?: QuadtreeInternalNode<T> | QuadtreeLeaf<T>): node is QuadtreeLeaf<T> {
   if (node && node.length === undefined) {
     return true;

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -603,25 +603,6 @@ export function getYAxisBounds(
 }
 
 /**
- * Checks if the domain is categorical (list of strings).
- * @param values
- * @returns True if the domain is categorical.
- */
-export function isDomainCategorical(values: (number | string | null)[]): boolean {
-  if (values === null || values.length === 0) {
-    return false;
-  }
-
-  for (const value of values) {
-    if (typeof value === 'number') {
-      return false;
-    }
-  }
-
-  return true;
-}
-
-/**
  * Populates y-axes with scaleDomain
  */
 export function getYAxesWithScaleDomains(

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -508,7 +508,7 @@ export function createTimelineXRangeLayer(
     id,
     name: '',
     opacity: 0.8,
-    showStateLineChart: false,
+    showAsLinePlot: false,
     yAxisId,
     ...args,
   };


### PR DESCRIPTION
Closes #640.

This is the first pass at showing mode changes as a line chart similar to how Raven works.

There's more work to go on this issue, right now horizontal rules aren't working properly and the _correct_ way to implement this is to generate a new type of Y axes which we're not currently doing.