### PR TITLE
Add UserInput component

### DIFF
--- a/src/components/model/ModelForm.svelte
+++ b/src/components/model/ModelForm.svelte
@@ -9,6 +9,7 @@
   import { getShortISOForDate } from '../../utilities/time';
   import { tooltip } from '../../utilities/tooltip';
   import Input from '../form/Input.svelte';
+  import UserInput from '../ui/Tags/UserInput.svelte';
 
   export let initialModelDescription: string = '';
   export let initialModelName: string = '';
@@ -17,6 +18,7 @@
   export let modelId: number | undefined;
   export let createdAt: string | undefined;
   export let user: User | null;
+  export let users: UserId[] = [];
 
   const dispatch = createEventDispatcher<{
     createPlan: number;
@@ -67,6 +69,14 @@
 
   function onDeleteModel() {
     dispatch('deleteModel');
+  }
+
+  function onSetOwner(event: CustomEvent<UserId[]>) {
+    owner = event.detail[0];
+  }
+
+  function onClearOwner() {
+    owner = null;
   }
 
   onDestroy(() => {
@@ -120,14 +130,22 @@
     </Input>
     <Input layout="inline">
       <label for="owner">Owner</label>
-      <input
-        class="st-input w-100"
-        name="owner"
-        bind:value={owner}
-        use:permissionHandler={{
-          hasPermission: hasUpdateModelPermission,
-          permissionError: updateModelPermissionError,
-        }}
+      <UserInput
+        allowMultiple={false}
+        {users}
+        {user}
+        selectedUsers={owner ? [owner] : []}
+        use={[
+          [
+            permissionHandler,
+            {
+              hasPermission: hasUpdateModelPermission,
+              permissionError: updateModelPermissionError,
+            },
+          ],
+        ]}
+        on:create={onSetOwner}
+        on:delete={onClearOwner}
       />
     </Input>
     {#if createdAt}

--- a/src/components/ui/Tags/PlanCollaboratorInput.svelte
+++ b/src/components/ui/Tags/PlanCollaboratorInput.svelte
@@ -4,10 +4,8 @@
   import { createEventDispatcher } from 'svelte';
   import type { User, UserId } from '../../../types/app';
   import type { Plan, PlanCollaborator, PlanCollaboratorSlim, PlanSlimmer } from '../../../types/plan';
-  import type { PlanCollaboratorTag, Tag, TagsChangeEvent } from '../../../types/tags';
   import type { ActionArray } from '../../../utilities/useActions';
-  import PlanCollaboratorInputRow from './PlanCollaboratorInputRow.svelte';
-  import TagsInput from './TagsInput.svelte';
+  import UserInput from './UserInput.svelte';
 
   export let collaborators: PlanCollaboratorSlim[] = [];
   export let users: UserId[] = [];
@@ -21,148 +19,66 @@
     delete: string;
   }>();
 
-  let inputRef: TagsInput | null;
-  let options: PlanCollaboratorTag[] = [];
-  let selected: Tag[] = [];
+  let groups: {
+    name: string;
+    users: UserId[];
+  }[] = [];
 
   $: allowableCollaborators = users.filter(user => {
     return !collaborators.find(collaborator => collaborator.collaborator === user);
   });
 
-  $: userIsCollaborator = (userId: UserId) => {
-    return allowableCollaborators.indexOf(userId) < 0;
-  };
-
   $: if (users) {
-    let newOptions: PlanCollaboratorTag[] = users.map(userToTag);
-    plans.forEach(p => {
-      // Filter out current plan
-      if (p.id !== plan.id) {
-        newOptions.push(planToTag(p));
-      }
-    });
-    // Filter out plans where owner and collaborators are already added
-    newOptions = newOptions.filter(tag => {
-      // If the tag is a user tag we don't need to filter on it
-      if (!tag.plan) {
-        return true;
-      }
-      // If owner is already a collaborator and there are no tag plan collaborators
-      // then this tag can be skipped
-      const ownerIsCollaborator = userIsCollaborator(tag.plan.owner);
-      if (ownerIsCollaborator && tag.plan.collaborators.length < 1) {
-        return false;
-      }
-      let anyTagCollaboratorsNotCollaborators = !!tag.plan.collaborators.find(
-        collaborator => !userIsCollaborator(collaborator.collaborator),
-      );
-      return !ownerIsCollaborator || anyTagCollaboratorsNotCollaborators;
-    });
+    let newGroupOptions: {
+      name: string;
+      users: UserId[];
+    }[] = [];
 
-    options = newOptions.sort((optionA, optionB) => {
-      if (optionA.plan && !optionB.plan) {
-        return -1;
-      }
-      if (!optionA.plan && optionB.plan) {
-        return 1;
-      }
-      if (optionA.plan && optionB.plan) {
-        return optionA.plan.updated_at > optionB.plan.updated_at ? -1 : 1;
-      }
-      return optionA.name < optionB.name ? -1 : 0;
-    });
-  }
-
-  $: selected = collaborators.map(collaborator => userToTag(collaborator.collaborator));
-
-  function getTagName(tag: PlanCollaboratorTag): string {
-    return tag.plan ? tag.plan.name : tag.name;
-  }
-
-  function compareTags(tagA: PlanCollaboratorTag, tagB: PlanCollaboratorTag): boolean {
-    return getTagName(tagA) === getTagName(tagB);
-  }
-
-  function addTag(tag: PlanCollaboratorTag) {
-    inputRef?.closeSuggestions();
-    inputRef?.updatePopperPosition();
-    let newCollaborators: PlanCollaborator[] = [];
-    const tagPlan = tag.plan;
-    if (!tagPlan) {
-      // Username case
-      newCollaborators.push({ collaborator: tag.name, plan_id: plan.id });
-    } else {
-      // Add collaborators from plan if not already a collaborator on the target plan
-      const tagPlanCollaborators = tagPlan.collaborators.map(c => c.collaborator);
-      tagPlanCollaborators.forEach(userId => {
-        if (!userIsCollaborator(userId)) {
-          newCollaborators.push({ collaborator: userId, plan_id: plan.id });
+    [...plans]
+      .sort((planA, planB) => {
+        return planA.updated_at > planB.updated_at ? -1 : 1;
+      })
+      .forEach(p => {
+        // Filter out current plan
+        if (p.id !== plan.id) {
+          newGroupOptions.push({
+            name: p.name,
+            users: [p.owner, ...p.collaborators.map(({ collaborator }) => `${collaborator}`)],
+          });
         }
       });
 
-      // Add plan owner if not already a collaborator in target/source plans
-      if (!userIsCollaborator(tagPlan.owner) && tagPlanCollaborators.indexOf(tagPlan.owner) < 0) {
-        newCollaborators.push({ collaborator: tagPlan.owner, plan_id: plan.id });
-      }
-    }
+    groups = newGroupOptions;
+  }
+
+  function addTag(event: CustomEvent<UserId[]>) {
+    const { detail: newUsers } = event;
+    const newCollaborators: PlanCollaborator[] = [];
+
+    newUsers.forEach(user => {
+      newCollaborators.push({ collaborator: user, plan_id: plan.id });
+    });
+
     if (user) {
       dispatch('create', newCollaborators);
       allowableCollaborators = allowableCollaborators.filter(
         collaborator => !newCollaborators.find(c => c.collaborator === collaborator),
       );
-      selected = selected.concat(newCollaborators.map(c => userToTag(c.collaborator)));
-    }
-  }
-
-  function userToTag(userId: UserId): PlanCollaboratorTag {
-    return {
-      color: '#EBECEC',
-      created_at: '',
-      id: -1,
-      name: userId || 'Unk',
-      owner: '',
-    };
-  }
-
-  function planToTag(plan: PlanSlimmer): PlanCollaboratorTag {
-    return {
-      color: '#EBECEC',
-      created_at: '',
-      id: -1,
-      name: '',
-      owner: '',
-      plan,
-    };
-  }
-
-  async function onTagsInputChange(event: TagsChangeEvent) {
-    const {
-      detail: { tag, type },
-    } = event;
-    if (type === 'remove') {
-      dispatch('delete', tag.name);
     }
   }
 </script>
 
-<TagsInput
-  bind:this={inputRef}
-  {addTag}
-  ignoreCase={false}
+<UserInput
   placeholder="Search collaborators or plans"
-  creatable={false}
+  selectedUsers={collaborators.map(({ collaborator }) => collaborator)}
   tagDisplayName="collaborator"
-  {compareTags}
-  {getTagName}
-  {options}
-  {selected}
-  minWidth={168}
-  on:change={onTagsInputChange}
-  let:prop={tag}
+  userGroups={groups}
+  users={allowableCollaborators}
   {use}
->
-  <PlanCollaboratorInputRow {tag} {collaborators} />
-</TagsInput>
+  {user}
+  on:create={addTag}
+  on:delete
+/>
 
 <style>
 </style>

--- a/src/components/ui/Tags/TagsInput.svelte
+++ b/src/components/ui/Tags/TagsInput.svelte
@@ -30,6 +30,7 @@
   export let id: string = '';
   export let ignoreCase: boolean = true;
   export let inputRef: HTMLInputElement | null = null;
+  export let minWidth: number = 82;
   export let name: string = '';
   export let placeholder: string = 'Enter a tag...';
   export let selected: Tag[] = [];
@@ -234,12 +235,10 @@
   bind:this={tagsRef}
   bind:clientWidth={tagsWidth}
 >
-  <div class="tags-input-container">
-    <div class="tags-input-selected-items">
-      {#each selectedTags as tag}
-        <TagChip {tag} removable={!disabled} on:click={() => onTagRemove(tag)} {disabled} ariaRole="option" />
-      {/each}
-    </div>
+  <div class="tags-input-selected-items">
+    {#each selectedTags as tag}
+      <TagChip {tag} removable={!disabled} on:click={() => onTagRemove(tag)} {disabled} ariaRole="option" />
+    {/each}
     {#if !disabled || (disabled && !selectedTags.length)}
       {#if !(!allowMultiple && selectedTags.length)}
         <input
@@ -248,6 +247,7 @@
           {disabled}
           placeholder={disabled ? '' : placeholder}
           class="st-input"
+          style:min-width={`${minWidth}px`}
           on:mouseup={openSuggestions}
           on:focus={openSuggestions}
           on:keydown|stopPropagation={onKeydown}
@@ -314,6 +314,7 @@
     display: flex;
     gap: 8px;
     max-height: 40vh;
+    overflow: hidden;
     padding: 2px;
   }
 
@@ -327,10 +328,6 @@
   :global(.tags-input.permission-disabled) input {
     cursor: not-allowed;
     opacity: 1;
-  }
-
-  .tags-input-container {
-    width: 100%;
   }
 
   .tags-input-selected-items {

--- a/src/components/ui/Tags/TagsInput.svelte
+++ b/src/components/ui/Tags/TagsInput.svelte
@@ -30,7 +30,6 @@
   export let id: string = '';
   export let ignoreCase: boolean = true;
   export let inputRef: HTMLInputElement | null = null;
-  export let minWidth: number = 82;
   export let name: string = '';
   export let placeholder: string = 'Enter a tag...';
   export let selected: Tag[] = [];
@@ -235,10 +234,12 @@
   bind:this={tagsRef}
   bind:clientWidth={tagsWidth}
 >
-  <div class="tags-input-selected-items">
-    {#each selectedTags as tag}
-      <TagChip {tag} removable={!disabled} on:click={() => onTagRemove(tag)} {disabled} ariaRole="option" />
-    {/each}
+  <div class="tags-input-container">
+    <div class="tags-input-selected-items">
+      {#each selectedTags as tag}
+        <TagChip {tag} removable={!disabled} on:click={() => onTagRemove(tag)} {disabled} ariaRole="option" />
+      {/each}
+    </div>
     {#if !disabled || (disabled && !selectedTags.length)}
       {#if !(!allowMultiple && selectedTags.length)}
         <input
@@ -247,7 +248,6 @@
           {disabled}
           placeholder={disabled ? '' : placeholder}
           class="st-input"
-          style:min-width={`${minWidth}px`}
           on:mouseup={openSuggestions}
           on:focus={openSuggestions}
           on:keydown|stopPropagation={onKeydown}
@@ -327,6 +327,10 @@
   :global(.tags-input.permission-disabled) input {
     cursor: not-allowed;
     opacity: 1;
+  }
+
+  .tags-input-container {
+    width: 100%;
   }
 
   .tags-input-selected-items {

--- a/src/components/ui/Tags/TagsInput.svelte
+++ b/src/components/ui/Tags/TagsInput.svelte
@@ -19,6 +19,7 @@
     updatePopperPosition();
     closeSuggestions();
   };
+  export let allowMultiple: boolean = true;
   export let createTagObject: (name: string) => Tag = (name: string) => {
     return { color: generateRandomPastelColor(), created_at: '', id: -1, name, owner: '' };
   };
@@ -239,19 +240,21 @@
       <TagChip {tag} removable={!disabled} on:click={() => onTagRemove(tag)} {disabled} ariaRole="option" />
     {/each}
     {#if !disabled || (disabled && !selectedTags.length)}
-      <input
-        {id}
-        {name}
-        {disabled}
-        placeholder={disabled ? '' : placeholder}
-        class="st-input"
-        style:min-width={`${minWidth}px`}
-        on:mouseup={openSuggestions}
-        on:focus={openSuggestions}
-        on:keydown|stopPropagation={onKeydown}
-        bind:value={searchText}
-        bind:this={inputRef}
-      />
+      {#if !(!allowMultiple && selectedTags.length)}
+        <input
+          {id}
+          {name}
+          {disabled}
+          placeholder={disabled ? '' : placeholder}
+          class="st-input"
+          style:min-width={`${minWidth}px`}
+          on:mouseup={openSuggestions}
+          on:focus={openSuggestions}
+          on:keydown|stopPropagation={onKeydown}
+          bind:value={searchText}
+          bind:this={inputRef}
+        />
+      {/if}
     {/if}
   </div>
   {#if suggestionsVisible}

--- a/src/components/ui/Tags/UserInput.svelte
+++ b/src/components/ui/Tags/UserInput.svelte
@@ -1,0 +1,153 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import type { User, UserId } from '../../../types/app';
+  import type { PlanCollaboratorTag, Tag, TagGroup, TagsChangeEvent } from '../../../types/tags';
+  import type { ActionArray } from '../../../utilities/useActions';
+  import TagsInput from './TagsInput.svelte';
+  import UserInputRow from './UserInputRow.svelte';
+
+  export let allowMultiple: boolean = true;
+  export let placeholder: string = 'Search users';
+  export let selectedUsers: UserId[] = [];
+  export let tagDisplayName = 'user';
+  export let userGroups: UserGroup[] = [];
+  export let users: UserId[] = [];
+  export let user: User | null;
+  export let use: ActionArray = [];
+
+  type UserGroup = {
+    name: string;
+    users: UserId[];
+  };
+
+  const dispatch = createEventDispatcher<{
+    create: UserId[];
+    delete: string;
+  }>();
+
+  let inputRef: TagsInput | null;
+  let selectedUsersMap: Record<string, boolean> = {};
+  let displayableUsers: UserId[] = [];
+  let displayableUserGroups: UserGroup[] = [];
+  let options: (Tag | TagGroup)[] = [];
+  let selected: Tag[] = [];
+
+  $: selectedUsersMap = selectedUsers.reduce(
+    (prevMap, userId) => ({
+      ...prevMap,
+      [`${userId}`]: true,
+    }),
+    {},
+  );
+  $: userIsSelected = (userId: UserId) => {
+    return selectedUsersMap[`${userId}`];
+  };
+  $: displayableUsers = users.filter(user => !userIsSelected(user));
+  $: displayableUserGroups = userGroups.filter(({ users }) => {
+    return users.filter(user => !userIsSelected(user)).length > 0;
+  });
+  $: {
+    let newOptions: (Tag | TagGroup)[] = displayableUsers.map(userToTag);
+    displayableUserGroups.forEach(userGroup => {
+      newOptions.push(groupToTag(userGroup));
+    });
+
+    options = newOptions.sort((optionA, optionB) => {
+      if ((optionA as TagGroup).members !== undefined && (optionB as TagGroup).members === undefined) {
+        return -1;
+      }
+      if ((optionA as TagGroup).members === undefined && (optionB as TagGroup).members !== undefined) {
+        return 1;
+      }
+      return optionA.name < optionB.name ? -1 : 0;
+    });
+  }
+
+  $: selected = selectedUsers.map(user => userToTag(user));
+
+  function getTagName(tag: Tag): string {
+    return tag.name;
+  }
+
+  function compareTags(tagA: PlanCollaboratorTag, tagB: PlanCollaboratorTag): boolean {
+    return getTagName(tagA) === getTagName(tagB);
+  }
+
+  function addTag(tag: Tag | TagGroup) {
+    inputRef?.closeSuggestions();
+    inputRef?.updatePopperPosition();
+    let newUsers: UserId[] = [];
+    const members = (tag as TagGroup).members;
+    if (!members) {
+      // Username case
+      newUsers.push(tag.name);
+    } else {
+      members.forEach(userId => {
+        if (!userIsSelected(userId)) {
+          newUsers.push(userId);
+        }
+      });
+    }
+
+    if (user) {
+      dispatch('create', newUsers);
+      displayableUsers = displayableUsers.filter(user => !newUsers.find(newUser => newUser === user));
+      selected = selected.concat(newUsers.map(newUser => userToTag(newUser)));
+    }
+  }
+
+  function userToTag(userId: UserId): Tag {
+    return {
+      color: '#EBECEC',
+      created_at: '',
+      id: -1,
+      name: userId || 'Unk',
+      owner: '',
+    };
+  }
+
+  function groupToTag(group: UserGroup): TagGroup {
+    return {
+      color: '#EBECEC',
+      created_at: '',
+      id: -1,
+      members: group.users.map(user => `${user}`),
+      name: group.name,
+      owner: '',
+    };
+  }
+
+  async function onTagsInputChange(event: TagsChangeEvent) {
+    const {
+      detail: { tag, type },
+    } = event;
+    if (type === 'remove') {
+      dispatch('delete', tag.name);
+    }
+  }
+</script>
+
+<TagsInput
+  bind:this={inputRef}
+  {addTag}
+  {allowMultiple}
+  ignoreCase={false}
+  {placeholder}
+  creatable={false}
+  {tagDisplayName}
+  {compareTags}
+  {getTagName}
+  {options}
+  {selected}
+  minWidth={168}
+  on:change={onTagsInputChange}
+  let:prop={tag}
+  {use}
+>
+  <UserInputRow {tag} {selectedUsers} />
+</TagsInput>
+
+<style>
+</style>

--- a/src/components/ui/Tags/UserInput.svelte
+++ b/src/components/ui/Tags/UserInput.svelte
@@ -141,6 +141,7 @@
   {getTagName}
   {options}
   {selected}
+  minWidth={168}
   on:change={onTagsInputChange}
   let:prop={tag}
   {use}

--- a/src/components/ui/Tags/UserInput.svelte
+++ b/src/components/ui/Tags/UserInput.svelte
@@ -141,7 +141,6 @@
   {getTagName}
   {options}
   {selected}
-  minWidth={168}
   on:change={onTagsInputChange}
   let:prop={tag}
   {use}

--- a/src/components/ui/Tags/UserInputRow.svelte
+++ b/src/components/ui/Tags/UserInputRow.svelte
@@ -3,31 +3,37 @@
 <script lang="ts">
   import PersonIcon from '@nasa-jpl/stellar/icons/person.svg?component';
   import type { UserId } from '../../../types/app';
-  import type { PlanCollaboratorSlim } from '../../../types/plan';
-  import type { PlanCollaboratorTag } from '../../../types/tags';
+  import type { Tag, TagGroup } from '../../../types/tags';
   import { tooltip } from '../../../utilities/tooltip';
   import TagChip from './Tag.svelte';
 
-  export let tag: PlanCollaboratorTag;
+  export let tag: Tag | TagGroup;
   export let disabled: boolean = false;
-  export let collaborators: PlanCollaboratorSlim[];
+  export let selectedUsers: UserId[];
 
-  let planUsers: UserId[] = [];
-  $: if (tag && tag.plan && collaborators) {
-    planUsers = Array.from(new Set(tag.plan.collaborators.map(c => c.collaborator).concat(tag.plan.owner)));
+  let users: UserId[] = [];
+  let tagGroup: TagGroup | null;
+  let userGroupTooltip: string = '';
+
+  $: if (tag && (tag as TagGroup).members !== undefined && selectedUsers) {
+    const group: TagGroup = tag as TagGroup;
+    users = Array.from(new Set(group.members.map(user => user)));
+    tagGroup = group;
+  } else {
+    tagGroup = null;
   }
-  $: collaboratorTooltipContent = planUsers.join(', ');
+  $: userGroupTooltip = users.join(', ');
 </script>
 
-{#if tag.plan}
-  <div class="as-plan" style="position: relative">
-    <div class="plan">
-      {tag.plan.name}
+{#if tagGroup}
+  <div class="as-group">
+    <div class="group">
+      {tagGroup.name}
     </div>
-    <div class="as-plan-tags">
-      {#if planUsers.length > 0}
-        <div use:tooltip={{ content: collaboratorTooltipContent, maxWidth: 320, placement: 'right', zIndex: 99999 }}>
-          <TagChip {disabled} tag={{ ...tag, name: `${planUsers.length}` }} removable={false}>
+    <div class="as-group-tags">
+      {#if users.length > 0}
+        <div use:tooltip={{ content: userGroupTooltip, maxWidth: 320, placement: 'right', zIndex: 99999 }}>
+          <TagChip {disabled} tag={{ ...tag, name: `${users.length}` }} removable={false}>
             <div class="tag-chip-icon">
               <PersonIcon />
             </div>
@@ -45,20 +51,21 @@
 {/if}
 
 <style>
-  .as-plan {
+  .as-group {
     align-items: center;
     display: flex;
     flex: 1;
     justify-content: space-between;
     overflow: hidden;
+    position: relative;
   }
 
-  .as-plan-tags {
+  .as-group-tags {
     display: flex;
     gap: 4px;
   }
 
-  .plan {
+  .group {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/routes/models/[id]/+page.svelte
+++ b/src/routes/models/[id]/+page.svelte
@@ -88,6 +88,7 @@
   import { constraints } from '../../../stores/constraints';
   import { initialModel, model } from '../../../stores/model';
   import { schedulingConditions, schedulingGoals } from '../../../stores/scheduling';
+  import { users } from '../../../stores/user';
   import type { User, UserId } from '../../../types/app';
   import type { ConstraintModelSpec, ConstraintModelSpecInsertInput } from '../../../types/constraint';
   import type {
@@ -665,6 +666,7 @@
         modelId={$model?.id}
         createdAt={$model?.created_at}
         user={data.user}
+        users={$users ?? []}
         on:createPlan={onCreatePlanWithModel}
         on:deleteModel={onDeleteModel}
         on:hasModelChanged={onModelMetadataChange}

--- a/src/types/tags.ts
+++ b/src/types/tags.ts
@@ -76,6 +76,8 @@ export type Tag = {
   owner: UserId;
 };
 
+export type TagGroup = Tag & { members: string[] };
+
 export type PlanCollaboratorTag = Tag & { plan?: PlanSlimmer };
 
 export type TagsMap = Record<Tag['id'], Tag>;


### PR DESCRIPTION
Pulls a lot of logic out of the existing `PlanCollaborator` component into a component with less plan specific logic.

To test:
1. Create a model
2. After redirected to the model edit page, verify that the `owner` input works similarly to the plan collaborator input, however only one user may be defined.
3. Verify that the plan collaborator field still works as expected.