### PR TITLE
Use one day as default plan duration

### DIFF
--- a/e2e-tests/tests/plans.test.ts
+++ b/e2e-tests/tests/plans.test.ts
@@ -83,7 +83,7 @@ test.describe.serial('Plans', () => {
     await plans.fillInputStartTime();
 
     const endTime = await plans.inputEndTime.inputValue();
-    expect(endTime).toEqual(plans.startTime);
+    expect(endTime).toEqual('2022-002T00:00:00');
   });
 
   test('Entering an invalid start should not prepopulate the end time', async () => {

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -34,7 +34,7 @@
   import { removeQueryParam } from '../../utilities/generic';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
-  import { convertUsToDurationString, getShortISOForDate, getUnixEpochTime } from '../../utilities/time';
+  import { convertUsToDurationString, getDoyTime, getShortISOForDate, getUnixEpochTime } from '../../utilities/time';
   import { min, required, timestamp } from '../../utilities/validators';
   import type { PageData } from './$types';
 
@@ -293,10 +293,15 @@
     goto(`${base}/plans/${plan.id}`);
   }
 
-  function onStartTimeChanged() {
+  async function onStartTimeChanged() {
     if ($startTimeDoyField.value && $startTimeDoyField.valid && $endTimeDoyField.value === '') {
-      endTimeDoyField.set($startTimeDoyField);
+      // Set end time as start time plus a day by default
+      const startTimeDate = new Date(getUnixEpochTime($startTimeDoyField.value));
+      startTimeDate.setDate(startTimeDate.getDate() + 1);
+      const newEndTimeDoy = getDoyTime(startTimeDate, false);
+      await endTimeDoyField.validateAndSet(newEndTimeDoy);
     }
+
     updateDurationString();
   }
 


### PR DESCRIPTION
Closes #1098

Testing:
1. Go to the plans page
2. Select a start date
3. The end date should auto populate with start date + one day even when rolling into the next month and year.