### PR TITLE
Fix editing of plan tags

### DIFF
--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -34,9 +34,9 @@
   let hasPlanUpdatePermission: boolean = false;
 
   $: permissionError = $planReadOnly ? PlanStatusMessages.READ_ONLY : 'You do not have permission to edit this plan.';
-
   $: {
     if (plan && user) {
+      console.log('$planReadOnly :>> ', $planReadOnly);
       hasPlanUpdatePermission = featurePermissions.plan.canUpdate(user, plan) && !$planReadOnly;
     } else {
       hasPlanUpdatePermission = false;

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -36,7 +36,6 @@
   $: permissionError = $planReadOnly ? PlanStatusMessages.READ_ONLY : 'You do not have permission to edit this plan.';
   $: {
     if (plan && user) {
-      console.log('$planReadOnly :>> ', $planReadOnly);
       hasPlanUpdatePermission = featurePermissions.plan.canUpdate(user, plan) && !$planReadOnly;
     } else {
       hasPlanUpdatePermission = false;

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -762,6 +762,9 @@ const queryPermissions = {
       isUserAdmin(user) || (getPermission(['update_expansion_rule_by_pk'], user) && isUserOwner(user, expansionRule))
     );
   },
+  UPDATE_PLAN: (user: User | null, plan: PlanWithOwners): boolean => {
+    return isUserAdmin(user) || (getPermission(['update_plan_by_pk'], user) && isPlanOwner(user, plan));
+  },
   UPDATE_PLAN_SNAPSHOT: (user: User | null): boolean => {
     return getPermission(['update_plan_snapshot_by_pk'], user);
   },
@@ -1021,7 +1024,7 @@ const featurePermissions: FeaturePermissions = {
     canCreate: user => queryPermissions.CREATE_PLAN(user),
     canDelete: (user, plan) => queryPermissions.DELETE_PLAN(user, plan),
     canRead: user => queryPermissions.GET_PLAN(user),
-    canUpdate: () => false, // no feature to update plan exists
+    canUpdate: (user, plan) => queryPermissions.UPDATE_PLAN(user, plan),
   },
   planBranch: {
     canCreateBranch: (user, plan, model) => queryPermissions.DUPLICATE_PLAN(user, plan, model),


### PR DESCRIPTION
Restore plan update permissions check, closes #1165.

Testing:
1. Create a plan as User A with role = `aerie_admin`
2. Open Plan Metadata panel and verify that you are able to add and remove tags from `Tags` input
3. Switch to role = `user` and re-verify step 2
4. Switch to role = `viewer` and verify that you are not allowed to edit the tags input
5. Logout and login as a different user and load the plan created in step 1
6. Verify that you are only able to edit the tags input on User A's plan while role = `aerie_admin`.