### PR TITLE
Scheduling Subscription and Canceling

### DIFF
--- a/e2e-tests/fixtures/Constraints.ts
+++ b/e2e-tests/fixtures/Constraints.ts
@@ -1,5 +1,6 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 import { adjectives, animals, colors, uniqueNamesGenerator } from 'unique-names-generator';
+import { fillEditorText } from '../utilities/editor.js';
 import { Models } from './Models.js';
 
 export class Constraints {
@@ -59,9 +60,7 @@ export class Constraints {
   }
 
   async fillConstraintDefinition() {
-    await this.inputConstraintDefinition.focus();
-    await this.inputConstraintDefinition.fill(this.constraintDefinition);
-    await this.inputConstraintDefinition.evaluate(e => e.blur());
+    await fillEditorText(this.inputConstraintDefinition, this.constraintDefinition);
   }
 
   async fillConstraintDescription() {

--- a/e2e-tests/fixtures/ExpansionRules.ts
+++ b/e2e-tests/fixtures/ExpansionRules.ts
@@ -1,6 +1,6 @@
 import { expect, type Locator, type Page } from '@playwright/test';
-import os from 'node:os';
 import { adjectives, animals, colors, uniqueNamesGenerator } from 'unique-names-generator';
+import { fillEditorText } from '../utilities/editor.js';
 import { getOptionValueFromText } from '../utilities/selectors.js';
 import { Dictionaries } from './Dictionaries.js';
 import { Models } from './Models.js';
@@ -75,15 +75,8 @@ export class ExpansionRules {
   }
 
   async fillInputEditor() {
-    await this.inputEditor.focus();
-    // Need to emulate actual clearing of editor instead of manipulating the
-    // underlying textbox, see: https://github.com/microsoft/playwright/issues/14126#issuecomment-1728327258
-    const isMac = os.platform() === 'darwin';
-    const modifier = isMac ? 'Meta' : 'Control';
-    await this.inputEditor.press(`${modifier}+A`);
-    await this.inputEditor.press(`Backspace`);
-    await this.inputEditor.fill(this.ruleLogic);
-    await this.inputEditor.evaluate(e => e.blur());
+    console.log('filling editor', this.inputEditor, this.ruleLogic);
+    await fillEditorText(this.inputEditor, this.ruleLogic);
   }
 
   async fillInputName() {

--- a/e2e-tests/fixtures/ExpansionRules.ts
+++ b/e2e-tests/fixtures/ExpansionRules.ts
@@ -75,7 +75,6 @@ export class ExpansionRules {
   }
 
   async fillInputEditor() {
-    console.log('filling editor', this.inputEditor, this.ruleLogic);
     await fillEditorText(this.inputEditor, this.ruleLogic);
   }
 

--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -164,23 +164,14 @@ export class Plan {
 
   async runAnalysis() {
     await this.analyzeButton.click();
-    await this.page.waitForSelector(this.schedulingStatusSelector('Incomplete'), { state: 'attached', strict: true });
-    await this.page.waitForSelector(this.schedulingStatusSelector('Incomplete'), { state: 'visible', strict: true });
-    await this.page.waitForSelector(this.schedulingStatusSelector('Complete'), { state: 'attached', strict: true });
-    await this.page.waitForSelector(this.schedulingStatusSelector('Complete'), { state: 'visible', strict: true });
+    await this.waitForSchedulingStatus('Incomplete');
+    await this.waitForSchedulingStatus('Complete');
   }
 
-  async runScheduling(expectFailure = false) {
+  async runScheduling(expectedFinalState = 'Complete') {
     await this.scheduleButton.click();
-    await this.page.waitForSelector(this.schedulingStatusSelector('Incomplete'), { state: 'attached', strict: true });
-    await this.page.waitForSelector(this.schedulingStatusSelector('Incomplete'), { state: 'visible', strict: true });
-    if (expectFailure) {
-      await this.page.waitForSelector(this.schedulingStatusSelector('Failed'), { state: 'attached', strict: true });
-      await this.page.waitForSelector(this.schedulingStatusSelector('Failed'), { state: 'visible', strict: true });
-    } else {
-      await this.page.waitForSelector(this.schedulingStatusSelector('Complete'), { state: 'attached', strict: true });
-      await this.page.waitForSelector(this.schedulingStatusSelector('Complete'), { state: 'visible', strict: true });
-    }
+    await this.waitForSchedulingStatus('Incomplete');
+    await this.waitForSchedulingStatus(expectedFinalState);
   }
 
   async selectActivityAnchorByIndex(index: number) {
@@ -347,5 +338,10 @@ export class Plan {
     this.schedulingGoalNewButton = page.locator(`button[name="new-scheduling-goal"]`);
     this.schedulingConditionNewButton = page.locator(`button[name="new-scheduling-condition"]`);
     this.schedulingSatisfiedActivity = page.locator('.scheduling-goal-analysis-activities-list > .satisfied-activity');
+  }
+
+  async waitForSchedulingStatus(status: string) {
+    await this.page.waitForSelector(this.schedulingStatusSelector(status), { state: 'attached', strict: true });
+    await this.page.waitForSelector(this.schedulingStatusSelector(status), { state: 'visible', strict: true });
   }
 }

--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -117,14 +117,17 @@ export class Plan {
   }
 
   async deleteAllActivities() {
-    await this.panelActivityDirectivesTable.getByRole('gridcell').first().click({ button: 'right' });
-    await this.page.locator('.context-menu > .context-menu-item:has-text("Select All Activity Directives")').click();
-    await this.panelActivityDirectivesTable.getByRole('gridcell').first().click({ button: 'right' });
-    await this.page.getByText(/Delete \d+ Activit(y|ies) Directives?/).click();
+    const gridCells = await this.panelActivityDirectivesTable.getByRole('gridcell');
+    if ((await gridCells.count()) > 0) {
+      await this.panelActivityDirectivesTable.getByRole('gridcell').first().click({ button: 'right' });
+      await this.page.locator('.context-menu > .context-menu-item:has-text("Select All Activity Directives")').click();
+      await this.panelActivityDirectivesTable.getByRole('gridcell').first().click({ button: 'right' });
+      await this.page.getByText(/Delete \d+ Activit(y|ies) Directives?/).click();
 
-    const applyPresetButton = this.page.getByRole('button', { name: 'Confirm' });
-    await applyPresetButton.waitFor({ state: 'attached', timeout: 1000 });
-    await applyPresetButton.click();
+      const confirmDeletionButton = this.page.getByRole('button', { name: 'Confirm' });
+      await confirmDeletionButton.waitFor({ state: 'attached', timeout: 1000 });
+      await confirmDeletionButton.click();
+    }
   }
 
   async fillActivityPresetName(presetName: string) {

--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -170,12 +170,17 @@ export class Plan {
     await this.page.waitForSelector(this.schedulingStatusSelector('Complete'), { state: 'visible', strict: true });
   }
 
-  async runScheduling() {
+  async runScheduling(expectFailure = false) {
     await this.scheduleButton.click();
     await this.page.waitForSelector(this.schedulingStatusSelector('Incomplete'), { state: 'attached', strict: true });
     await this.page.waitForSelector(this.schedulingStatusSelector('Incomplete'), { state: 'visible', strict: true });
-    await this.page.waitForSelector(this.schedulingStatusSelector('Complete'), { state: 'attached', strict: true });
-    await this.page.waitForSelector(this.schedulingStatusSelector('Complete'), { state: 'visible', strict: true });
+    if (expectFailure) {
+      await this.page.waitForSelector(this.schedulingStatusSelector('Failed'), { state: 'attached', strict: true });
+      await this.page.waitForSelector(this.schedulingStatusSelector('Failed'), { state: 'visible', strict: true });
+    } else {
+      await this.page.waitForSelector(this.schedulingStatusSelector('Complete'), { state: 'attached', strict: true });
+      await this.page.waitForSelector(this.schedulingStatusSelector('Complete'), { state: 'visible', strict: true });
+    }
   }
 
   async selectActivityAnchorByIndex(index: number) {

--- a/e2e-tests/fixtures/SchedulingConditions.ts
+++ b/e2e-tests/fixtures/SchedulingConditions.ts
@@ -1,5 +1,6 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 import { adjectives, animals, colors, uniqueNamesGenerator } from 'unique-names-generator';
+import { fillEditorText } from '../utilities/editor.js';
 import { getOptionValueFromText } from '../utilities/selectors.js';
 import { Models } from './Models.js';
 
@@ -64,9 +65,7 @@ export class SchedulingConditions {
   }
 
   async fillConditionDefinition() {
-    await this.inputConditionDefinition.focus();
-    await this.inputConditionDefinition.fill(this.conditionDefinition);
-    await this.inputConditionDefinition.evaluate(e => e.blur());
+    await fillEditorText(this.inputConditionDefinition, this.conditionDefinition);
   }
 
   async fillConditionDescription() {

--- a/e2e-tests/fixtures/SchedulingGoals.ts
+++ b/e2e-tests/fixtures/SchedulingGoals.ts
@@ -1,4 +1,5 @@
 import { expect, type Locator, type Page } from '@playwright/test';
+import { fillEditorText } from '../utilities/editor.js';
 import { getOptionValueFromText } from '../utilities/selectors.js';
 import { Models } from './Models.js';
 
@@ -61,9 +62,7 @@ export class SchedulingGoals {
   }
 
   async fillGoalDefinition() {
-    await this.inputGoalDefinition.focus();
-    await this.inputGoalDefinition.fill(this.goalDefinition);
-    await this.inputGoalDefinition.evaluate(e => e.blur());
+    await fillEditorText(this.inputGoalDefinition, this.goalDefinition);
   }
 
   async fillGoalDescription() {

--- a/e2e-tests/tests/scheduling.test.ts
+++ b/e2e-tests/tests/scheduling.test.ts
@@ -114,7 +114,6 @@ test.describe.serial('Scheduling', () => {
     await plan.panelActivityTypes.getByRole('button', { name: 'CreateActivity-GrowBanana' }).click();
     await plan.showPanel('Scheduling Goals');
     await plan.waitForSchedulingStatus('Modified');
-    await plan.runAnalysis();
   });
 
   test('Delete scheduling goal', async () => {

--- a/e2e-tests/tests/scheduling.test.ts
+++ b/e2e-tests/tests/scheduling.test.ts
@@ -36,6 +36,7 @@ test.beforeAll(async ({ browser }) => {
 });
 
 test.afterAll(async () => {
+  await plan.deleteAllActivities();
   await plans.goto();
   await plans.deletePlan();
   await models.goto();
@@ -65,14 +66,14 @@ test.describe.serial('Scheduling', () => {
     await expect(plan.schedulingGoalEnabledCheckboxSelector(goalName1)).toBeChecked();
     await plan.schedulingGoalEnabledCheckboxSelector(goalName1).uncheck();
     await expect(plan.schedulingGoalEnabledCheckboxSelector(goalName1)).not.toBeChecked();
-    await plan.runScheduling(true);
+    await plan.runScheduling('Failed');
     await expect(plan.schedulingGoalDifferenceBadge).not.toBeVisible();
     await plan.schedulingGoalEnabledCheckboxSelector(goalName1).check();
     await expect(plan.schedulingGoalEnabledCheckboxSelector(goalName1)).toBeChecked();
   });
 
   test('The condition should prevent showing +10 in the goals badge', async () => {
-    await plan.runScheduling(true);
+    await plan.runScheduling('Failed');
     await expect(plan.schedulingGoalDifferenceBadge).toHaveText('+0');
   });
 
@@ -106,6 +107,14 @@ test.describe.serial('Scheduling', () => {
     await expect(plan.schedulingGoalDifferenceBadge).toHaveText('+0');
     await plan.runAnalysis();
     await expect(plan.schedulingGoalDifferenceBadge).toHaveText('+0');
+  });
+
+  test('Modifying the plan should result in scheduling status marked as out of date', async () => {
+    await plan.showPanel('Activity Types');
+    await plan.panelActivityTypes.getByRole('button', { name: 'CreateActivity-GrowBanana' }).click();
+    await plan.showPanel('Scheduling Goals');
+    await plan.waitForSchedulingStatus('Modified');
+    await plan.runAnalysis();
   });
 
   test('Delete scheduling goal', async () => {

--- a/e2e-tests/tests/scheduling.test.ts
+++ b/e2e-tests/tests/scheduling.test.ts
@@ -65,14 +65,14 @@ test.describe.serial('Scheduling', () => {
     await expect(plan.schedulingGoalEnabledCheckboxSelector(goalName1)).toBeChecked();
     await plan.schedulingGoalEnabledCheckboxSelector(goalName1).uncheck();
     await expect(plan.schedulingGoalEnabledCheckboxSelector(goalName1)).not.toBeChecked();
-    await plan.runScheduling();
+    await plan.runScheduling(true);
     await expect(plan.schedulingGoalDifferenceBadge).not.toBeVisible();
     await plan.schedulingGoalEnabledCheckboxSelector(goalName1).check();
     await expect(plan.schedulingGoalEnabledCheckboxSelector(goalName1)).toBeChecked();
   });
 
   test('The condition should prevent showing +10 in the goals badge', async () => {
-    await plan.runScheduling();
+    await plan.runScheduling(true);
     await expect(plan.schedulingGoalDifferenceBadge).toHaveText('+0');
   });
 

--- a/e2e-tests/utilities/editor.ts
+++ b/e2e-tests/utilities/editor.ts
@@ -1,0 +1,14 @@
+import { Locator } from '@playwright/test';
+import os from 'node:os';
+
+export async function fillEditorText(editor: Locator, text: string) {
+  await editor.focus();
+  // Need to emulate actual clearing of editor instead of manipulating the
+  // underlying textbox, see: https://github.com/microsoft/playwright/issues/14126#issuecomment-1728327258
+  const isMac = os.platform() === 'darwin';
+  const modifier = isMac ? 'Meta' : 'Control';
+  await editor.press(`${modifier}+A`);
+  await editor.press(`Backspace`);
+  await editor.fill(text);
+  await editor.evaluate(e => e.blur());
+}

--- a/src/components/scheduling/SchedulingGoalsPanel.svelte
+++ b/src/components/scheduling/SchedulingGoalsPanel.svelte
@@ -6,7 +6,12 @@
   import { afterUpdate, beforeUpdate } from 'svelte';
   import { PlanStatusMessages } from '../../enums/planStatusMessages';
   import { plan, planReadOnly } from '../../stores/plan';
-  import { enableScheduling, schedulingSpecGoals, schedulingStatus, selectedSpecId } from '../../stores/scheduling';
+  import {
+    enableScheduling,
+    schedulingAnalysisStatus,
+    schedulingSpecGoals,
+    selectedSpecId,
+  } from '../../stores/scheduling';
   import type { User } from '../../types/app';
   import type { SchedulingSpecGoal } from '../../types/scheduling';
   import type { ViewGridSection } from '../../types/view';
@@ -65,7 +70,7 @@
 <Panel>
   <svelte:fragment slot="header">
     <GridMenu {gridSection} title="Scheduling Goals" />
-    <PanelHeaderActions status={$schedulingStatus} indeterminate>
+    <PanelHeaderActions status={$schedulingAnalysisStatus} indeterminate>
       <PanelHeaderActionButton
         title="Analyze"
         on:click={() => effects.schedule(true, $plan, user)}

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -75,10 +75,9 @@
   import {
     enableScheduling,
     latestSchedulingRequest,
-    resetSchedulingStores,
     satisfiedSchedulingGoalCount,
     schedulingAnalysisStatus,
-    schedulingGoalCount,
+    schedulingGoalCount
   } from '../../../stores/scheduling';
   import {
     enableSimulation,
@@ -403,7 +402,6 @@
     resetConstraintStores();
     resetExpansionStores();
     resetPlanStores();
-    resetSchedulingStores();
     resetSimulationStores();
     closeActiveModal();
   });

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -77,7 +77,7 @@
     latestSchedulingRequest,
     satisfiedSchedulingGoalCount,
     schedulingAnalysisStatus,
-    schedulingGoalCount
+    schedulingGoalCount,
   } from '../../../stores/scheduling';
   import {
     enableSimulation,

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -727,6 +727,13 @@
               Scheduling analysis not run
             {/if}
           </div>
+          {#if $schedulingAnalysisStatus === Status.Pending || $schedulingAnalysisStatus === Status.Incomplete}
+            <button
+              on:click={() => effects.cancelSchedulingRequest($latestSchedulingRequest.analysis_id, data.user)}
+              class="st-button cancel-button"
+              disabled={$planReadOnly}>Cancel</button
+            >
+          {/if}
         </svelte:fragment>
       </PlanNavButton>
       <ExtensionMenu

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -6,7 +6,6 @@ import type {
   SchedulingGoalAnalysis,
   SchedulingGoalSlim,
   SchedulingRequest,
-  SchedulingRequestSlim,
   SchedulingSpec,
   SchedulingSpecCondition,
   SchedulingSpecGoal,
@@ -45,13 +44,6 @@ export const schedulingSpec = gqlSubscribable<SchedulingSpec | null>(
 export const schedulingRequests = gqlSubscribable<SchedulingRequest[]>(
   gql.SUB_SCHEDULING_REQUESTS,
   { specId: selectedSpecId },
-  [],
-  null,
-);
-
-export const schedulingRequestsAll = gqlSubscribable<SchedulingRequestSlim[]>(
-  gql.SUB_SCHEDULING_REQUESTS_ALL,
-  null,
   [],
   null,
 );

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -1,14 +1,18 @@
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
-import type { Status } from '../enums/status';
-import { plan } from '../stores/plan';
+import { Status } from '../enums/status';
+import { plan, planId, planRevision } from '../stores/plan';
 import type {
   SchedulingCondition,
   SchedulingGoalAnalysis,
   SchedulingGoalSlim,
+  SchedulingRequest,
+  SchedulingRequestSlim,
+  SchedulingSpec,
   SchedulingSpecCondition,
   SchedulingSpecGoal,
 } from '../types/scheduling';
 import gql from '../utilities/gql';
+import { simulationDatasetsPlan } from './simulation';
 import { gqlSubscribable } from './subscribable';
 
 /* Writeable. */
@@ -24,6 +28,33 @@ export const schedulingStatus: Writable<Status | null> = writable(null);
 export const selectedSpecId = derived(plan, $plan => $plan?.scheduling_specifications[0]?.id ?? null);
 
 /* Subscriptions. */
+
+export const schedulingSpec = gqlSubscribable<SchedulingSpec | null>(
+  gql.SUB_SCHEDULING_SPEC,
+  { planId },
+  null,
+  null,
+  (specs: SchedulingSpec[]) => {
+    if (specs && specs.length > 0) {
+      return specs[0];
+    }
+    return null;
+  },
+);
+
+export const schedulingRequests = gqlSubscribable<SchedulingRequest[]>(
+  gql.SUB_SCHEDULING_REQUESTS,
+  { specId: selectedSpecId },
+  [],
+  null,
+);
+
+export const schedulingRequestsAll = gqlSubscribable<SchedulingRequestSlim[]>(
+  gql.SUB_SCHEDULING_REQUESTS_ALL,
+  null,
+  [],
+  null,
+);
 
 export const schedulingConditionsAll = gqlSubscribable<SchedulingCondition[]>(
   gql.SUB_SCHEDULING_CONDITIONS,
@@ -113,12 +144,11 @@ export const schedulingSpecGoals = derived(
   },
 );
 
-export const latestAnalyses = derived(
+export const latestSchedulingGoalAnalyses = derived(
   [selectedSpecId, schedulingSpecGoals],
   ([$selectedSpecId, $schedulingSpecGoals]) => {
     const analysisIdToSpecGoalMap: Record<number, SchedulingGoalAnalysis[]> = {};
     let latestAnalysisId = -1;
-
     $schedulingSpecGoals.forEach(schedulingSpecGoal => {
       schedulingSpecGoal.goal.analyses.forEach(analysis => {
         if (analysis.request.specification_id !== $selectedSpecId) {
@@ -133,15 +163,89 @@ export const latestAnalyses = derived(
         }
       });
     });
-
     return analysisIdToSpecGoalMap[latestAnalysisId] || [];
   },
 );
 
-export const schedulingGoalCount = derived(latestAnalyses, $latestAnalyses => Object.keys($latestAnalyses).length);
+export const latestSchedulingRequest = derived([schedulingRequests], ([$schedulingRequests]) => {
+  return $schedulingRequests[0] || null;
+});
+
+export const schedulingGoalCount = derived(
+  latestSchedulingGoalAnalyses,
+  $latestSchedulingGoalAnalyses => Object.keys($latestSchedulingGoalAnalyses).length,
+);
 export const satisfiedSchedulingGoalCount = derived(
-  latestAnalyses,
-  $latestAnalyses => Object.values($latestAnalyses).filter(analysis => analysis.satisfied).length,
+  latestSchedulingGoalAnalyses,
+  $latestSchedulingGoalAnalyses =>
+    Object.values($latestSchedulingGoalAnalyses).filter(analysis => analysis.satisfied).length,
+);
+
+export const schedulingAnalysisStatus = derived(
+  [
+    latestSchedulingRequest,
+    latestSchedulingGoalAnalyses,
+    schedulingSpec,
+    planRevision,
+    schedulingGoalCount,
+    satisfiedSchedulingGoalCount,
+    simulationDatasetsPlan,
+  ],
+  ([
+    $latestSchedulingRequest,
+    $latestSchedulingGoalAnalyses,
+    $schedulingSpec,
+    $planRevision,
+    $schedulingGoalCount,
+    $satisfiedSchedulingGoalCount,
+    $simulationDatasetsPlan,
+  ]) => {
+    // No status if there are no requests
+    if (!$latestSchedulingRequest) {
+      return null;
+    } else if ($latestSchedulingRequest.status === 'incomplete') {
+      return Status.Incomplete;
+    } else if ($latestSchedulingRequest.status === 'pending' && !$latestSchedulingRequest.canceled) {
+      return Status.Pending;
+    } else if ($latestSchedulingRequest.canceled) {
+      return Status.Canceled;
+    } else {
+      let matchingSimDataset;
+      if (typeof $latestSchedulingRequest.dataset_id === 'number') {
+        matchingSimDataset = $simulationDatasetsPlan.find(d => d.dataset_id === $latestSchedulingRequest.dataset_id);
+      }
+
+      /*
+        Stale if:
+        - the latest scheduling request specifies a dataset id and the matching sim dataset's plan revision does not match the current plan revision
+        - the latest scheduling request does not specify a dataset id and the scheduling spec's plan revision does not match the current plan revision
+        - the scheduling spec revision does not match latest scheduling request revision
+      */
+      let schedulingPlanRevOutdated = false;
+      if (matchingSimDataset) {
+        schedulingPlanRevOutdated = !!matchingSimDataset && matchingSimDataset.plan_revision !== $planRevision;
+      } else {
+        schedulingPlanRevOutdated = !!$schedulingSpec && $schedulingSpec?.plan_revision !== $planRevision;
+      }
+
+      if (
+        schedulingPlanRevOutdated ||
+        ($schedulingSpec && $schedulingSpec.revision !== $latestSchedulingRequest.specification_revision)
+      ) {
+        return Status.Modified;
+      } else if ($latestSchedulingRequest.status === 'failed') {
+        return Status.Failed;
+      } else if ($latestSchedulingRequest.status === 'success' && $latestSchedulingGoalAnalyses) {
+        // If not all activities were satisfied, mark the status as failed
+        if ($schedulingGoalCount !== $satisfiedSchedulingGoalCount) {
+          return Status.Failed;
+        } else {
+          return Status.Complete;
+        }
+      }
+    }
+    return Status.Pending;
+  },
 );
 
 export const enableScheduling: Readable<boolean> = derived([schedulingSpecGoals], ([$schedulingSpecGoals]) => {

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -20,7 +20,6 @@ export const schedulingColumns: Writable<string> = writable('2fr 3px 1fr');
 export const schedulingFormColumns: Writable<string> = writable('1fr 3px 2fr');
 export const schedulingConditionsFormColumns: Writable<string> = writable('1fr 3px 2fr');
 export const schedulingGoalsColumns: Writable<string> = writable('1fr 3px 2fr');
-export const schedulingStatus: Writable<Status | null> = writable(null);
 
 /* Derived. */
 
@@ -243,9 +242,3 @@ export const schedulingAnalysisStatus = derived(
 export const enableScheduling: Readable<boolean> = derived([schedulingSpecGoals], ([$schedulingSpecGoals]) => {
   return $schedulingSpecGoals.filter(schedulingSpecGoal => schedulingSpecGoal.enabled).length > 0;
 });
-
-/* Helper Functions. */
-
-export function resetSchedulingStores() {
-  schedulingStatus.set(null);
-}

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -203,12 +203,12 @@ export const schedulingAnalysisStatus = derived(
     // No status if there are no requests
     if (!$latestSchedulingRequest) {
       return null;
+    } else if ($latestSchedulingRequest.canceled) {
+      return Status.Canceled;
     } else if ($latestSchedulingRequest.status === 'incomplete') {
       return Status.Incomplete;
     } else if ($latestSchedulingRequest.status === 'pending' && !$latestSchedulingRequest.canceled) {
       return Status.Pending;
-    } else if ($latestSchedulingRequest.canceled) {
-      return Status.Canceled;
     } else {
       let matchingSimDataset;
       if (typeof $latestSchedulingRequest.dataset_id === 'number') {

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -125,5 +125,3 @@ export type SchedulingRequest = {
   specification_revision: number;
   status: 'success' | 'failed' | 'incomplete' | 'pending';
 };
-
-export type SchedulingRequestSlim = Pick<SchedulingRequest, 'canceled' | 'specification_id' | 'status'>;

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -70,9 +70,8 @@ export type SchedulingGoalInsertInput = Omit<
 >;
 
 export type SchedulingResponse = {
-  datasetId: number | null;
+  analysisId: number | null;
   reason: SchedulingError;
-  status: 'complete' | 'failed' | 'incomplete';
 };
 
 export type SchedulingSpec = {
@@ -114,3 +113,17 @@ export type SchedulingSpecGoalInsertInput = {
   goal_id: number;
   specification_id: number;
 };
+
+export type SchedulingRequest = {
+  analysis_id: number;
+  canceled: boolean;
+  dataset_id: number | null;
+  reason: SchedulingError | null;
+  requested_at: string;
+  requested_by: string;
+  specification_id: number;
+  specification_revision: number;
+  status: 'success' | 'failed' | 'incomplete' | 'pending';
+};
+
+export type SchedulingRequestSlim = Pick<SchedulingRequest, 'canceled' | 'specification_id' | 'status'>;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -16,9 +16,9 @@ import {
   savingExpansionSet,
 } from '../stores/expansion';
 import { createModelError, createPlanError, creatingModel, creatingPlan, models } from '../stores/plan';
-import { schedulingStatus, selectedSpecId } from '../stores/scheduling';
+import { schedulingRequests, selectedSpecId } from '../stores/scheduling';
 import { commandDictionaries } from '../stores/sequencing';
-import { selectedSpanId, simulationDatasetId } from '../stores/simulation';
+import { selectedSpanId, simulationDataset, simulationDatasetId } from '../stores/simulation';
 import { createTagError } from '../stores/tags';
 import { applyViewUpdate, view, viewUpdateTimeline } from '../stores/views';
 import type {
@@ -100,6 +100,7 @@ import type {
   SchedulingGoal,
   SchedulingGoalInsertInput,
   SchedulingGoalSlim,
+  SchedulingRequest,
   SchedulingResponse,
   SchedulingSpec,
   SchedulingSpecCondition,
@@ -145,7 +146,7 @@ import type {
 import type { Row, Timeline } from '../types/timeline';
 import type { View, ViewDefinition, ViewInsertInput, ViewSlim, ViewUpdateInput } from '../types/view';
 import { ActivityDeletionAction } from './activities';
-import { convertToQuery, getSearchParameterNumber, setQueryParam, sleep } from './generic';
+import { convertToQuery, getSearchParameterNumber, setQueryParam } from './generic';
 import gql, { convertToGQLArray } from './gql';
 import {
   showConfirmModal,
@@ -3742,53 +3743,58 @@ const effects = {
             throw Error(`Plan revision for plan ${plan.id} was not found.`);
           }
 
-          let incomplete = true;
-          schedulingStatus.set(Status.Incomplete);
-          do {
-            const data = await reqHasura<SchedulingResponse>(gql.SCHEDULE, { specificationId }, user);
-            const { schedule } = data;
-            if (schedule != null) {
-              const { datasetId, reason, status } = schedule;
-
-              if (status === 'complete') {
-                schedulingStatus.set(Status.Complete);
-                incomplete = false;
-                if (datasetId != null) {
-                  const simDatasetIdData = await reqHasura<{ id: number }>(
-                    gql.GET_SIMULATION_DATASET_ID,
-                    { datasetId },
-                    user,
-                  );
-                  const { simulation_dataset } = simDatasetIdData;
-                  // the request above will return either 0 or 1 element
-                  if (Array.isArray(simulation_dataset) && simulation_dataset.length > 0) {
-                    simulationDatasetId.set(simulation_dataset[0].id);
-                  }
-                }
-                showSuccessToast(`Scheduling ${analysis_only ? 'Analysis ' : ''}Complete`);
-              } else if (status === 'failed') {
-                schedulingStatus.set(Status.Failed);
-                catchSchedulingError(reason);
-                incomplete = false;
-
-                showFailureToast(`Scheduling ${analysis_only ? 'Analysis ' : ''}Failed`);
-                catchError(`Scheduling ${analysis_only ? 'Analysis ' : ''}Failed`);
-              } else if (status === 'incomplete') {
-                schedulingStatus.set(Status.Incomplete);
-              }
-
-              await sleep(500); // Sleep half-second before re-scheduling.
-            } else {
-              throw Error('Unable to schedule');
+          const data = await reqHasura<SchedulingResponse>(gql.SCHEDULE, { specificationId }, user);
+          const { schedule } = data;
+          if (schedule) {
+            const { reason, analysisId } = schedule;
+            if (reason) {
+              catchSchedulingError(reason);
             }
-          } while (incomplete);
+            const unsubscribe = schedulingRequests.subscribe(async (requests: SchedulingRequest[]) => {
+              const matchingRequest = requests.find(request => request.analysis_id === analysisId);
+              if (matchingRequest) {
+                if (matchingRequest.status === 'success') {
+                  // If a new simulation was run during scheduling, the response will include a datasetId
+                  // which will need to be cross referenced with a simulation_dataset.id so we
+                  // can load that new simulation.
+                  const currentSimulationDataset = get(simulationDataset);
+                  if (
+                    typeof matchingRequest.dataset_id === 'number' &&
+                    currentSimulationDataset !== null &&
+                    matchingRequest.dataset_id !== currentSimulationDataset.id
+                  ) {
+                    const simDatasetIdData = await reqHasura<{ id: number }>(
+                      gql.GET_SIMULATION_DATASET_ID,
+                      { datasetId: matchingRequest.dataset_id },
+                      user,
+                    );
+                    const { simulation_dataset } = simDatasetIdData;
+                    // the request above will return either 0 or 1 element
+                    if (Array.isArray(simulation_dataset) && simulation_dataset.length > 0) {
+                      simulationDatasetId.set(simulation_dataset[0].id);
+                    }
+                  }
+                  showSuccessToast(`Scheduling ${analysis_only ? 'Analysis ' : ''}Complete`);
+                  unsubscribe();
+                } else if (matchingRequest.status === 'failed') {
+                  if (matchingRequest.reason) {
+                    catchSchedulingError(matchingRequest.reason);
+                    showFailureToast(`Scheduling ${analysis_only ? 'Analysis ' : ''}Failed`);
+                  }
+                  unsubscribe();
+                }
+              }
+            });
+          } else {
+            throw Error('Unable to schedule');
+          }
         }
       } else {
         throw Error('Plan is not defined.');
       }
     } catch (e) {
       catchError(e as Error);
-      schedulingStatus.set(Status.Failed);
+      showFailureToast('Scheduling failed');
     }
   },
 

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -2084,16 +2084,6 @@ const gql = {
     }
   `,
 
-  SUB_SCHEDULING_REQUESTS_ALL: `#graphql
-    subscription SubSchedulingRequestsAll {
-      scheduling_request(order_by: { analysis_id: desc }) {
-        canceled
-        specification_id
-        status
-      }
-    }
-  `,
-
   SUB_SCHEDULING_SPEC: `#graphql
     subscription SubSchedulingSpec($planId: Int!) {
       scheduling_specification(where: { plan_id: { _eq: $planId } }, limit: 1) {

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1466,8 +1466,7 @@ const gql = {
     query Schedule($specificationId: Int!) {
       schedule(specificationId: $specificationId) {
         reason
-        status
-        datasetId
+        analysisId
       }
     }
   `,
@@ -2059,6 +2058,44 @@ const gql = {
     }
   `,
 
+  SUB_SCHEDULING_REQUESTS: `#graphql
+    subscription SubSchedulingRequests($specId: Int!) {
+      scheduling_request(where: { specification_id: { _eq: $specId } }, order_by: { analysis_id: desc }) {
+        specification_id
+        analysis_id
+        requested_at
+        requested_by
+        status
+        reason
+        dataset_id
+        specification_revision
+        canceled
+      }
+    }
+  `,
+
+  SUB_SCHEDULING_REQUESTS_ALL: `#graphql
+    subscription SubSchedulingRequestsAll {
+      scheduling_request(order_by: { analysis_id: desc }) {
+        canceled
+        specification_id
+        status
+      }
+    }
+  `,
+
+  SUB_SCHEDULING_SPEC: `#graphql
+    subscription SubSchedulingSpec($planId: Int!) {
+      scheduling_specification(where: { plan_id: { _eq: $planId } }, limit: 1) {
+        id
+        revision
+        plan_id
+        plan_revision
+        analysis_only
+      }
+    }
+  `,
+
   SUB_SCHEDULING_SPEC_CONDITIONS: `#graphql
     subscription SubSchedulingSpecConditions($specification_id: Int!) {
       specConditions: scheduling_specification_conditions(where: { specification_id: { _eq: $specification_id } }, order_by: { condition_id: asc }) {
@@ -2173,6 +2210,7 @@ const gql = {
         simulation_datasets(order_by: { id: desc }) {
           canceled
           id
+          dataset_id
           plan_revision
           requested_at
           requested_by

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -14,6 +14,16 @@ const gql = {
     }
   `,
 
+  CANCEL_SCHEDULING_REQUEST: `#graphql
+    mutation CancelSchedulingRequest($id: Int!) {
+      update_scheduling_request(where: { analysis_id: { _eq: $id } }, _set: {
+        canceled: true
+      }) {
+        affected_rows
+      }
+    }
+  `,
+
   CANCEL_SIMULATION: `#graphql
     mutation CancelSim($id: Int!) {
       update_simulation_dataset_by_pk(pk_columns: {id: $id}, _set: {

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -292,6 +292,9 @@ const queryPermissions = {
       isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model, preset))
     );
   },
+  CANCEL_PENDING_SCHEDULING_REQUEST: (user: User | null): boolean => {
+    return isUserAdmin(user) || getPermission(['update_scheduling_request'], user);
+  },
   CANCEL_PENDING_SIMULATION: (user: User | null): boolean => {
     return isUserAdmin(user) || getPermission(['update_simulation_dataset_by_pk'], user);
   },


### PR DESCRIPTION
Subscribe to scheduling runs, refine computation and display of scheduling status, and allow users to cancel the current scheduling request if pending or incomplete.

Changes:
- Subscribe to the `scheduling_requests` table, filtered by current scheduling spec id
- Subscribe to current scheduling spec
- Refactor `effects.schedule` to use a temporary subscription on the `schedulingRequests` store (which is now a gql subscription) instead of polling the `schedule` action
- Display modified status for scheduling when out of date with scheduling spec or plan revision

Closes #1040, closes #1047.

Testing:
1. Make a plan
2. Verify that scheduling status in the navbar is not present as no scheduling runs have been performed
3. Add a scheduling goal to the plan in a new tab that should add activities 
4. Verify that the scheduling status for the plan is marked as modified without having to refresh the page
5. Run scheduling analysis
6. Scheduling status should transition to in-progress and then to failure
7. Inside the plan's scheduling panel the goal should indicate that not all goals were satisfied
8. Verify that the navbar status on hover indicates 1 unsatisfied goal
9. Run scheduling
10. Scheduling status should transition to in-progress and then to success
11. Refresh the page and ensure that the status remains success
12. Modify the plan (move an activity)
13. Re-run scheduling
14. Ensure that a new simulation is loaded in the UI (check simulation panel) after scheduling completes
15. Modify the scheduling goal in the other tab
16. Ensure that the scheduling status is now modified