### PR TITLE
Overwrite `activeRole` cookie when it's not contained in allowed roles list

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -100,8 +100,8 @@ const handleSSOAuth: Handle = async ({ event, resolve }) => {
       event.cookies.set('user', userCookie, cookieOpts);
     }
 
-    // don't overwrite existing activeRole
-    if (!activeRoleCookie || activeRoleCookie === 'deleted') {
+    // don't overwrite existing activeRole, unless it doesn't exist anymore
+    if (!activeRoleCookie || activeRoleCookie === 'deleted' || !roles.allowedRoles.includes(activeRoleCookie)) {
       event.cookies.set('activeRole', roles.defaultRole, cookieOpts);
     }
   }


### PR DESCRIPTION
Small one-line change that overwrites the `activeRole` cookie with a default role if the active role is no longer a part of the user's allowed roles

This should help remove some of the "your requested role does not exist in the DB" Hasura errors.