### PR TITLE
Consistent display of model and version in model dropdowns

### DIFF
--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -279,7 +279,8 @@
           <option value={null} />
           {#each models as model}
             <option value={model.id} disabled={!hasModelPermission(model.id, mode, user)}>
-              {model.name} ({model.id})
+              {model.name}
+              (Version: {model.version})
             </option>
           {/each}
         </select>

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -291,6 +291,7 @@
           {#each $models as model}
             <option value={model.id}>
               {model.name}
+              (Version: {model.version})
             </option>
           {/each}
         </select>

--- a/src/components/expansion/ExpansionSetForm.svelte
+++ b/src/components/expansion/ExpansionSetForm.svelte
@@ -196,6 +196,7 @@
           {#each $models as model}
             <option value={model.id} disabled={!hasModelPermission(model.id, user)}>
               {model.name}
+              (Version: {model.version})
             </option>
           {/each}
         </select>

--- a/src/components/scheduling/conditions/SchedulingConditionForm.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditionForm.svelte
@@ -245,7 +245,8 @@
           <option value={null} />
           {#each models as model}
             <option value={model.id} disabled={!hasModelPermission(model.id, mode, user)}>
-              {model.name} ({model.id})
+              {model.name}
+              (Version: {model.version})
             </option>
           {/each}
         </select>

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte
@@ -315,7 +315,8 @@
           <option value={null} />
           {#each models as model}
             <option value={model.id} disabled={!hasModelPermission(model.id, mode, user)}>
-              {model.name} ({model.id})
+              {model.name}
+              (Version: {model.version})
             </option>
           {/each}
         </select>


### PR DESCRIPTION
Always show model + version in model dropdowns instead of just model or model and model ID. Closes #1099.