### PR TITLE
Mission Model canary cron job

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,15 +1,6 @@
 name: Mission Model Canary
 
 on:
-  # TODO: remove before merge
-  # begin remove section
-  pull_request:
-    branches:
-      - develop
-  push:
-    branches:
-      - develop
-  # end remove section
   workflow_dispatch:
   schedule:
     - cron: '0 * * * *' # every hour at the top of the hour

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,22 @@
+name: Mission Model Canary
+
+on:
+  # TODO: remove before merge
+  # begin remove section
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+  # end remove section
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *' # every hour at the top of the hour
+
+jobs:
+  canary:
+    uses: ./.github/workflows/test.yml
+    with:
+      env: 'canary'
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,12 @@ on:
     tags:
       - v*
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      env:
+        description: 'Github Actions environment that the test workflow should run under'
+        type: string
+        required: false
 
 env:
   AERIE_PASSWORD: '${{secrets.AERIE_PASSWORD}}'
@@ -54,7 +60,7 @@ jobs:
             **/unit-test-results
   e2e-test:
     runs-on: ubuntu-latest
-    environment: test-workflow
+    environment: ${{ inputs.env || 'test-workflow' }}
     steps:
       - name: Checkout Repo (UI)
         uses: actions/checkout@v4


### PR DESCRIPTION
closes https://github.com/NASA-AMMOS/aerie-ui/issues/1220

Adds a new Github Action workflow `canary.yml` that (currently) runs on the top of the hour, every hour, the `test.yml` workflow against the `develop` branch with the current `banananation.jar` model that's hardcoded in the repo.

This way, the canary e2e test run should only fail when the mission model needs to be recompiled, due to an interface change in the backend repo. This way, the UI devs can easily see if an outdated model is at fault for their e2e tests failing in unrelated PRs.

To summarize:
 - if the canary cron job is failing its runs, we need to update `banananation.jar`, and your PR changes likely aren't the cause of e2e tests failing
 - if the canary cron job is passing its runs, but your PR e2e tests are still failing... then _your_ code is likely the problem

Some future work that would streamline this process even further: make a new workflow that (on failed canary run detection) automatically builds a new `banananation.jar` and opens a PR into the UI repo to update it.