### PR TITLE
Fixes the seq editor repeat arg issue and a typescript not registered…

### DIFF
--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -29,7 +29,7 @@
   let commandDictionaryJson: AmpcsCommandDictionary | null = null;
   let commandDictionaryTsFiles: TypeScriptFile[] = [];
   let monaco: Monaco;
-  let editor: any;
+  let editor: Editor.IStandaloneCodeEditor;
   let sequenceEditorModel: Editor.ITextModel;
 
   $: effects
@@ -45,7 +45,6 @@
     const { typescript } = languages;
     const { typescriptDefaults } = typescript;
     const options = typescriptDefaults.getCompilerOptions();
-    editor = monaco.editor.create(document.createElement('div'));
     typescriptDefaults.setCompilerOptions({ ...options, lib: ['esnext'], strictNullChecks: true });
   }
 
@@ -67,6 +66,10 @@
     a.click();
   }
 
+  function editorCreated(event: CustomEvent<Editor.IStandaloneCodeEditor>) {
+    editor = event.detail;
+  }
+
   function workerFullyLoaded(
     event: CustomEvent<{ model: Editor.ITextModel; worker: languages.typescript.TypeScriptWorker }>,
   ) {
@@ -84,28 +87,30 @@
    * Used to update the custom worker to use the selected command dictionary.
    */
   async function workerUpdateModel() {
-    try {
-      /**
-       * We don't have a way to check if the editor is initialized or not so it was throwing a "typescript not registered"
-       * error here. This is a hacky workaround to see if the editor is ready and we can load the typescript worker.
-       * :woozy:
-       *
-       * https://github.com/microsoft/monaco-editor/issues/115
-       */
-      editor.onDidScrollChange(async () => {
-        const tsWorker = await monaco.languages.typescript.getTypeScriptWorker();
-        const worker = await tsWorker();
+    if (editor) {
+      try {
+        /**
+         * We don't have a way to check if the editor is initialized or not so it was throwing a "typescript not registered"
+         * error here. This is a hacky workaround to see if the editor is ready and we can load the typescript worker.
+         * :woozy:
+         *
+         * https://github.com/microsoft/monaco-editor/issues/115
+         */
+        editor.onDidScrollChange(async () => {
+          const tsWorker = await monaco.languages.typescript.getTypeScriptWorker();
+          const worker = await tsWorker();
 
-        if (commandDictionaryJson && sequenceEditorModel) {
-          worker.updateModelConfig({
-            command_dict_str: JSON.stringify(commandDictionaryJson ?? {}),
-            model_id: sequenceEditorModel.id,
-            should_inject: true,
-          });
-        }
-      });
-    } catch (reason) {
-      console.log('Failed to pass the command dictionary to the custom worker.', reason);
+          if (commandDictionaryJson && sequenceEditorModel) {
+            worker.updateModelConfig({
+              command_dict_str: JSON.stringify(commandDictionaryJson ?? {}),
+              model_id: sequenceEditorModel.id,
+              should_inject: true,
+            });
+          }
+        });
+      } catch (reason) {
+        console.log('Failed to pass the command dictionary to the custom worker.', reason);
+      }
     }
   }
 </script>
@@ -135,6 +140,7 @@
         tabSize={2}
         value={sequenceDefinition}
         on:didChangeModelContent
+        on:editor={editorCreated}
         on:fullyLoaded={workerFullyLoaded}
       />
     </svelte:fragment>

--- a/src/components/ui/MonacoEditor.svelte
+++ b/src/components/ui/MonacoEditor.svelte
@@ -48,6 +48,7 @@
 
   const dispatch = createEventDispatcher<{
     didChangeModelContent: { e: Editor.IModelContentChangedEvent; value: string };
+    editor: Editor.IStandaloneCodeEditor;
     fullyLoaded: { model: Editor.ITextModel; worker: TypeScriptWorker };
   }>();
 
@@ -101,6 +102,8 @@
     };
     monaco = await import('monaco-editor');
     editor = monaco.editor.create(div, options, override);
+
+    dispatch('editor', editor);
 
     if (language && language === 'typescript') {
       monaco.languages.typescript.typescriptDefaults.setWorkerOptions({

--- a/src/workers/customCodes.ts
+++ b/src/workers/customCodes.ts
@@ -187,14 +187,4 @@ Suggestion: ${balancedTime}`,
   UncaughtArgumentType: (): ErrorCode => {
     return { id: CustomErrorCodes.Type.UNCAUGHT_ARG, message: `Error: Command Argument Type Mismatch` };
   },
-  /**
-   * uncheckable warning code and message.
-   */
-  UncheckableArgumentType: (): ErrorCode => {
-    return {
-      id: CustomErrorCodes.Type.UNCHECK_ARG,
-      message: `Warning: Not able to evaluate and validate identifier.
-Suggestion: Use literals when you can`,
-    };
-  },
 };

--- a/src/workers/workerHelpers.ts
+++ b/src/workers/workerHelpers.ts
@@ -188,29 +188,6 @@ export function findNextChildOfKind(
 }
 
 /**
- * Checks if a TypeScript AST node is a literal (string, number, boolean).
- *
- * @param {ts.Node} node - The TypeScript AST node to check.
- * @returns {boolean} `true` if the node is a literal (string, number, boolean), `false` otherwise.
- *
- * @example
- * const node = ... // some TypeScript AST node
- * const result = isLiteral(node);
- * console.log(result);  // Outputs: true or false
- */
-function isLiteral(node: tsc.Node): boolean {
-  switch (node.kind) {
-    case tsc.SyntaxKind.StringLiteral:
-    case tsc.SyntaxKind.NumericLiteral:
-    case tsc.SyntaxKind.TrueKeyword:
-    case tsc.SyntaxKind.FalseKeyword:
-      return true;
-    default:
-      return false;
-  }
-}
-
-/**
  * Removes quotation marks from the input string.
  *
  * @param {string} input - The string from which to remove quotation marks.
@@ -422,16 +399,6 @@ export function validateArguments(
   // ignore specific eDSL local and parameter values
   if (arg_val.startsWith('locals.') || arg_val.startsWith('parameters.')) {
     return false;
-  }
-
-  // ignore identifier as we need literals to do the checks
-  if (!isLiteral(argumentNode)) {
-    return makeDiagnostic(
-      CustomErrorCodes.UncheckableArgumentType(),
-      sourceFile,
-      argumentNode,
-      tsc.DiagnosticCategory.Warning,
-    );
   }
 
   let validation_resp: ValidationReturn;


### PR DESCRIPTION
… error we were seeing

Closes #1130.

This fixes the problem we were seeing with repeat args, turns out we don't need the code that was doing an extraneous check because it was originally added for doing arithmetic inside the sequence editor.

This also fixes another issue I was seeing where getting the tsworker was failing because the editor wasn't ready.