### PR TITLE
Fix incomplete import path for customTS worker

### DIFF
--- a/src/components/ui/MonacoEditor.svelte
+++ b/src/components/ui/MonacoEditor.svelte
@@ -104,7 +104,7 @@
 
     if (language && language === 'typescript') {
       monaco.languages.typescript.typescriptDefaults.setWorkerOptions({
-        customWorkerPath: '/customTS.worker.js',
+        customWorkerPath: `${base}/customTS.worker.js`,
       });
 
       if (actionProvider) {


### PR DESCRIPTION
Not easily testable. Must be deployed on https://gateway.eurc-dev.jpl.nasa.gov/

To test on https://gateway.eurc-dev.jpl.nasa.gov/aerie:
1. With the network dev tab open in chrome, navigate to https://gateway.eurc-dev.jpl.nasa.gov/aerie/expansion/rules/new
2. Verify that `customTS.worker.js` is no longer 404ing