### PR TITLE
Fix: Remove permission from model dropdown that prevents the model from ever being selected

### DIFF
--- a/src/components/expansion/ExpansionSetForm.svelte
+++ b/src/components/expansion/ExpansionSetForm.svelte
@@ -71,7 +71,7 @@
     permissionError = `You do not have permission to ${mode === 'edit' ? 'edit this' : 'create an'} expansion set.`;
   }
 
-  function hasModelPermission(modelId: number): boolean {
+  function hasModelPermission(modelId: number, user: User | null): boolean {
     const model = $models.find(model => model.id === modelId);
     if (user && model) {
       return featurePermissions.expansionSets.canCreate(user, plans, model);
@@ -199,14 +199,10 @@
           class="st-select w-100"
           name="modelId"
           on:change={() => (selectedExpansionRules = {})}
-          use:permissionHandler={{
-            hasPermission,
-            permissionError,
-          }}
         >
           <option value={null} />
           {#each $models as model}
-            <option value={model.id} disabled={!hasModelPermission(model.id)}>
+            <option value={model.id} disabled={!hasModelPermission(model.id, user)}>
               {model.name}
             </option>
           {/each}


### PR DESCRIPTION
To test:
1. Create a plan
2. Navigate to `/expansion/sets/new` to create a new expansion set
3. Verify that you are able to click on the model dropdown to select a model