### PR TITLE
Fix constraint violations display

### DIFF
--- a/src/components/constraints/ConstraintsPanel.svelte
+++ b/src/components/constraints/ConstraintsPanel.svelte
@@ -70,7 +70,7 @@
           errors: constraintResponse.errors,
           results: constraintResponse.results && {
             ...constraintResponse.results,
-            violations: constraintResponse.results.violations.map(violation => ({
+            violations: constraintResponse.results.violations?.map(violation => ({
               ...violation,
               // Filter violations/windows by time bounds
               windows: violation.windows.filter(window => window.end >= startTimeMs && window.start <= endTimeMs),

--- a/src/components/constraints/ConstraintsPanel.svelte
+++ b/src/components/constraints/ConstraintsPanel.svelte
@@ -70,11 +70,12 @@
           errors: constraintResponse.errors,
           results: constraintResponse.results && {
             ...constraintResponse.results,
-            violations: constraintResponse.results.violations?.map(violation => ({
-              ...violation,
-              // Filter violations/windows by time bounds
-              windows: violation.windows.filter(window => window.end >= startTimeMs && window.start <= endTimeMs),
-            })),
+            violations:
+              constraintResponse.results.violations?.map(violation => ({
+                ...violation,
+                // Filter violations/windows by time bounds
+                windows: violation.windows.filter(window => window.end >= startTimeMs && window.start <= endTimeMs),
+              })) ?? null,
           },
           success: constraintResponse.success,
           type: constraintResponse.type,

--- a/src/components/constraints/ConstraintsPanel.svelte
+++ b/src/components/constraints/ConstraintsPanel.svelte
@@ -8,7 +8,6 @@
   import PlanRightArrow from '@nasa-jpl/stellar/icons/plan_with_right_arrow.svg?component';
   import VisibleHideIcon from '@nasa-jpl/stellar/icons/visible_hide.svg?component';
   import VisibleShowIcon from '@nasa-jpl/stellar/icons/visible_show.svg?component';
-  import { isEmpty } from 'lodash-es';
   import { PlanStatusMessages } from '../../enums/planStatusMessages';
   import {
     checkConstraintsStatus,
@@ -65,18 +64,18 @@
     $constraints.forEach(constraint => {
       const constraintResponse = $constraintResponseMap[constraint.id];
       if (constraintResponse) {
-        // Filter violations/windows by time bounds
-        if (constraintResponse.results && !isEmpty(constraintResponse.results)) {
-          constraintResponse.results.violations = constraintResponse.results.violations.map(violation => ({
-            ...violation,
-            windows: violation.windows.filter(window => window.end >= startTimeMs && window.start <= endTimeMs),
-          }));
-        }
         filteredConstraintResponseMap[constraint.id] = {
           constraintId: constraintResponse.constraintId,
           constraintName: constraintResponse.constraintName,
           errors: constraintResponse.errors,
-          results: constraintResponse.results,
+          results: constraintResponse.results && {
+            ...constraintResponse.results,
+            violations: constraintResponse.results.violations.map(violation => ({
+              ...violation,
+              // Filter violations/windows by time bounds
+              windows: violation.windows.filter(window => window.end >= startTimeMs && window.start <= endTimeMs),
+            })),
+          },
           success: constraintResponse.success,
           type: constraintResponse.type,
         };

--- a/src/components/timeline/ConstraintViolations.svelte
+++ b/src/components/timeline/ConstraintViolations.svelte
@@ -4,10 +4,10 @@
   import type { ScaleTime } from 'd3-scale';
   import { select } from 'd3-selection';
   import { createEventDispatcher, onMount } from 'svelte';
-  import type { ConstraintResult } from '../../types/constraint';
+  import type { ConstraintResultWithName } from '../../types/constraint';
   import type { TimeRange } from '../../types/timeline';
 
-  export let constraintResults: ConstraintResult[] = [];
+  export let constraintResults: ConstraintResultWithName[] = [];
   export let drawHeight: number = 0;
   export let drawWidth: number = 0;
   export let mousemove: MouseEvent | undefined;
@@ -82,7 +82,7 @@
   function onMousemove(e: MouseEvent | undefined): void {
     if (e) {
       const { offsetX } = e;
-      const constraintResultsWithViolations: ConstraintResult[] = [];
+      const constraintResultsWithViolations: ConstraintResultWithName[] = [];
 
       for (const constraintResult of constraintResults || []) {
         for (const constraintViolation of constraintResult.violations || []) {

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -15,7 +15,7 @@
     ActivityDirectivesMap,
   } from '../../types/activity';
   import type { User } from '../../types/app';
-  import type { ConstraintResult } from '../../types/constraint';
+  import type { ConstraintResultWithName } from '../../types/constraint';
   import type { Plan } from '../../types/plan';
   import type { Resource, SimulationDataset, Span, SpanId, SpansMap, SpanUtilityMaps } from '../../types/simulation';
   import type {
@@ -51,7 +51,7 @@
   export let activityDirectivesByView: ActivityDirectivesByView = { byLayerId: {}, byTimelineId: {} };
   export let activityDirectivesMap: ActivityDirectivesMap = {};
   export let autoAdjustHeight: boolean = false;
-  export let constraintResults: ConstraintResult[] = [];
+  export let constraintResults: ConstraintResultWithName[] = [];
   export let dpr: number = 0;
   export let drawHeight: number = 0;
   export let drawWidth: number = 0;
@@ -102,7 +102,7 @@
   let mouseDownActivityDirectivesByLayer: Record<number, ActivityDirective[]> = {};
   let mouseDownSpansByLayer: Record<number, Span[]> = {};
   let mouseOverActivityDirectivesByLayer: Record<number, ActivityDirective[]> = {};
-  let mouseOverConstraintResults: ConstraintResult[] = []; // For this row.
+  let mouseOverConstraintResults: ConstraintResultWithName[] = []; // For this row.
   let mouseOverPointsByLayer: Record<number, Point[]> = {};
   let mouseOverSpansByLayer: Record<number, Span[]> = {};
   let mouseOverGapsByLayer: Record<number, Point[]> = {};

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -9,7 +9,7 @@
   import { viewUpdateTimeline } from '../../stores/views';
   import type { ActivityDirectiveId, ActivityDirectivesByView, ActivityDirectivesMap } from '../../types/activity';
   import type { User } from '../../types/app';
-  import type { ConstraintResult } from '../../types/constraint';
+  import type { ConstraintResultWithName } from '../../types/constraint';
   import type { Plan } from '../../types/plan';
   import type {
     Resource,
@@ -54,7 +54,7 @@
 
   export let activityDirectivesByView: ActivityDirectivesByView = { byLayerId: {}, byTimelineId: {} };
   export let activityDirectivesMap: ActivityDirectivesMap = {};
-  export let constraintResults: ConstraintResult[] = [];
+  export let constraintResults: ConstraintResultWithName[] = [];
   export let hasUpdateDirectivePermission: boolean = false;
   export let hasUpdateSimulationPermission: boolean = false;
   export let maxTimeRange: TimeRange = { end: 0, start: 0 };

--- a/src/components/timeline/TimelineHistogram.svelte
+++ b/src/components/timeline/TimelineHistogram.svelte
@@ -190,7 +190,7 @@
     constraintResults
       .filter(result => !isEmpty(result))
       .forEach(constraintResult => {
-        constraintResult.violations.forEach(violation => {
+        constraintResult.violations?.forEach(violation => {
           violation.windows.forEach(window => {
             if (xScaleMax !== null) {
               const xStart = xScaleMax(window.start);

--- a/src/components/timeline/Tooltip.svelte
+++ b/src/components/timeline/Tooltip.svelte
@@ -2,10 +2,8 @@
 
 <script lang="ts">
   import { select } from 'd3-selection';
-  import { find } from 'lodash-es';
-  import { constraintResponseMap } from '../../stores/constraints';
   import type { ActivityDirective } from '../../types/activity';
-  import type { ConstraintResponse, ConstraintResult } from '../../types/constraint';
+  import type { ConstraintResultWithName } from '../../types/constraint';
   import type { Span } from '../../types/simulation';
   import type { LinePoint, MouseOver, Point, XRangePoint } from '../../types/timeline';
   import { getDoyTime } from '../../utilities/time';
@@ -13,7 +11,7 @@
   export let mouseOver: MouseOver | null;
 
   let activityDirectives: ActivityDirective[] = [];
-  let constraintResults: ConstraintResult[] = [];
+  let constraintResults: ConstraintResultWithName[] = [];
   let points: Point[] = [];
   let gaps: Point[] = [];
   let spans: Span[] = [];
@@ -123,7 +121,7 @@
       tooltipText = `${tooltipText}<hr>`;
     }
 
-    constraintResults.forEach((constraintResult: ConstraintResult, i: number) => {
+    constraintResults.forEach((constraintResult: ConstraintResultWithName, i: number) => {
       const text = textForConstraintViolation(constraintResult);
       tooltipText = `${tooltipText} ${text}`;
 
@@ -187,21 +185,14 @@
     `;
   }
 
-  function textForConstraintViolation(constraintViolation: ConstraintResult): string {
-    const matchResponse: ConstraintResponse = find(
-      Object.values(constraintResponseMap),
-      (response: ConstraintResponse) => response.results === constraintViolation,
-    );
-
-    return matchResponse
-      ? `
+  function textForConstraintViolation(constraintViolation: ConstraintResultWithName): string {
+    return `
       <div>
         Constraint Violation
         <br>
-        Name: ${matchResponse.constraintName}
+        Name: ${constraintViolation.constraintName}
       </div>
-    `
-      : '';
+    `;
   }
 
   function textForLinePoint(point: LinePoint): string {

--- a/src/components/timeline/XAxis.svelte
+++ b/src/components/timeline/XAxis.svelte
@@ -5,14 +5,14 @@
   import { select, type Selection } from 'd3-selection';
   import { zoom as d3Zoom, zoomIdentity, type D3ZoomEvent, type ZoomBehavior, type ZoomTransform } from 'd3-zoom';
   import { createEventDispatcher } from 'svelte';
-  import type { ConstraintResult } from '../../types/constraint';
+  import type { ConstraintResultWithName } from '../../types/constraint';
   import type { TimeRange, XAxisTick } from '../../types/timeline';
   import { getTimeZoneName } from '../../utilities/time';
   import { TimelineInteractionMode } from '../../utilities/timeline';
   import ConstraintViolations from './ConstraintViolations.svelte';
   import RowXAxisTicks from './RowXAxisTicks.svelte';
 
-  export let constraintResults: ConstraintResult[] = [];
+  export let constraintResults: ConstraintResultWithName[] = [];
   export let drawHeight: number = 70;
   export let drawWidth: number = 0;
   export let marginLeft: number = 50;

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -617,7 +617,7 @@
         <VerticalCollapseIcon />
         <svelte:fragment slot="metadata">
           <div>
-            Constraint violations: {Object.values($constraintResponseMap).filter(
+            Constraints violated: {Object.values($constraintResponseMap).filter(
               response => response.results.violations.length,
             ).length}
           </div>

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -618,7 +618,7 @@
         <svelte:fragment slot="metadata">
           <div>
             Constraints violated: {Object.values($constraintResponseMap).filter(
-              response => response.results.violations.length,
+              response => response.results.violations?.length,
             ).length}
           </div>
         </svelte:fragment>

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -37,7 +37,7 @@
     selectActivity,
     selectedActivityDirectiveId,
   } from '../../../stores/activities';
-  import { checkConstraintsStatus, constraintResults, resetConstraintStores } from '../../../stores/constraints';
+  import { checkConstraintsStatus, constraintResponseMap, resetConstraintStores } from '../../../stores/constraints';
   import {
     activityErrorRollups,
     allErrors,
@@ -616,7 +616,11 @@
       >
         <VerticalCollapseIcon />
         <svelte:fragment slot="metadata">
-          <div>Constraint violations: {$constraintResults.filter(result => result.violations.length).length}</div>
+          <div>
+            Constraint violations: {Object.values($constraintResponseMap).filter(
+              response => response.results.violations.length,
+            ).length}
+          </div>
         </svelte:fragment>
       </PlanNavButton>
       <PlanNavButton

--- a/src/stores/constraints.ts
+++ b/src/stores/constraints.ts
@@ -49,7 +49,7 @@ export const constraintResponseMap: Readable<Record<Constraint['id'], Constraint
         ...response,
         results: {
           ...response.results,
-          violations: response.results.violations.map(violation => ({
+          violations: response.results.violations?.map(violation => ({
             ...violation,
             windows: violation.windows.map(({ end, start }) => ({
               end: $planStartTimeMs + end / 1000,

--- a/src/stores/constraints.ts
+++ b/src/stores/constraints.ts
@@ -49,13 +49,14 @@ export const constraintResponseMap: Readable<Record<Constraint['id'], Constraint
         ...response,
         results: {
           ...response.results,
-          violations: response.results.violations?.map(violation => ({
-            ...violation,
-            windows: violation.windows.map(({ end, start }) => ({
-              end: $planStartTimeMs + end / 1000,
-              start: $planStartTimeMs + start / 1000,
-            })),
-          })),
+          violations:
+            response.results.violations?.map(violation => ({
+              ...violation,
+              windows: violation.windows.map(({ end, start }) => ({
+                end: $planStartTimeMs + end / 1000,
+                start: $planStartTimeMs + start / 1000,
+              })),
+            })) ?? null,
         },
       })),
       'constraintId',

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -34,6 +34,8 @@ export type ConstraintResult = {
   violations: ConstraintViolation[];
 };
 
+export type ConstraintResultWithName = ConstraintResult & { constraintName: string };
+
 export type ConstraintResponse = {
   constraintId: Constraint['id'];
   constraintName: Constraint['name'];

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -31,7 +31,7 @@ export type ConstraintViolation = {
 export type ConstraintResult = {
   gaps: TimeRange[];
   resourceIds: string[];
-  violations: ConstraintViolation[];
+  violations: ConstraintViolation[] | null;
 };
 
 export type ConstraintResultWithName = ConstraintResult & { constraintName: string };

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -1,6 +1,6 @@
 import type { Selection } from 'd3-selection';
 import type { ActivityDirective } from './activity';
-import type { ConstraintResult } from './constraint';
+import type { ConstraintResultWithName } from './constraint';
 import type { Span } from './simulation';
 
 export interface ActivityLayer extends Layer {
@@ -96,7 +96,7 @@ export type MouseDown = {
 
 export type MouseOver = {
   activityDirectives?: ActivityDirective[];
-  constraintResults?: ConstraintResult[];
+  constraintResults?: ConstraintResultWithName[];
   e: MouseEvent;
   gaps?: Point[];
   layerId: number;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -5,7 +5,7 @@ import type { CommandDictionary as AmpcsCommandDictionary } from '@nasa-jpl/aeri
 import { get } from 'svelte/store';
 import { SearchParameters } from '../enums/searchParameters';
 import { activityDirectives, activityDirectivesMap, selectedActivityDirectiveId } from '../stores/activities';
-import { checkConstraintsStatus, constraintResponse } from '../stores/constraints';
+import { checkConstraintsStatus, rawConstraintResponses } from '../stores/constraints';
 import { catchError, catchSchedulingError } from '../stores/errors';
 import {
   createExpansionRuleError,
@@ -311,23 +311,22 @@ const effects = {
           },
           user,
         );
-        const { constraintResponses } = data;
-        if (constraintResponses) {
-          constraintResponse.set(constraintResponses);
+        if (data.constraintResponses) {
+          rawConstraintResponses.set(data.constraintResponses);
 
           // find only the constraints compiled.
-          const successfulConstraintResults: ConstraintResult[] = constraintResponses
+          const successfulConstraintResults: ConstraintResult[] = data.constraintResponses
             .filter(constraintResponse => constraintResponse.success)
             .map(constraintResponse => constraintResponse.results);
 
-          const failedConstraintResponses = constraintResponses.filter(
+          const failedConstraintResponses = data.constraintResponses.filter(
             constraintResponse => !constraintResponse.success,
           );
 
-          if (successfulConstraintResults.length === 0 && constraintResponses.length > 0) {
+          if (successfulConstraintResults.length === 0 && data.constraintResponses.length > 0) {
             showFailureToast('All Constraints Failed');
             checkConstraintsStatus.set(Status.Failed);
-          } else if (successfulConstraintResults.length !== constraintResponses.length) {
+          } else if (successfulConstraintResults.length !== data.constraintResponses.length) {
             showFailureToast('Partial Constraints Checked');
             checkConstraintsStatus.set(successfulConstraintResults.length !== 0 ? Status.Incomplete : Status.Failed);
           } else {


### PR DESCRIPTION
## Bug Description

<img width="1281" alt="Screenshot 2024-01-10 at 8 22 18 PM" src="https://github.com/NASA-AMMOS/aerie-ui/assets/1189602/e0e04c75-6e31-490d-be2c-d73af619fa9b">

1. Upload banananation
2. Make a plan that's a week long
3. Add a GrowBanana activity. Set its`growingDuration` to `3d` and its `quantity` to `1000`
4. Add the following constraint
```typescript
export default (): Constraint => {
  return Real.Resource("/fruit").greaterThan(500)
}
```
5. Open the constraint panel
6. Check constraints
7. Observe that the navbar says there are violations, and that there are red violation counts in the constraints panel, but that no red regions are highlighted on the timeline, and no violations appear when expanding the violation details in the constraints panel.

## Recommended fix

A detailed reading of https://github.com/NASA-AMMOS/aerie-ui/pull/1022 shows that some of the reactive variables related to constraints were rerouted, leading to some transformations to be left out of the pipeline. Concretely, the `$constraintResult` variable was previously responsible for translating constraint violations windows from "offset from plan start in microseconds" to "milliseconds since the unix epoch". After the above PR, this translation was no longer occurring, leading to downstream confusion.

This PR removes the `$constraintResult` variable entirely, moving that transformation into the `$constraintResponseMap` reactive variable. Any constraint code must be derived from `$constraintResponseMap`, without reaching around it to use the un-processed constraintResponses. To this end, this PR renames `constraintResponse` to `rawConstraintResponses` (pluralized to reflect plural usage elsewhere in the code), to hopefully make it harder to make that mistake.

`textForConstraintViolation` was using a brittle approach to try to find the constraint response corresponding to the given violation. This PR instead threads the `constraintName` through to the usage of this function, so that it can do its job without relying on global variables. This is why a number of uses of `ConstraintResult` were updated to `ConstraintResultWithName`.

Lastly, this PR changes the label in the constraints nav bar. According to the Constraints panel, a single constraint can contain many violations. The nav bar, however, only counts the number of constraints violated, and does not sum up the total number of violations. To this end, this PR rewords "Constraint violations: 5" to instead read "Constraints violated: 5"