### PR TITLE
Split Resource -> LinePoint Processing Across Multiple Frames

### DIFF
--- a/src/components/timeline/LayerLine.svelte
+++ b/src/components/timeline/LayerLine.svelte
@@ -71,7 +71,7 @@
   $: onContextMenu(contextmenu);
   $: onMousemove(mousemove);
   $: onMouseout(mouseout);
-  $: resources && processResourcesToLinePoints(resources);
+  $: processResourcesToLinePoints(resources);
   $: offscreenPoint = ctx && generateOffscreenPoint(lineColor, pointRadius);
 
   onMount(() => {

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -82,7 +82,6 @@ export interface LineLayer extends Layer {
 }
 
 export interface LinePoint extends Point {
-  radius: number;
   y: number;
 }
 


### PR DESCRIPTION
After looking into it a bit more, I feel like pushing the resource-to-linepoint work into a worker doesn't seem like a viable strategy. In order to handle mouse interactions we would need a copy of the data both inside the worker and in the window, so I think passing this data back and forth seems inevitable. The most efficient way to do that would be to crunch the resource data into typed arrays and then transfer ownership of them to the worker, but at that point we've already done like 90% of the work of processing the line points 🤷‍♂️ 

So due to this, and also because trying to fetch the resource data within the worker introduces some extra complexity, I feel like it makes sense to keep this data fetching/processing within the window (and stores). But what we _can_ do instead is just try to make this work non-blocking. So this PR will process resource values for up to 32ms, and then once that's elapsed, will split the remaining work into a new frame.