### PR TITLE
Refresh simulation results after scheduling

### DIFF
--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -69,6 +69,7 @@ export type SchedulingGoalInsertInput = Omit<
 >;
 
 export type SchedulingResponse = {
+  datasetId: number | null;
   reason: SchedulingError;
   status: 'complete' | 'failed' | 'incomplete';
 };

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -3705,11 +3705,23 @@ const effects = {
             const data = await reqHasura<SchedulingResponse>(gql.SCHEDULE, { specificationId }, user);
             const { schedule } = data;
             if (schedule != null) {
-              const { reason, status } = schedule;
+              const { datasetId, reason, status } = schedule;
 
               if (status === 'complete') {
                 schedulingStatus.set(Status.Complete);
                 incomplete = false;
+                if (datasetId != null) {
+                  const simDatasetIdData = await reqHasura<{ id: number }>(
+                    gql.GET_SIMULATION_DATASET_ID,
+                    { datasetId },
+                    user,
+                  );
+                  const { simulation_dataset } = simDatasetIdData;
+                  // the request above will return either 0 or 1 element
+                  if (Array.isArray(simulation_dataset) && simulation_dataset.length > 0) {
+                    simulationDatasetId.set(simulation_dataset[0].id);
+                  }
+                }
                 showSuccessToast(`Scheduling ${analysis_only ? 'Analysis ' : ''}Complete`);
               } else if (status === 'failed') {
                 schedulingStatus.set(Status.Failed);

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1158,6 +1158,14 @@ const gql = {
     }
   `,
 
+  GET_SIMULATION_DATASET_ID: `#graphql
+    query GetSimulationDatasetId($datasetId: Int!) {
+      simulation_dataset(where: {dataset_id: {_eq: $datasetId}}) {
+        id
+      }
+    }
+  `,
+
   GET_SPANS: `#graphql
     query GetSpans($datasetId: Int!) {
       span(where: { dataset_id: { _eq: $datasetId } }, order_by: { start_offset: asc }) {
@@ -1399,6 +1407,7 @@ const gql = {
       schedule(specificationId: $specificationId) {
         reason
         status
+        datasetId
       }
     }
   `,


### PR DESCRIPTION
Scheduling almost always stores its latest simulation results into the database and returns the corresponding dataset id so the user does not have to simulate yet another time. In this PR, I get this id, convert it to a simulation dataset id, and update the corresponding shared variable so that the views are updated with the latest dataset. 

Thank you @duranb for the help. 