### PR TITLE
Include all non-derived simulation stores when resetting sim stores

### DIFF
--- a/src/stores/simulation.ts
+++ b/src/stores/simulation.ts
@@ -204,10 +204,18 @@ export const selectedSpan = derived([spansMap, selectedSpanId], ([$spansMap, $se
 
 export function resetSimulationStores() {
   externalResources.set([]);
-  resources.set([]);
+  externalResourceNames.set([]);
+  fetchingResources.set(false);
+  fetchingResourcesExternal.set(false);
+  selectedSpanId.update(() => null);
+  simulation.updateValue(() => null);
   simulationDatasetId.set(-1);
   simulationDataset.updateValue(() => null);
+  simulationDatasetLatest.updateValue(() => null);
   simulationTemplates.updateValue(() => []);
-  simulation.updateValue(() => null);
+  simulationDatasetsPlan.updateValue(() => []);
+  simulationDatasetsAll.updateValue(() => []);
   spans.set([]);
+  resources.set([]);
+  resourceTypes.set([]);
 }


### PR DESCRIPTION
Closes #1005. Fix was to ensure that all non-derived simulation stores get reset when running `resetSimulationStores`. This includes several other stores besides `simulationDatasetLatest` which were also not getting properly reset. 

See #1005 for instructions on how to reproduce this case.