### PR TITLE
Handle non-gap null values in line and x-range plots

### DIFF
--- a/src/components/timeline/LayerLine.svelte
+++ b/src/components/timeline/LayerLine.svelte
@@ -112,7 +112,7 @@
 
         line = d3Line<LinePoint>()
           .x(d => (xScaleView as ScaleTime<number, number, never>)(d.x))
-          .y(d => stateLinePlotYScale(d.y.toString()) as number)
+          .y(d => stateLinePlotYScale(d.y?.toString()) as number)
           .defined(d => d.y !== null) // Skip any gaps in resource data instead of interpolating
           .curve(curveLinear);
       } else {
@@ -155,7 +155,7 @@
         let y: number;
 
         if (showAsLinePlot) {
-          y = stateLinePlotYScale(point.y.toString()) as number;
+          y = stateLinePlotYScale(point.y?.toString()) as number;
         } else {
           y = yScale(point.y) as number;
         }

--- a/src/components/timeline/LayerXRange.svelte
+++ b/src/components/timeline/LayerXRange.svelte
@@ -258,7 +258,7 @@
         const domainMap: Record<string, string> = {};
         for (let i = 0; i < values.length; ++i) {
           const { x, y, is_gap } = values[i];
-          const text = y as string;
+          const text = y === null && !is_gap ? 'null' : (y as string);
           points.push({
             id: id++,
             is_gap,
@@ -274,7 +274,7 @@
         domain = schema.variants.map(({ label }) => label);
         for (let i = 0; i < values.length; ++i) {
           const { x, y, is_gap } = values[i];
-          const text = y as string;
+          const text = y === null && !is_gap ? 'null' : (y as string);
           points.push({
             id: id++,
             is_gap,

--- a/src/components/timeline/LayerXRange.svelte
+++ b/src/components/timeline/LayerXRange.svelte
@@ -98,7 +98,7 @@
 
       for (let i = 0; i < points.length; ++i) {
         const point = points[i];
-        if (point.is_gap) {
+        if (point.is_gap || point.is_null) {
           continue;
         }
 
@@ -248,6 +248,7 @@
           points.push({
             id: id++,
             is_gap,
+            is_null: false,
             label: { text },
             name,
             type: 'x-range',
@@ -258,26 +259,32 @@
         const domainMap: Record<string, string> = {};
         for (let i = 0; i < values.length; ++i) {
           const { x, y, is_gap } = values[i];
-          const text = y === null && !is_gap ? 'null' : (y as string);
+          const isNull = y === null;
+          const text = isNull ? '' : (y as string);
           points.push({
             id: id++,
             is_gap,
+            is_null: isNull,
             label: { text },
             name,
             type: 'x-range',
             x,
           });
-          domainMap[text] = text;
+          if (!isNull) {
+            domainMap[text] = text;
+          }
         }
         domain = Object.values(domainMap);
       } else if (schema.type === 'variant') {
         domain = schema.variants.map(({ label }) => label);
         for (let i = 0; i < values.length; ++i) {
           const { x, y, is_gap } = values[i];
-          const text = y === null && !is_gap ? 'null' : (y as string);
+          const isNull = y === null;
+          const text = isNull ? '' : (y as string);
           points.push({
             id: id++,
             is_gap,
+            is_null: isNull,
             label: { text },
             name,
             type: 'x-range',

--- a/src/components/timeline/RowHeader.svelte
+++ b/src/components/timeline/RowHeader.svelte
@@ -131,7 +131,7 @@
       {/if}
     </div>
   </div>
-  {#if expanded && yAxes.length}
+  {#if expanded}
     <div class="row-header-right-column" style:width={`${yAxesWidth}px`}>
       <div class="row-header-y-axes">
         <RowYAxes

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -200,6 +200,7 @@ export interface XRangeLayer extends Layer {
 
 export interface XRangePoint extends Point {
   is_gap?: boolean;
+  is_null?: boolean;
   label: Label;
 }
 


### PR DESCRIPTION
Closes #602

Testing:
1. Load Clipper TT6 plan and x-range layer with resources noted in #602. Render one x-range normally and the other as a line chart.
2. Confirm that null values do not show up in either x-range or line rendering.
3. Load an external profile suitable for x-range rendering with gaps and confirm that the gaps still display normally in both x-range and line modes.

TODO: 
- [x] Determine if plots should enumerate "null" in the scale and show "null" as a state or just leave it out?