### PR TITLE
Scheduling status fixes

### DIFF
--- a/src/components/ui/DataGrid/DataGrid.svelte
+++ b/src/components/ui/DataGrid/DataGrid.svelte
@@ -274,7 +274,6 @@ This has been seen to result in unintended and often glitchy behavior, which oft
         dispatch('cellMouseOver', event);
       },
       onCellValueChanged(event: CellValueChangedEvent<RowData>) {
-        console.log('event :>> ', event);
         dispatch('cellValueChanged', event);
       },
       onColumnMoved(event: ColumnMovedEvent<RowData>) {

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -179,6 +179,7 @@ export const schedulingAnalysisStatus = derived(
     schedulingSpec,
     planRevision,
     schedulingGoalCount,
+    schedulingGoals,
     satisfiedSchedulingGoalCount,
     simulationDatasetsPlan,
   ],
@@ -188,11 +189,12 @@ export const schedulingAnalysisStatus = derived(
     $schedulingSpec,
     $planRevision,
     $schedulingGoalCount,
+    $schedulingGoals,
     $satisfiedSchedulingGoalCount,
     $simulationDatasetsPlan,
   ]) => {
     // No status if there are no requests
-    if (!$latestSchedulingRequest) {
+    if (!$latestSchedulingRequest || $schedulingGoals.length < 1) {
       return null;
     } else if ($latestSchedulingRequest.canceled) {
       return Status.Canceled;

--- a/src/stores/simulation.ts
+++ b/src/stores/simulation.ts
@@ -74,7 +74,7 @@ export const simulationDatasetsPlan = gqlSubscribable<SimulationDataset[]>(
   { planId },
   [],
   null,
-  v => v[0]?.simulation_datasets,
+  v => v[0]?.simulation_datasets || [],
 );
 
 export const simulationDatasetsAll = gqlSubscribable<SimulationDatasetSlim[]>(

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -3784,12 +3784,11 @@ const effects = {
                 } else if (matchingRequest.status === 'success') {
                   // If a new simulation was run during scheduling, the response will include a datasetId
                   // which will need to be cross referenced with a simulation_dataset.id so we
-                  // can load that new simulation.
+                  // can load that new simulation. Load the associated sim dataset if it is not already loaded
                   const currentSimulationDataset = get(simulationDataset);
                   if (
                     typeof matchingRequest.dataset_id === 'number' &&
-                    currentSimulationDataset !== null &&
-                    matchingRequest.dataset_id !== currentSimulationDataset.dataset_id
+                    (!currentSimulationDataset || matchingRequest.dataset_id !== currentSimulationDataset.dataset_id)
                   ) {
                     const simDatasetIdData = await reqHasura<{ id: number }>(
                       gql.GET_SIMULATION_DATASET_ID,


### PR DESCRIPTION
This PR cleans up a few edge cases for scheduling status and closes #1147.
Changes:
- Set scheduling status to null if no scheduling goals found
- Ensure simulation datasets for plan store defaults to empty array if no sims found which was causing an uncaught error after scheduling completed and no simulations had previously been run
- Load the optionally returned sim dataset even if there is no currently loaded simulation dataset