### PR TITLE
Default plans table sorting to descending IDs

### DIFF
--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -51,6 +51,7 @@
       filter: 'number',
       headerName: 'ID',
       resizable: true,
+      sort: 'desc',
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -55,7 +55,7 @@
       sortable: true,
       suppressAutoSize: true,
       suppressSizeToFit: true,
-      width: 60,
+      width: 75,
     },
     { field: 'name', filter: 'text', headerName: 'Name', resizable: true, sortable: true },
     {


### PR DESCRIPTION
To test:

1. Load the `/plans` page
2. Verify that the plans table is initially sorted by plan ID in descending order indicated by an arrow in the "ID" column
3. Create a new plan
4. Verify that the new plan is now displayed at the top of the table instead of at the bottom