### PR TITLE
Fix incorrect tag deletion logic

### DIFF
--- a/e2e-tests/fixtures/Tags.ts
+++ b/e2e-tests/fixtures/Tags.ts
@@ -1,0 +1,89 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { adjectives, animals, colors, uniqueNamesGenerator } from 'unique-names-generator';
+
+export class Tags {
+  alertError: Locator;
+  confirmModal: Locator;
+  confirmModalDeleteButton: Locator;
+  createButton: Locator;
+  inputColor: Locator;
+  inputName: Locator;
+  tableRow: Locator;
+  tableRowDeleteButton: Locator;
+  tableRowTagId: Locator;
+  tagId: string;
+  tagName: string;
+
+  constructor(public page: Page) {
+    this.tagName = uniqueNamesGenerator({ dictionaries: [adjectives, colors, animals] });
+    this.updatePage(page);
+  }
+
+  async createTag() {
+    await expect(this.tableRow).not.toBeVisible();
+    await this.fillInputName();
+    await this.fillInputColor();
+    await this.createButton.click();
+    await this.tableRow.waitFor({ state: 'attached' });
+    await this.tableRow.waitFor({ state: 'visible' });
+    await expect(this.tableRow).toBeVisible();
+    await expect(this.tableRowTagId).toBeVisible();
+    const el = await this.tableRowTagId.elementHandle();
+    if (el) {
+      this.tagId = (await el.textContent()) as string;
+    }
+  }
+
+  async deleteTag() {
+    await expect(this.tableRow).toBeVisible();
+    await expect(this.tableRowDeleteButton).not.toBeVisible();
+
+    await this.tableRow.hover();
+    await this.tableRowDeleteButton.waitFor({ state: 'attached' });
+    await this.tableRowDeleteButton.waitFor({ state: 'visible' });
+    await expect(this.tableRowDeleteButton).toBeVisible();
+
+    await expect(this.confirmModal).not.toBeVisible();
+    await this.tableRowDeleteButton.click();
+    await this.confirmModal.waitFor({ state: 'attached' });
+    await this.confirmModal.waitFor({ state: 'visible' });
+    await expect(this.confirmModal).toBeVisible();
+
+    await expect(this.confirmModalDeleteButton).toBeVisible();
+    await this.confirmModalDeleteButton.click();
+    await this.tableRow.waitFor({ state: 'detached' });
+    await this.tableRow.waitFor({ state: 'hidden' });
+    await expect(this.tableRow).not.toBeVisible();
+  }
+
+  async fillInputColor() {
+    await this.inputColor.focus();
+    await this.inputColor.fill('#0000ff');
+    await this.inputColor.blur();
+  }
+
+  async fillInputName() {
+    await this.inputName.focus();
+    await this.inputName.fill(this.tagName);
+    await this.inputName.blur();
+  }
+
+  async goto() {
+    await this.page.goto('/tags', { waitUntil: 'networkidle' });
+    await this.page.waitForTimeout(250);
+  }
+
+  updatePage(page: Page): void {
+    this.alertError = page.locator('.alert-error');
+    this.confirmModal = page.locator(`.modal:has-text("Delete Tag")`);
+    this.confirmModalDeleteButton = this.confirmModal.getByRole('button', { name: 'Delete' });
+    this.createButton = page.getByRole('button', { name: 'Create' });
+    this.inputName = page.locator('input[name="name"]');
+    this.inputColor = page.locator('input[name="color"]');
+    this.page = page;
+    this.tableRow = page.locator(`.ag-row:has-text("${this.tagName}")`);
+    this.tableRowDeleteButton = page.locator(`.ag-row:has-text("${this.tagName}") >> button[aria-label="Delete Tag"]`);
+    this.tableRowTagId = page.locator(`.ag-row:has-text("${this.tagName}") > div >> nth=0`);
+  }
+}

--- a/e2e-tests/tests/tags.test.ts
+++ b/e2e-tests/tests/tags.test.ts
@@ -16,7 +16,7 @@ test.afterAll(async () => {
   await context.close();
 });
 
