### PR TITLE
Converted parcel to derived store

### DIFF
--- a/e2e-tests/fixtures/Dictionaries.ts
+++ b/e2e-tests/fixtures/Dictionaries.ts
@@ -104,7 +104,7 @@ export class Dictionaries {
   async createSequenceAdaptation(): Promise<void> {
     await this.updatePage(this.page, DictionaryType.SequenceAdaptation);
 
-    this.createDictionary(
+    await this.createDictionary(
       this.sequenceAdaptationBuffer,
       'Sequence Adaptation',
       this.sequenceAdaptationTableRow,

--- a/e2e-tests/fixtures/Dictionaries.ts
+++ b/e2e-tests/fixtures/Dictionaries.ts
@@ -72,7 +72,7 @@ export class Dictionaries {
     );
   }
 
-  private async createDictionary(
+  async createDictionary(
     dictionaryBuffer: Buffer,
     dictionaryName: string,
     tableRow: Locator,
@@ -201,7 +201,7 @@ export class Dictionaries {
     await this.page.waitForTimeout(250);
   }
 
-  private readDictionary(dictionaryName: string, dictionaryPath: string): Buffer {
+  readDictionary(dictionaryName: string, dictionaryPath: string): Buffer {
     const dictionaryFile = readFileSync(dictionaryPath)
       .toString()
       .replace(/GENERIC/, dictionaryName);
@@ -210,11 +210,7 @@ export class Dictionaries {
     return Buffer.from(dictionary);
   }
 
-  private async updatePage(
-    page: Page,
-    dictionaryType: DictionaryType,
-    dictionaryName?: string | undefined,
-  ): Promise<void> {
+  async updatePage(page: Page, dictionaryType: DictionaryType, dictionaryName?: string | undefined): Promise<void> {
     this.page = page;
 
     this.confirmModal = this.page.locator(`.modal:has-text("Delete ${dictionaryType}")`);

--- a/e2e-tests/fixtures/Dictionaries.ts
+++ b/e2e-tests/fixtures/Dictionaries.ts
@@ -34,7 +34,6 @@ export class Dictionaries {
   sequenceAdaptationBuffer: Buffer;
   sequenceAdaptationPath: string = 'e2e-tests/data/sequence-adaptation.js';
   sequenceAdaptationTableRow: Locator;
-  sequenceAdaptationTableRowCount: number;
   sequenceAdaptationTableRowDeleteButton: Locator;
   sequenceAdaptationTableRows: Locator;
 
@@ -159,9 +158,11 @@ export class Dictionaries {
       await tableRow.waitFor({ state: 'hidden' });
       await expect(tableRow).not.toBeVisible();
     } else {
+      await this.updatePage(this.page, type);
+
       // This will never go below 0.
-      expect(Math.max(0, (await this.sequenceAdaptationTableRows.count()) - 1)).toEqual(
-        this.sequenceAdaptationTableRowCount,
+      expect(Math.max(0, (await this.sequenceAdaptationTableRows.count()) - 1)).toBe(
+        await this.sequenceAdaptationTableRows.count(),
       );
     }
   }
@@ -240,7 +241,6 @@ export class Dictionaries {
       this.sequenceAdaptationTableRows = this.page
         .locator('.panel', { hasText: 'Sequence Adaptations' })
         .locator('.body .ag-row');
-      this.sequenceAdaptationTableRowCount = await this.sequenceAdaptationTableRows.count();
       this.sequenceAdaptationTableRow = this.sequenceAdaptationTableRows.first();
       this.sequenceAdaptationTableRowDeleteButton = this.sequenceAdaptationTableRow.locator(
         `button[aria-label="Delete ${DictionaryType.SequenceAdaptation}"]`,

--- a/e2e-tests/fixtures/Parcels.ts
+++ b/e2e-tests/fixtures/Parcels.ts
@@ -2,6 +2,7 @@ import { Locator, Page, expect } from '@playwright/test';
 import { adjectives, animals, colors, uniqueNamesGenerator } from 'unique-names-generator';
 
 export class Parcels {
+  cancelButton: Locator;
   closeButton: Locator;
   confirmModal: Locator;
   confirmModalDeleteButton: Locator;
@@ -45,7 +46,7 @@ export class Parcels {
     await expect(this.tableRow).not.toBeVisible();
     await this.nameField.fill(this.parcelName);
     await this.createButton.click();
-    await this.closeButton.click();
+    await this.cancelButton.click();
     await this.tableRow.waitFor({ state: 'attached' });
     await this.tableRow.waitFor({ state: 'visible' });
     await expect(this.tableRow).toBeVisible();
@@ -81,6 +82,7 @@ export class Parcels {
   updatePage(page: Page): void {
     this.page = page;
 
+    this.cancelButton = page.locator(`button:has-text("Cancel")`);
     this.closeButton = page.locator(`button:has-text("Close")`);
     this.confirmModal = page.locator(`.modal:has-text("Delete Parcel")`);
     this.confirmModalDeleteButton = page.locator(`.modal:has-text("Delete Parcel") >> button:has-text("Delete")`);

--- a/src/components/parcels/ParcelForm.svelte
+++ b/src/components/parcels/ParcelForm.svelte
@@ -54,7 +54,7 @@
   }>();
 
   $: {
-    if ($parcel !== null) {
+    if ($parcel !== null && $parcel !== undefined) {
       parcelChannelDictionaryId = $parcel.channel_dictionary_id;
       parcelCommandDictionaryId = $parcel.command_dictionary_id;
       parcelCreatedAt = $parcel.created_at;

--- a/src/components/parcels/ParcelForm.svelte
+++ b/src/components/parcels/ParcelForm.svelte
@@ -23,13 +23,6 @@
   import SectionTitle from '../ui/SectionTitle.svelte';
   import DictionaryTable from './DictionaryTable.svelte';
 
-  export let initialParcelChannelDictionaryId: number | null = null;
-  export let initialParcelCommandDictionaryId: number | null = null;
-  export let initialParcelCreatedAt: string | null = null;
-  export let initialParcelName: string = '';
-  export let initialParcelId: number | null = null;
-  export let initialParcelOwner: UserId = '';
-  export let initialSequenceAdaptationId: number | null = null;
   export let mode: 'create' | 'edit' = 'create';
   export let user: User | null;
 
@@ -37,28 +30,45 @@
   let pageSubtitle: string = '';
   let pageTitle: string = '';
   let parcelModified: boolean = false;
-  let parcelChannelDictionaryId: number | null = initialParcelChannelDictionaryId;
-  let parcelCommandDictionaryId: number | null = initialParcelCommandDictionaryId;
-  let parcelCreatedAt: string | null = initialParcelCreatedAt;
-  let parcelName: string = initialParcelName;
-  let parcelId: number | null = initialParcelId;
-  let parcelOwner: UserId = initialParcelOwner;
-  let parcelSequenceAdaptationId: number | null = initialSequenceAdaptationId;
+  let parcelChannelDictionaryId: number | null;
+  let parcelCommandDictionaryId: number | null;
+  let parcelCreatedAt: string | null;
+  let parcelName: string;
+  let parcelId: number | null;
+  let parcelOwner: UserId;
+  let parcelSequenceAdaptationId: number | null;
   let permissionError = 'You do not have permission to edit this parcel.';
   let saveButtonClass: 'primary' | 'secondary' = 'primary';
   let saveButtonText: string = '';
   let saveButtonEnabled: boolean = false;
-  let savedParcelChannelDictionaryId: number | null = parcelChannelDictionaryId;
-  let savedParcelCommandDictionaryId: number | null = parcelCommandDictionaryId;
-  let savedParcelName: string = parcelName;
+  let savedParcelChannelDictionaryId: number | null;
+  let savedParcelCommandDictionaryId: number | null;
+  let savedParcelName: string;
   let savedParameterDictionaryIds: Record<number, boolean> = {};
-  let savedSequenceAdaptationId: number | null = parcelSequenceAdaptationId;
+  let savedSequenceAdaptationId: number | null;
   let savingParcel: boolean = false;
   let selectedParmeterDictionaries: Record<number, boolean> = {};
 
   const dispatch = createEventDispatcher<{
     save: { parcelId: number };
   }>();
+
+  $: {
+    if ($parcel !== null) {
+      parcelChannelDictionaryId = $parcel.channel_dictionary_id;
+      parcelCommandDictionaryId = $parcel.command_dictionary_id;
+      parcelCreatedAt = $parcel.created_at;
+      parcelName = $parcel.name;
+      parcelId = $parcel.id;
+      parcelOwner = $parcel.owner;
+      parcelSequenceAdaptationId = $parcel.sequence_adaptation_id;
+
+      savedParcelChannelDictionaryId = $parcel.channel_dictionary_id;
+      savedParcelCommandDictionaryId = $parcel.command_dictionary_id;
+      savedParcelName = $parcel.name;
+      savedSequenceAdaptationId = $parcel.sequence_adaptation_id;
+    }
+  }
 
   $: selectedParmeterDictionaries = savedParameterDictionaryIds = $parcelToParameterDictionaries.reduce(
     (prevBooleanMap: Record<number, boolean>, parcelToParameterDictionary: ParcelToParameterDictionary) => {
@@ -155,7 +165,7 @@
 
       for (const paramDictionaryId of parcelToParameterDictionaryIdsToDelete) {
         const parcelId: number | undefined = $parcelToParameterDictionaries.find(
-          p => p.parameter_dictionary_id === paramDictionaryId && p.parcel_id === initialParcelId,
+          p => p.parameter_dictionary_id === paramDictionaryId && p.parcel_id === parcelId,
         )?.id;
 
         if (parcelId) {

--- a/src/components/parcels/ParcelForm.svelte
+++ b/src/components/parcels/ParcelForm.svelte
@@ -130,6 +130,7 @@
 
   function onToggleParameterDictionary(event: CustomEvent<{ ids: Record<number, boolean> }>) {
     selectedParmeterDictionaries = event.detail.ids;
+    console.log(selectedParmeterDictionaries);
   }
 
   function onToggleSequenceAdaptation(event: CustomEvent<{ id: number | null }>) {
@@ -161,20 +162,21 @@
     }
 
     if (parcelToParameterDictionaryIdsToDelete.length > 0) {
-      const idsToDelete = [];
+      const parcelToParameterDictionariesToDelete: ParcelToParameterDictionary[] = [];
 
       for (const paramDictionaryId of parcelToParameterDictionaryIdsToDelete) {
-        const parcelId: number | undefined = $parcelToParameterDictionaries.find(
-          p => p.parameter_dictionary_id === paramDictionaryId && p.parcel_id === parcelId,
-        )?.id;
+        const parcelToParameterDictionary: ParcelToParameterDictionary | undefined =
+          $parcelToParameterDictionaries.find(
+            p => p.parameter_dictionary_id === paramDictionaryId && p.parcel_id === $parcel?.id,
+          );
 
-        if (parcelId) {
-          idsToDelete.push(parcelId);
+        if (parcelToParameterDictionary) {
+          parcelToParameterDictionariesToDelete.push(parcelToParameterDictionary);
         }
+      }
 
-        if (idsToDelete.length > 0 && $parcel) {
-          await effects.deleteParcelToParameterDictionaries(idsToDelete, user);
-        }
+      if (parcelToParameterDictionariesToDelete.length > 0) {
+        await effects.deleteParcelToParameterDictionaries(parcelToParameterDictionariesToDelete, user);
       }
     }
   }

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -8,6 +8,7 @@
   import {
     parameterDictionaries as parameterDictionariesStore,
     parcel,
+    parcelId,
     parcelToParameterDictionaries,
     parcels,
     userSequenceFormColumns,
@@ -73,7 +74,7 @@
   }
   $: {
     if (sequenceParcelId) {
-      $parcel = $parcels.find(p => p.id === sequenceParcelId) ?? null;
+      $parcelId = sequenceParcelId;
 
       loadSequenceAdaptation($parcel?.sequence_adaptation_id);
     }

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -4,7 +4,7 @@
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import type { ICellRendererParams } from 'ag-grid-community';
-  import { parcel, parcels, userSequences, userSequencesColumns } from '../../stores/sequencing';
+  import { parcelId, parcels, userSequences, userSequencesColumns } from '../../stores/sequencing';
   import type { User, UserId } from '../../types/app';
   import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { UserSequence } from '../../types/sequencing';
@@ -108,7 +108,7 @@
 
   async function setParcel(): Promise<void> {
     if (selectedSequence !== null) {
-      $parcel = await effects.getParcel(selectedSequence.parcel_id, user);
+      $parcelId = selectedSequence.parcel_id;
     }
   }
 

--- a/src/routes/parcels/edit/[id]/+page.svelte
+++ b/src/routes/parcels/edit/[id]/+page.svelte
@@ -7,14 +7,4 @@
   export let data: PageData;
 </script>
 
-<ParcelForm
-  initialParcelChannelDictionaryId={data.initialParcel.channel_dictionary_id}
-  initialParcelCommandDictionaryId={data.initialParcel.command_dictionary_id}
-  initialParcelCreatedAt={data.initialParcel.created_at}
-  initialParcelId={data.initialParcel.id}
-  initialParcelName={data.initialParcel.name}
-  initialParcelOwner={data.initialParcel.owner}
-  initialSequenceAdaptationId={data.initialParcel.sequence_adaptation_id}
-  mode="edit"
-  user={data.user}
-/>
+<ParcelForm mode="edit" user={data.user} />

--- a/src/routes/parcels/edit/[id]/+page.svelte
+++ b/src/routes/parcels/edit/[id]/+page.svelte
@@ -1,10 +1,20 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { onDestroy, onMount } from 'svelte';
   import ParcelForm from '../../../../components/parcels/ParcelForm.svelte';
+  import { parcelId } from '../../../../stores/sequencing';
   import type { PageData } from './$types';
 
   export let data: PageData;
+
+  onMount(() => {
+    $parcelId = data.initialParcel.id;
+  });
+
+  onDestroy(() => {
+    $parcelId = null;
+  });
 </script>
 
 <ParcelForm mode="edit" user={data.user} />

--- a/src/routes/parcels/edit/[id]/+page.ts
+++ b/src/routes/parcels/edit/[id]/+page.ts
@@ -1,6 +1,5 @@
 import { base } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
-import { parcelId } from '../../../../stores/sequencing';
 import type { Parcel } from '../../../../types/sequencing';
 import effects from '../../../../utilities/effects';
 import { parseFloatOrNull } from '../../../../utilities/generic';
@@ -18,8 +17,6 @@ export const load: PageLoad = async ({ parent, params }) => {
       const initialParcel: Parcel | null = await effects.getParcel(parcelIdAsNumber, user);
 
       if (initialParcel !== null) {
-        parcelId.set(initialParcel?.id);
-
         return {
           initialParcel,
           user,

--- a/src/routes/parcels/edit/[id]/+page.ts
+++ b/src/routes/parcels/edit/[id]/+page.ts
@@ -1,6 +1,6 @@
 import { base } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
-import { parcel } from '../../../../stores/sequencing';
+import { parcelId } from '../../../../stores/sequencing';
 import type { Parcel } from '../../../../types/sequencing';
 import effects from '../../../../utilities/effects';
 import { parseFloatOrNull } from '../../../../utilities/generic';
@@ -16,9 +16,10 @@ export const load: PageLoad = async ({ parent, params }) => {
 
     if (parcelIdAsNumber !== null) {
       const initialParcel: Parcel | null = await effects.getParcel(parcelIdAsNumber, user);
-      parcel.set(initialParcel);
 
       if (initialParcel !== null) {
+        parcelId.set(initialParcel?.id);
+
         return {
           initialParcel,
           user,

--- a/src/routes/parcels/new/+page.ts
+++ b/src/routes/parcels/new/+page.ts
@@ -1,10 +1,7 @@
-import { parcelId } from '../../../stores/sequencing';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
-
-  parcelId.set(null);
 
   return { user };
 };

--- a/src/routes/parcels/new/+page.ts
+++ b/src/routes/parcels/new/+page.ts
@@ -1,7 +1,10 @@
+import { parcelId } from '../../../stores/sequencing';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
   const { user } = await parent();
+
+  parcelId.set(null);
 
   return { user };
 };

--- a/src/stores/sequencing.ts
+++ b/src/stores/sequencing.ts
@@ -27,9 +27,7 @@ export const parsedCommandDictionaries: Writable<Record<string, AmpcsCommandDict
 
 export const parsedParameterDictionaries: Writable<Record<string, AmpcsParameterDictionary>> = writable({});
 
-export const parcel: Writable<Parcel | null> = writable(null);
-
-export const parcelId: Readable<number> = derived(parcel, $parcel => ($parcel ? $parcel.id : -1));
+export const parcelId: Writable<number | null> = writable(null);
 
 /* Subscriptions. */
 
@@ -52,6 +50,14 @@ export const parcelToParameterDictionaries = gqlSubscribable<ParcelToParameterDi
 );
 
 export const parcels = gqlSubscribable<Parcel[]>(gql.SUB_PARCELS, {}, [], null);
+
+export const parcel: Readable<Parcel | null> = derived([parcels, parcelId], ([$parcels, $parcelId]) => {
+  if (!$parcels || !$parcelId) {
+    return null;
+  }
+
+  return $parcels.filter(parcel => parcel.id === $parcelId)[0];
+});
 
 export const parcelBundles: Readable<ParcelBundle[]> = derived(
   [parcels, parcelToParameterDictionaries, commandDictionaries],

--- a/src/types/sequencing.ts
+++ b/src/types/sequencing.ts
@@ -43,7 +43,6 @@ export type ParcelBundle = {
 } & Omit<Parcel, 'command_dictionary_id' | 'updated_at'>;
 
 export type ParcelToParameterDictionary = {
-  id: number;
   parameter_dictionary_id: number;
   parcel_id: number;
 };

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -2239,22 +2239,30 @@ const effects = {
     }
   },
 
-  async deleteParcelToParameterDictionaries(ids: number[], user: User | null): Promise<number | null> {
+  async deleteParcelToParameterDictionaries(
+    parcelToParameterDictionariesToDelete: ParcelToParameterDictionary[],
+    user: User | null,
+  ): Promise<number | null> {
     try {
       if (!queryPermissions.DELETE_PARCEL_TO_PARAMETER_DICTIONARIES(user)) {
         throwPermissionError('delete parcel to parameter dictionaries');
       }
 
+      const parcelIds = parcelToParameterDictionariesToDelete.map(p => p.parcel_id);
+      const parameterDictionaryIds = parcelToParameterDictionariesToDelete.map(p => p.parameter_dictionary_id);
+
       const data = await reqHasura<{ affected_rows: number }>(
         gql.DELETE_PARCEL_TO_PARAMETER_DICTIONARIES,
-        { ids },
+        { parameterDictionaryIds, parcelIds },
         user,
       );
+
       const { delete_parcel_to_parameter_dictionary } = data;
+
       if (delete_parcel_to_parameter_dictionary != null) {
         const { affected_rows } = delete_parcel_to_parameter_dictionary;
 
-        if (affected_rows !== ids.length) {
+        if (affected_rows !== parameterDictionaryIds.length) {
           throw Error('Some parcel to parameter dictionaries were not successfully deleted');
         }
 

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -898,8 +898,8 @@ const gql = {
   `,
 
   DELETE_PARCEL_TO_PARAMETER_DICTIONARIES: `#graphql
-    mutation deleteParcelToParameterDictionaries($ids: [Int!]!) {
-        ${Queries.DELETE_PARCEL_TO_PARAMETER_DICTIONARY}(where: { id: { _in: $ids } }) {
+    mutation deleteParcelToParameterDictionary($parameterDictionaryIds: [Int!]!, $parcelIds: [Int!]!) {
+        ${Queries.DELETE_PARCEL_TO_PARAMETER_DICTIONARY}(where: { parcel_id: { _in: $parcelIds }, _and: { parameter_dictionary_id: { _in: $parameterDictionaryIds}}} ) {
           affected_rows
       }
     }


### PR DESCRIPTION
Closes #1292.

`$parcel` was previously being used as a `Writable` store so that's changed now. `$parcelId` gets set and `$parcel` is derived using our existing parcel subscription to keep it in sync for all users.