### PR TITLE
Add SSO support

### DIFF
--- a/.env
+++ b/.env
@@ -5,6 +5,6 @@ PUBLIC_GATEWAY_SERVER_URL=http://localhost:9000
 PUBLIC_HASURA_CLIENT_URL=http://localhost:8080/v1/graphql
 PUBLIC_HASURA_SERVER_URL=http://localhost:8080/v1/graphql
 PUBLIC_HASURA_WEB_SOCKET_URL=ws://localhost:8080/v1/graphql
-PUBLIC_AUTH_SSO_ENABLED=true
+PUBLIC_AUTH_SSO_ENABLED=false
 # VITE_HOST=localhost.jpl.nasa.gov
 # VITE_HTTPS=true

--- a/.env
+++ b/.env
@@ -6,3 +6,5 @@ PUBLIC_HASURA_CLIENT_URL=http://localhost:8080/v1/graphql
 PUBLIC_HASURA_SERVER_URL=http://localhost:8080/v1/graphql
 PUBLIC_HASURA_WEB_SOCKET_URL=ws://localhost:8080/v1/graphql
 PUBLIC_LOGIN_PAGE=enabled
+# VITE_HOST=localhost.jpl.nasa.gov
+# VITE_HTTPS=true

--- a/.env
+++ b/.env
@@ -5,6 +5,6 @@ PUBLIC_GATEWAY_SERVER_URL=http://localhost:9000
 PUBLIC_HASURA_CLIENT_URL=http://localhost:8080/v1/graphql
 PUBLIC_HASURA_SERVER_URL=http://localhost:8080/v1/graphql
 PUBLIC_HASURA_WEB_SOCKET_URL=ws://localhost:8080/v1/graphql
-PUBLIC_LOGIN_PAGE=enabled
+PUBLIC_AUTH_TYPE=JWT
 # VITE_HOST=localhost.jpl.nasa.gov
 # VITE_HTTPS=true

--- a/.env
+++ b/.env
@@ -5,6 +5,6 @@ PUBLIC_GATEWAY_SERVER_URL=http://localhost:9000
 PUBLIC_HASURA_CLIENT_URL=http://localhost:8080/v1/graphql
 PUBLIC_HASURA_SERVER_URL=http://localhost:8080/v1/graphql
 PUBLIC_HASURA_WEB_SOCKET_URL=ws://localhost:8080/v1/graphql
-PUBLIC_AUTH_TYPE=JWT
+PUBLIC_AUTH_SSO_ENABLED=true
 # VITE_HOST=localhost.jpl.nasa.gov
 # VITE_HTTPS=true

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 /.svelte-kit
 test-results
 unit-test-results
+*.local

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -8,8 +8,7 @@ services:
     container_name: aerie_gateway
     depends_on: ['postgres']
     environment:
-      AUTH_TYPE: default
-      AUTH_UI_URL: 'http://localhost/login'
+      AUTH_TYPE: none
       GQL_API_URL: http://localhost:8080/v1/graphql
       HASURA_GRAPHQL_JWT_SECRET: '${HASURA_GRAPHQL_JWT_SECRET}'
       LOG_FILE: console

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -8,7 +8,8 @@ services:
     container_name: aerie_gateway
     depends_on: ['postgres']
     environment:
-      AUTH_TYPE: none
+      AUTH_TYPE: default
+      AUTH_UI_URL: 'http://localhost/login'
       GQL_API_URL: http://localhost:8080/v1/graphql
       HASURA_GRAPHQL_JWT_SECRET: '${HASURA_GRAPHQL_JWT_SECRET}'
       LOG_FILE: console

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -6,6 +6,7 @@ This document provides detailed information about environment variables for Aeri
 | -------------------------------- | --------------------------------------------------------------------------------------------------------- | -------- | -------------------------------- |
 | `ORIGIN`                         | Url of where the UI is served from. See the [Svelte Kit Adapter Node docs][svelte-kit-adapter-node-docs]. | `string` | http://localhost                 |
 | `PUBLIC_AERIE_FILE_STORE_PREFIX` | Prefix to prepend to files uploaded through simulation configuration.                                     | `string` | /usr/src/app/merlin_file_store/  |
+| `PUBLIC_AUTH_SSO_ENABLED`        | Whether to use the SSO-based auth flow, or the /login page auth flow                                      | `string` | false                            |
 | `PUBLIC_GATEWAY_CLIENT_URL`      | Url of the Gateway as called from the client (i.e. web browser)                                           | `string` | http://localhost:9000            |
 | `PUBLIC_GATEWAY_SERVER_URL`      | Url of the Gateway as called from the server (i.e. Node.js container)                                     | `string` | http://localhost:9000            |
 | `PUBLIC_HASURA_CLIENT_URL`       | Url of Hasura as called from the client (i.e. web browser)                                                | `string` | http://localhost:8080/v1/graphql |

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -11,4 +11,3 @@ This document provides detailed information about environment variables for Aeri
 | `PUBLIC_HASURA_CLIENT_URL`       | Url of Hasura as called from the client (i.e. web browser)                                                | `string` | http://localhost:8080/v1/graphql |
 | `PUBLIC_HASURA_SERVER_URL`       | Url of Hasura as called from the server (i.e. Node.js container)                                          | `string` | http://localhost:8080/v1/graphql |
 | `PUBLIC_HASURA_WEB_SOCKET_URL`   | Url of Hasura called to establish a web-socket connection from the client                                 | `string` | ws://localhost:8080/v1/graphql   |
-| `PUBLIC_LOGIN_PAGE`              | Set to `enabled` to turn on login page. Otherwise set to `disabled` to turn off login page.               | `string` | enabled                          |

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "@types/toastify-js": "^1.11.1",
         "@typescript-eslint/eslint-plugin": "^5.60.1",
         "@typescript-eslint/parser": "^5.60.1",
+        "@vitejs/plugin-basic-ssl": "^1.0.2",
         "@vitest/ui": "^0.32.2",
         "cloc": "^2.11.0",
         "d3-format": "^3.1.0",
