### PR TITLE
refactor: use mouseup instead of click on menu items

### DIFF
--- a/src/components/menus/MenuItem.svelte
+++ b/src/components/menus/MenuItem.svelte
@@ -23,8 +23,8 @@
   }
 </script>
 
-<!-- svelte-ignore a11y-click-events-have-key-events a11y-interactive-supports-focus -->
-<div class="menu-item" class:disabled class:selected role="menuitem" use:useActions={use} on:click={onClick}>
+<!-- svelte-ignore a11y-interactive-supports-focus -->
+<div class="menu-item" class:disabled class:selected role="menuitem" use:useActions={use} on:mouseup={onClick}>
   <slot />
 </div>
 


### PR DESCRIPTION
The main annoyance right now is that if you attempt to click on a Menu item where you mouse down on the wrong item, then drag the mouse and mouse up on the intended item, the menu goes away and nothing happens.

Changing the event to mouse up should just respect the last item that was hovered and had the mouse up event.