### PR TITLE
Fix extra argument value display

### DIFF
--- a/src/components/parameters/ExtraneousParameters.svelte
+++ b/src/components/parameters/ExtraneousParameters.svelte
@@ -37,6 +37,14 @@
       dispatch('reset', 'extra');
     }
   }
+
+  function getStringValue(value: unknown): string {
+    if (typeof value === 'object') {
+      return JSON.stringify(value);
+    }
+
+    return `${value}`;
+  }
 </script>
 
 <div class="extra-parameters-container">
@@ -68,7 +76,7 @@
         </div>
         <Input>
           <input
-            value={argumentsMap[extraArgument] ? `${argumentsMap[extraArgument]}` : ''}
+            value={argumentsMap[extraArgument] ? getStringValue(argumentsMap[extraArgument]) : ''}
             class="st-input w-100 error"
             readonly
             type="text"
@@ -76,7 +84,7 @@
           <div class="parameter-right" slot="right">
             <button
               class="st-button icon"
-              value={argumentsMap[extraArgument] ? `${argumentsMap[extraArgument]}` : ''}
+              value={argumentsMap[extraArgument] ? getStringValue(argumentsMap[extraArgument]) : ''}
               use:tooltip={{ content: 'Copy value to clipboard', placement: 'top' }}
               on:click={onCopy}
             >


### PR DESCRIPTION
Resolves #1125 

To test:
1. Upload a Banananation model
2. Create a plan using that model
3. Add a `ParameterTest` activity and explicitly set one of the struct/array values
4. Go to localhost:8080 and navigate to the `activity_type` table
5. Edit the row of the `ParameterTest` activity type that you have added to the plan
6. In the `parameters` column of that row, change the name of one of the struct/array parameters that you explicit had set in the plan and save
7. Navigate back to the plan and select the directive of the activity type that you modified
8. Verify that an Extraneous Parameter is displayed and that the value is not `[object Object]` in the input field