@@ -1221,6 +1222,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-basic-ssl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.0.2.tgz",
+      "integrity": "sha512-DKHKVtpI+eA5fvObVgQ3QtTGU70CcCnedalzqmGSR050AzKZMdUzgC8KmlOneHWH8dF2hJ3wkC9+8FDVAaDRCw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.6.0"
+      },
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -7698,6 +7711,13 @@
         "@typescript-eslint/types": "5.60.1",
         "eslint-visitor-keys": "^3.3.0"
       }
+    },
+    "@vitejs/plugin-basic-ssl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-basic-ssl/-/plugin-basic-ssl-1.0.2.tgz",
+      "integrity": "sha512-DKHKVtpI+eA5fvObVgQ3QtTGU70CcCnedalzqmGSR050AzKZMdUzgC8KmlOneHWH8dF2hJ3wkC9+8FDVAaDRCw==",
+      "dev": true,
+      "requires": {}
     },
     "@vitest/expect": {
       "version": "0.32.2",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@types/toastify-js": "^1.11.1",
     "@typescript-eslint/eslint-plugin": "^5.60.1",
     "@typescript-eslint/parser": "^5.60.1",
+    "@vitejs/plugin-basic-ssl": "^1.0.2",
     "@vitest/ui": "^0.32.2",
     "cloc": "^2.11.0",
     "d3-format": "^3.1.0",

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,10 +1,13 @@
 import type { Handle } from '@sveltejs/kit';
-import { parse } from 'cookie';
+import { parse, type CookieSerializeOptions } from 'cookie';
 import jwtDecode from 'jwt-decode';
 import type { BaseUser, ParsedUserToken, User } from './types/app';
 import effects from './utilities/effects';
 import { isLoginEnabled } from './utilities/login';
 import { ADMIN_ROLE } from './utilities/permissions';
+import type { ReqAuthResponse, ReqSessionResponse } from './types/auth';
+import { reqGatewayForwardCookies } from './utilities/requests';
+import { base } from '$app/paths';
 
 export const handle: Handle = async ({ event, resolve }) => {
   try {
@@ -20,45 +23,77 @@ export const handle: Handle = async ({ event, resolve }) => {
         rolePermissions,
         token: '',
       };
-    } else {
-      const cookieHeader = event.request.headers.get('cookie') ?? '';
-      const cookies = parse(cookieHeader);
-      const { activeRole: activeRoleCookie = null, user: userCookie = null } = cookies;
 
-      if (userCookie) {
-        const userBuffer = Buffer.from(userCookie, 'base64');
-        const userStr = userBuffer.toString('utf-8');
-        const baseUser: BaseUser = JSON.parse(userStr);
-        const { success } = await effects.session(baseUser);
-        const decodedToken: ParsedUserToken = jwtDecode(baseUser.token);
+      return await resolve(event);
+    }
 
-        if (success) {
-          const allowedRoles = decodedToken['https://hasura.io/jwt/claims']['x-hasura-allowed-roles'];
-          const defaultRole = decodedToken['https://hasura.io/jwt/claims']['x-hasura-default-role'];
-          const activeRole = activeRoleCookie ?? defaultRole;
-          const user: User = {
-            ...baseUser,
-            activeRole,
-            allowedRoles,
-            defaultRole,
-            permissibleQueries: null,
-            rolePermissions: null,
-          };
-          const permissibleQueries = await effects.getUserQueries(user);
+    const cookieHeader = event.request.headers.get('cookie') ?? '';
+    const cookies = parse(cookieHeader);
+    const { activeRole: activeRoleCookie = null, user: userCookie = null } = cookies;
 
-          const rolePermissions = await effects.getRolePermissions(user);
-          event.locals.user = {
-            ...user,
-            permissibleQueries,
-            rolePermissions,
-          };
-        } else {
-          event.locals.user = null;
-        }
-      } else {
-        event.locals.user = null;
+    // try to get role with current JWT
+    if (userCookie) {
+      const user = await computeRolesFromCookies(userCookie, activeRoleCookie);
+      if (user) {
+        event.locals.user = user;
+        return await resolve(event);
       }
     }
+
+    console.log(`trying SSO, since JWT was invalid`);
+
+    // pass all cookies to the gateway, who can determine if we have any valid SSO tokens
+    const validationData = await reqGatewayForwardCookies<ReqSessionResponse>('/auth/validateSSO', cookieHeader);
+
+    if (!validationData.success) {
+      console.log('Invalid SSO token, redirecting to login UI page');
+      // if we're already on the login page, don't redirect
+      // otherwise we get stuck in a redirect loop
+      return event.url.pathname.startsWith('/login')
+        ? await resolve(event)
+        : new Response(null, {
+            headers: {
+              // message field from gateway response will contain our login UI URL
+              location: `${validationData.message}`,
+            },
+            status: 307,
+          });
+    }
+
+    // otherwise, if we have a valid token, login with token to generate new JWT
+    const loginData = await reqGatewayForwardCookies<ReqAuthResponse>('/auth/loginSSO', cookieHeader);
+
+    if (loginData.success) {
+      const user: BaseUser = {
+        id: loginData.message,
+        token: loginData.token ?? '',
+      };
+
+      const roles = await computeRolesFromJWT(user, activeRoleCookie);
+
+      if (roles) {
+        console.log(`successfully SSO'd for user ${user.id}`);
+
+        event.locals.user = roles;
+
+        // create and set cookies
+        const userStr = JSON.stringify(user);
+        const userCookie = Buffer.from(userStr).toString('base64');
+        const cookieOpts: CookieSerializeOptions = {
+          httpOnly: false,
+          path: `${base}/`,
+          sameSite: 'none',
+        };
+        event.cookies.set('user', userCookie, cookieOpts);
+        event.cookies.set('activeRole', roles.defaultRole, cookieOpts);
+
+        return await resolve(event);
+      }
+    }
+
+    // otherwise, we can't auth
+    console.log('unable to auth with JWT or SSO token');
+    event.locals.user = null;
   } catch (e) {
     console.log(e);
     event.locals.user = null;
@@ -66,3 +101,43 @@ export const handle: Handle = async ({ event, resolve }) => {
 
   return await resolve(event);
 };
+
+async function computeRolesFromCookies(
+  userCookie: string | null,
+  activeRoleCookie: string | null,
+): Promise<User | null> {
+  const userBuffer = Buffer.from(userCookie ?? '', 'base64');
+  const userStr = userBuffer.toString('utf-8');
+  const baseUser: BaseUser = JSON.parse(userStr);
+
+  return computeRolesFromJWT(baseUser, activeRoleCookie);
+}
+
+async function computeRolesFromJWT(baseUser: BaseUser, activeRole: string | null): Promise<User | null> {
+  const { success } = await effects.session(baseUser);
+  if (!success) {
+    return null;
+  }
+
+  const decodedToken: ParsedUserToken = jwtDecode(baseUser.token);
+
+  const allowedRoles = decodedToken['https://hasura.io/jwt/claims']['x-hasura-allowed-roles'];
+  const defaultRole = decodedToken['https://hasura.io/jwt/claims']['x-hasura-default-role'];
+  activeRole ??= defaultRole;
+  const user: User = {
+    ...baseUser,
+    activeRole,
+    allowedRoles,
+    defaultRole,
+    permissibleQueries: null,
+    rolePermissions: null,
+  };
+  const permissibleQueries = await effects.getUserQueries(user);
+
+  const rolePermissions = await effects.getRolePermissions(user);
+  return {
+    ...user,
+    permissibleQueries,
+    rolePermissions,
+  };
+}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -14,7 +14,7 @@ export const handle: Handle = async ({ event, resolve }) => {
       return await resolve(event);
     }
 
-    if (env.PUBLIC_AUTH_TYPE === 'SSO') {
+    if (env.PUBLIC_AUTH_SSO_ENABLED === 'true') {
       return await handleSSOAuth({ event, resolve });
     } else {
       return await handleJWTAuth({ event, resolve });

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -112,9 +112,13 @@ async function computeRolesFromCookies(
 ): Promise<User | null> {
   const userBuffer = Buffer.from(userCookie ?? '', 'base64');
   const userStr = userBuffer.toString('utf-8');
-  const baseUser: BaseUser = JSON.parse(userStr);
 
-  return computeRolesFromJWT(baseUser, activeRoleCookie);
+  try {
+    const baseUser: BaseUser = JSON.parse(userStr);
+    return computeRolesFromJWT(baseUser, activeRoleCookie);
+  } catch {
+    return null;
+  }
 }
 
 async function computeRolesFromJWT(baseUser: BaseUser, activeRole: string | null): Promise<User | null> {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -32,7 +32,7 @@ export const handle: Handle = async ({ event, resolve }) => {
     const validationData = await reqGatewayForwardCookies<ReqValidateSSOResponse>(
       '/auth/validateSSO',
       cookieHeader,
-      event.request.url
+      event.request.url,
     );
 
     if (!validationData.success) {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -24,8 +24,11 @@ export const handle: Handle = async ({ event, resolve }) => {
 
     console.log(`trying SSO, since JWT was invalid`);
 
+    // trim any __data.json?x-sveltekit queries to just base url
+    const trimmedURL = event.request.url.substring(0, event.request.url.lastIndexOf("/"));
+
     // pass all cookies to the gateway, who can determine if we have any valid SSO tokens
-    const validationData = await reqGatewayForwardCookies<ReqValidateSSOResponse>('/auth/validateSSO', cookieHeader);
+    const validationData = await reqGatewayForwardCookies<ReqValidateSSOResponse>('/auth/validateSSO', cookieHeader, trimmedURL);
 
     if (!validationData.success) {
       console.log('Invalid SSO token, redirecting to login UI page');

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -127,10 +127,10 @@ async function computeRolesFromJWT(baseUser: BaseUser, activeRole: string | null
 
   const allowedRoles = decodedToken['https://hasura.io/jwt/claims']['x-hasura-allowed-roles'];
   const defaultRole = decodedToken['https://hasura.io/jwt/claims']['x-hasura-default-role'];
-  activeRole ??= defaultRole;
+
   const user: User = {
     ...baseUser,
-    activeRole,
+    activeRole: activeRole ?? defaultRole,
     allowedRoles,
     defaultRole,
     permissibleQueries: null,

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -77,6 +77,7 @@ const handleSSOAuth: Handle = async ({ event, resolve }) => {
   }
 
   // otherwise, we had a valid SSO token, so compute roles from returned JWT
+  // note, this sets a new JWT cookie each time
   const user: BaseUser = {
     id: validationData.userId ?? '',
     token: validationData.token ?? '',
@@ -98,7 +99,10 @@ const handleSSOAuth: Handle = async ({ event, resolve }) => {
       sameSite: 'none',
     };
     event.cookies.set('user', userCookie, cookieOpts);
-    event.cookies.set('activeRole', roles.defaultRole, cookieOpts);
+    // don't overwrite existing activeRole
+    if (!activeRoleCookie) {
+      event.cookies.set('activeRole', roles.defaultRole, cookieOpts);
+    }
   } else {
     event.locals.user = null;
   }

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -19,7 +19,6 @@ export const handle: Handle = async ({ event, resolve }) => {
     } else {
       return await handleJWTAuth({ event, resolve });
     }
-
   } catch (e) {
     console.log(e);
     event.locals.user = null;
@@ -29,84 +28,83 @@ export const handle: Handle = async ({ event, resolve }) => {
 };
 
 const handleJWTAuth: Handle = async ({ event, resolve }) => {
-    const cookieHeader = event.request.headers.get('cookie') ?? '';
-    const cookies = parse(cookieHeader);
-    const { activeRole: activeRoleCookie = null, user: userCookie } = cookies;
+  const cookieHeader = event.request.headers.get('cookie') ?? '';
+  const cookies = parse(cookieHeader);
+  const { activeRole: activeRoleCookie = null, user: userCookie } = cookies;
 
-    // try to get role with current JWT
-    if (userCookie) {
-      const user = await computeRolesFromCookies(userCookie, activeRoleCookie);
-      if (user) {
-        event.locals.user = user;
-        return await resolve(event);
-      }
+  // try to get role with current JWT
+  if (userCookie) {
+    const user = await computeRolesFromCookies(userCookie, activeRoleCookie);
+    if (user) {
+      event.locals.user = user;
+      return await resolve(event);
     }
+  }
 
-    // if we're already on the login page, don't redirect
-    // otherwise we get stuck in a redirect loop
-    return event.url.pathname.startsWith('/login') || event.url.pathname.startsWith('/auth')
-      ? await resolve(event)
-      : new Response(null, {
-          headers: {
-            location: `${base}/login`,
-          },
-          status: 307,
-        });
-}
-
-const handleSSOAuth: Handle = async ({ event, resolve }) => {
-    const cookieHeader = event.request.headers.get('cookie') ?? '';
-    const cookies = parse(cookieHeader);
-    const { activeRole: activeRoleCookie = null } = cookies;
-
-    // pass all cookies to the gateway, who can determine if we have any valid SSO tokens
-    const validationData = await reqGatewayForwardCookies<ReqValidateSSOResponse>(
-      '/auth/validateSSO',
-      cookieHeader,
-      event.request.url,
-    );
-
-    if (!validationData.success) {
-      console.log('Invalid SSO token, redirecting to SSO login UI page');
-      return new Response(null, {
+  // if we're already on the login page, don't redirect
+  // otherwise we get stuck in a redirect loop
+  return event.url.pathname.startsWith('/login') || event.url.pathname.startsWith('/auth')
+    ? await resolve(event)
+    : new Response(null, {
         headers: {
-          // redirectURL field from gateway response will contain our login UI URL
-          location: `${validationData.redirectURL}`,
+          location: `${base}/login`,
         },
         status: 307,
       });
-    }
+};
 
-    // otherwise, we had a valid SSO token, so compute roles from returned JWT
-    const user: BaseUser = {
-      id: validationData.userId ?? '',
-      token: validationData.token ?? '',
+const handleSSOAuth: Handle = async ({ event, resolve }) => {
+  const cookieHeader = event.request.headers.get('cookie') ?? '';
+  const cookies = parse(cookieHeader);
+  const { activeRole: activeRoleCookie = null } = cookies;
+
+  // pass all cookies to the gateway, who can determine if we have any valid SSO tokens
+  const validationData = await reqGatewayForwardCookies<ReqValidateSSOResponse>(
+    '/auth/validateSSO',
+    cookieHeader,
+    event.request.url,
+  );
+
+  if (!validationData.success) {
+    console.log('Invalid SSO token, redirecting to SSO login UI page');
+    return new Response(null, {
+      headers: {
+        // redirectURL field from gateway response will contain our login UI URL
+        location: `${validationData.redirectURL}`,
+      },
+      status: 307,
+    });
+  }
+
+  // otherwise, we had a valid SSO token, so compute roles from returned JWT
+  const user: BaseUser = {
+    id: validationData.userId ?? '',
+    token: validationData.token ?? '',
+  };
+
+  const roles = await computeRolesFromJWT(user, activeRoleCookie);
+
+  if (roles) {
+    console.log(`successfully SSO'd for user ${user.id}`);
+
+    event.locals.user = roles;
+
+    // create and set cookies
+    const userStr = JSON.stringify(user);
+    const userCookie = Buffer.from(userStr).toString('base64');
+    const cookieOpts: CookieSerializeOptions = {
+      httpOnly: false,
+      path: `${base}/`,
+      sameSite: 'none',
     };
+    event.cookies.set('user', userCookie, cookieOpts);
+    event.cookies.set('activeRole', roles.defaultRole, cookieOpts);
+  } else {
+    event.locals.user = null;
+  }
 
-    const roles = await computeRolesFromJWT(user, activeRoleCookie);
-
-    if (roles) {
-      console.log(`successfully SSO'd for user ${user.id}`);
-
-      event.locals.user = roles;
-
-      // create and set cookies
-      const userStr = JSON.stringify(user);
-      const userCookie = Buffer.from(userStr).toString('base64');
-      const cookieOpts: CookieSerializeOptions = {
-        httpOnly: false,
-        path: `${base}/`,
-        sameSite: 'none',
-      };
-      event.cookies.set('user', userCookie, cookieOpts);
-      event.cookies.set('activeRole', roles.defaultRole, cookieOpts);
-
-    } else {
-      event.locals.user = null;
-    }
-
-    return await resolve(event);
-}
+  return await resolve(event);
+};
 
 async function computeRolesFromCookies(
   userCookie: string | null,

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -10,14 +10,6 @@ import { env } from '$env/dynamic/public';
 
 export const handle: Handle = async ({ event, resolve }) => {
   try {
-    // sveltekit makes a request for json data from layout.server.ts as its first request for a page.
-    // we want to ignore that here, and instead run our hook logic for the actual SSR request
-    // this is mainly so that if we need to redirect, we have a human-readable URL (e.g. /plans/1)
-    // instead of some internal sveltekit URL (/plans/__data.json?x-sveltekit-invalidate=10)
-    if (event.request.url.includes('__data.json')) {
-      return await resolve(event);
-    }
-
     if (env.PUBLIC_AUTH_SSO_ENABLED === 'true') {
       return await handleSSOAuth({ event, resolve });
     } else {
@@ -68,7 +60,7 @@ const handleSSOAuth: Handle = async ({ event, resolve }) => {
   const validationData = await reqGatewayForwardCookies<ReqValidateSSOResponse>(
     '/auth/validateSSO',
     cookieHeader,
-    event.request.url,
+    event.url.toString(),
   );
 
   if (!validationData.success) {

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,11 +1,11 @@
 import { base } from '$app/paths';
+import { redirect } from '@sveltejs/kit';
 import { shouldRedirectToLogin } from '../utilities/login';
 import type { LayoutServerLoad } from './$types';
-import { goto } from '$app/navigation';
 
 export const load: LayoutServerLoad = async ({ locals, url }) => {
   if (!url.pathname.includes('login') && shouldRedirectToLogin(locals.user)) {
-    return goto(`${base}/`);
+    return redirect(302, base);
   }
   return { ...locals };
 };

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -5,7 +5,7 @@ import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals, url }) => {
   if (!url.pathname.includes('login') && shouldRedirectToLogin(locals.user)) {
-    return redirect(302, base);
+    throw redirect(302, base);
   }
   return { ...locals };
 };

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,11 +1,11 @@
 import { base } from '$app/paths';
-import { redirect } from '@sveltejs/kit';
 import { shouldRedirectToLogin } from '../utilities/login';
 import type { LayoutServerLoad } from './$types';
+import { goto } from '$app/navigation';
 
 export const load: LayoutServerLoad = async ({ locals, url }) => {
   if (!url.pathname.includes('login') && shouldRedirectToLogin(locals.user)) {
-    throw redirect(302, `${base}/login`);
+    return goto(`${base}/`);
   }
   return { ...locals };
 };

--- a/src/routes/auth/logout/+server.ts
+++ b/src/routes/auth/logout/+server.ts
@@ -7,7 +7,7 @@ export const POST: RequestHandler = async event => {
   const invalidated = await reqGatewayForwardCookies<boolean>(
     '/auth/logoutSSO',
     event.request.headers.get('cookie') ?? '',
-    base
+    base,
   );
   return json(
     { message: 'Logout successful', success: invalidated },

--- a/src/routes/auth/logout/+server.ts
+++ b/src/routes/auth/logout/+server.ts
@@ -2,13 +2,16 @@ import { base } from '$app/paths';
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 import { reqGatewayForwardCookies } from '../../../utilities/requests';
+import { env } from '$env/dynamic/public';
 
 export const POST: RequestHandler = async event => {
-  const invalidated = await reqGatewayForwardCookies<boolean>(
-    '/auth/logoutSSO',
-    event.request.headers.get('cookie') ?? '',
-    base,
-  );
+  const invalidated = (env.PUBLIC_AUTH_TYPE === "SSO")
+    ? await reqGatewayForwardCookies<boolean>(
+          '/auth/logoutSSO',
+          event.request.headers.get('cookie') ?? '',
+          base)
+    : true;
+
   return json(
     { message: 'Logout successful', success: invalidated },
     {

--- a/src/routes/auth/logout/+server.ts
+++ b/src/routes/auth/logout/+server.ts
@@ -5,12 +5,10 @@ import { reqGatewayForwardCookies } from '../../../utilities/requests';
 import { env } from '$env/dynamic/public';
 
 export const POST: RequestHandler = async event => {
-  const invalidated = (env.PUBLIC_AUTH_TYPE === "SSO")
-    ? await reqGatewayForwardCookies<boolean>(
-          '/auth/logoutSSO',
-          event.request.headers.get('cookie') ?? '',
-          base)
-    : true;
+  const invalidated =
+    env.PUBLIC_AUTH_TYPE === 'SSO'
+      ? await reqGatewayForwardCookies<boolean>('/auth/logoutSSO', event.request.headers.get('cookie') ?? '', base)
+      : true;
 
   return json(
     { message: 'Logout successful', success: invalidated },

--- a/src/routes/auth/logout/+server.ts
+++ b/src/routes/auth/logout/+server.ts
@@ -6,7 +6,7 @@ import { env } from '$env/dynamic/public';
 
 export const POST: RequestHandler = async event => {
   const invalidated =
-    env.PUBLIC_AUTH_TYPE === 'SSO'
+    env.PUBLIC_AUTH_SSO_ENABLED === 'true'
       ? await reqGatewayForwardCookies<boolean>('/auth/logoutSSO', event.request.headers.get('cookie') ?? '', base)
       : true;
 

--- a/src/routes/auth/logout/+server.ts
+++ b/src/routes/auth/logout/+server.ts
@@ -1,10 +1,12 @@
 import { base } from '$app/paths';
 import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
+import { reqGatewayForwardCookies } from '../../../utilities/requests';
 
-export const POST: RequestHandler = async () => {
+export const POST: RequestHandler = async (event) => {
+  const invalidated = await reqGatewayForwardCookies<boolean>("/auth/logoutSSO", event.request.headers.get("cookie") ?? "");
   return json(
-    { message: 'Logout successful', success: true },
+    { message: 'Logout successful', success: invalidated},
     {
       headers: {
         'set-cookie': `activeRole=deleted; path=${base}/,user=deleted; path=${base}/; expires=Thu, 01 Jan 1970 00:00:00 GMT`,

--- a/src/routes/auth/logout/+server.ts
+++ b/src/routes/auth/logout/+server.ts
@@ -7,6 +7,7 @@ export const POST: RequestHandler = async event => {
   const invalidated = await reqGatewayForwardCookies<boolean>(
     '/auth/logoutSSO',
     event.request.headers.get('cookie') ?? '',
+    event.url.origin,
   );
   return json(
     { message: 'Logout successful', success: invalidated },

--- a/src/routes/auth/logout/+server.ts
+++ b/src/routes/auth/logout/+server.ts
@@ -3,10 +3,13 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 import { reqGatewayForwardCookies } from '../../../utilities/requests';
 
-export const POST: RequestHandler = async (event) => {
-  const invalidated = await reqGatewayForwardCookies<boolean>("/auth/logoutSSO", event.request.headers.get("cookie") ?? "");
+export const POST: RequestHandler = async event => {
+  const invalidated = await reqGatewayForwardCookies<boolean>(
+    '/auth/logoutSSO',
+    event.request.headers.get('cookie') ?? '',
+  );
   return json(
-    { message: 'Logout successful', success: invalidated},
+    { message: 'Logout successful', success: invalidated },
     {
       headers: {
         'set-cookie': `activeRole=deleted; path=${base}/,user=deleted; path=${base}/; expires=Thu, 01 Jan 1970 00:00:00 GMT`,

--- a/src/routes/auth/logout/+server.ts
+++ b/src/routes/auth/logout/+server.ts
@@ -7,7 +7,7 @@ export const POST: RequestHandler = async event => {
   const invalidated = await reqGatewayForwardCookies<boolean>(
     '/auth/logoutSSO',
     event.request.headers.get('cookie') ?? '',
-    event.url.origin,
+    base
   );
   return json(
     { message: 'Logout successful', success: invalidated },

--- a/src/routes/login/+page.ts
+++ b/src/routes/login/+page.ts
@@ -1,5 +1,4 @@
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import { redirect } from '@sveltejs/kit';
 import { hasNoAuthorization } from '../../utilities/permissions';
 import type { PageLoad } from './$types';
@@ -7,7 +6,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
 
-  if (env.PUBLIC_LOGIN_PAGE === 'disabled' || (user && !hasNoAuthorization(user))) {
+  if (user && !hasNoAuthorization(user)) {
     throw redirect(302, `${base}/plans`);
   }
 

--- a/src/stores/subscribable.ts
+++ b/src/stores/subscribable.ts
@@ -41,7 +41,7 @@ export function gqlSubscribable<T>(
             console.log(error);
 
             if ('reason' in error && error.reason.includes(EXPIRED_JWT)) {
-              await logout();
+              await logout(EXPIRED_JWT);
             } else {
               subscribers.forEach(({ next }) => {
                 if (initialValue !== null) {

--- a/src/stores/subscribable.ts
+++ b/src/stores/subscribable.ts
@@ -41,7 +41,7 @@ export function gqlSubscribable<T>(
             console.log(error);
 
             if ('reason' in error && error.reason.includes(EXPIRED_JWT)) {
-              await logout(EXPIRED_JWT);
+              await logout();
             } else {
               subscribers.forEach(({ next }) => {
                 if (initialValue !== null) {

--- a/src/stores/subscribable.ts
+++ b/src/stores/subscribable.ts
@@ -92,7 +92,7 @@ export function gqlSubscribable<T>(
       if (userCookie) {
         try {
           const splitCookie = userCookie.split('user=')[1];
-          const decodedUserCookie = atob(splitCookie);
+          const decodedUserCookie = atob(decodeURIComponent(splitCookie));
           const parsedUserCookie: BaseUser = JSON.parse(decodedUserCookie);
           return parsedUserCookie.token;
         } catch (e) {

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -36,8 +36,8 @@ export type ReqSessionResponse = {
 
 export type ReqValidateSSOResponse = {
   message: string;
+  redirectURL?: string;
   success: boolean;
   token?: string;
   userId?: string;
-  redirectURL?: string;
 };

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -33,3 +33,11 @@ export type ReqSessionResponse = {
   message: string;
   success: boolean;
 };
+
+export type ReqValidateSSOResponse = {
+  message: string;
+  success: boolean;
+  token?: string;
+  userId?: string;
+  redirectURL?: string;
+};

--- a/src/utilities/login.test.ts
+++ b/src/utilities/login.test.ts
@@ -1,6 +1,6 @@
 import { env } from '$env/dynamic/public';
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { isLoginEnabled, shouldRedirectToLogin } from './login';
+import { shouldRedirectToLogin } from './login';
 import { ADMIN_ROLE } from './permissions';
 
 vi.mock('$env/dynamic/public', () => ({
@@ -12,19 +12,6 @@ vi.mock('$env/dynamic/public', () => ({
 describe('login util functions', () => {
   afterEach(() => {
     vi.resetAllMocks();
-  });
-
-  describe('isLoginEnabled', () => {
-    test('Should return whether or not the login page is enabled', () => {
-      vi.mocked(env).PUBLIC_LOGIN_PAGE = '';
-      expect(isLoginEnabled()).toEqual(true);
-
-      vi.mocked(env).PUBLIC_LOGIN_PAGE = 'enabled';
-      expect(isLoginEnabled()).toEqual(true);
-
-      vi.mocked(env).PUBLIC_LOGIN_PAGE = 'disabled';
-      expect(isLoginEnabled()).toEqual(false);
-    });
   });
 
   describe('shouldRedirectToLogin', () => {

--- a/src/utilities/login.test.ts
+++ b/src/utilities/login.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import { shouldRedirectToLogin } from './login';
 import { ADMIN_ROLE } from './permissions';
 
+vi.mock('$env/dynamic/public', () => import.meta.env); // https://github.com/sveltejs/kit/issues/8180
+
 describe('login util functions', () => {
   afterEach(() => {
     vi.resetAllMocks();

--- a/src/utilities/login.test.ts
+++ b/src/utilities/login.test.ts
@@ -2,12 +2,6 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import { shouldRedirectToLogin } from './login';
 import { ADMIN_ROLE } from './permissions';
 
-vi.mock('$env/dynamic/public', () => ({
-  env: {
-    PUBLIC_LOGIN_PAGE: '',
-  },
-}));
-
 describe('login util functions', () => {
   afterEach(() => {
     vi.resetAllMocks();

--- a/src/utilities/login.test.ts
+++ b/src/utilities/login.test.ts
@@ -1,4 +1,3 @@
-import { env } from '$env/dynamic/public';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { shouldRedirectToLogin } from './login';
 import { ADMIN_ROLE } from './permissions';
@@ -16,8 +15,6 @@ describe('login util functions', () => {
 
   describe('shouldRedirectToLogin', () => {
     test('Should determine if the route should redirect to the login page when login is enabled', () => {
-      vi.mocked(env).PUBLIC_LOGIN_PAGE = 'enabled';
-
       expect(shouldRedirectToLogin(null)).toEqual(true);
       expect(
         shouldRedirectToLogin({
@@ -30,37 +27,6 @@ describe('login util functions', () => {
           token: 'foo',
         }),
       ).toEqual(true);
-
-      expect(
-        shouldRedirectToLogin({
-          activeRole: 'user',
-          allowedRoles: [ADMIN_ROLE, 'user'],
-          defaultRole: 'user',
-          id: 'foo',
-          permissibleQueries: {
-            constraints: true,
-          },
-          rolePermissions: {},
-          token: 'foo',
-        }),
-      ).toEqual(false);
-    });
-
-    test('Should not redirect if login is disabled', () => {
-      vi.mocked(env).PUBLIC_LOGIN_PAGE = 'disabled';
-
-      expect(shouldRedirectToLogin(null)).toEqual(false);
-      expect(
-        shouldRedirectToLogin({
-          activeRole: 'user',
-          allowedRoles: [ADMIN_ROLE, 'user'],
-          defaultRole: 'user',
-          id: 'foo',
-          permissibleQueries: {},
-          rolePermissions: {},
-          token: 'foo',
-        }),
-      ).toEqual(false);
 
       expect(
         shouldRedirectToLogin({

--- a/src/utilities/login.ts
+++ b/src/utilities/login.ts
@@ -14,7 +14,7 @@ export async function logout(reason?: string) {
     await fetch(`${base}/auth/logout`, { method: 'POST' });
     if (env.PUBLIC_AUTH_SSO_ENABLED === 'true') {
       // hooks will handle SSO redirect
-      await goto(base);
+      await goto(base, { invalidateAll: true });
     } else {
       await goto(`${base}/login${reason ? '?reason=' + reason : ''}`, { invalidateAll: true });
     }

--- a/src/utilities/login.ts
+++ b/src/utilities/login.ts
@@ -1,22 +1,16 @@
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
 import { base } from '$app/paths';
-import { env } from '$env/dynamic/public';
 import type { User } from '../types/app';
 import { hasNoAuthorization } from './permissions';
 
-export function isLoginEnabled() {
-  // if PUBLIC_LOGIN_PAGE is not explicitly set to "disabled", then assume it is enabled
-  return env.PUBLIC_LOGIN_PAGE !== 'disabled';
-}
-
 export function shouldRedirectToLogin(user: User | null) {
-  return isLoginEnabled() && (!user || hasNoAuthorization(user));
+  return (!user || hasNoAuthorization(user));
 }
 
 export async function logout(reason?: string) {
   if (browser) {
     await fetch(`${base}/auth/logout`, { method: 'POST' });
-    await goto(`${base}/login${reason ? '?reason=' + reason : ''}`, { invalidateAll: true });
+    await goto(`${base}/`);
   }
 }

--- a/src/utilities/login.ts
+++ b/src/utilities/login.ts
@@ -5,10 +5,10 @@ import type { User } from '../types/app';
 import { hasNoAuthorization } from './permissions';
 
 export function shouldRedirectToLogin(user: User | null) {
-  return (!user || hasNoAuthorization(user));
+  return !user || hasNoAuthorization(user);
 }
 
-export async function logout(reason?: string) {
+export async function logout() {
   if (browser) {
     await fetch(`${base}/auth/logout`, { method: 'POST' });
     await goto(`${base}/`);

--- a/src/utilities/login.ts
+++ b/src/utilities/login.ts
@@ -1,6 +1,7 @@
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import type { User } from '../types/app';
 import { hasNoAuthorization } from './permissions';
 
@@ -8,9 +9,14 @@ export function shouldRedirectToLogin(user: User | null) {
   return !user || hasNoAuthorization(user);
 }
 
-export async function logout() {
+export async function logout(reason?: string) {
   if (browser) {
     await fetch(`${base}/auth/logout`, { method: 'POST' });
-    await goto(`${base}/`);
+    if (env.PUBLIC_AUTH_SSO_ENABLED === 'true') {
+      // hooks will handle SSO redirect
+      await goto(base);
+    } else {
+      await goto(`${base}/login${reason ? '?reason=' + reason : ''}`, { invalidateAll: true });
+    }
   }
 }

--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -153,7 +153,7 @@ export async function reqHasura<T = any>(
       }
     } else if (code === INVALID_JWT) {
       // awaiting here only works if SSR is disabled
-      logout();
+      logout(error?.message);
     }
 
     throw new Error(error?.message ?? defaultError);

--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -152,7 +152,7 @@ export async function reqHasura<T = any>(
       }
     } else if (code === INVALID_JWT) {
       // awaiting here only works if SSR is disabled
-      logout(error?.message);
+      logout();
     }
 
     throw new Error(error?.message ?? defaultError);

--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -83,6 +83,24 @@ export async function reqGateway<T = any>(
 }
 
 /**
+ * Function to make HTTP requests to the Aerie Gateway, forwarding all cookies
+ */
+export async function reqGatewayForwardCookies<T = any>(path: string, cookies: string): Promise<T> {
+  const GATEWAY_URL = browser ? env.PUBLIC_GATEWAY_CLIENT_URL : env.PUBLIC_GATEWAY_SERVER_URL;
+
+  const opts = {
+    headers: {
+      cookie: cookies,
+    },
+  };
+
+  const validationResponse = await fetch(`${GATEWAY_URL}${path}`, opts);
+  const validationData: T = await validationResponse.json();
+
+  return validationData;
+}
+
+/**
  * Function to make HTTP POST requests to the Hasura GraphQL API.
  */
 export async function reqHasura<T = any>(

--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -85,12 +85,13 @@ export async function reqGateway<T = any>(
 /**
  * Function to make HTTP requests to the Aerie Gateway, forwarding all cookies
  */
-export async function reqGatewayForwardCookies<T = any>(path: string, cookies: string): Promise<T> {
+export async function reqGatewayForwardCookies<T = any>(path: string, cookies: string, referrer?: string): Promise<T> {
   const GATEWAY_URL = browser ? env.PUBLIC_GATEWAY_CLIENT_URL : env.PUBLIC_GATEWAY_SERVER_URL;
 
   const opts = {
     headers: {
       cookie: cookies,
+      referrer: referrer ?? "",
     },
   };
 

--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -91,7 +91,7 @@ export async function reqGatewayForwardCookies<T = any>(path: string, cookies: s
   const opts = {
     headers: {
       cookie: cookies,
-      referrer: referrer ?? "",
+      referrer: referrer ?? '',
     },
   };
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -42,6 +42,9 @@ const config = ({ mode }) => {
         },
       ),
     ],
+    server: {
+      host: viteEnvVars.VITE_HOST ?? 'localhost',
+    },
     test: {
       alias: [{ find: /^svelte$/, replacement: 'svelte/internal' }], // https://github.com/vitest-dev/vitest/issues/2834
       environment: 'jsdom',

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,54 +1,59 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import svg from '@poppanator/sveltekit-svg';
+import basicSsl from '@vitejs/plugin-basic-ssl';
+import { defineConfig, loadEnv } from 'vite';
 import { WorkerBuildPlugin } from './vite.worker-build-plugin';
 
-/** @type {import('vite').UserConfig} */
-const config = {
-  build: {
-    minify: true,
-  },
-  css: {
-    devSourcemap: true,
-  },
-  plugins: [
-    sveltekit(),
-    svg({
-      svgoOptions: {
-        multipass: true,
-        plugins: [
-          {
-            name: 'preset-default',
-            // by default svgo removes the viewBox which prevents svg icons from scaling
-            // not a good idea! https://github.com/svg/svgo/pull/1461
-            params: { overrides: { removeViewBox: false } },
-          },
-          {
-            name: 'addClassesToSVGElement',
-            params: {
-              classNames: ['st-icon'],
-            },
-          },
-        ],
-      },
-    }),
-    WorkerBuildPlugin(
-      ['./src/workers/customTS.worker.ts', './node_modules/monaco-editor/esm/vs/language/typescript/ts.worker.js'],
-      {
-        log: true,
-      },
-    ),
-  ],
-  test: {
-    alias: [{ find: /^svelte$/, replacement: 'svelte/internal' }], // https://github.com/vitest-dev/vitest/issues/2834
-    environment: 'jsdom',
-    include: ['./src/**/*.test.ts'],
-    outputFile: {
-      html: 'unit-test-results/html-results/index.html',
-      json: 'unit-test-results/json-results.json',
-      junit: 'unit-test-results/junit-results.xml',
+const config = ({ mode }) => {
+  const viteEnvVars = loadEnv(mode, process.cwd());
+  return defineConfig({
+    build: {
+      minify: true,
     },
-    reporters: ['verbose', 'json', 'junit', 'html'],
-  },
+    css: {
+      devSourcemap: true,
+    },
+    plugins: [
+      ...(viteEnvVars.VITE_HTTPS === 'true' ? [basicSsl()] : []),
+      sveltekit(),
+      svg({
+        svgoOptions: {
+          multipass: true,
+          plugins: [
+            {
+              name: 'preset-default',
+              // by default svgo removes the viewBox which prevents svg icons from scaling
+              // not a good idea! https://github.com/svg/svgo/pull/1461
+              params: { overrides: { removeViewBox: false } },
+            },
+            {
+              name: 'addClassesToSVGElement',
+              params: {
+                classNames: ['st-icon'],
+              },
+            },
+          ],
+        },
+      }),
+      WorkerBuildPlugin(
+        ['./src/workers/customTS.worker.ts', './node_modules/monaco-editor/esm/vs/language/typescript/ts.worker.js'],
+        {
+          log: true,
+        },
+      ),
+    ],
+    test: {
+      alias: [{ find: /^svelte$/, replacement: 'svelte/internal' }], // https://github.com/vitest-dev/vitest/issues/2834
+      environment: 'jsdom',
+      include: ['./src/**/*.test.ts'],
+      outputFile: {
+        html: 'unit-test-results/html-results/index.html',
+        json: 'unit-test-results/json-results.json',
+        junit: 'unit-test-results/junit-results.xml',
+      },
+      reporters: ['verbose', 'json', 'junit', 'html'],
+    },
+  });
 };
 
 export default config;


### PR DESCRIPTION
closes https://github.com/NASA-AMMOS/aerie/issues/1100

This PR significantly reworks the `hooks.server.ts` logic to support SSO in addition to the `/login` page. Using a new environment variable `PUBLIC_AUTH_SSO_ENABLED`, the top level hook auth flow is now as follows:

```javascript
if (env.PUBLIC_AUTH_SSO_ENABLED === 'true') {
   return await handleSSOAuth({ event, resolve });
} else {
   return await handleJWTAuth({ event, resolve });
}
```

### `handleJWTAuth`
`handleJWTAuth` is just a refactored version of the existing auth flow:
 - validate + populate `event.locals.user` using existing JWT cookie (by hitting Gateway's `/auth/session`)
 - if JWT was invalid / nonexistent, redirect to `/login`

### `handleSSOAuth`
`handleSSOAuth` is a new flow that supports SSO auth by forwarding cookies to new Gateway endpoints, which will check SSO token validity (e.g. CAM token) and return JWTs or redirections accordingly:
 - forward cookies to `/auth/validateSSO`, which will run an auth provider specific SSO validation
 - if above validation was successful, Gateway returns an Aerie JWT, which we store in cookies and use in `Auth:` headers as usual.
 - else, the SSO token was invalid or DNE, Gateway returns the URL of the auth providers login page (e.g. CAM-UI), which we redirect the user to.

## Logout
The UI also switches on this `PUBLIC_AUTH_SSO_ENABLED` env var during logout, where it'll either call the Gateway's `/auth/logoutSSO` (which invalidates the SSO token using the auth provider), or just clear the JWT and redirect to `/`.

On the next page load, the UI will run through the auth flow in `hooks.server.ts`, which will correctly redirect us to either `/login` or the SSO login page, depending on `PUBLIC_AUTH_SSO_ENABLED`.

This design allows the UI to remain auth provider agnostic. The Gateway can then be extended to support other auth providers (e.g. https://aws.amazon.com/cognito).

The corresponding Gateway PR (https://github.com/NASA-AMMOS/aerie-gateway/pull/51) defines these new auth endpoints, as well as lists the testing steps and possible env var configurations.