### PR TITLE
Added Z to convertDoyToYmd to stop local timezone conversion

### DIFF
--- a/src/utilities/time.test.ts
+++ b/src/utilities/time.test.ts
@@ -43,10 +43,10 @@ test('convertUsToDurationString', () => {
 });
 
 test('convertDoyToYmd', () => {
-  expect(convertDoyToYmd('2023-001T00:10:12', false)).toEqual('2023-01-01T00:10:12');
-  expect(convertDoyToYmd('2023-001T00:00:00', false)).toEqual('2023-01-01T00:00:00');
-  expect(convertDoyToYmd('2023-032T00:00:00', false)).toEqual('2023-02-01T00:00:00');
-  expect(convertDoyToYmd('2023-048T10:32:44.123', true)).toEqual('2023-02-17T10:32:44.123');
+  expect(convertDoyToYmd('2023-001T00:10:12', false)).toEqual('2023-01-01T00:10:12Z');
+  expect(convertDoyToYmd('2023-001T00:00:00', false)).toEqual('2023-01-01T00:00:00Z');
+  expect(convertDoyToYmd('2023-032T00:00:00', false)).toEqual('2023-02-01T00:00:00Z');
+  expect(convertDoyToYmd('2023-048T10:32:44.123', true)).toEqual('2023-02-17T10:32:44.123Z');
 });
 
 test('getDaysInMonth', () => {

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -85,9 +85,9 @@ export function convertDoyToYmd(doyString: string, includeMsecs = true): string 
         padStart(`${date.getUTCDate()}`, 2, '0'),
       ].join('-')}T${parsedDoy.time}`;
       if (includeMsecs) {
-        return ymdString + 'Z';
+        return `${ymdString}Z`;
       }
-      return ymdString.replace(/(\.\d+)/, '') + 'Z';
+      return `${ymdString.replace(/(\.\d+)/, '')}Z`;
     } else {
       // doyString is already in ymd format
       return doyString;

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -85,9 +85,9 @@ export function convertDoyToYmd(doyString: string, includeMsecs = true): string 
         padStart(`${date.getUTCDate()}`, 2, '0'),
       ].join('-')}T${parsedDoy.time}`;
       if (includeMsecs) {
-        return ymdString;
+        return ymdString + 'Z';
       }
-      return ymdString.replace(/(\.\d+)/, '');
+      return ymdString.replace(/(\.\d+)/, '') + 'Z';
     } else {
       // doyString is already in ymd format
       return doyString;


### PR DESCRIPTION
Closes #1087.

Add 'Z' to the return value of `convertDoyToYmd` so a local timezone conversion doesn't happen.