### PR TITLE
Display username in app menu

### DIFF
--- a/src/components/app/Nav.svelte
+++ b/src/components/app/Nav.svelte
@@ -22,7 +22,7 @@
 
 <div class="nav">
   <div class="left">
-    <AppMenu />
+    <AppMenu {user} />
     <div class="divider" />
     <div class="title st-typography-medium">
       <slot name="title" />

--- a/src/components/menus/AppMenu.svelte
+++ b/src/components/menus/AppMenu.svelte
@@ -98,7 +98,10 @@
         evt.stopPropagation();
       }}
     >
-      Logged in as&nbsp;<span class="st-typography-medium">{user?.id || 'Unknown'}</span>
+      <span>
+        Logged in as
+        <span class="st-typography-medium">{user?.id || 'Unknown'}</span>
+      </span>
     </button>
   </Menu>
 </div>

--- a/src/components/menus/AppMenu.svelte
+++ b/src/components/menus/AppMenu.svelte
@@ -99,8 +99,7 @@
       }}
     >
       <span>
-        Logged in as
-        <span class="st-typography-medium">{user?.id || 'Unknown'}</span>
+        Logged in as <span class="st-typography-medium">{user?.id || 'Unknown'}</span>
       </span>
     </button>
   </Menu>

--- a/src/components/menus/AppMenu.svelte
+++ b/src/components/menus/AppMenu.svelte
@@ -19,10 +19,13 @@
   import JournalTextIcon from 'bootstrap-icons/icons/journal-text.svg?component';
   import JournalsIcon from 'bootstrap-icons/icons/journals.svg?component';
   import AerieWordmarkDark from '../../assets/aerie-wordmark-dark.svg?component';
+  import type { User } from '../../types/app';
   import { logout } from '../../utilities/login';
   import { showAboutModal } from '../../utilities/modal';
   import Menu from './Menu.svelte';
   import MenuItem from './MenuItem.svelte';
+
+  export let user: User | null = null;
 
   let appMenu: Menu;
 </script>
@@ -88,6 +91,15 @@
       <InfoCircleIcon />
       About
     </MenuItem>
+    <!-- Render user display as a button to intercept click events and prevent menu closure on click -->
+    <button
+      class="st-button tertiary app-menu--user"
+      on:click|capture={evt => {
+        evt.stopPropagation();
+      }}
+    >
+      Logged in as&nbsp;<span class="st-typography-medium">{user?.id || 'Unknown'}</span>
+    </button>
   </Menu>
 </div>
 
@@ -109,5 +121,19 @@
     justify-content: center;
     line-height: 24px;
     width: 88px;
+  }
+
+  .app-menu--user {
+    background: var(--st-gray-10);
+    border-top: 1px solid var(--st-gray-15);
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    color: var(--st-gray-60);
+    cursor: default;
+    flex: 1;
+    height: auto;
+    justify-content: flex-start;
+    padding: 8px;
+    width: 100%;
   }
 </style>


### PR DESCRIPTION
Closes #1019 by displaying the username in the app menu.
<img width="212" alt="image" src="https://github.com/NASA-AMMOS/aerie-ui/assets/4419607/e463c819-63fc-4bdc-89a1-c0034b84fd9b">

@lklyne feel free to take a pass at this one if you'd like or provide input on tweaks / a different location or presentation.