### PR TITLE
Upload file before setting activity parameter path

### DIFF
--- a/e2e-tests/tests/plan-activities.test.ts
+++ b/e2e-tests/tests/plan-activities.test.ts
@@ -100,6 +100,6 @@ test.describe.serial('Plan Activities', () => {
 
     const errorBadge = await page.locator('.input-error-badge-root');
 
-    expect(errorBadge).toBeAttached();
+    expect(errorBadge).not.toBeAttached();
   });
 });

--- a/e2e-tests/tests/plan-activities.test.ts
+++ b/e2e-tests/tests/plan-activities.test.ts
@@ -91,4 +91,15 @@ test.describe.serial('Plan Activities', () => {
     await page.locator('.modal-content select').nth(1).selectOption('anchor-root');
     await page.getByRole('button', { name: 'Confirm' }).click();
   });
+
+  test('Setting an input path successfully uploads the corresponding file', async () => {
+    await plan.panelActivityTypes.getByRole('button', { name: 'CreateActivity-LineCount' }).click();
+
+    await page.locator('input[type="file"]').click();
+    await page.locator('input[type="file"]').setInputFiles('./e2e-tests/data/valid-view.json');
+
+    const errorBadge = await page.locator('.input-error-badge-root');
+
+    expect(errorBadge).toBeNull();
+  });
 });

--- a/e2e-tests/tests/plan-activities.test.ts
+++ b/e2e-tests/tests/plan-activities.test.ts
@@ -100,6 +100,6 @@ test.describe.serial('Plan Activities', () => {
 
     const errorBadge = await page.locator('.input-error-badge-root');
 
-    expect(errorBadge).toBeNull();
+    expect(errorBadge).toBeAttached();
   });
 });

--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -197,21 +197,21 @@
   function updateAnchor({ detail: anchorId }: CustomEvent<ActivityDirectiveId>) {
     const { id } = activityDirective;
     if ($plan) {
-      effects.updateActivityDirective($plan, id, { anchor_id: anchorId }, user);
+      effects.updateActivityDirective($plan, id, { anchor_id: anchorId }, activityType, user);
     }
   }
 
   function updateAnchorEdge({ detail: isStart }: CustomEvent<boolean>) {
     const { id } = activityDirective;
     if ($plan) {
-      effects.updateActivityDirective($plan, id, { anchored_to_start: isStart }, user);
+      effects.updateActivityDirective($plan, id, { anchored_to_start: isStart }, activityType, user);
     }
   }
 
   function updateStartOffset({ detail: offset }: CustomEvent<string>) {
     const { id } = activityDirective;
     if ($plan) {
-      effects.updateActivityDirective($plan, id, { start_offset: offset }, user);
+      effects.updateActivityDirective($plan, id, { start_offset: offset }, activityType, user);
     }
   }
 
@@ -234,7 +234,14 @@
     const { arguments: argumentsMap, id } = activityDirective;
     const newArguments = getArguments(argumentsMap, formParameter);
     if ($plan) {
-      effects.updateActivityDirective($plan, id, { arguments: newArguments }, user);
+      effects.updateActivityDirective(
+        $plan,
+        id,
+        { arguments: newArguments },
+        activityType,
+        user,
+        formParameter.file ? [formParameter.file] : [],
+      );
     }
   }
 
@@ -246,7 +253,7 @@
       switch (selectedCategory) {
         case 'invalidParameter':
           if ($plan) {
-            effects.updateActivityDirective($plan, id, { arguments: {} }, user);
+            effects.updateActivityDirective($plan, id, { arguments: {} }, activityType, user);
           }
           break;
         case 'extra':
@@ -263,7 +270,7 @@
               },
               {},
             );
-            effects.updateActivityDirective($plan, id, { arguments: cleanedArguments }, user);
+            effects.updateActivityDirective($plan, id, { arguments: cleanedArguments }, activityType, user);
           }
           break;
       }
@@ -280,7 +287,7 @@
         : null,
     });
     if ($plan) {
-      effects.updateActivityDirective($plan, id, { arguments: newArguments }, user);
+      effects.updateActivityDirective($plan, id, { arguments: newArguments }, activityType, user);
     }
   }
 
@@ -290,7 +297,7 @@
     const { id, metadata } = activityDirective;
     const newActivityMetadata = getActivityMetadata(metadata, key, value);
     if ($plan) {
-      effects.updateActivityDirective($plan, id, { metadata: newActivityMetadata }, user);
+      effects.updateActivityDirective($plan, id, { metadata: newActivityMetadata }, activityType, user);
     }
   }
 
@@ -339,7 +346,7 @@
       if ($activityNameField.value) {
         const { id } = activityDirective;
         if ($plan) {
-          effects.updateActivityDirective($plan, id, { name: $activityNameField.value }, user);
+          effects.updateActivityDirective($plan, id, { name: $activityNameField.value }, activityType, user);
         }
       } else {
         resetActivityName();
@@ -354,7 +361,7 @@
       const planStartTimeDoy = getDoyTime(new Date(planStartTimeYmd));
       const start_offset = getIntervalFromDoyRange(planStartTimeDoy, $startTimeDoyField.value);
       if ($plan) {
-        effects.updateActivityDirective($plan, id, { start_offset }, user);
+        effects.updateActivityDirective($plan, id, { start_offset }, activityType, user);
       }
     }
   }
@@ -384,7 +391,7 @@
     activityNameField.reset(initialValue);
     const { id } = activityDirective;
     if ($plan) {
-      effects.updateActivityDirective($plan, id, { name: initialValue }, user);
+      effects.updateActivityDirective($plan, id, { name: initialValue }, activityType, user);
     }
   }
 

--- a/src/components/timeline/LayerActivity.svelte
+++ b/src/components/timeline/LayerActivity.svelte
@@ -224,7 +224,7 @@
     if (dragActivityDirectiveActive !== null && dragStartX !== null && dragCurrentX !== null) {
       if (dragStartX !== dragCurrentX && plan) {
         const start_offset = getIntervalUnixEpochTime(planStartTimeMs, dragCurrentX);
-        effects.updateActivityDirective(plan, dragActivityDirectiveActive.id, { start_offset }, user);
+        effects.updateActivityDirective(plan, dragActivityDirectiveActive.id, { start_offset }, null, user);
       }
 
       dragActivityDirectiveActive = null;


### PR DESCRIPTION
Resolves #421 

To test:
1. Create a banananation plan
2. Add `LineCount` activity
3. Set the `path` parameter of `LineCount`
4. Verify that after selecting a file, the error badge no longer shows up