### PR TITLE
Re-run simulations

### DIFF
--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -120,8 +120,6 @@
   }
   $: if ($startTimeDoyField.invalid || $endTimeDoyField.invalid) {
     buttonTooltip = 'Simulation start and end times are not valid';
-  } else if ($simulationStatus === Status.Complete || $simulationStatus === Status.Failed) {
-    buttonTooltip = 'Simulation up-to-date';
   } else {
     buttonTooltip = '';
   }
@@ -135,6 +133,12 @@
   } else {
     filteredSimulationDatasets = $simulationDatasetsPlan;
   }
+
+  $: enableRerunSimulation =
+    !$enableSimulation &&
+    ($simulationStatus === Status.Complete ||
+      $simulationStatus === Status.Canceled ||
+      $simulationStatus === Status.Failed);
 
   async function onChangeFormParameters(event: CustomEvent<FormParameter>) {
     if ($simulation !== null && $plan !== null) {
@@ -293,9 +297,11 @@
     <GridMenu {gridSection} title="Simulation" />
     <PanelHeaderActions>
       <PanelHeaderActionButton
-        disabled={!$enableSimulation || $startTimeDoyField.invalid || $endTimeDoyField.invalid}
+        disabled={(!$enableSimulation && !enableRerunSimulation) ||
+          $startTimeDoyField.invalid ||
+          $endTimeDoyField.invalid}
         tooltipContent={buttonTooltip}
-        title="Simulate"
+        title={enableRerunSimulation ? 'Re-Run Simulation' : 'Simulate'}
         showLabel
         use={[
           [
@@ -308,7 +314,7 @@
             },
           ],
         ]}
-        on:click={() => effects.simulate($plan, user)}
+        on:click={() => effects.simulate($plan, enableRerunSimulation, user)}
       />
     </PanelHeaderActions>
   </svelte:fragment>

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -601,7 +601,7 @@
         progress={$simulationProgress}
         disabled={!$enableSimulation}
         showStatusInMenu={false}
-        on:click={() => effects.simulate($plan, data.user)}
+        on:click={() => effects.simulate($plan, false, data.user)}
       >
         <PlayIcon />
         <svelte:fragment slot="metadata">

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -428,7 +428,7 @@
   function onKeydown(event: KeyboardEvent): void {
     if (isSaveEvent(event)) {
       event.preventDefault();
-      effects.simulate($plan, data.user);
+      effects.simulate($plan, false, data.user);
     }
   }
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -3841,14 +3841,13 @@ const effects = {
     }
   },
 
-  async simulate(plan: Plan | null, user: User | null): Promise<void> {
+  async simulate(plan: Plan | null, force: boolean = false, user: User | null): Promise<void> {
     try {
       if (plan !== null) {
         if (!queryPermissions.SIMULATE(user, plan, plan.model)) {
           throwPermissionError('simulate this plan');
         }
-
-        const data = await reqHasura<SimulateResponse>(gql.SIMULATE, { planId: plan.id }, user);
+        const data = await reqHasura<SimulateResponse>(gql.SIMULATE, { force, planId: plan.id }, user);
         const { simulate } = data;
         if (simulate != null) {
           const { simulationDatasetId: newSimulationDatasetId } = simulate;

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1483,8 +1483,8 @@ const gql = {
   `,
 
   SIMULATE: `#graphql
-    query Simulate($planId: Int!) {
-      simulate(planId: $planId) {
+    query Simulate($planId: Int!, $force: Boolean!) {
+      simulate(planId: $planId, force: $force) {
         reason
         simulationDatasetId
         status


### PR DESCRIPTION
Allow users to re-run complete, canceled, and failed simulations.
- `effects.simulate` takes a `force` boolean parameter which is passed through to the `simulate` query.
- Simulation panel displays a "Re-Run" button next to "Simulate" when appropriate

Requires running this aerie branch https://github.com/NASA-AMMOS/aerie/pull/1359

Closes #408