### PR TITLE
Add a string comparison on the output of the `derived` store

### DIFF
--- a/src/components/ui/Association/AssociationForm.svelte
+++ b/src/components/ui/Association/AssociationForm.svelte
@@ -110,19 +110,10 @@
   let saveButtonEnabled: boolean = false;
   let saveButtonText: string = 'Save';
 
-  let prevMetadataTags: Tag[] = initialMetadataTags;
-  let prevDefinitionTags: Tag[] = initialDefinitionTags;
-
-  $: if (diffTags(prevMetadataTags, initialMetadataTags)) {
-    metadataTags = initialMetadataTags;
-    prevMetadataTags = initialMetadataTags;
-  }
+  $: metadataTags = initialMetadataTags;
+  $: definitionTags = initialDefinitionTags;
   $: defintionAuthor = initialDefinitionAuthor ?? user?.id ?? null;
   $: definitionCode = initialDefinitionCode;
-  $: if (diffTags(prevDefinitionTags, initialDefinitionTags)) {
-    definitionTags = initialDefinitionTags;
-    prevDefinitionTags = initialDefinitionTags;
-  }
 
   $: isMetadataModified = diffMetadata(
     {

--- a/src/stores/derivedDeeply.ts
+++ b/src/stores/derivedDeeply.ts
@@ -1,0 +1,38 @@
+import { derived, type Readable, type Stores, type StoresValues } from 'svelte/store';
+
+export function derivedDeeply<S extends Stores, T>(
+  stores: S,
+  fn: (values: StoresValues<S>) => T,
+  initialValue?: T,
+): Readable<T> {
+  return derived(
+    stores,
+    ($stores, _set, update) => {
+      const nextValue = fn($stores);
+
+      update(prevValue => {
+        let prevValueString: string;
+        let nextValueString: string;
+
+        if (typeof prevValue === 'object') {
+          prevValueString = JSON.stringify(prevValue);
+        } else {
+          prevValueString = `${prevValue}`;
+        }
+
+        if (typeof nextValue === 'object') {
+          nextValueString = JSON.stringify(nextValue);
+        } else {
+          nextValueString = `${nextValue}`;
+        }
+
+        if (prevValueString === nextValueString) {
+          return prevValue;
+        }
+
+        return nextValue as T;
+      });
+    },
+    initialValue,
+  );
+}

--- a/src/stores/derivedDeeply.ts
+++ b/src/stores/derivedDeeply.ts
@@ -30,7 +30,7 @@ export function derivedDeeply<S extends Stores, T>(
           return prevValue;
         }
 
-        return nextValue as T;
+        return nextValue;
       });
     },
     initialValue,

--- a/src/stores/scheduling.ts
+++ b/src/stores/scheduling.ts
@@ -17,6 +17,7 @@ import type {
 } from '../types/scheduling';
 import gql from '../utilities/gql';
 import { convertResponseToMetadata } from '../utilities/scheduling';
+import { derivedDeeply } from './derivedDeeply';
 import { simulationDatasetsPlan } from './simulation';
 import { gqlSubscribable } from './subscribable';
 import { tags } from './tags';
@@ -77,7 +78,7 @@ export const schedulingPlanSpecification = gqlSubscribable<SchedulingPlanSpecifi
 );
 
 /* Derived. */
-export const schedulingConditions = derived(
+export const schedulingConditions = derivedDeeply(
   [schedulingConditionResponses, tags],
   ([$schedulingConditionResponses, $tags]) => {
     return $schedulingConditionResponses.map(schedulingConditionResponse =>
@@ -89,13 +90,13 @@ export const schedulingConditions = derived(
   },
 );
 
-export const schedulingGoals = derived([schedulingGoalResponses, tags], ([$schedulingGoalResponses, $tags]) => {
+export const schedulingGoals = derivedDeeply([schedulingGoalResponses, tags], ([$schedulingGoalResponses, $tags]) => {
   return $schedulingGoalResponses.map(schedulingGoalResponse =>
     convertResponseToMetadata<SchedulingGoalMetadata, SchedulingGoalDefinition>(schedulingGoalResponse, $tags),
   );
 });
 
-export const schedulingConditionMetadata = derived(
+export const schedulingConditionMetadata = derivedDeeply(
   [schedulingConditionResponse, tags],
   ([$schedulingConditionResponse, $tags]) => {
     if ($schedulingConditionResponse) {
@@ -108,12 +109,18 @@ export const schedulingConditionMetadata = derived(
   },
 );
 
-export const schedulingGoalMetadata = derived([schedulingGoalResponse, tags], ([$schedulingGoalResponse, $tags]) => {
-  if ($schedulingGoalResponse) {
-    return convertResponseToMetadata<SchedulingGoalMetadata, SchedulingGoalDefinition>($schedulingGoalResponse, $tags);
-  }
-  return null;
-});
+export const schedulingGoalMetadata = derivedDeeply(
+  [schedulingGoalResponse, tags],
+  ([$schedulingGoalResponse, $tags]) => {
+    if ($schedulingGoalResponse) {
+      return convertResponseToMetadata<SchedulingGoalMetadata, SchedulingGoalDefinition>(
+        $schedulingGoalResponse,
+        $tags,
+      );
+    }
+    return null;
+  },
+);
 
 export const schedulingConditionsMap: Readable<Record<string, SchedulingConditionMetadata>> = derived(
   [schedulingConditions],


### PR DESCRIPTION
This uses a string comparison on the final output of a derived store to determine if the output actually differs in value and not just by pointer.

To test:
1. Create a scheduling condition or goal and save it
2. After saving, add a tag to the metadata
3. Verify that after pressing Enter in the tags input, the newly added tag doesn't go away
4. Duplicate the chrome tab
5. Click the "Save" button in one tab
6. Verify that the other tab now has the newly added tag

To compare with what would happen before, just swap out the `derivedDeeply` with `derived` in the `schedulingConditionMetadata` or `schedulingGoalMetadata` store and perform the same steps above.