### PR TITLE
Remove max-width on tooltip

### DIFF
--- a/src/css/tooltip.css
+++ b/src/css/tooltip.css
@@ -46,6 +46,10 @@
   gap: 4px;
 }
 
+.tippy-box {
+  max-width: none !important;
+}
+
 .tippy-box[data-theme~='error'] {
   background-color: #f8d7da;
   box-shadow: 0 0 20px 4px rgba(154, 161, 177, 0.15), 0 4px 80px -8px rgba(36, 40, 47, 0.25),


### PR DESCRIPTION
Closes #1101. Test by adding a line layer with a resource with a very long name and then hover over the name in the row header axis label.