### PR TITLE
Update GH Actions in Workflows to Node 20

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
           cache: npm
@@ -31,20 +31,20 @@ jobs:
       - name: Install Production Dependencies
         run: npm ci --production
       - name: Login to the Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ github.token }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Extract Metadata (tags and labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}
       - name: Build Docker Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           load: true
@@ -58,7 +58,7 @@ jobs:
           ignore-unfixed: true
           severity: 'CRITICAL'
       - name: Push Docker Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -28,22 +28,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
       - name: NASA Scrub
         run: |
           pip install nasa-scrub
           python3 -m scrub.tools.parsers.translate_results /home/runner/work/aerie-ui/results/*.sarif /home/runner/work/aerie-ui/results/codeql.scrub ${{ github.workspace }} scrub
           python3 -m scrub.tools.parsers.csv_parser /home/runner/work/aerie-ui/results
       - name: Upload Security Scan Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Security Scan Results
           path: /home/runner/work/aerie-ui/results/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,9 @@ jobs:
     environment: test-workflow
     steps:
       - name: Checkout Repo (UI)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node (UI)
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
           cache: npm
@@ -47,18 +47,14 @@ jobs:
         run: npm run test:e2e
       - name: Test (unit)
         run: npm run test:unit
-      - name: Upload Results (Test - e2e)
+      - name: Upload Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Test Results
-          path: '**/e2e-test-results'
-      - name: Upload Results (Test - unit)
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Test Results
-          path: '**/unit-test-results'
+          path: |
+            **/e2e-test-results
+            **/unit-test-results
       - name: Print Logs for Services (Aerie)
         if: always()
         run: docker compose -f docker-compose-test.yml logs -t


### PR DESCRIPTION
Sister PR of https://github.com/NASA-AMMOS/aerie/pull/1339. 

Updates all actions to use their Node 20 versions. 

Combined the Test Result upload steps into a single steps to avoid [the breaking change in `upload-artifact`](https://github.com/actions/download-artifact?tab=readme-ov-file#v4---whats-new).

Unlike in the main Aerie repo, no change had to be made to Security Scan's upload process since it only scans one language.

Successful Workflow Runs for Verification:
- [x] [Publish](https://github.com/NASA-AMMOS/aerie-ui/actions/runs/8011861990)
- [x] [Lint](https://github.com/NASA-AMMOS/aerie-ui/actions/runs/8011858497?pr=1135)
- [x] [Test](https://github.com/NASA-AMMOS/aerie-ui/actions/runs/8011858493?pr=1135)
- [x] [Security Scan](https://github.com/NASA-AMMOS/aerie-ui/actions/runs/8011858495?pr=1135)