### PR TITLE
SeqJSON Import - Symbol arguments and Immediate/Hardware Commands

### DIFF
--- a/src/utilities/new-sequence-editor/from-seq-json.test.ts
+++ b/src/utilities/new-sequence-editor/from-seq-json.test.ts
@@ -21,6 +21,74 @@ describe('from-seq-json.ts', () => {
     expect(sequence).toEqual(expectedSequence);
   });
 
+  it('Symbols should not be quoted', () => {
+    const seqJson: SeqJson = {
+      id: 'testSymbol',
+      locals: [
+        {
+          name: 'L00UINT',
+          type: 'UINT',
+        },
+        {
+          name: 'L00INT',
+          type: 'INT',
+        },
+        {
+          name: 'L01INT',
+          type: 'INT',
+        },
+      ],
+      metadata: {},
+
+      steps: [
+        {
+          args: [
+            {
+              type: 'symbol',
+              value: 'L00UINT',
+            },
+            {
+              type: 'number',
+              value: 10,
+            },
+          ],
+          description: 'line argument',
+          stem: 'PYRO_FIRE',
+
+          time: {
+            type: 'COMMAND_COMPLETE',
+          },
+          type: 'command',
+        },
+        {
+          args: [
+            {
+              type: 'symbol',
+              value: 'L00INT',
+            },
+            {
+              type: 'symbol',
+              value: 'L01INT',
+            },
+          ],
+          stem: 'DDM_BANANA',
+          time: {
+            type: 'COMMAND_COMPLETE',
+          },
+          type: 'command',
+        },
+      ],
+    };
+    const sequence = seqJsonToSequence(seqJson, [], null);
+    const expectedSequence = `@ID "testSymbol"
+@LOCALS L00UINT L00INT L01INT
+
+C PYRO_FIRE L00UINT 10 # line argument
+C DDM_BANANA L00INT L01INT
+`;
+    expect(sequence).toEqual(expectedSequence);
+  });
+
   it('converts a seq json LGO to sequence', () => {
     const seqJson: SeqJson = {
       id: 'test',
@@ -216,7 +284,7 @@ C FSW_CMD_3
     const sequence = seqJsonToSequence(seqJson, [], null);
     const expectedSequence = `@ID "42"
 
-A2024-001T00:00:00 FSW_CMD_0 TRUE 0xFF "Hello" "World" [FALSE 0xAA "Foo" "BAR" TRUE 0xBB "Baz" "BAT"]
+A2024-001T00:00:00 FSW_CMD_0 TRUE 0xFF "Hello" World [FALSE 0xAA "Foo" BAR TRUE 0xBB "Baz" BAT]
 R00:01:00 FSW_CMD_1 22
 E15:00:00 FSW_CMD_2 "Fab"
 C FSW_CMD_3
@@ -380,6 +448,10 @@ C FSW_CMD_2 10 "ENUM" # fsw cmd 2 description
         },
         {
           args: [],
+          stem: 'IC2',
+        },
+        {
+          args: [],
           description: 'noop command, no arguments',
           metadata: { processor: 'VC1A' },
           stem: 'NOOP',
@@ -393,6 +465,7 @@ C FSW_CMD_2 10 "ENUM" # fsw cmd 2 description
 
 @IMMEDIATE
 IC "1" 2 3 # immediate command
+IC2
 NOOP # noop command, no arguments
 @METADATA "processor" "VC1A"
 `;
@@ -413,6 +486,9 @@ NOOP # noop command, no arguments
         {
           stem: 'HWC2',
         },
+        {
+          stem: 'HWC3',
+        },
       ],
       id: 'testHardware',
       metadata: {},
@@ -425,7 +501,9 @@ NOOP # noop command, no arguments
 HWC # hardware command
 @METADATA "foo" "bar"
 @METADATA "hardware" "HWC"
-HWC2`;
+HWC2
+HWC3
+`;
     expect(sequence).toEqual(expectedSequence);
   });
 

--- a/src/utilities/new-sequence-editor/from-seq-json.ts
+++ b/src/utilities/new-sequence-editor/from-seq-json.ts
@@ -43,7 +43,6 @@ export function seqJsonBaseArgToSequence(
 ): string {
   switch (arg.type) {
     case 'string':
-    case 'symbol':
       return `"${arg.value}"`;
     case 'boolean':
       return arg.value ? 'TRUE' : 'FALSE';
@@ -195,7 +194,14 @@ export function seqJsonToSequence(
         const args = seqJsonArgsToSequence(icmd.args);
         const description = icmd.description ? seqJsonDescriptionToSequence(icmd.description) : '';
         const metadata = icmd.metadata ? seqJsonMetadataToSequence(icmd.metadata) : '';
-        sequence.push(`${icmd.stem}${args}${description}${metadata}`);
+        let immediateString = `${icmd.stem}${args}${description}`;
+        // add a new line if on doesn't exit at the end of the immediateString
+        if (!immediateString.endsWith('\n')) {
+          immediateString += '\n';
+        }
+        // Add metadata data if it exists
+        immediateString += metadata;
+        sequence.push(immediateString);
       }
     }
 
@@ -206,7 +212,14 @@ export function seqJsonToSequence(
       for (const hdw of seqJson.hardware_commands) {
         const description = hdw.description ? seqJsonDescriptionToSequence(hdw.description) : '';
         const metadata = hdw.metadata ? seqJsonMetadataToSequence(hdw.metadata) : '';
-        sequence.push(`${hdw.stem}${description}${metadata}`);
+        let hardwareString = `${hdw.stem}${description}`;
+        // add a new line if on doesn't exit at the end of the immediateString
+        if (!hardwareString.endsWith('\n')) {
+          hardwareString += '\n';
+        }
+        // Add metadata data if it exists
+        hardwareString += metadata;
+        sequence.push(hardwareString);
       }
     }
   }


### PR DESCRIPTION
Closes #1299 #1300 #1301 

* Symbol arguments should not be quoted when importing from seqjson
* fix hardware/immediate command not having newline per command on seqjson import

**TESTING:**
I updated the unit test to account for these bugs.

Here is a SeqJSON that test both issues
* Upload Bananation Dictionary
* Create Parcel with dictionary
* Create a new sequence
* Upload the SeqJSON 
[symbol_vc_hdw_bug.json](https://github.com/NASA-AMMOS/aerie-ui/files/15438216/symbol_vc_hdw_bug.json)

Output should be this:
```
@ID "test"
@LOCALS L00UNIT L01INT

C PREPARE_LOAF L00UNIT L01INT

@HARDWARE
HDW_BLENDER_DUMP
HDW_BLENDER_DUMP # description
HDW_BLENDER_DUMP
@METADATA "Key" "Value"
HDW_BLENDER_DUMP
```

**NOTE: You will see errors in the editor because you can't mix command types**
