### PR TITLE
Rename plan

### DIFF
--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -46,6 +46,7 @@ export class Plan {
   planCollaboratorInput: Locator;
   planCollaboratorInputContainer: Locator;
   planCollaboratorLoadingInput: Locator;
+  planNameInput: Locator;
   planTitle: Locator;
   reSimulateButton: Locator;
   roleSelector: Locator;
@@ -185,6 +186,13 @@ export class Plan {
     await this.panelActivityForm.getByPlaceholder('Enter preset name').blur();
   }
 
+  async fillPlanName(name: string) {
+    await this.planNameInput.fill(name);
+    await this.planNameInput.evaluate(e => e.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' })));
+    await this.planNameInput.evaluate(e => e.dispatchEvent(new Event('change')));
+    await this.planNameInput.blur();
+  }
+
   async fillSimulationTemplateName(templateName: string) {
     await this.panelSimulation.getByRole('button', { name: 'Set Template' }).click();
     await this.panelSimulation.locator('.dropdown-header').waitFor({ state: 'attached' });
@@ -238,6 +246,11 @@ export class Plan {
     await this.page.getByRole('row', { name: goalName }).getByRole('checkbox').click();
     await this.page.getByRole('button', { name: 'Update' }).click();
     await this.page.locator(this.schedulingGoalListItemSelector(goalName)).waitFor({ state: 'detached' });
+  }
+
+  async renamePlan(name: string) {
+    await this.fillPlanName(name);
+    await this.waitForToast('Plan Updated Successfully');
   }
 
   async runAnalysis() {
@@ -415,6 +428,7 @@ export class Plan {
     this.planTitle = page.locator(`.plan-title:has-text("${this.planName}")`);
     this.planCollaboratorInputContainer = this.panelPlanMetadata.locator('.input:has-text("Collaborators")');
     this.planCollaboratorInput = this.planCollaboratorInputContainer.getByPlaceholder('Search collaborators or plans');
+    this.planNameInput = page.locator('input[name="plan-name"]');
     this.planCollaboratorLoadingInput = this.planCollaboratorInputContainer.getByPlaceholder('Loading...');
     this.roleSelector = page.locator(`.nav select`);
     this.reSimulateButton = page.locator('.header-actions button:has-text("Re-Run")');

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -306,4 +306,8 @@
   .plan-form-field :global(fieldset) {
     padding: 0;
   }
+
+  .plan-form-field :global(fieldset .error *) {
+    padding-left: calc(40% + 8px);
+  }
 </style>

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -3,8 +3,10 @@
 <script lang="ts">
   import { PlanStatusMessages } from '../../enums/planStatusMessages';
   import { SearchParameters } from '../../enums/searchParameters';
-  import { planReadOnly, planReadOnlySnapshot } from '../../stores/plan';
+  import { field } from '../../stores/form';
+  import { planMetadata, planReadOnly, planReadOnlySnapshot } from '../../stores/plan';
   import { planSnapshotId, planSnapshotsWithSimulations } from '../../stores/planSnapshots';
+  import { plans } from '../../stores/plans';
   import { simulationDataset, simulationDatasetId } from '../../stores/simulation';
   import { viewTogglePanel } from '../../stores/views';
   import type { User, UserId } from '../../types/app';
@@ -17,7 +19,9 @@
   import { featurePermissions } from '../../utilities/permissions';
   import { getShortISOForDate } from '../../utilities/time';
   import { tooltip } from '../../utilities/tooltip';
+  import { required, unique } from '../../utilities/validators';
   import Collapse from '../Collapse.svelte';
+  import Field from '../form/Field.svelte';
   import Input from '../form/Input.svelte';
   import CardList from '../ui/CardList.svelte';
   import FilterToggleButton from '../ui/FilterToggleButton.svelte';
@@ -61,6 +65,14 @@
     filteredPlanSnapshots = $planSnapshotsWithSimulations;
   }
 
+  $: planNameField = field<string>(plan?.name ?? '', [
+    required,
+    unique(
+      $plans.filter(p => p.id !== plan?.id).map(p => p.name),
+      'Plan name already exists',
+    ),
+  ]);
+
   async function onTagsInputChange(event: TagsChangeEvent) {
     const {
       detail: { tag, type },
@@ -102,16 +114,28 @@
   function onToggleFilter() {
     isFilteredBySimulation = !isFilteredBySimulation;
   }
+
+  async function onPlanNameChange() {
+    if (plan && $planNameField.dirtyAndValid && $planNameField.value) {
+      // Optimistically update plan metadata
+      planMetadata.updateValue(pm => (pm ? { ...pm, name: $planNameField.value } : null));
+      effects.updatePlan(plan, { name: $planNameField.value }, user);
+    }
+  }
 </script>
 
 <div class="plan-form">
   {#if plan}
     <fieldset>
       <Collapse title="Details">
-        <Input layout="inline">
-          <label use:tooltip={{ content: 'Name', placement: 'top' }} for="name">Plan Name</label>
-          <input class="st-input w-100" disabled name="name" value={plan.name} />
-        </Input>
+        <div class="plan-form-field">
+          <Field field={planNameField} on:change={onPlanNameChange}>
+            <Input layout="inline">
+              <label use:tooltip={{ content: 'Name', placement: 'top' }} for="plan-name">Plan Name</label>
+              <input autocomplete="off" class="st-input w-100" name="plan-name" placeholder="Enter a plan name" />
+            </Input>
+          </Field>
+        </div>
         <Input layout="inline">
           <label use:tooltip={{ content: 'ID', placement: 'top' }} for="id">Plan ID</label>
           <input class="st-input w-100" disabled name="id" value={plan.id} />
@@ -199,7 +223,7 @@
               [
                 permissionHandler,
                 {
-                  hasPermission: hasPlanUpdatePermission,
+                  hasPermission: hasPlanUpdatePermission && !$planReadOnly,
                   permissionError,
                 },
               ],
@@ -277,5 +301,9 @@
   .buttons {
     column-gap: 4px;
     display: flex;
+  }
+
+  .plan-form-field :global(fieldset) {
+    padding: 0;
   }
 </style>

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -132,7 +132,16 @@
           <Field field={planNameField} on:change={onPlanNameChange}>
             <Input layout="inline">
               <label use:tooltip={{ content: 'Name', placement: 'top' }} for="plan-name">Plan Name</label>
-              <input autocomplete="off" class="st-input w-100" name="plan-name" placeholder="Enter a plan name" />
+              <input
+                autocomplete="off"
+                class="st-input w-100"
+                name="plan-name"
+                placeholder="Enter a plan name"
+                use:permissionHandler={{
+                  hasPermission: hasPlanUpdatePermission,
+                  permissionError,
+                }}
+              />
             </Input>
           </Field>
         </div>
@@ -223,7 +232,7 @@
               [
                 permissionHandler,
                 {
-                  hasPermission: hasPlanUpdatePermission && !$planReadOnly,
+                  hasPermission: hasPlanUpdatePermission,
                   permissionError,
                 },
               ],

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -272,7 +272,7 @@
       }));
       await effects.createPlanTags(newPlanTags, newPlan, user);
       newPlan.tags = planTags.map(tag => ({ tag }));
-      plans.updateValue(() => [...$plans, newPlan]);
+      plans.updateValue(storePlans => [...storePlans, newPlan]);
     }
   }
 
@@ -280,7 +280,7 @@
     const success = await effects.deletePlan(plan, user);
 
     if (success) {
-      plans.updateValue(() => $plans.filter(p => plan.id !== p.id));
+      plans.updateValue(storePlans => storePlans.filter(p => plan.id !== p.id));
     }
   }
 

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -340,7 +340,7 @@
   }
 
   $: if (
-    $plan &&
+    $initialPlan &&
     $simulationDataset !== null &&
     (getSimulationStatus($simulationDataset) === Status.Complete ||
       getSimulationStatus($simulationDataset) === Status.Complete)
@@ -351,7 +351,7 @@
     effects
       .getSpans(
         datasetId,
-        $simulationDataset.simulation_start_time ?? $plan.start_time,
+        $simulationDataset.simulation_start_time ?? $initialPlan.start_time,
         data.user,
         simulationDataAbortController.signal,
       )
@@ -545,7 +545,7 @@
 
 <svelte:window on:keydown={onKeydown} bind:innerWidth={windowWidth} />
 
-<PageTitle subTitle={data.initialPlan.name} title="Plans" />
+<PageTitle subTitle={$plan?.name} title="Plans" />
 <CssGrid
   class="plan-container"
   rows={$planSnapshot
@@ -554,7 +554,9 @@
 >
   <Nav user={data.user}>
     <div class="title" slot="title">
-      <PlanMenu plan={data.initialPlan} user={data.user} />
+      {#if $plan}
+        <PlanMenu plan={$plan} user={data.user} />
+      {/if}
 
       {#if $planReadOnlyMergeRequest || data.initialPlan.parent_plan?.is_locked}
         <button

--- a/src/stores/plans.ts
+++ b/src/stores/plans.ts
@@ -1,0 +1,16 @@
+import type { PlanSlim } from '../types/plan';
+import gql from '../utilities/gql';
+import { getDoyTime, getDoyTimeFromInterval } from '../utilities/time';
+import { gqlSubscribable } from './subscribable';
+
+/* Subscriptions. */
+
+export const plans = gqlSubscribable<PlanSlim[]>(gql.SUB_PLANS, {}, [], null, plans => {
+  return (plans as PlanSlim[]).map(plan => {
+    return {
+      ...plan,
+      end_time_doy: getDoyTimeFromInterval(plan.start_time, plan.duration),
+      start_time_doy: getDoyTime(new Date(plan.start_time)),
+    };
+  });
+});

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -103,6 +103,7 @@ import type {
   PlanMergeNonConflictingActivity,
   PlanMergeRequestSchema,
   PlanMergeResolution,
+  PlanMetadata,
   PlanSchema,
   PlanSlim,
 } from '../types/plan';
@@ -4668,6 +4669,28 @@ const effects = {
       catchError('Parcel Update Failed', e as Error);
       showFailureToast('Parcel Update Failed');
       return null;
+    }
+  },
+
+  async updatePlan(plan: Plan, planMetadata: Partial<PlanMetadata>, user: User | null): Promise<void> {
+    try {
+      if (!queryPermissions.UPDATE_PLAN(user, plan)) {
+        throwPermissionError('update plan');
+      }
+
+      const data = await reqHasura(gql.UPDATE_PLAN, { plan: planMetadata, plan_id: plan.id }, user);
+      const { updatePlan } = data;
+
+      if (updatePlan.id != null) {
+        showSuccessToast('Plan Updated Successfully');
+        return;
+      } else {
+        throw Error(`Unable to update plan with ID: "${plan.id}"`);
+      }
+    } catch (e) {
+      catchError('Plan Update Failed', e as Error);
+      showFailureToast('Plan Update Failed');
+      return;
     }
   },
 

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -178,6 +178,7 @@ export enum Queries {
   UPDATE_MISSION_MODEL = 'update_mission_model_by_pk',
   UPDATE_PARCEL = 'update_parcel_by_pk',
   UPDATE_PLAN_SNAPSHOT = 'update_plan_snapshot_by_pk',
+  UPDATE_PLAN = 'update_plan_by_pk',
   UPDATE_SCHEDULING_CONDITION_METADATA = 'update_scheduling_condition_metadata_by_pk',
   UPDATE_SCHEDULING_GOAL_METADATA = 'update_scheduling_goal_metadata_by_pk',
   UPDATE_SCHEDULING_REQUEST = 'update_scheduling_request',
@@ -2255,6 +2256,33 @@ const gql = {
     }
   `,
 
+  SUB_PLANS: `#graphql
+    subscription SubPlans {
+      plans: ${Queries.PLANS}(order_by: { id: desc }) {
+        collaborators {
+          collaborator
+        }
+        created_at
+        duration
+        id
+        model_id
+        name
+        owner
+        revision
+        start_time
+        updated_at
+        updated_by
+        tags {
+          tag {
+            color
+            id
+            name
+          }
+        }
+      }
+    }
+`,
+
   SUB_PLANS_USER_WRITABLE: `#graphql
     subscription SubPlansUserWritable($userId: String!) {
       ${Queries.PLANS}(where: {_or: [{owner: {_eq: $userId}}, {collaborators: {collaborator: {_eq: $userId}}}]}, order_by: {id: desc}) {
@@ -3089,6 +3117,16 @@ const gql = {
     mutation UpdateParcel($id: Int!, $parcel: parcel_set_input!) {
       updateParcel: ${Queries.UPDATE_PARCEL}(
         pk_columns: { id: $id }, _set: $parcel
+      ) {
+        id
+      }
+    }
+  `,
+
+  UPDATE_PLAN: `#graphql
+    mutation UpdatePlan($plan_id: Int!, $plan: plan_set_input!) {
+      updatePlan: ${Queries.UPDATE_PLAN}(
+        pk_columns: { id: $plan_id }, _set: $plan
       ) {
         id
       }

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -785,6 +785,7 @@ const queryPermissions = {
     return isUserAdmin(user) || getPermission([Queries.PARCELS], user);
   },
   SUB_PARCEL_TO_PARAMETER_DICTIONARIES: () => true,
+  SUB_PLANS: () => true,
   SUB_PLANS_USER_WRITABLE: () => true,
   SUB_PLAN_DATASET: () => true,
   SUB_PLAN_LOCKED: () => true,

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -896,6 +896,9 @@ const queryPermissions = {
   UPDATE_PARCEL: (user: User | null, parcel: AssetWithOwner<Parcel>): boolean => {
     return isUserAdmin(user) || (getPermission([Queries.UPDATE_PARCEL], user) && isUserOwner(user, parcel));
   },
+  UPDATE_PLAN: (user: User | null, plan: PlanWithOwners): boolean => {
+    return isUserAdmin(user) || (getPermission([Queries.UPDATE_PLAN], user) && isPlanOwner(user, plan));
+  },
   UPDATE_PLAN_SNAPSHOT: (user: User | null): boolean => {
     return getPermission([Queries.UPDATE_PLAN_SNAPSHOT], user);
   },
@@ -1267,7 +1270,7 @@ const featurePermissions: FeaturePermissions = {
     canCreate: user => queryPermissions.CREATE_PLAN(user),
     canDelete: (user, plan) => queryPermissions.DELETE_PLAN(user, plan),
     canRead: user => queryPermissions.GET_PLAN(user),
-    canUpdate: (user, plan) => queryPermissions.CREATE_PLAN_TAGS(user, plan),
+    canUpdate: (user, plan) => queryPermissions.UPDATE_PLAN(user, plan),
   },
   planBranch: {
     canCreateBranch: (user, plan, model) => queryPermissions.DUPLICATE_PLAN(user, plan, model),

--- a/src/utilities/validators.ts
+++ b/src/utilities/validators.ts
@@ -24,11 +24,11 @@ export function required(value: number | string): Promise<ValidationResult> {
   });
 }
 
-export function unique(existingValues: string[]): (value: string) => Promise<ValidationResult> {
+export function unique(existingValues: string[], message?: string): (value: string) => Promise<ValidationResult> {
   return (value: string): Promise<ValidationResult> =>
     new Promise(resolve => {
       if (existingValues.indexOf(value) > -1) {
-        return resolve('Value already exists');
+        return resolve(message || 'Value already exists');
       } else {
         return resolve(null);
       }


### PR DESCRIPTION
Closes #497 by adding ability to rename plan from within the `Plan Metadata` panel inside of a plan. Refactors plans page to subscribe to a list of plans so that plan name changes immediately appear.

Testing:
1. Create a plan and open it.
2. In another tab, open up the plans page
3. Open the `Plan Metadata` panel and ensure that the Plan Name field is editable
4. Type in a new Plan Name and hit enter or blur
5. The plan name should update and should also change in the app nav
6. The plan name in the plans page should automatically update to the new name
7. Type in an existing plan name and ensure that a warning appears about name uniqueness and that an update is not triggered.