-test.describe.serial.only('Tags', () => {
+test.describe.serial('Tags', () => {
   test('Create tag button should be disabled with no errors', async () => {
     await expect(tags.inputName).toBeVisible();
     await expect(tags.alertError).not.toBeVisible();

--- a/e2e-tests/tests/tags.test.ts
+++ b/e2e-tests/tests/tags.test.ts
@@ -1,0 +1,51 @@
+import test, { expect, type BrowserContext, type Page } from '@playwright/test';
+import { Tags } from '../fixtures/Tags.js';
+let context: BrowserContext;
+let tags: Tags;
+let page: Page;
+
+test.beforeAll(async ({ browser }) => {
+  context = await browser.newContext();
+  page = await context.newPage();
+  tags = new Tags(page);
+  await tags.goto();
+});
+
+test.afterAll(async () => {
+  await page.close();
+  await context.close();
+});
+
+test.describe.serial.only('Tags', () => {
+  test('Create tag button should be disabled with no errors', async () => {
+    await expect(tags.inputName).toBeVisible();
+    await expect(tags.alertError).not.toBeVisible();
+    await expect(tags.createButton).toBeDisabled();
+  });
+
+  test('Create tag button should be disabled after only entering a name', async () => {
+    await expect(tags.createButton).toBeDisabled();
+    await tags.fillInputName();
+    await expect(tags.createButton).toBeEnabled();
+  });
+
+  test('Create tag', async () => {
+    await tags.createTag();
+  });
+
+  test('Delete tag', async () => {
+    await tags.deleteTag();
+  });
+
+  test('Create button should be disabled after submitting once', async () => {
+    // Setup the test
+    await expect(tags.tableRow).not.toBeVisible();
+    await tags.fillInputName();
+    await tags.createButton.click();
+    // The create button shouldn't be there
+    await expect(tags.createButton).toBeDisabled();
+
+    // Cleanup
+    await tags.deleteTag();
+  });
+});

--- a/src/routes/tags/+page.svelte
+++ b/src/routes/tags/+page.svelte
@@ -239,14 +239,7 @@
       'Delete Tag',
     );
     if (confirm) {
-      // TODO how should we handle partial success?
-      const constraintTagDeletionSuccess = await effects.deleteConstraintMetadataTags([tag.id], user);
-      const expansionRuleTagDeletionSuccess = await effects.deleteExpansionRuleTags([tag.id], user);
-      const tagDeletionSuccess = await effects.deleteTag(tag, user);
-
-      if (constraintTagDeletionSuccess && expansionRuleTagDeletionSuccess && tagDeletionSuccess) {
-        tags = tags.filter(t => t.id !== tag.id);
-      }
+      await effects.deleteTag(tag, user);
       // Stop editing if the selected tag is the one being deleted
       if (selectedTag?.id === tag.id) {
         exitEditing(false);

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -1847,25 +1847,6 @@ const effects = {
     return false;
   },
 
-  async deleteConstraintMetadataTags(ids: Tag['id'][], user: User | null): Promise<boolean> {
-    try {
-      if (!queryPermissions.DELETE_CONSTRAINT_METADATA_TAGS(user)) {
-        throwPermissionError('delete constraint tags');
-      }
-
-      const data = await reqHasura<{ affected_rows: number }>(gql.DELETE_CONSTRAINT_METADATA_TAGS, { ids }, user);
-      if (data.delete_constraint_tags != null) {
-        return true;
-      } else {
-        throw Error('Unable to delete constraint tags');
-      }
-    } catch (e) {
-      catchError('Delete Constraint Tags Failed', e as Error);
-      showFailureToast('Delete Constraint Tags Failed');
-      return false;
-    }
-  },
-
   async deleteConstraintPlanSpecifications(plan: Plan, constraintIds: number[], user: User | null): Promise<boolean> {
     try {
       if (!queryPermissions.DELETE_CONSTRAINT_PLAN_SPECIFICATIONS(user, plan)) {
@@ -2191,34 +2172,6 @@ const effects = {
     }
   },
 
-  async deleteSchedulingConditionTags(ids: Tag['id'][], user: User | null): Promise<number | null> {
-    try {
-      if (!queryPermissions.DELETE_SCHEDULING_CONDITION_METADATA_TAGS(user)) {
-        throwPermissionError('delete scheduling condition tags');
-      }
-
-      const data = await reqHasura<{ affected_rows: number }>(
-        gql.DELETE_SCHEDULING_CONDITION_METADATA_TAGS,
-        { ids },
-        user,
-      );
-      const { delete_scheduling_condition_tags } = data;
-      if (delete_scheduling_condition_tags != null) {
-        const { affected_rows } = delete_scheduling_condition_tags;
-        if (affected_rows !== ids.length) {
-          throw Error('Some scheduling condition tags were not successfully created');
-        }
-        return affected_rows;
-      } else {
-        throw Error('Unable to delete scheduling condition tags');
-      }
-    } catch (e) {
-      catchError('Delete Scheduling Condition Tags Failed', e as Error);
-      showFailureToast('Delete Scheduling Condition Tags Failed');
-      return null;
-    }
-  },
-
   async deleteSchedulingGoal(goal: SchedulingGoalMetadata, user: User | null): Promise<boolean> {
     try {
       if (!queryPermissions.DELETE_SCHEDULING_GOAL_METADATA(user, goal)) {
@@ -2247,30 +2200,6 @@ const effects = {
       catchError('Scheduling Goal Delete Failed', e as Error);
       showFailureToast('Scheduling Goal Delete Failed');
       return false;
-    }
-  },
-
-  async deleteSchedulingGoalTags(ids: Tag['id'][], user: User | null): Promise<number | null> {
-    try {
-      if (!queryPermissions.DELETE_SCHEDULING_GOAL_METADATA_TAGS(user)) {
-        throwPermissionError('delete scheduling goal tags');
-      }
-
-      const data = await reqHasura<{ affected_rows: number }>(gql.DELETE_SCHEDULING_GOAL_METADATA_TAGS, { ids }, user);
-      const { delete_scheduling_goal_tags } = data;
-      if (delete_scheduling_goal_tags != null) {
-        const { affected_rows } = delete_scheduling_goal_tags;
-        if (affected_rows !== ids.length) {
-          throw Error('Some scheduling goal tags were not successfully created');
-        }
-        return affected_rows;
-      } else {
-        throw Error('Unable to delete scheduling goal tags');
-      }
-    } catch (e) {
-      catchError('Delete Scheduling Goal Tags Failed', e as Error);
-      showFailureToast('Delete Scheduling Goal Tags Failed');
-      return null;
     }
   },
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -1855,9 +1855,6 @@ const effects = {
 
       const data = await reqHasura<{ affected_rows: number }>(gql.DELETE_CONSTRAINT_METADATA_TAGS, { ids }, user);
       if (data.delete_constraint_tags != null) {
-        if (data.delete_constraint_tags.affected_rows !== ids.length) {
-          throw Error('Some constraint tags were not successfully deleted');
-        }
         return true;
       } else {
         throw Error('Unable to delete constraint tags');
@@ -1935,9 +1932,6 @@ const effects = {
       const { delete_expansion_rule_tags } = data;
       if (delete_expansion_rule_tags != null) {
         const { affected_rows } = delete_expansion_rule_tags;
-        if (affected_rows !== ids.length) {
-          throw Error('Some expansion rule tags were not successfully deleted');
-        }
         return affected_rows;
       } else {
         throw Error('Unable to delete expansion rule tags');
@@ -2323,6 +2317,7 @@ const effects = {
         throwPermissionError('delete tags');
       }
 
+      await reqHasura<{ id: number }>(gql.DELETE_TAG, { id: tag.id }, user);
       showSuccessToast('Tag Deleted Successfully');
       return true;
     } catch (e) {

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -680,14 +680,6 @@ const gql = {
     }
   `,
 
-  DELETE_CONSTRAINT_METADATA_TAGS: `#graphql
-    mutation DeleteConstraintMetadataTags($ids: [Int!]!) {
-      ${Queries.DELETE_CONSTRAINT_TAGS}(where: { tag_id: { _in: $ids } }) {
-          affected_rows
-      }
-    }
-  `,
-
   DELETE_CONSTRAINT_MODEL_SPECIFICATIONS: `#graphql
     mutation DeleteConstraintModelSpecification($constraintIds: [Int!]!, $modelId: Int!) {
       ${Queries.DELETE_CONSTRAINT_MODEL_SPECIFICATIONS}(
@@ -814,14 +806,6 @@ const gql = {
     }
   `,
 
-  DELETE_SCHEDULING_CONDITION_METADATA_TAGS: `#graphql
-    mutation DeleteSchedulingConditionMetadataTags($ids: [Int!]!) {
-      ${Queries.DELETE_SCHEDULING_CONDITION_METADATA_TAGS}(where: { tag_id: { _in: $ids } }) {
-          affected_rows
-      }
-    }
-  `,
-
   DELETE_SCHEDULING_CONDITION_MODEL_SPECIFICATIONS: `#graphql
     mutation DeleteSchedulingConditionModelSpecification($conditionIds: [Int!]!, $modelId: Int!) {
       ${Queries.DELETE_SCHEDULING_CONDITION_MODEL_SPECIFICATIONS}(
@@ -856,14 +840,6 @@ const gql = {
     mutation DeleteSchedulingGoal($id: Int!) {
       deleteSchedulingGoalMetadata: ${Queries.DELETE_SCHEDULING_GOAL_METADATA}(id: $id) {
         id
-      }
-    }
-  `,
-
-  DELETE_SCHEDULING_GOAL_METADATA_TAGS: `#graphql
-    mutation DeleteSchedulingGoalMetadataTags($ids: [Int!]!) {
-      ${Queries.DELETE_SCHEDULING_GOAL_METADATA_TAGS}(where: { tag_id: { _in: $ids } }) {
-          affected_rows
       }
     }
   `,

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -450,9 +450,6 @@ const queryPermissions = {
       (getPermission([Queries.DELETE_CONSTRAINT_METADATA], user) && isUserOwner(user, constraintMetadata))
     );
   },
-  DELETE_CONSTRAINT_METADATA_TAGS: (user: User | null): boolean => {
-    return isUserAdmin(user) || getPermission([Queries.DELETE_CONSTRAINT_TAGS], user);
-  },
   DELETE_CONSTRAINT_MODEL_SPECIFICATIONS: (user: User | null): boolean => {
     return isUserAdmin(user) || getPermission([Queries.DELETE_CONSTRAINT_MODEL_SPECIFICATIONS], user);
   },
@@ -513,9 +510,6 @@ const queryPermissions = {
       (getPermission([Queries.DELETE_SCHEDULING_CONDITION_METADATA], user) && isUserOwner(user, conditionMetadata))
     );
   },
-  DELETE_SCHEDULING_CONDITION_METADATA_TAGS: (user: User | null): boolean => {
-    return isUserAdmin(user) || getPermission([Queries.DELETE_SCHEDULING_CONDITION_METADATA_TAGS], user);
-  },
   DELETE_SCHEDULING_CONDITION_MODEL_SPECIFICATIONS: () => true,
   DELETE_SCHEDULING_CONDITION_PLAN_SPECIFICATIONS: (user: User | null): boolean => {
     return isUserAdmin(user) || getPermission([Queries.DELETE_SCHEDULING_SPECIFICATION_CONDITIONS], user);
@@ -528,9 +522,6 @@ const queryPermissions = {
       isUserAdmin(user) ||
       (getPermission([Queries.DELETE_SCHEDULING_GOAL_METADATA], user) && isUserOwner(user, goalMetadata))
     );
-  },
-  DELETE_SCHEDULING_GOAL_METADATA_TAGS: (user: User | null): boolean => {
-    return isUserAdmin(user) || getPermission([Queries.DELETE_SCHEDULING_GOAL_METADATA_TAGS], user);
   },
   DELETE_SCHEDULING_GOAL_MODEL_SPECIFICATIONS: () => true,
   DELETE_SCHEDULING_GOAL_PLAN_SPECIFICATIONS: (user: User | null): boolean => {


### PR DESCRIPTION
Tag deletion was incorrectly reporting that tag deletion queries were failing and was also not actually deleting the tag.  This PR depends on https://github.com/NASA-AMMOS/aerie/pull/1372 being merged in to take advantage of the tag associations being automatically cleaned up once a tag is deleted from the tags table.