### PR TITLE
Take "out of plan bounds" activities into account in total count display

### DIFF
--- a/src/components/menus/ActivityStatusMenu.svelte
+++ b/src/components/menus/ActivityStatusMenu.svelte
@@ -11,33 +11,16 @@
 
   export let activityErrorCounts: ActivityErrorCounts;
   export let activityDirectiveValidationStatuses: ActivityDirectiveValidationStatus[] = [];
+  export let invalidActivityCount: number = 0;
   export let compactNavMode: boolean = false;
 
   const dispatch = createEventDispatcher();
 
-  let invalidActivityCount: number = 0;
   let totalActivitiesCheckedCount: number = 0;
-  let totalActivityCount: number = 0;
 
-  $: {
-    ({ invalidActivityCount, totalActivitiesCheckedCount, totalActivityCount } =
-      activityDirectiveValidationStatuses.reduce(
-        (prevCounts, validationStatus) => {
-          return {
-            invalidActivityCount:
-              prevCounts.invalidActivityCount + (validationStatus.validations.success === false ? 1 : 0),
-            totalActivitiesCheckedCount:
-              prevCounts.totalActivitiesCheckedCount + (validationStatus.status === 'complete' ? 1 : 0),
-            totalActivityCount: prevCounts.totalActivityCount + 1,
-          };
-        },
-        {
-          invalidActivityCount: 0,
-          totalActivitiesCheckedCount: 0,
-          totalActivityCount: 0,
-        },
-      ));
-  }
+  $: totalActivitiesCheckedCount = activityDirectiveValidationStatuses.reduce((prevCount, validationStatus) => {
+    return prevCount + (validationStatus.status === 'complete' ? 1 : 0);
+  }, 0);
 
   function onClickViewConsole() {
     dispatch('viewActivityValidations');
@@ -55,7 +38,10 @@
   <svelte:fragment slot="metadata">
     <div class="activity-status-nav-container">
       <div class="total-count">
-        {totalActivitiesCheckedCount}/{totalActivityCount} activit{totalActivityCount !== 1 ? 'ies' : 'y'} checked
+        {totalActivitiesCheckedCount}/{activityDirectiveValidationStatuses.length} activit{activityDirectiveValidationStatuses.length !==
+        1
+          ? 'ies'
+          : 'y'} checked
       </div>
       {#if invalidActivityCount === 0}
         <div class="no-errors">No problems detected</div>

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -508,7 +508,7 @@
     </svelte:fragment>
     <svelte:fragment slot="right">
       <ActivityStatusMenu
-      activityDirectiveValidationStatuses={$activityDirectiveValidationStatuses}
+        activityDirectiveValidationStatuses={$activityDirectiveValidationStatuses}
         {activityErrorCounts}
         {compactNavMode}
         {invalidActivityCount}

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -147,6 +147,7 @@
   let hasScheduleAnalysisPermission: boolean = false;
   let hasSimulatePermission: boolean = false;
   let hasCheckConstraintsPermission: boolean = false;
+  let invalidActivityCount: number = 0;
   let planHasBeenLocked = false;
   let planSnapshotActivityDirectives: ActivityDirective[] = [];
   let schedulingAnalysisStatus: Status | null;
@@ -156,7 +157,7 @@
   let simulationDataAbortController: AbortController;
   let resourcesExternalAbortController: AbortController;
 
-  $: activityErrorCounts = $activityErrorRollups.reduce(
+  $: ({ invalidActivityCount, ...activityErrorCounts } = $activityErrorRollups.reduce(
     (prevCounts, activityErrorRollup) => {
       let extra = prevCounts.extra + activityErrorRollup.errorCounts.extra;
       let invalidAnchor = prevCounts.invalidAnchor + activityErrorRollup.errorCounts.invalidAnchor;
@@ -167,10 +168,19 @@
       let wrongType = prevCounts.wrongType + activityErrorRollup.errorCounts.wrongType;
 
       let all = extra + invalidAnchor + invalidParameter + missing + outOfBounds + wrongType;
-
       return {
         all,
         extra,
+        invalidActivityCount:
+          activityErrorRollup.errorCounts.extra ||
+          activityErrorRollup.errorCounts.invalidAnchor ||
+          activityErrorRollup.errorCounts.invalidParameter ||
+          activityErrorRollup.errorCounts.missing ||
+          activityErrorRollup.errorCounts.outOfBounds ||
+          activityErrorRollup.errorCounts.pending ||
+          activityErrorRollup.errorCounts.wrongType
+            ? prevCounts.invalidActivityCount + 1
+            : prevCounts.invalidActivityCount,
         invalidAnchor,
         invalidParameter,
         missing,
@@ -182,6 +192,7 @@
     {
       all: 0,
       extra: 0,
+      invalidActivityCount: 0,
       invalidAnchor: 0,
       invalidParameter: 0,
       missing: 0,
@@ -189,7 +200,7 @@
       pending: 0,
       wrongType: 0,
     },
-  );
+  ));
   $: hasCreateViewPermission = featurePermissions.view.canCreate(data.user);
   $: hasUpdateViewPermission = $view !== null ? featurePermissions.view.canUpdate(data.user, $view) : false;
   $: if ($plan) {
@@ -497,9 +508,10 @@
     </svelte:fragment>
     <svelte:fragment slot="right">
       <ActivityStatusMenu
+      activityDirectiveValidationStatuses={$activityDirectiveValidationStatuses}
         {activityErrorCounts}
         {compactNavMode}
-        activityDirectiveValidationStatuses={$activityDirectiveValidationStatuses}
+        {invalidActivityCount}
         on:viewActivityValidations={() => {
           errorConsole.openConsole(ConsoleTabs.ACTIVITY);
         }}


### PR DESCRIPTION
Resolves #1058 

To test:

1. Create a plan and add any number of activities
2. Select an activity
3. Edit the anchor of the activity to be a negative duration relative to plan start
4. Verify that the nav bar now displays a "1" for the activity status.