### PR TITLE
Set correct path for uploaded file in sim config

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 ORIGIN=http://localhost:3000
+PUBLIC_AERIE_FILE_STORE_PREFIX=/usr/src/app/merlin_file_store/
 PUBLIC_GATEWAY_CLIENT_URL=http://localhost:9000
 PUBLIC_GATEWAY_SERVER_URL=http://localhost:9000
 PUBLIC_HASURA_CLIENT_URL=http://localhost:8080/v1/graphql

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -2,12 +2,13 @@
 
 This document provides detailed information about environment variables for Aerie UI.
 
-| Name                           | Description                                                                                               | Type     | Default                          |
-| ------------------------------ | --------------------------------------------------------------------------------------------------------- | -------- | -------------------------------- |
-| `ORIGIN`                       | Url of where the UI is served from. See the [Svelte Kit Adapter Node docs][svelte-kit-adapter-node-docs]. | `string` | http://localhost                 |
-| `PUBLIC_GATEWAY_CLIENT_URL`    | Url of the Gateway as called from the client (i.e. web browser)                                           | `string` | http://localhost:9000            |
-| `PUBLIC_GATEWAY_SERVER_URL`    | Url of the Gateway as called from the server (i.e. Node.js container)                                     | `string` | http://localhost:9000            |
-| `PUBLIC_HASURA_CLIENT_URL`     | Url of Hasura as called from the client (i.e. web browser)                                                | `string` | http://localhost:8080/v1/graphql |
-| `PUBLIC_HASURA_SERVER_URL`     | Url of Hasura as called from the server (i.e. Node.js container)                                          | `string` | http://localhost:8080/v1/graphql |
-| `PUBLIC_HASURA_WEB_SOCKET_URL` | Url of Hasura called to establish a web-socket connection from the client                                 | `string` | ws://localhost:8080/v1/graphql   |
-| `PUBLIC_LOGIN_PAGE`            | Set to `enabled` to turn on login page. Otherwise set to `disabled` to turn off login page.               | `string` | enabled                          |
+| Name                             | Description                                                                                               | Type     | Default                          |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------- | -------- | -------------------------------- |
+| `ORIGIN`                         | Url of where the UI is served from. See the [Svelte Kit Adapter Node docs][svelte-kit-adapter-node-docs]. | `string` | http://localhost                 |
+| `PUBLIC_AERIE_FILE_STORE_PREFIX` | Prefix to prepend to files uploaded through simulation configuration.                                     | `string` | /usr/src/app/merlin_file_store/  |
+| `PUBLIC_GATEWAY_CLIENT_URL`      | Url of the Gateway as called from the client (i.e. web browser)                                           | `string` | http://localhost:9000            |
+| `PUBLIC_GATEWAY_SERVER_URL`      | Url of the Gateway as called from the server (i.e. Node.js container)                                     | `string` | http://localhost:9000            |
+| `PUBLIC_HASURA_CLIENT_URL`       | Url of Hasura as called from the client (i.e. web browser)                                                | `string` | http://localhost:8080/v1/graphql |
+| `PUBLIC_HASURA_SERVER_URL`       | Url of Hasura as called from the server (i.e. Node.js container)                                          | `string` | http://localhost:8080/v1/graphql |
+| `PUBLIC_HASURA_WEB_SOCKET_URL`   | Url of Hasura called to establish a web-socket connection from the client                                 | `string` | ws://localhost:8080/v1/graphql   |
+| `PUBLIC_LOGIN_PAGE`              | Set to `enabled` to turn on login page. Otherwise set to `disabled` to turn off login page.               | `string` | enabled                          |

--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -131,7 +131,7 @@
         arguments: newArgumentsMap,
       };
 
-      effects.updateSimulation($plan, newSimulation, user, newFiles);
+      effects.updateSimulation($plan, newSimulation, user, newFiles, $plan.model.parameters.parameters);
     }
   }
 
@@ -149,7 +149,7 @@
         arguments: newArguments,
       };
 
-      effects.updateSimulation($plan, newSimulation, user, newFiles);
+      effects.updateSimulation($plan, newSimulation, user, newFiles, $plan.model.parameters.parameters);
     }
   }
 

