### PR TITLE
Fix simulation template padding

### DIFF
--- a/src/components/parameters/Parameters.svelte
+++ b/src/components/parameters/Parameters.svelte
@@ -84,10 +84,15 @@
   .parameters-container :global(> div.highlight) {
     box-sizing: border-box;
     padding: 4px 0;
+    border: 1px solid transparent;
+    margin-top: -1px;
+    margin-bottom: -1px;
   }
 
   .parameters-container :global(> div.highlight:hover) {
-    box-shadow: 0px 0px 0px 1px var(--st-gray-20);
+    /* box-shadow: 0px 0px 0px 1px var(--st-gray-20); */
+    border-top: 1px solid var(--st-gray-20);
+    border-bottom: 1px solid var(--st-gray-20);
   }
 
   .parameter-info {

--- a/src/components/parameters/Parameters.svelte
+++ b/src/components/parameters/Parameters.svelte
@@ -82,17 +82,16 @@
   }
 
   .parameters-container :global(> div.highlight) {
-    box-sizing: border-box;
-    padding: 4px 0;
     border: 1px solid transparent;
-    margin-top: -1px;
+    box-sizing: border-box;
     margin-bottom: -1px;
+    margin-top: -1px;
+    padding: 4px 0;
   }
 
   .parameters-container :global(> div.highlight:hover) {
-    /* box-shadow: 0px 0px 0px 1px var(--st-gray-20); */
-    border-top: 1px solid var(--st-gray-20);
     border-bottom: 1px solid var(--st-gray-20);
+    border-top: 1px solid var(--st-gray-20);
   }
 
   .parameter-info {

--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -475,10 +475,6 @@
     margin-top: 8px;
   }
 
-  .simulation-template {
-    margin-left: -7px;
-  }
-
   :global(.simulation-collapse.collapse .content) {
     margin: 0;
   }


### PR DESCRIPTION
- Remove the custom left margin causing simulation template to be cut off on the left side.
- Swap the hover state for a parameter to have a top and bottom border instead of a box shadow. Not necessary for the above change, but this is more extensible if we want to change the overflow of the container in the future. 

![image](https://github.com/NASA-AMMOS/aerie-ui/assets/6529667/d5de6ce8-e947-4c71-be15-408796e9d8cb)

Closes #1163 