### PR TITLE
Fix y axis auto scaling

### DIFF
--- a/src/utilities/timeline.test.ts
+++ b/src/utilities/timeline.test.ts
@@ -177,7 +177,7 @@ test('getYAxisBounds', () => {
       [layer1.id]: [resourceWithNoValues],
     }),
   ).toEqual([0, 10]);
-  expect(getYAxisBounds(yAxis, layers, resourcesByViewLayerId, { end: 4, start: 3 })).toEqual([12, 13]);
+  expect(getYAxisBounds(yAxis, layers, resourcesByViewLayerId, { end: 4, start: 3 })).toEqual([11, 14]);
   expect(
     getYAxisBounds({ ...yAxis, domainFitMode: 'fitPlan' }, layers, resourcesByViewLayerId, { end: 4, start: 3 }),
   ).toEqual([10, 15]);

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -551,7 +551,7 @@ export function getYAxisBounds(
             }
           }
           // Identify the first value to the right of the viewTimeRange
-          if (viewTimeRange && value.x > viewTimeRange.start) {
+          if (viewTimeRange && value.x > viewTimeRange.end) {
             if (value.is_gap) {
               rightValue = undefined;
             } else {
@@ -580,16 +580,18 @@ export function getYAxisBounds(
             }
           }
         });
-        // If viewTimeRange is supplied and the minY and maxY are still undefined,
-        // look for the first numerical value to the left and to the right of the time window
-        if (
-          viewTimeRange &&
-          (minY === undefined || maxY === undefined) &&
-          leftValue !== undefined &&
-          rightValue !== undefined
-        ) {
-          minY = Math.min(leftValue.y as number, rightValue.y as number);
-          maxY = Math.max(leftValue.y as number, rightValue.y as number);
+        // Account for the neighboring left and right values as these values are connected to in line drawing
+        if (viewTimeRange) {
+          minY = Math.min(
+            minY ?? Number.MAX_SAFE_INTEGER,
+            leftValue !== undefined && leftValue.y ? (leftValue.y as number) : Number.MAX_SAFE_INTEGER,
+            rightValue !== undefined && rightValue.y ? (rightValue.y as number) : Number.MAX_SAFE_INTEGER,
+          );
+          maxY = Math.max(
+            maxY ?? Number.MIN_SAFE_INTEGER,
+            leftValue !== undefined && leftValue.y ? (leftValue.y as number) : Number.MIN_SAFE_INTEGER,
+            rightValue !== undefined && rightValue.y ? (rightValue.y as number) : Number.MIN_SAFE_INTEGER,
+          );
         }
       });
     }


### PR DESCRIPTION
Fixes y-axis autoscaling for the "Autofit Time Window" Domain Fitting option. Closes #1043.

Testing:
- Load a plan with a variety of line plots
- Enable "Autofit Time Window" domain fitting option in the timeline editor for the line plots if not already enabled
- Pan and zoom around the data and ensure that the domain fitting correctly reflects the available data. Mainly, ensure that neighboring points (right outside of the view time range) are taken into account when computing the domain.