### PR TITLE
Switch timeline navigation mode to interact when page loses focus

### DIFF
--- a/src/components/timeline/TimelineInteractionModeControl.svelte
+++ b/src/components/timeline/TimelineInteractionModeControl.svelte
@@ -2,7 +2,7 @@
   import CursorDefaultIcon from '@nasa-jpl/stellar/icons/cursor_default.svg?component';
   import MoveIcon from '@nasa-jpl/stellar/icons/move.svg?component';
   import { createEventDispatcher, onMount } from 'svelte';
-  import { isMacOs } from '../../utilities/generic';
+  import { addPageFocusListener, isMacOs } from '../../utilities/generic';
   import { isMetaOrCtrlPressed } from '../../utilities/keyboardEvents';
   import { TimelineInteractionMode } from '../../utilities/timeline';
   import { tooltip } from '../../utilities/tooltip';
@@ -22,15 +22,25 @@
     document.addEventListener('keydown', onKeydown);
     document.addEventListener('keyup', onKeyup);
 
+    // Add page focus listener to handle command + tab events that
+    // can cause the mode change to be stuck in Navigation mode on Macs.
+    const removeDocumentFocusListener = addPageFocusListener(e => {
+      if (e === 'out') {
+        dispatch('change', TimelineInteractionMode.Interact);
+      }
+    });
+
     return () => {
       document.removeEventListener('keydown', onKeydown);
       document.removeEventListener('keyup', onKeyup);
+      removeDocumentFocusListener();
     };
   });
 
   function onKeydown(e: KeyboardEvent) {
     // If user holds meta/control while not focused on an input then activate navigation mode
     const keyActive = isMacOs() ? e.key === 'Meta' : e.key === 'Control';
+    console.log('onKeydown', e, keyActive);
     if (isMetaOrCtrlPressed(e)) {
       // If the meta key is the one pressed enter navigation mode
       if (keyActive && (e.target as HTMLElement).tagName !== 'INPUT') {

--- a/src/components/timeline/TimelineInteractionModeControl.svelte
+++ b/src/components/timeline/TimelineInteractionModeControl.svelte
@@ -40,7 +40,6 @@
   function onKeydown(e: KeyboardEvent) {
     // If user holds meta/control while not focused on an input then activate navigation mode
     const keyActive = isMacOs() ? e.key === 'Meta' : e.key === 'Control';
-    console.log('onKeydown', e, keyActive);
     if (isMetaOrCtrlPressed(e)) {
       // If the meta key is the one pressed enter navigation mode
       if (keyActive && (e.target as HTMLElement).tagName !== 'INPUT') {


### PR DESCRIPTION
Currently we use `command` as our zoom and pan modifier for timeline interactions. When a Mac user presses command+tab to switch to another application, the UI gets stuck in Navigation mode since the resulting command keyup is not detected. This PR introduces a listener for page focus events and sets the interaction mode back to navigation when page focus is lost. This is not a perfect solution as the user could have set interaction mode to Navigation by clicking on the mode button and the mode would be reset but it's likely that most users would be using the keyboard shortcuts the majority of the time.