### PR TITLE
Fix/734/external dataset loading

### DIFF
--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -6,7 +6,12 @@
   import { zoom as d3Zoom, zoomIdentity, type D3ZoomEvent, type ZoomBehavior, type ZoomTransform } from 'd3-zoom';
   import { pick } from 'lodash-es';
   import { createEventDispatcher } from 'svelte';
-  import { allResources, fetchingResources, fetchingResourcesExternal } from '../../stores/simulation';
+  import {
+    allResources,
+    fetchingResources,
+    fetchingResourcesExternal,
+    fetchingResourcesExternalNames,
+  } from '../../stores/simulation';
   import { selectedRow } from '../../stores/views';
   import type {
     ActivityDirective,
@@ -340,7 +345,7 @@
         </g>
       </svg>
       <!-- Loading indicator -->
-      {#if hasResourceLayer && ($fetchingResources || $fetchingResourcesExternal)}
+      {#if hasResourceLayer && ($fetchingResources || $fetchingResourcesExternal || $fetchingResourcesExternalNames)}
         <div class="loading st-typography-label">Loading</div>
       {/if}
       <!-- Layers of Canvas Visualizations. -->

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -6,12 +6,7 @@
   import { zoom as d3Zoom, zoomIdentity, type D3ZoomEvent, type ZoomBehavior, type ZoomTransform } from 'd3-zoom';
   import { pick } from 'lodash-es';
   import { createEventDispatcher } from 'svelte';
-  import {
-    allResources,
-    fetchingResources,
-    fetchingResourcesExternal,
-    fetchingResourcesExternalNames,
-  } from '../../stores/simulation';
+  import { allResources, fetchingResources, fetchingResourcesExternal } from '../../stores/simulation';
   import { selectedRow } from '../../stores/views';
   import type {
     ActivityDirective,
@@ -345,7 +340,7 @@
         </g>
       </svg>
       <!-- Loading indicator -->
-      {#if hasResourceLayer && ($fetchingResources || $fetchingResourcesExternal || $fetchingResourcesExternalNames)}
+      {#if hasResourceLayer && ($fetchingResources || $fetchingResourcesExternal)}
         <div class="loading st-typography-label">Loading</div>
       {/if}
       <!-- Layers of Canvas Visualizations. -->

--- a/src/components/timeline/form/TimelineEditorPanel.svelte
+++ b/src/components/timeline/form/TimelineEditorPanel.svelte
@@ -12,7 +12,7 @@
   import { ViewConstants } from '../../../enums/view';
   import { activityTypes, maxTimeRange, viewTimeRange } from '../../../stores/plan';
   import {
-    externalResources,
+    externalResourceNames,
     resourceTypes,
     resourcesByViewLayerId,
     simulationDataset,
@@ -436,8 +436,8 @@
       return $activityTypes.map(t => t.name);
     } else if (layer.chartType === 'line' || layer.chartType === 'x-range') {
       return $resourceTypes
-        .concat($externalResources)
         .map(t => t.name)
+        .concat($externalResourceNames)
         .sort();
     }
     return [];

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -72,6 +72,7 @@
   } from '../../../stores/scheduling';
   import {
     enableSimulation,
+    externalResourceNames,
     externalResources,
     fetchingResources,
     resetSimulationStores,
@@ -156,6 +157,7 @@
   let windowWidth = 0;
   let simulationDataAbortController: AbortController;
   let resourcesExternalAbortController: AbortController;
+  let externalDatasetNamesAbortController: AbortController;
 
   $: ({ invalidActivityCount, ...activityErrorCounts } = $activityErrorRollups.reduce(
     (prevCounts, activityErrorRollup) => {
@@ -291,6 +293,12 @@
   }
 
   $: if ($plan) {
+    externalDatasetNamesAbortController?.abort();
+    externalDatasetNamesAbortController = new AbortController();
+    effects
+      .getExternalDatasetNames($plan.id, data.user, externalDatasetNamesAbortController.signal)
+      .then(names => ($externalResourceNames = names));
+
     resourcesExternalAbortController?.abort();
     resourcesExternalAbortController = new AbortController();
     effects

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -261,8 +261,6 @@
     effects
       .getResourceTypes($plan.model_id, data.user)
       .then(initialResourceTypes => ($resourceTypes = initialResourceTypes));
-
-    // TODO fetch external resource types
   }
   $: if (data.initialPlanSnapshotId !== null) {
     $planSnapshotId = data.initialPlanSnapshotId;

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -259,6 +259,8 @@
     effects
       .getResourceTypes($plan.model_id, data.user)
       .then(initialResourceTypes => ($resourceTypes = initialResourceTypes));
+
+    // TODO fetch external resource types
   }
   $: if (data.initialPlanSnapshotId !== null) {
     $planSnapshotId = data.initialPlanSnapshotId;
@@ -294,7 +296,7 @@
     effects
       .getResourcesExternal(
         $plan.id,
-        $simulationDatasetId ?? null,
+        $simulationDatasetId > -1 ? $simulationDatasetId : null,
         $plan.start_time,
         data.user,
         resourcesExternalAbortController.signal,

--- a/src/stores/simulation.ts
+++ b/src/stores/simulation.ts
@@ -34,6 +34,8 @@ export const fetchingResources: Writable<boolean> = writable(false);
 
 export const fetchingResourcesExternal: Writable<boolean> = writable(false);
 
+export const fetchingResourcesExternalNames: Writable<boolean> = writable(false);
+
 export const resourceTypes: Writable<ResourceType[]> = writable([]);
 
 export const spans: Writable<Span[]> = writable([]);

--- a/src/stores/simulation.ts
+++ b/src/stores/simulation.ts
@@ -26,6 +26,8 @@ export const simulationDatasetId: Writable<number> = writable(-1);
 
 export const externalResources: Writable<Resource[]> = writable([]);
 
+export const externalResourceNames: Writable<string[]> = writable([]);
+
 export const resources: Writable<Resource[]> = writable([]);
 
 export const fetchingResources: Writable<boolean> = writable(false);

--- a/src/stores/simulation.ts
+++ b/src/stores/simulation.ts
@@ -34,8 +34,6 @@ export const fetchingResources: Writable<boolean> = writable(false);
 
 export const fetchingResourcesExternal: Writable<boolean> = writable(false);
 
-export const fetchingResourcesExternalNames: Writable<boolean> = writable(false);
-
 export const resourceTypes: Writable<ResourceType[]> = writable([]);
 
 export const spans: Writable<Span[]> = writable([]);

--- a/src/types/simulation.ts
+++ b/src/types/simulation.ts
@@ -9,6 +9,10 @@ export type PlanDataset = {
   offset_from_plan_start: string;
 };
 
+export type PlanDatasetNames = {
+  dataset: { profiles: { name: string }[] };
+};
+
 export type Profile = {
   dataset_id: number;
   duration: string;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -2606,7 +2606,7 @@ const effects = {
           }
         }
 
-        return resourceNames;
+        return [...new Set(resourceNames)];
       } else {
         throw Error('Unable to get external resource names');
       }

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -20,7 +20,6 @@ import { commandDictionaries } from '../stores/sequencing';
 import {
   fetchingResources,
   fetchingResourcesExternal,
-  fetchingResourcesExternalNames,
   selectedSpanId,
   simulationDatasetId,
 } from '../stores/simulation';
@@ -2615,7 +2614,6 @@ const effects = {
       const error = e as Error;
       if (error.name !== 'AbortError') {
         catchError(error);
-        fetchingResourcesExternalNames.set(false);
       }
       return [];
     }

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -20,6 +20,7 @@ import { commandDictionaries } from '../stores/sequencing';
 import {
   fetchingResources,
   fetchingResourcesExternal,
+  fetchingResourcesExternalNames,
   selectedSpanId,
   simulationDatasetId,
 } from '../stores/simulation';
@@ -2614,7 +2615,7 @@ const effects = {
       const error = e as Error;
       if (error.name !== 'AbortError') {
         catchError(error);
-        fetchingResourcesExternal.set(false);
+        fetchingResourcesExternalNames.set(false);
       }
       return [];
     }
@@ -2926,8 +2927,10 @@ const effects = {
     try {
       fetchingResourcesExternal.set(true);
 
-      // TODO type better or refactor
-      const clauses: any = [{ simulation_dataset_id: { _is_null: true } }];
+      // Always fetch external resources that aren't tied to a simulation, optionally get the resources tied to one if we have a dataset ID.
+      const clauses: { simulation_dataset_id: { _is_null: boolean } | { _eq: number } }[] = [
+        { simulation_dataset_id: { _is_null: true } },
+      ];
       if (simulationDatasetId !== null) {
         clauses.push({ simulation_dataset_id: { _eq: simulationDatasetId } });
       }

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -2885,16 +2885,18 @@ const effects = {
   ): Promise<Resource[]> {
     try {
       fetchingResourcesExternal.set(true);
+
+      // TODO type better or refactor
+      const clauses: any = [{ simulation_dataset_id: { _is_null: true } }];
+      if (simulationDatasetId !== null) {
+        clauses.push({ simulation_dataset_id: { _eq: simulationDatasetId } });
+      }
+
       const data = await reqHasura<PlanDataset[]>(
         gql.GET_PROFILES_EXTERNAL,
         {
           planId,
-          simulationDatasetFilter:
-            simulationDatasetId === null
-              ? {
-                  _is_null: true,
-                }
-              : { _eq: simulationDatasetId },
+          simulationDatasetFilter: clauses,
         },
         user,
         signal,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1051,8 +1051,8 @@ const gql = {
   `,
 
   GET_PROFILES_EXTERNAL: `#graphql
-    query GetProfilesExternal($planId: Int!, $simulationDatasetFilter: Int_comparison_exp) {
-      plan_dataset(where: { plan_id: { _eq: $planId }, simulation_dataset_id: $simulationDatasetFilter }) {
+    query GetProfilesExternal($planId: Int!, $simulationDatasetFilter: [plan_dataset_bool_exp!]) {
+      plan_dataset(where: { plan_id: { _eq: $planId }, _or: $simulationDatasetFilter }) {
         dataset {
           profiles {
             dataset_id

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1074,6 +1074,18 @@ const gql = {
     }
   `,
 
+  GET_PROFILES_EXTERNAL_NAMES: `#graphql
+    query GetProfilesExternalNames($planId: Int!) {
+      plan_dataset(where: { plan_id: { _eq: $planId }}) {
+        dataset {
+          profiles {
+            name
+          }
+        }
+      }
+    }
+  `,
+
   GET_RESOURCE_TYPES: `#graphql
     query GetResourceTypes($model_id: Int!, $limit: Int) {
       resource_types: resource_type(where: { model_id: { _eq: $model_id } }, order_by: { name: asc }, limit: $limit) {


### PR DESCRIPTION
Closes #734.

This PR fixes behavior around loading external datasets that aren't attached to a simulation, and also only loads the name for the timeline editor so it doesn't hang while trying to load all the profiles.