### PR TITLE
ActivityDecomposition Pagination

### DIFF
--- a/src/components/activity/ActivityDecomposition.svelte
+++ b/src/components/activity/ActivityDecomposition.svelte
@@ -27,7 +27,7 @@
   $: span = rootSpanId !== null ? spansMap[rootSpanId] : null;
   $: isRoot = span ? !span.parent_id : true;
   $: type = span?.type || '';
-  $: childIds = span !== null ? spanUtilityMaps?.spanIdToChildIdsMap[span?.id] : [];
+  $: childIds = span !== null ? spanUtilityMaps?.spanIdToChildIdsMap[span?.id] || [] : [];
   $: hasChildren = childIds ? childIds.length > 0 : false;
   $: role = isRoot ? 'tree' : 'treeitem';
   $: nodeClass =

--- a/src/components/activity/ActivityDecomposition.svelte
+++ b/src/components/activity/ActivityDecomposition.svelte
@@ -14,6 +14,7 @@
   export let selectedSpanId: SpanId | null = null;
   export let spansMap: SpansMap = {};
   export let spanUtilityMaps: SpanUtilityMaps;
+  export let childPageSize: number = 25;
 
   const dispatch = createEventDispatcher<{
     select: number | null;
@@ -21,6 +22,7 @@
 
   let childIds: SpanId[] = [];
   let span: Span | null = null;
+  let childLimit = childPageSize;
 
   $: span = rootSpanId !== null ? spansMap[rootSpanId] : null;
   $: isRoot = span ? !span.parent_id : true;
@@ -32,6 +34,7 @@
     'activity-decomposition-node activity-decomposition-' +
     (rootSpanId === selectedSpanId ? 'selected st-typography-medium' : 'unselected st-typography-body');
   $: buttonClass = 'st-button icon' + (!hasChildren ? ' st-button-no-hover' : '');
+  $: childIdsInView = childIds.slice(0, childLimit);
 
   function toggle() {
     expanded = !expanded;
@@ -68,11 +71,16 @@
 
   {#if hasChildren && expanded}
     <ul>
-      {#each childIds as childId}
+      {#each childIdsInView as childId}
         <li>
           <svelte:self {spansMap} rootSpanId={spansMap[childId]?.id} {selectedSpanId} {spanUtilityMaps} on:select />
         </li>
       {/each}
+      {#if childIds.length !== childIdsInView.length}
+        <button on:click={() => (childLimit += childPageSize)} class="st-button tertiary show-more">
+          Show more ({childIds.length - childIdsInView.length})
+        </button>
+      {/if}
     </ul>
   {/if}
 {/if}
@@ -136,5 +144,10 @@
   .st-button-no-hover:hover {
     background: none;
     cursor: default;
+  }
+
+  .st-button.show-more {
+    border-radius: 2px;
+    margin-left: 20px;
   }
 </style>

--- a/src/components/activity/ActivityDecomposition.svelte
+++ b/src/components/activity/ActivityDecomposition.svelte
@@ -23,6 +23,13 @@
   let childIds: SpanId[] = [];
   let span: Span | null = null;
   let childLimit = childPageSize;
+  let isRoot: boolean = true;
+  let type: string;
+  let hasChildren: boolean = false;
+  let role: 'tree' | 'treeitem' = 'tree';
+  let nodeClass: string = '';
+  let buttonClass: string = '';
+  let childIdsInView: SpanId[] = [];
 
   $: span = rootSpanId !== null ? spansMap[rootSpanId] : null;
   $: isRoot = span ? !span.parent_id : true;

--- a/src/components/activity/ActivityDecomposition.svelte.test.ts
+++ b/src/components/activity/ActivityDecomposition.svelte.test.ts
@@ -1,6 +1,6 @@
 import { cleanup, getByText, render } from '@testing-library/svelte';
 import { afterEach, describe, expect, it } from 'vitest';
-import type { SpansMap, SpanUtilityMaps } from '../../types/simulation';
+import type { SpanUtilityMaps, SpansMap } from '../../types/simulation';
 import ActivityDecomposition from './ActivityDecomposition.svelte';
 
 const spanUtilityMaps: SpanUtilityMaps = {
@@ -183,5 +183,18 @@ describe('Activity Decomposition component', () => {
 
     // Should see a message warning about the missing activity
     expect(getByText(container, `Activity not found`)).to.exist;
+  });
+
+  it('Should display "show more" button to load more child spans', () => {
+    const { container } = render(ActivityDecomposition, {
+      childPageSize: 1,
+      rootSpanId: 12,
+      selectedSpanId: 12,
+      spanUtilityMaps,
+      spansMap,
+    });
+
+    // Should display a "show more" button
+    expect(getByText(container, `Show more (1)`)).to.exist;
   });
 });


### PR DESCRIPTION
Paginate child nodes in ActivityDecomposition to resolve performance issues when loading decompositions with very large sets of children. Click on "show more" button to load next page of child nodes.

Closes #1223

#### Testing
1. Load a plan with an activity that decomposes into a tree where at least one node has a very long and flat list of children. Endurance model is best for this test but certain Clipper activities may also work. One way to test smaller decompositions is to modify the `childPageSize` prop in ActivityDecomposition to set the pagination limit to a much lower size. 
2. View the metadata for a span
3. Activity Decomposition tree should render performantly
4. If more child nodes are available but not shown, a "show more (x)" button should appear where "x" is the number of remaining spans yet to be shown.