### PR TITLE
Tooltip delay

### DIFF
--- a/src/components/plan/PlanNavButton.svelte
+++ b/src/components/plan/PlanNavButton.svelte
@@ -1,7 +1,8 @@
-<script context="module">
-  import { writable } from 'svelte/store';
+<script context="module" lang="ts">
+  let isNavHovered: boolean = false;
 
-  export const isNavHovered = writable(false);
+  let showTimeout: number | undefined;
+  let hideTimeout: number | undefined;
 </script>
 
 <script lang="ts">
@@ -30,10 +31,6 @@
 
   let menu: Menu;
 
-  // Add delay functions to handle the navbar button hover
-  let showTimeout: number | undefined;
-  let hideTimeout: number | undefined;
-
   function delayedShow() {
     // Clear any existing hide timeout to prevent hiding if we're showing again
     if (hideTimeout !== undefined) {
@@ -41,11 +38,10 @@
     }
 
     // If no other nav button is currently hovered, apply the delay
-    if (!$isNavHovered) {
+    if (!isNavHovered) {
       showTimeout = window.setTimeout(() => {
-        console.log('delayedShow');
+        isNavHovered = true;
         menu.show();
-        isNavHovered.set(true);
       }, 500); // Show delay in milliseconds
     } else {
       // If another nav button is already hovered, show the menu immediately
@@ -60,9 +56,9 @@
 
     hideTimeout = window.setTimeout(() => {
       // Check if the mouse is not over any nav button
-      if (!document.querySelector('.nav-button:hover')) {
+      if (isNavHovered) {
         menu.hide();
-        isNavHovered.set(false);
+        isNavHovered = false;
       }
     }, 500); // Hide delay in milliseconds
   }

--- a/src/components/plan/PlanNavButton.svelte
+++ b/src/components/plan/PlanNavButton.svelte
@@ -36,7 +36,9 @@
 
   function delayedShow() {
     // Clear any existing hide timeout to prevent hiding if we're showing again
-    if (hideTimeout !== undefined) clearTimeout(hideTimeout);
+    if (hideTimeout !== undefined) {
+      clearTimeout(hideTimeout);
+    }
 
     // If no other nav button is currently hovered, apply the delay
     if (!$isNavHovered) {
@@ -52,7 +54,9 @@
   }
 
   function delayedHide() {
-    if (showTimeout !== undefined) clearTimeout(showTimeout);
+    if (showTimeout !== undefined) {
+      clearTimeout(showTimeout);
+    }
 
     hideTimeout = window.setTimeout(() => {
       // Check if the mouse is not over any nav button

--- a/src/components/plan/PlanNavButton.svelte
+++ b/src/components/plan/PlanNavButton.svelte
@@ -64,7 +64,13 @@
   }
 </script>
 
-<div class="nav-button st-typography-medium" role="none" on:mouseenter={delayedShow} on:mouseleave={delayedHide}>
+<div
+  class="nav-button st-typography-medium"
+  role="none"
+  on:mouseenter={delayedShow}
+  on:mouseleave={delayedHide}
+  on:click|stopPropagation={() => menu.show()}
+>
   <div class="nav-button-icon-container">
     <slot />
     <span class="nav-button-status">

--- a/src/components/plan/PlanNavButton.svelte
+++ b/src/components/plan/PlanNavButton.svelte
@@ -62,6 +62,20 @@
       }
     }, 500); // Hide delay in milliseconds
   }
+
+  function instantShow() {
+    // Clear any existing hide timeout to prevent hiding if we're showing again
+    if (hideTimeout !== undefined) {
+      clearTimeout(hideTimeout);
+    }
+
+    if (showTimeout !== undefined) {
+      clearTimeout(showTimeout);
+    }
+
+    isNavHovered = true;
+    menu.show();
+  }
 </script>
 
 <div
@@ -69,7 +83,7 @@
   role="none"
   on:mouseenter={delayedShow}
   on:mouseleave={delayedHide}
-  on:click|stopPropagation={() => menu.show()}
+  on:click|stopPropagation={instantShow}
 >
   <div class="nav-button-icon-container">
     <slot />

--- a/src/components/plan/PlanNavButton.svelte
+++ b/src/components/plan/PlanNavButton.svelte
@@ -1,3 +1,9 @@
+<script context="module">
+  import { writable } from 'svelte/store';
+
+  export const isNavHovered = writable(false);
+</script>
+
 <script lang="ts">
   import PlayIcon from '@nasa-jpl/stellar/icons/play.svg?component';
   import type { Status } from '../../enums/status';
@@ -23,14 +29,42 @@
   export let title: string;
 
   let menu: Menu;
+
+  // Add delay functions to handle the navbar button hover
+  let showTimeout: number | undefined;
+  let hideTimeout: number | undefined;
+
+  function delayedShow() {
+    // Clear any existing hide timeout to prevent hiding if we're showing again
+    if (hideTimeout !== undefined) clearTimeout(hideTimeout);
+
+    // If no other nav button is currently hovered, apply the delay
+    if (!$isNavHovered) {
+      showTimeout = window.setTimeout(() => {
+        console.log('delayedShow');
+        menu.show();
+        isNavHovered.set(true);
+      }, 500); // Show delay in milliseconds
+    } else {
+      // If another nav button is already hovered, show the menu immediately
+      menu.show();
+    }
+  }
+
+  function delayedHide() {
+    if (showTimeout !== undefined) clearTimeout(showTimeout);
+
+    hideTimeout = window.setTimeout(() => {
+      // Check if the mouse is not over any nav button
+      if (!document.querySelector('.nav-button:hover')) {
+        menu.hide();
+        isNavHovered.set(false);
+      }
+    }, 500); // Hide delay in milliseconds
+  }
 </script>
 
-<div
-  class="nav-button st-typography-medium"
-  role="none"
-  on:mouseenter={() => menu.show()}
-  on:mouseleave={() => menu.hide()}
->
+<div class="nav-button st-typography-medium" role="none" on:mouseenter={delayedShow} on:mouseleave={delayedHide}>
   <div class="nav-button-icon-container">
     <slot />
     <span class="nav-button-status">

--- a/src/utilities/permissionHandler.ts
+++ b/src/utilities/permissionHandler.ts
@@ -50,6 +50,7 @@ export const permissionHandler: Action<HTMLElement, PermissionHandlerProps> = (
   const tip: any = tippy(node, {
     ...params,
     ...(permissionError !== null ? { content: permissionError } : {}),
+    delay: 500,
     plugins: [permission],
   });
 

--- a/src/utilities/tooltip.ts
+++ b/src/utilities/tooltip.ts
@@ -58,6 +58,7 @@ export function tooltip(node: Element, params: any = {}): any {
   // https://atomiks.github.io/tippyjs/v6/all-props/
   const tip: any = tippy(node, {
     ...processedParams,
+    delay: 500,
     plugins: [disabled],
   });
 


### PR DESCRIPTION
Small tweak to fix tooltips and popover menus coming in accidentally. It's good UX to introduce a small delay, which is especially helpful in the top right section where there's multiple ribbons with hover states. 
- Add 500ms delay to all tippy tooltips
- Add 500ms delay to nav items
- Treat nav items as singletons, so after 1 delay, moving to other items has no delay
- Add 300ms delay on mouse out to prevent accidentally closing the menu.
- No delay for timeline hover guide
- Clicking a plan menu item skips the delay

![CleanShot 2024-03-26 at 12 22 31](https://github.com/NASA-AMMOS/aerie-ui/assets/6529667/899b3879-51e8-4f98-aa72-e41e2d4d9e3c)

Closes #1177 