### PR TITLE
Fix ability for admin to edit tags on associations that they do not own

### DIFF
--- a/src/components/constraints/ConstraintForm.svelte
+++ b/src/components/constraints/ConstraintForm.svelte
@@ -38,12 +38,18 @@
   const permissionError = `You do not have permission to ${mode === 'edit' ? 'edit this' : 'create a'} constraint.`;
 
   let hasCreateDefinitionCodePermission: boolean = false;
+  let hasWriteDefinitionTagsPermission: boolean = false;
   let hasWriteMetadataPermission: boolean = false;
   let pageTitle = mode === 'edit' ? 'Constraints' : 'New Constraint';
   let pageSubtitle = mode === 'edit' ? initialConstraintName : '';
   let constraintsTsFiles: TypeScriptFile[] = [];
 
   $: hasCreateDefinitionCodePermission = featurePermissions.constraints.canCreate(user);
+  $: if (user) {
+    hasWriteDefinitionTagsPermission = featurePermissions.constraints.canUpdateDefinition(user, {
+      author: mode === 'create' ? user.id : initialConstraintDefinitionAuthor ?? user.id,
+    });
+  }
   $: hasWriteMetadataPermission =
     mode === 'create'
       ? featurePermissions.constraints.canCreate(user)
@@ -186,7 +192,11 @@
       tagsToUpdate: Tag[];
     }>,
   ) {
-    if (initialConstraintId !== null && initialConstraintRevision !== null) {
+    if (
+      initialConstraintId !== null &&
+      initialConstraintRevision !== null &&
+      initialConstraintDefinitionAuthor !== undefined
+    ) {
       const {
         detail: { tagIdsToDelete, tagsToUpdate },
       } = event;
@@ -201,6 +211,7 @@
       await effects.updateConstraintDefinitionTags(
         initialConstraintId,
         initialConstraintRevision,
+        initialConstraintDefinitionAuthor,
         constraintDefinitionTagsToUpdate,
         tagIdsToDelete,
         user,
@@ -216,6 +227,7 @@
   displayName="Constraint"
   {hasCreateDefinitionCodePermission}
   {hasWriteMetadataPermission}
+  {hasWriteDefinitionTagsPermission}
   initialDefinitionAuthor={initialConstraintDefinitionAuthor}
   initialDefinitionCode={initialConstraintDefinitionCode}
   initialDescription={initialConstraintDescription}

--- a/src/components/scheduling/SchedulingGoalsPanel.svelte
+++ b/src/components/scheduling/SchedulingGoalsPanel.svelte
@@ -67,8 +67,7 @@
   $: if ($plan) {
     hasAnalyzePermission =
       featurePermissions.schedulingGoalsPlanSpec.canAnalyze(user, $plan, $plan.model) && !$planReadOnly;
-    hasSpecEditPermission =
-      featurePermissions.schedulingGoalsPlanSpec.canUpdateSpecification(user, $plan) && !$planReadOnly;
+    hasSpecEditPermission = featurePermissions.schedulingGoalsPlanSpec.canUpdate(user, $plan) && !$planReadOnly;
     hasRunPermission = featurePermissions.schedulingGoalsPlanSpec.canRun(user, $plan, $plan.model) && !$planReadOnly;
   }
 

--- a/src/components/scheduling/conditions/SchedulingConditionForm.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditionForm.svelte
@@ -43,10 +43,16 @@
   } scheduling condition.`;
 
   let hasCreateDefinitionCodePermission: boolean = false;
+  let hasWriteDefinitionTagsPermission: boolean = false;
   let hasWriteMetadataPermission: boolean = false;
 
   let conditionsTsFiles: TypeScriptFile[] = [];
   $: hasCreateDefinitionCodePermission = featurePermissions.schedulingConditions.canCreate(user);
+  $: if (user) {
+    hasWriteDefinitionTagsPermission = featurePermissions.schedulingConditions.canUpdateDefinition(user, {
+      author: mode === 'create' ? user.id : initialConditionDefinitionAuthor ?? user.id,
+    });
+  }
   $: hasWriteMetadataPermission =
     mode === 'create'
       ? featurePermissions.schedulingConditions.canCreate(user)
@@ -188,7 +194,11 @@
       tagsToUpdate: Tag[];
     }>,
   ) {
-    if (initialConditionId !== null && initialConditionRevision !== null) {
+    if (
+      initialConditionId !== null &&
+      initialConditionRevision !== null &&
+      initialConditionDefinitionAuthor !== undefined
+    ) {
       const {
         detail: { tagIdsToDelete, tagsToUpdate },
       } = event;
@@ -203,6 +213,7 @@
       await effects.updateSchedulingConditionDefinitionTags(
         initialConditionId,
         initialConditionRevision,
+        initialConditionDefinitionAuthor,
         conditionDefinitionTagsToUpdate,
         tagIdsToDelete,
         user,
@@ -215,6 +226,7 @@
   allMetadata={$schedulingConditions}
   displayName="Scheduling Condition"
   {hasCreateDefinitionCodePermission}
+  {hasWriteDefinitionTagsPermission}
   {hasWriteMetadataPermission}
   initialDefinitionAuthor={initialConditionDefinitionAuthor}
   initialDefinitionCode={initialConditionDefinitionCode}

--- a/src/components/scheduling/goals/SchedulingGoalForm.svelte
+++ b/src/components/scheduling/goals/SchedulingGoalForm.svelte
@@ -44,9 +44,15 @@
 
   let goalsTsFiles: TypeScriptFile[] = [];
   let hasCreateDefinitionCodePermission: boolean = false;
+  let hasWriteDefinitionTagsPermission: boolean = false;
   let hasWriteMetadataPermission: boolean = false;
 
   $: hasCreateDefinitionCodePermission = featurePermissions.schedulingGoals.canCreate(user);
+  $: if (user) {
+    hasWriteDefinitionTagsPermission = featurePermissions.schedulingGoals.canUpdateDefinition(user, {
+      author: mode === 'create' ? user.id : initialGoalDefinitionAuthor ?? user.id,
+    });
+  }
   $: hasWriteMetadataPermission =
     mode === 'create'
       ? featurePermissions.schedulingGoals.canCreate(user)
@@ -186,7 +192,7 @@
       tagsToUpdate: Tag[];
     }>,
   ) {
-    if (initialGoalId !== null && initialGoalRevision !== null) {
+    if (initialGoalId !== null && initialGoalRevision !== null && initialGoalDefinitionAuthor !== undefined) {
       const {
         detail: { tagIdsToDelete, tagsToUpdate },
       } = event;
@@ -199,6 +205,7 @@
       await effects.updateSchedulingGoalDefinitionTags(
         initialGoalId,
         initialGoalRevision,
+        initialGoalDefinitionAuthor,
         goalDefinitionTagsToUpdate,
         tagIdsToDelete,
         user,
@@ -211,6 +218,7 @@
   allMetadata={$schedulingGoals}
   displayName="Scheduling Goal"
   {hasCreateDefinitionCodePermission}
+  {hasWriteDefinitionTagsPermission}
   {hasWriteMetadataPermission}
   initialDefinitionAuthor={initialGoalDefinitionAuthor}
   initialDefinitionCode={initialGoalDefinitionCode}

--- a/src/components/ui/Association/AssociationForm.svelte
+++ b/src/components/ui/Association/AssociationForm.svelte
@@ -353,7 +353,7 @@
         <button class="st-button secondary ellipsis" on:click={onClose}>
           {mode === 'create' ? 'Cancel' : 'Close'}
         </button>
-        {#if mode === 'edit' && saveButtonEnabled}
+        {#if mode === 'edit' && (isMetadataModified || isDefinitionModified || isDefinitionTagsModified)}
           <button class="st-button secondary ellipsis" on:click={revert}> Revert </button>
         {/if}
         <button

--- a/src/components/ui/Association/AssociationForm.svelte
+++ b/src/components/ui/Association/AssociationForm.svelte
@@ -105,7 +105,7 @@
   let owner: UserId = initialOwner ?? user?.id ?? null;
   let isPublic: boolean = initialPublic;
   let isDefinitionModified: boolean = false;
-  let isDefinitionDataModified: boolean = false;
+  let isDefinitionTagsModified: boolean = false;
   let isMetadataModified: boolean = false;
   let referenceModelId: number | null = initialReferenceModelId;
   let saveButtonEnabled: boolean = false;
@@ -133,7 +133,7 @@
     },
   );
   $: isDefinitionModified = diffDefinition({ definition: initialDefinitionCode }, { definition: definitionCode });
-  $: isDefinitionDataModified = diffTags(initialDefinitionTags || [], definitionTags);
+  $: isDefinitionTagsModified = diffTags(initialDefinitionTags || [], definitionTags);
   $: hasUpdateDefinitionPermission = hasWriteDefinitionTagsPermission || isDefinitionModified;
   $: pageTitle = mode === 'edit' ? 's' : 'New ';
   $: pageSubtitle = mode === 'edit' ? initialName : '';
@@ -143,11 +143,11 @@
     owner !== '' &&
     definitionCode !== '' &&
     name !== '' &&
-    (isMetadataModified || isDefinitionDataModified || isDefinitionModified);
+    (isMetadataModified || (isDefinitionTagsModified && hasUpdateDefinitionPermission) || isDefinitionModified);
   $: saveButtonClass = saveButtonEnabled ? 'primary' : 'secondary';
   $: if (mode === 'edit' && (isMetadataModified || isDefinitionModified)) {
     saveButtonText = 'Saved';
-    if ((isMetadataModified || isDefinitionDataModified) && !isDefinitionModified) {
+    if ((isMetadataModified || isDefinitionTagsModified) && !isDefinitionModified) {
       saveButtonText = 'Save';
     } else if (isDefinitionModified) {
       saveButtonText = 'Save as new version';
@@ -285,7 +285,7 @@
       if (isMetadataModified) {
         await saveMetadata();
       }
-      if (isDefinitionDataModified && !isDefinitionModified) {
+      if (isDefinitionTagsModified && !isDefinitionModified) {
         await saveDefinitionRevisionTags();
       } else if (isDefinitionModified) {
         await createNewDefinition();

--- a/src/components/ui/Association/AssociationForm.svelte
+++ b/src/components/ui/Association/AssociationForm.svelte
@@ -72,6 +72,7 @@
   export let formColumns: string = '1fr 3px 2fr';
   export let hasCreateDefinitionCodePermission: boolean = false;
   export let hasWriteMetadataPermission: boolean = false;
+  export let hasWriteDefinitionTagsPermission: boolean = false;
   export let initialDefinitionAuthor: UserId | undefined = undefined;
   export let initialDefinitionCode: string = 'export default ():  => {\n\n}\n';
   export let initialDescription: string = '';
@@ -133,7 +134,7 @@
   );
   $: isDefinitionModified = diffDefinition({ definition: initialDefinitionCode }, { definition: definitionCode });
   $: isDefinitionDataModified = diffTags(initialDefinitionTags || [], definitionTags);
-  $: hasUpdateDefinitionPermission = user?.id === defintionAuthor || user?.id === initialOwner || isDefinitionModified;
+  $: hasUpdateDefinitionPermission = hasWriteDefinitionTagsPermission || isDefinitionModified;
   $: pageTitle = mode === 'edit' ? 's' : 'New ';
   $: pageSubtitle = mode === 'edit' ? initialName : '';
   $: referenceModelId = initialReferenceModelId;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -4092,12 +4092,13 @@ const effects = {
   async updateConstraintDefinitionTags(
     constraintId: number,
     constraintRevision: number,
+    constraintAuthor: UserId,
     tags: ConstraintDefinitionTagsInsertInput[],
     tagIdsToDelete: number[],
     user: User | null,
   ): Promise<number | null> {
     try {
-      if (!queryPermissions.UPDATE_CONSTRAINT_DEFINITION_TAGS(user)) {
+      if (!queryPermissions.UPDATE_CONSTRAINT_DEFINITION_TAGS(user, { author: constraintAuthor })) {
         throwPermissionError('create constraint definition tags');
       }
 
@@ -4267,12 +4268,13 @@ const effects = {
   async updateSchedulingConditionDefinitionTags(
     conditionId: number,
     conditionRevision: number,
+    conditionAuthor: UserId,
     tags: SchedulingConditionDefinitionTagsInsertInput[],
     tagIdsToDelete: number[],
     user: User | null,
   ): Promise<number | null> {
     try {
-      if (!queryPermissions.UPDATE_SCHEDULING_CONDITION_DEFINITION_TAGS(user)) {
+      if (!queryPermissions.UPDATE_SCHEDULING_CONDITION_DEFINITION_TAGS(user, { author: conditionAuthor })) {
         throwPermissionError('create scheduling condition definition tags');
       }
 
@@ -4397,12 +4399,13 @@ const effects = {
   async updateSchedulingGoalDefinitionTags(
     goalId: number,
     goalRevision: number,
+    goalAuthor: UserId,
     tags: SchedulingGoalDefinitionTagsInsertInput[],
     tagIdsToDelete: number[],
     user: User | null,
   ): Promise<number | null> {
     try {
-      if (!queryPermissions.UPDATE_SCHEDULING_GOAL_DEFINITION_TAGS(user)) {
+      if (!queryPermissions.UPDATE_SCHEDULING_GOAL_DEFINITION_TAGS(user, { author: goalAuthor })) {
         throwPermissionError('create scheduling condition definition tags');
       }
 


### PR DESCRIPTION
Resolves #1192 

To test:

1. Create a constraint or scheduling goal/condition as a specific user
2. Switch to a different user as the "aerie-admin" role and attempt to edit the asset created in step 1
3. Verify that the user is able to add/remove tags to the asset definition
4. Switch to the "user" role
5. Verify that the user is no longer able to edit the tags
6. Modify the definition code
7. Verify that the user is now able to add/remove tags because it is associated to the new definition and will create a new version (any user should be allowed to create new versions)