### PR TITLE
Fixed not being able to delete expansion sets

### DIFF
--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -1840,7 +1840,7 @@ const effects = {
       );
 
       if (confirm) {
-        const data = await reqHasura<{ id: number }>(gql.DELETE_EXPANSION_SET, { id: set.name }, user);
+        const data = await reqHasura<{ id: number }>(gql.DELETE_EXPANSION_SET, { id: set.id }, user);
         if (data.deleteExpansionSet != null) {
           showSuccessToast('Expansion Set Deleted Successfully');
           return true;


### PR DESCRIPTION
Turns out we were using the expansion set name for the delete mutation rather than the ID so it was failing.