### PR TITLE
Avoid SSR fetch

### DIFF
--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -386,11 +386,13 @@
 
 <div bind:this={timelineDiv} bind:clientWidth class="timeline" id={`timeline-${timeline?.id}`}>
   <div bind:this={timelineHistogramDiv} class="timeline-time-row">
-    <TimelineTimeDisplay
-      planEndTimeDoy={plan?.end_time_doy}
-      planStartTimeDoy={plan?.start_time_doy}
-      width={timeline?.marginLeft}
-    />
+    {#if plan}
+      <TimelineTimeDisplay
+        planEndTimeDoy={plan?.end_time_doy}
+        planStartTimeDoy={plan?.start_time_doy}
+        width={timeline?.marginLeft}
+      />
+    {/if}
     <div class="timeline-histogram-container">
       <TimelineHistogram
         activityDirectives={timeline && activityDirectivesByView?.byTimelineId[timeline.id]

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -12,7 +12,7 @@
   import WaterfallIcon from '@nasa-jpl/stellar/icons/waterfall.svg?component';
   import GearWideConnectedIcon from 'bootstrap-icons/icons/gear-wide-connected.svg?component';
   import { keyBy } from 'lodash-es';
-  import { onDestroy } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import Nav from '../../../components/app/Nav.svelte';
   import PageTitle from '../../../components/app/PageTitle.svelte';
   import Console from '../../../components/console/Console.svelte';
@@ -225,7 +225,7 @@
       featurePermissions.schedulingGoalsPlanSpec.canAnalyze(data.user, $plan, $plan.model) && !$planReadOnly;
     hasSimulatePermission = featurePermissions.simulation.canRun(data.user, $plan, $plan.model) && !$planReadOnly;
   }
-  $: if (data.initialPlan) {
+  if (data.initialPlan) {
     $plan = data.initialPlan;
     $planEndTimeMs = getUnixEpochTime(data.initialPlan.end_time_doy);
     $planStartTimeMs = getUnixEpochTime(data.initialPlan.start_time_doy);
@@ -267,12 +267,6 @@
 
     activityTypes.updateValue(() => data.initialActivityTypes);
     planTags.updateValue(() => data.initialPlanTags);
-
-    // Asynchronously fetch resource types
-    effects.getResourceTypes($plan.model_id, data.user).then(initialResourceTypes => {
-      $resourceTypes = initialResourceTypes;
-      $resourceTypesLoading = false;
-    });
   }
   $: if (data.initialPlanSnapshotId !== null) {
     $planSnapshotId = data.initialPlanSnapshotId;
@@ -390,6 +384,16 @@
   $: numConstraintsWithErrors = Object.values($constraintResponseMap).filter(
     response => response.errors?.length,
   ).length;
+
+  onMount(() => {
+    if ($plan) {
+      // Asynchronously fetch resource types
+      effects.getResourceTypes($plan.model_id, data.user).then(initialResourceTypes => {
+        $resourceTypes = initialResourceTypes;
+        $resourceTypesLoading = false;
+      });
+    }
+  });
 
   onDestroy(() => {
     resetActivityStores();

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import { page } from '$app/stores';
@@ -12,7 +13,7 @@
   import WaterfallIcon from '@nasa-jpl/stellar/icons/waterfall.svg?component';
   import GearWideConnectedIcon from 'bootstrap-icons/icons/gear-wide-connected.svg?component';
   import { keyBy } from 'lodash-es';
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy } from 'svelte';
   import Nav from '../../../components/app/Nav.svelte';
   import PageTitle from '../../../components/app/PageTitle.svelte';
   import Console from '../../../components/console/Console.svelte';
@@ -225,7 +226,7 @@
       featurePermissions.schedulingGoalsPlanSpec.canAnalyze(data.user, $plan, $plan.model) && !$planReadOnly;
     hasSimulatePermission = featurePermissions.simulation.canRun(data.user, $plan, $plan.model) && !$planReadOnly;
   }
-  if (data.initialPlan) {
+  $: if (data.initialPlan) {
     $plan = data.initialPlan;
     $planEndTimeMs = getUnixEpochTime(data.initialPlan.end_time_doy);
     $planStartTimeMs = getUnixEpochTime(data.initialPlan.start_time_doy);
@@ -385,15 +386,13 @@
     response => response.errors?.length,
   ).length;
 
-  onMount(() => {
-    if ($plan) {
-      // Asynchronously fetch resource types
-      effects.getResourceTypes($plan.model_id, data.user).then(initialResourceTypes => {
-        $resourceTypes = initialResourceTypes;
-        $resourceTypesLoading = false;
-      });
-    }
-  });
+  $: if ($plan && browser) {
+    // Asynchronously fetch resource types
+    effects.getResourceTypes($plan.model_id, data.user).then(initialResourceTypes => {
+      $resourceTypes = initialResourceTypes;
+      $resourceTypesLoading = false;
+    });
+  }
 
   onDestroy(() => {
     resetActivityStores();

--- a/src/stores/activities.ts
+++ b/src/stores/activities.ts
@@ -153,4 +153,8 @@ export function resetActivityStores() {
   activityMetadataDefinitions.updateValue(() => []);
   activityDirectivesMap.set({});
   selectedActivityDirectiveId.set(null);
+  activityDirectives.updateValue(() => []);
+  anchorValidationStatuses.updateValue(() => []);
+  activityMetadataDefinitions.updateValue(() => []);
+  activityDirectiveValidationStatuses.updateValue(() => []);
 }


### PR DESCRIPTION
Closes #1160 by moving the fetching of resource types in the plan page to an `onMount`. Also manually resets activity subscription stores on `resetActivityStores` since otherwise the user has to wait until the store is next used (next time the user loads some plan) in order for them to update which can cause the stale activities to temporarily be displayed on a different plan. Also hides `TimelineTimeDisplay` if no plan exists yet to avoid a flash of `undefined` time content, discovered while playing with the main fix in this PR.