--- a/src/utilities/effects.test.ts
+++ b/src/utilities/effects.test.ts
@@ -317,12 +317,12 @@ describe('Handle modal and requests in effects', () => {
       const modelParameters: ParametersMap = {
         parameter0: { order: 0, schema: { type: 'int' } },
         parameter1: { order: 1, schema: { type: 'path' } },
-        parameter2: { order: 2, schema: { type: 'struct', items: { x: { type: 'boolean' }, y: { type: 'path' } } } },
+        parameter2: { order: 2, schema: { items: { x: { type: 'boolean' }, y: { type: 'path' } }, type: 'struct' } },
         parameter3: {
           order: 3,
-          schema: { type: 'series', items: { type: 'variant', variants: [{ key: 'A', label: 'A' }] } },
+          schema: { items: { type: 'variant', variants: [{ key: 'A', label: 'A' }] }, type: 'series' },
         },
-        parameter4: { order: 4, schema: { type: 'series', items: { type: 'path' } } },
+        parameter4: { order: 4, schema: { items: { type: 'path' }, type: 'series' } },
       };
       const simArgs: ArgumentsMap = {
         parameter0: 1,

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -4386,7 +4386,7 @@ const effects = {
   },
 };
 
-function replacePaths(
+export function replacePaths(
   modelParameters: ParametersMap | null,
   simArgs: ArgumentsMap,
   filenames: Record<string, string>,
@@ -4419,7 +4419,7 @@ function replacePathsHelper(schema: ValueSchema, arg: Argument, filenames: Recor
         return res;
       })();
     case 'series':
-      return arg.map((x: Argument) => replacePathsHelper(schema, x, filenames));
+      return arg.map((x: Argument) => replacePathsHelper(schema.items, x, filenames));
     default:
       return arg;
   }

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -4386,7 +4386,11 @@ const effects = {
   },
 };
 
-function replacePaths(modelParameters: ParametersMap | null, simArgs: ArgumentsMap, filenames: any): ArgumentsMap {
+function replacePaths(
+  modelParameters: ParametersMap | null,
+  simArgs: ArgumentsMap,
+  filenames: Record<string, string>,
+): ArgumentsMap {
   if (modelParameters === null) {
     return simArgs;
   }
@@ -4402,7 +4406,7 @@ function replacePaths(modelParameters: ParametersMap | null, simArgs: ArgumentsM
   return result;
 }
 
-function replacePathsHelper(schema: ValueSchema, arg: Argument, filenames: any) {
+function replacePathsHelper(schema: ValueSchema, arg: Argument, filenames: Record<string, string>) {
   switch (schema.type) {
     case 'path':
       return filenames[arg] || arg;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -4123,10 +4123,9 @@ const effects = {
       const original_filename_to_id: Record<string, number> = {};
       for (let i = 0; i < ids.length; i++) {
         const id = ids[i];
-        if (id === null) {
-          continue;
+        if (id !== null) {
+          original_filename_to_id[newFiles[i].name] = id;
         }
-        original_filename_to_id[newFiles[i].name] = id;
       }
 
       const filenames: Record<string, string> = {};
@@ -4135,10 +4134,9 @@ const effects = {
         const response = (await reqHasura<[{ name: string }]>(gql.GET_UPLOADED_FILENAME, { id }, user))[
           'uploaded_file'
         ];
-        if (response == null) {
-          continue;
+        if (response !== null) {
+          filenames[newFile.name] = `${env.PUBLIC_AERIE_FILE_STORE_PREFIX}${response[0]['name']}`;
         }
-        filenames[newFile.name] = `${env.PUBLIC_AERIE_FILE_STORE_PREFIX}${response[0]['name']}`;
       }
 
       const data = await reqHasura<Pick<Simulation, 'id'>>(
@@ -4399,10 +4397,9 @@ export function replacePaths(
   for (const parameterName in modelParameters) {
     const parameter: Parameter = modelParameters[parameterName];
     const arg: Argument = simArgs[parameterName];
-    if (arg === undefined) {
-      continue;
+    if (arg !== undefined) {
+      result[parameterName] = replacePathsHelper(parameter.schema, arg, filenames);
     }
-    result[parameterName] = replacePathsHelper(parameter.schema, arg, filenames);
   }
   return result;
 }

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -4120,9 +4120,11 @@ const effects = {
 
       const ids = await effects.uploadFiles(newFiles, user);
       const original_filename_to_id: Record<string, number> = {};
-      for (var i = 0; i < ids.length; i++) {
+      for (let i = 0; i < ids.length; i++) {
         const id = ids[i];
-        if (id === null) continue;
+        if (id === null) {
+          continue;
+        }
         original_filename_to_id[newFiles[i].name] = id;
       }
 
@@ -4132,8 +4134,9 @@ const effects = {
         const response = (await reqHasura<[{ name: string }]>(gql.GET_UPLOADED_FILENAME, { id }, user))[
           'uploaded_file'
         ];
-        if (response == null) continue;
-        console.log({ name: newFile.name, id, response });
+        if (response == null) {
+          continue;
+        }
         filenames[newFile.name] = `/usr/src/app/merlin_file_store/${response[0]['name']}`;
       }
 
@@ -4384,12 +4387,16 @@ const effects = {
 };
 
 function replacePaths(modelParameters: ParametersMap | null, simArgs: ArgumentsMap, filenames: any): ArgumentsMap {
-  if (modelParameters === null) return simArgs;
+  if (modelParameters === null) {
+    return simArgs;
+  }
   const result: ArgumentsMap = {};
   for (const parameterName in modelParameters) {
     const parameter: Parameter = modelParameters[parameterName];
     const arg: Argument = simArgs[parameterName];
-    if (arg === undefined) continue;
+    if (arg === undefined) {
+      continue;
+    }
     result[parameterName] = replacePathsHelper(parameter.schema, arg, filenames);
   }
   return result;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -1,5 +1,6 @@
 import { goto } from '$app/navigation';
 import { base } from '$app/paths';
+import { env } from '$env/dynamic/public';
 import type { CommandDictionary as AmpcsCommandDictionary } from '@nasa-jpl/aerie-ampcs';
 import { get } from 'svelte/store';
 import { SearchParameters } from '../enums/searchParameters';
@@ -4137,7 +4138,7 @@ const effects = {
         if (response == null) {
           continue;
         }
-        filenames[newFile.name] = `/usr/src/app/merlin_file_store/${response[0]['name']}`;
+        filenames[newFile.name] = `${env.PUBLIC_AERIE_FILE_STORE_PREFIX}${response[0]['name']}`;
       }
 
       const data = await reqHasura<Pick<Simulation, 'id'>>(

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -14,8 +14,8 @@ const gql = {
     }
   `,
 
-  CANCEL_SIMULATION: `#graphql
-    mutation CancelSim($id: Int!) {
+  CANCEL_PENDING_SIMULATION: `#graphql
+    mutation CancelPendingSim($id: Int!) {
       update_simulation_dataset_by_pk(pk_columns: {id: $id}, _set: {
         canceled: true
       }) {

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -14,8 +14,8 @@ const gql = {
     }
   `,
 
-  CANCEL_PENDING_SIMULATION: `#graphql
-    mutation CancelPendingSim($id: Int!) {
+  CANCEL_SIMULATION: `#graphql
+    mutation CancelSim($id: Int!) {
       update_simulation_dataset_by_pk(pk_columns: {id: $id}, _set: {
         canceled: true
       }) {
@@ -1220,6 +1220,14 @@ const gql = {
           content
           filePath
         }
+      }
+    }
+  `,
+
+  GET_UPLOADED_FILENAME: `#graphql
+    query GetUploadedFileName($id: Int!) {
+      uploaded_file(where: { id: { _eq: $id }}) {
+        name
       }
     }
   `,


### PR DESCRIPTION
Closes #1046 

## Description
Aerie allows the mission model to declare a sim config parameter of type `Path`. The Aerie UI displays this parameter type with a `Browse` button that allows the user to upload a file.

The aerie gateway changes the names of uploaded files to ensure uniqueness (e.g. if I upload `banananation.jar` multiple times, I do not typically want it to overwrite other files with the same name).

The Aerie UI sets the name of the `Path` parameter in the sim config to the name of the original file, not the modified name generated by the gateway. This path also omits the absolute path prefix of the location at which the `aerie_file_store` is mounted in the `aerie_merlin` and `aerie_merlin_worker_*` containers.

As a consequence of the above, there is no way for the mission model to take the provided `Path` parameter and resolve it to the correct file location in the file system. This negates the utility of using `Path` parameters in a sim config.

## Problem Statement
A mission model should be able to use a sim config parameter of type `Path` to find a file that the planner uploaded using the UI's sim config form.

## Approach
The most targeted fix (i.e. a fix that only touches one repo) is to update the UI to fill in the Path parameter with the correct absolute path to the uploaded file. It can do this with the following steps:
1. After uploading the files, keep track of the uploaded file ids
2. Issue a follow-up query to get the generated names of those files
3. Traverse the sim config, finding all `Path` parameters and replace them with a hard-coded prefix followed by the generated filename, e.g:
```
/usr/src/app/merlin_file_store/my-file-name-1702092509728-CMvkjzriKBQvuc.json
```

A drawback of this approach is that it hard-codes the mount point `/usr/src/app/merlin_file_store/`. Perhaps an easy step we could take would be to set this in an environment variable.

- [x] TODO set `/usr/src/app/merlin_file_store/` in an environment variable

## Verification
As a manual test, upload a banananation mission model, and upload a text file to the `initialDataPath` sim config parameter. Run a simulation, and observe the `/data/line_count` resource - it should correctly report the number of lines in your uploaded file.

## Future work
- The fact that the UI needs to know the mount point of the `merlin_file_store` feels a bit strange - in theory, the simulation context should be able to add that prefix to every provided path parameter.
- There is no way to choose an existing file, or even see the existing set of uploaded files. It may be worth looking into some UI to manage uploaded files