### PR TITLE
Filter scheduling goals and conditions by plan scheduling specification id

### DIFF
--- a/src/components/scheduling/Scheduling.svelte
+++ b/src/components/scheduling/Scheduling.svelte
@@ -55,18 +55,17 @@
 
   async function deleteGoal(goal: SchedulingGoalSlim) {
     const { scheduling_specification_goal } = goal;
-    const specification_id = scheduling_specification_goal.specification_id;
-    const plan = plans?.find(plan => plan.scheduling_specifications[0]?.id === specification_id);
+    let plan = null;
+    if (scheduling_specification_goal) {
+      const specification_id = scheduling_specification_goal.specification_id;
+      plan = plans?.find(plan => plan.scheduling_specifications[0]?.id === specification_id) ?? null;
+    }
+    const success = await effects.deleteSchedulingGoal(goal, plan, user);
+    if (success) {
+      schedulingGoalsAll.filterValueById(goal.id);
 
-    if (plan) {
-      const success = await effects.deleteSchedulingGoal(goal, plan, user);
-
-      if (success) {
-        schedulingGoalsAll.filterValueById(goal.id);
-
-        if (goal.id === selectedGoal?.id) {
-          selectedGoal = null;
-        }
+      if (goal.id === selectedGoal?.id) {
+        selectedGoal = null;
       }
     }
   }

--- a/src/components/scheduling/Scheduling.svelte
+++ b/src/components/scheduling/Scheduling.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import { schedulingColumns, schedulingConditions, schedulingGoals } from '../../stores/scheduling';
+  import { schedulingColumns, schedulingConditionsAll, schedulingGoalsAll } from '../../stores/scheduling';
   import type { User } from '../../types/app';
   import type { DataGridRowSelection } from '../../types/data-grid';
   import type { PlanSchedulingSpec } from '../../types/plan';
@@ -22,14 +22,14 @@
   let editorTitle: string = 'Scheduling';
 
   $: if (selectedCondition !== null) {
-    const found = $schedulingConditions.findIndex(condition => condition.id === selectedCondition?.id);
+    const found = $schedulingConditionsAll.findIndex(condition => condition.id === selectedCondition?.id);
     if (found === -1) {
       selectedCondition = null;
     }
   }
 
   $: if (selectedGoal !== null) {
-    const found = $schedulingGoals.findIndex(goal => goal.id === selectedGoal?.id);
+    const found = $schedulingGoalsAll.findIndex(goal => goal.id === selectedGoal?.id);
     if (found === -1) {
       selectedGoal = null;
     }
@@ -44,7 +44,7 @@
       const success = await effects.deleteSchedulingCondition(condition, plan, user);
 
       if (success) {
-        schedulingConditions.filterValueById(condition.id);
+        schedulingConditionsAll.filterValueById(condition.id);
 
         if (condition.id === selectedCondition?.id) {
           selectedCondition = null;
@@ -62,7 +62,7 @@
       const success = await effects.deleteSchedulingGoal(goal, plan, user);
 
       if (success) {
-        schedulingGoals.filterValueById(goal.id);
+        schedulingGoalsAll.filterValueById(goal.id);
 
         if (goal.id === selectedGoal?.id) {
           selectedGoal = null;
@@ -73,7 +73,7 @@
 
   function deleteConditionContext(event: CustomEvent<number>) {
     const id = event.detail;
-    const condition = $schedulingConditions.find(s => s.id === id);
+    const condition = $schedulingConditionsAll.find(s => s.id === id);
     if (condition) {
       deleteCondition(condition);
     }
@@ -81,7 +81,7 @@
 
   function deleteGoalContext(event: CustomEvent<number>) {
     const id = event.detail;
-    const goal = $schedulingGoals.find(s => s.id === id);
+    const goal = $schedulingGoalsAll.find(s => s.id === id);
     if (goal) {
       deleteGoal(goal);
     }
@@ -129,7 +129,7 @@
     <SchedulingGoals
       {plans}
       {selectedGoal}
-      schedulingGoals={$schedulingGoals}
+      schedulingGoals={$schedulingGoalsAll}
       {user}
       on:deleteGoal={deleteGoalContext}
       on:rowSelected={toggleGoal}
@@ -138,7 +138,7 @@
     <SchedulingConditions
       {plans}
       {selectedCondition}
-      schedulingConditions={$schedulingConditions}
+      schedulingConditions={$schedulingConditionsAll}
       {user}
       on:deleteCondition={deleteConditionContext}
       on:rowSelected={toggleCondition}

--- a/src/components/scheduling/conditions/SchedulingConditions.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditions.svelte
@@ -121,24 +121,22 @@
     editCondition({ id: event.detail[0] as number });
   }
 
-  function hasDeletePermission(condition: SchedulingCondition) {
-    const { scheduling_specification_conditions } = condition;
-    const specification_id = scheduling_specification_conditions[0].specification_id;
-    const plan = plans?.find(plan => plan.scheduling_specifications[0]?.id === specification_id);
-    if (plan) {
-      return featurePermissions.schedulingConditions.canDelete(user, plan);
+  function getPlanForCondition(condition: SchedulingCondition): PlanSchedulingSpec | null {
+    // If there is no spec id attached to the goal, the goal is not associated with a plan
+    let plan = null;
+    if (condition.scheduling_specification_conditions.length > 0) {
+      const specification_id = condition.scheduling_specification_conditions[0].specification_id;
+      plan = plans?.find(plan => plan.scheduling_specifications[0]?.id === specification_id) ?? null;
     }
-    return false;
+    return plan;
+  }
+
+  function hasDeletePermission(condition: SchedulingCondition) {
+    return featurePermissions.schedulingConditions.canDelete(user, getPlanForCondition(condition), condition);
   }
 
   function hasEditPermission(condition: SchedulingCondition) {
-    const { scheduling_specification_conditions } = condition;
-    const specification_id = scheduling_specification_conditions[0].specification_id;
-    const plan = plans?.find(plan => plan.scheduling_specifications[0]?.id === specification_id);
-    if (plan) {
-      return featurePermissions.schedulingConditions.canUpdate(user, plan);
-    }
-    return false;
+    return featurePermissions.schedulingConditions.canUpdate(user, getPlanForCondition(condition), condition);
   }
 
   function hasCreatePermission(user: User): boolean {

--- a/src/components/scheduling/goals/SchedulingGoals.svelte
+++ b/src/components/scheduling/goals/SchedulingGoals.svelte
@@ -150,42 +150,24 @@
     editGoal({ id: event.detail[0] as number });
   }
 
-  function hasDeletePermission(goal: SchedulingGoal) {
+  function getPlanForGoal(goal: SchedulingGoal): PlanSchedulingSpec | null {
     // If there is no spec id attached to the goal, the goal is not associated with a plan
-    // and should not be editable/deletable
-    if (
-      !goal.scheduling_specification_goal ||
-      typeof goal.scheduling_specification_goal.specification_id !== 'number'
-    ) {
-      return false;
+    let plan = null;
+    if (goal.scheduling_specification_goal) {
+      const {
+        scheduling_specification_goal: { specification_id },
+      } = goal;
+      plan = plans?.find(plan => plan.scheduling_specifications[0]?.id === specification_id) ?? null;
     }
-    const {
-      scheduling_specification_goal: { specification_id },
-    } = goal;
-    const plan = plans?.find(plan => plan.scheduling_specifications[0]?.id === specification_id);
-    if (plan) {
-      return featurePermissions.schedulingGoals.canDelete(user, plan);
-    }
-    return false;
+    return plan;
+  }
+
+  function hasDeletePermission(goal: SchedulingGoal) {
+    return featurePermissions.schedulingGoals.canDelete(user, getPlanForGoal(goal), goal);
   }
 
   function hasEditPermission(goal: SchedulingGoal) {
-    // If there is no spec id attached to the goal, the goal is not associated with a plan
-    // and should not be editable/deletable
-    if (
-      !goal.scheduling_specification_goal ||
-      typeof goal.scheduling_specification_goal.specification_id !== 'number'
-    ) {
-      return false;
-    }
-    const {
-      scheduling_specification_goal: { specification_id },
-    } = goal;
-    const plan = plans?.find(plan => plan.scheduling_specifications[0]?.id === specification_id);
-    if (plan) {
-      return featurePermissions.schedulingGoals.canUpdate(user, plan);
-    }
-    return false;
+    return featurePermissions.schedulingGoals.canUpdate(user, getPlanForGoal(goal), goal);
   }
 
   function hasCreatePermission(user: User): boolean {

--- a/src/components/scheduling/goals/SchedulingGoals.svelte
+++ b/src/components/scheduling/goals/SchedulingGoals.svelte
@@ -151,6 +151,14 @@
   }
 
   function hasDeletePermission(goal: SchedulingGoal) {
+    // If there is no spec id attached to the goal, the goal is not associated with a plan
+    // and should not be editable/deletable
+    if (
+      !goal.scheduling_specification_goal ||
+      typeof goal.scheduling_specification_goal.specification_id !== 'number'
+    ) {
+      return false;
+    }
     const {
       scheduling_specification_goal: { specification_id },
     } = goal;
@@ -162,6 +170,14 @@
   }
 
   function hasEditPermission(goal: SchedulingGoal) {
+    // If there is no spec id attached to the goal, the goal is not associated with a plan
+    // and should not be editable/deletable
+    if (
+      !goal.scheduling_specification_goal ||
+      typeof goal.scheduling_specification_goal.specification_id !== 'number'
+    ) {
+      return false;
+    }
     const {
       scheduling_specification_goal: { specification_id },
     } = goal;

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -52,7 +52,7 @@ export const schedulingGoals = derived(
   [selectedSpecId, schedulingGoalsAll],
   ([$selectedSpecId, $schedulingGoalsAll]) => {
     return $schedulingGoalsAll
-      .filter(goal => goal.scheduling_specification_goal.specification_id === $selectedSpecId)
+      .filter(goal => goal.scheduling_specification_goal?.specification_id === $selectedSpecId)
       .map(goal => {
         return {
           ...goal,

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -25,42 +25,118 @@ export const selectedSpecId = derived(plan, $plan => $plan?.scheduling_specifica
 
 /* Subscriptions. */
 
-export const schedulingConditions = gqlSubscribable<SchedulingCondition[]>(gql.SUB_SCHEDULING_CONDITIONS, {}, [], null);
+export const schedulingConditionsAll = gqlSubscribable<SchedulingCondition[]>(
+  gql.SUB_SCHEDULING_CONDITIONS,
+  {},
+  [],
+  null,
+);
 
-export const schedulingGoals = gqlSubscribable<SchedulingGoalSlim[]>(gql.SUB_SCHEDULING_GOALS, {}, [], null);
+export const schedulingConditions = derived(
+  [selectedSpecId, schedulingConditionsAll],
+  ([$selectedSpecId, $schedulingConditionsAll]) => {
+    return $schedulingConditionsAll.map(schedulingSpecCondition => {
+      return {
+        ...schedulingSpecCondition,
+        scheduling_specification_conditions: schedulingSpecCondition.scheduling_specification_conditions.filter(
+          condition => condition.specification_id === $selectedSpecId,
+        ),
+      };
+    });
+  },
+);
 
-export const schedulingSpecConditions = gqlSubscribable<SchedulingSpecCondition[]>(
+export const schedulingGoalsAll = gqlSubscribable<SchedulingGoalSlim[]>(gql.SUB_SCHEDULING_GOALS, {}, [], null);
+
+export const schedulingGoals = derived(
+  [selectedSpecId, schedulingGoalsAll],
+  ([$selectedSpecId, $schedulingGoalsAll]) => {
+    return $schedulingGoalsAll
+      .filter(goal => goal.scheduling_specification_goal.specification_id === $selectedSpecId)
+      .map(goal => {
+        return {
+          ...goal,
+          analyses: goal.analyses.filter(analysis => analysis.request.specification_id === $selectedSpecId),
+        };
+      });
+  },
+);
+
+export const schedulingSpecConditionsAll = gqlSubscribable<SchedulingSpecCondition[]>(
   gql.SUB_SCHEDULING_SPEC_CONDITIONS,
   { specification_id: selectedSpecId },
   [],
   null,
 );
 
-export const schedulingSpecGoals = gqlSubscribable<SchedulingSpecGoal[]>(
+export const schedulingSpecConditions = derived(
+  [selectedSpecId, schedulingSpecConditionsAll],
+  ([$selectedSpecId, $schedulingSpecConditionsAll]) => {
+    return $schedulingSpecConditionsAll
+      .filter(schedulingSpecCondition => schedulingSpecCondition.specification_id === $selectedSpecId)
+      .map(schedulingSpecCondition => {
+        return {
+          ...schedulingSpecCondition,
+          condition: {
+            ...schedulingSpecCondition.condition,
+            scheduling_specification_conditions:
+              schedulingSpecCondition.condition.scheduling_specification_conditions.filter(
+                condition => condition.specification_id === $selectedSpecId,
+              ),
+          },
+        };
+      });
+  },
+);
+
+export const schedulingSpecGoalsAll = gqlSubscribable<SchedulingSpecGoal[]>(
   gql.SUB_SCHEDULING_SPEC_GOALS,
   { specification_id: selectedSpecId },
   [],
   null,
 );
 
-export const latestAnalyses = derived(schedulingSpecGoals, $schedulingSpecGoals => {
-  const analysisIdToSpecGoalMap: Record<number, SchedulingGoalAnalysis[]> = {};
-  let latestAnalysisId = -1;
+export const schedulingSpecGoals = derived(
+  [selectedSpecId, schedulingSpecGoalsAll],
+  ([$selectedSpecId, $schedulingSpecGoalsAll]) => {
+    return $schedulingSpecGoalsAll
+      .filter(schedulingSpecGoal => schedulingSpecGoal.specification_id === $selectedSpecId)
+      .map(specGoal => {
+        return {
+          ...specGoal,
+          goal: {
+            ...specGoal.goal,
+            analyses: specGoal.goal.analyses.filter(analysis => analysis.request.specification_id === $selectedSpecId),
+          },
+        };
+      });
+  },
+);
 
-  $schedulingSpecGoals.forEach(schedulingSpecGoal => {
-    schedulingSpecGoal.goal.analyses.forEach(analysis => {
-      if (!analysisIdToSpecGoalMap[analysis.analysis_id]) {
-        analysisIdToSpecGoalMap[analysis.analysis_id] = [];
-      }
-      analysisIdToSpecGoalMap[analysis.analysis_id].push(analysis);
-      if (analysis.analysis_id > latestAnalysisId) {
-        latestAnalysisId = analysis.analysis_id;
-      }
+export const latestAnalyses = derived(
+  [selectedSpecId, schedulingSpecGoals],
+  ([$selectedSpecId, $schedulingSpecGoals]) => {
+    const analysisIdToSpecGoalMap: Record<number, SchedulingGoalAnalysis[]> = {};
+    let latestAnalysisId = -1;
+
+    $schedulingSpecGoals.forEach(schedulingSpecGoal => {
+      schedulingSpecGoal.goal.analyses.forEach(analysis => {
+        if (analysis.request.specification_id !== $selectedSpecId) {
+          return;
+        }
+        if (!analysisIdToSpecGoalMap[analysis.analysis_id]) {
+          analysisIdToSpecGoalMap[analysis.analysis_id] = [];
+        }
+        analysisIdToSpecGoalMap[analysis.analysis_id].push(analysis);
+        if (analysis.analysis_id > latestAnalysisId) {
+          latestAnalysisId = analysis.analysis_id;
+        }
+      });
     });
-  });
 
-  return analysisIdToSpecGoalMap[latestAnalysisId] || [];
-});
+    return analysisIdToSpecGoalMap[latestAnalysisId] || [];
+  },
+);
 
 export const schedulingGoalCount = derived(latestAnalyses, $latestAnalyses => Object.keys($latestAnalyses).length);
 export const satisfiedSchedulingGoalCount = derived(

--- a/src/types/permissions.ts
+++ b/src/types/permissions.ts
@@ -6,6 +6,10 @@ export type AssetWithOwner<T = any> = Partial<T> & {
   owner: UserId;
 };
 
+export type AssetWithAuthor<T = any> = Partial<T> & {
+  author: UserId;
+};
+
 export type ModelWithOwner = Pick<Model, 'id' | 'owner'>;
 
 export type PermissibleQueriesMap = Record<string, true>;

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -40,6 +40,7 @@ export type SchedulingCondition = {
 
 export type SchedulingGoalAnalysis = {
   analysis_id: number;
+  request: { specification_id: number };
   satisfied: boolean;
   satisfying_activities: { activity_id: number }[];
 };

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -16,7 +16,7 @@ export type SchedulingGoal = {
   revision: number;
   scheduling_specification_goal: {
     specification_id: number;
-  };
+  } | null;
   tags: { tag: Tag }[];
 };
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -1197,9 +1197,9 @@ const effects = {
       }
 
       const data = await reqHasura<SchedulingSpecGoal>(gql.CREATE_SCHEDULING_SPEC_GOAL, { spec_goal }, user);
-      const { createSchedulingGoal } = data;
-      if (createSchedulingGoal != null) {
-        const { specification_id } = createSchedulingGoal;
+      const { createSchedulingSpecGoal } = data;
+      if (createSchedulingSpecGoal != null) {
+        const { specification_id } = createSchedulingSpecGoal;
         return specification_id;
       } else {
         throw Error('Unable to create a scheduling spec goal');

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -1974,11 +1974,11 @@ const effects = {
 
   async deleteSchedulingCondition(
     condition: SchedulingCondition,
-    plan: PlanSchedulingSpec,
+    plan: PlanSchedulingSpec | null,
     user: User | null,
   ): Promise<boolean> {
     try {
-      if (!queryPermissions.DELETE_SCHEDULING_CONDITION(user, plan)) {
+      if (!queryPermissions.DELETE_SCHEDULING_CONDITION(user, plan, condition)) {
         throwPermissionError('delete this scheduling condition');
       }
 
@@ -2006,7 +2006,11 @@ const effects = {
     }
   },
 
-  async deleteSchedulingGoal(goal: SchedulingGoalSlim, plan: PlanSchedulingSpec, user: User | null): Promise<boolean> {
+  async deleteSchedulingGoal(
+    goal: SchedulingGoalSlim,
+    plan: PlanSchedulingSpec | null,
+    user: User | null,
+  ): Promise<boolean> {
     try {
       if (!queryPermissions.DELETE_SCHEDULING_GOAL(user, plan)) {
         throwPermissionError('delete this scheduling goal');

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1925,6 +1925,9 @@ const gql = {
       goals: scheduling_goal(order_by: { id: desc }) {
         analyses(limit: 0) {
           analysis_id
+          request {
+            specification_id
+          }
         }
         author
         created_date
@@ -1937,6 +1940,9 @@ const gql = {
         name
         scheduling_specification_goal {
           specification_id
+          specification {
+            plan_id
+          }
         }
         revision
         tags {
@@ -1961,6 +1967,9 @@ const gql = {
           modified_date
           name
           revision
+          scheduling_specification_conditions {
+            specification_id
+          }
         }
         specification {
           analysis_only
@@ -1987,6 +1996,9 @@ const gql = {
             satisfied
             satisfying_activities {
               activity_id
+            }
+            request {
+              specification_id
             }
           }
           author


### PR DESCRIPTION
Closes #601

Testing:
1. Create a plan.
2. Create a goal and associate it with the plan.
3. Run scheduling for the plan.
4. Create a second plan.
5. Associate the goal with the second plan.
6. Open up scheduling in the second plan.
7. Verify that none of the scheduling results from the first plan are present.

Additional fixes:
- Use correct property when destructing createSchedulingSpecGoal response
- Handle goals not associated with plans (from plan deletion) in the SchedulingGoals table. For now the delete and edit icons on these goals will be disabled until goal versioning is implemented.