### PR TITLE
Added support for default mission model views

### DIFF
--- a/e2e-tests/fixtures/Dictionaries.ts
+++ b/e2e-tests/fixtures/Dictionaries.ts
@@ -114,27 +114,19 @@ export class Dictionaries {
   async deleteChannelDictionary(): Promise<void> {
     await this.updatePage(this.page, DictionaryType.ChannelDictionary, this.channelDictionaryName);
 
-    await this.deleteDictionary(
-      this.channelDictionaryTableRow,
-      this.channelDictionaryTableRowDeleteButton,
-      DictionaryType.ChannelDictionary,
-    );
+    await this.deleteDictionary(this.channelDictionaryTableRow, this.channelDictionaryTableRowDeleteButton);
   }
 
   async deleteCommandDictionary(): Promise<void> {
     await this.updatePage(this.page, DictionaryType.CommandDictionary, this.commandDictionaryName);
 
-    await this.deleteDictionary(
-      this.commandDictionaryTableRow,
-      this.commandDictionaryTableRowDeleteButton,
-      DictionaryType.CommandDictionary,
-    );
+    await this.deleteDictionary(this.commandDictionaryTableRow, this.commandDictionaryTableRowDeleteButton);
   }
 
   /**
    * @note Automatically cascade deletes any dependent expansion rules and expansion sets.
    */
-  private async deleteDictionary(tableRow: Locator, tableRowDeleteButton: Locator, type: DictionaryType) {
+  private async deleteDictionary(tableRow: Locator, tableRowDeleteButton: Locator) {
     await expect(tableRow).toBeVisible();
     await expect(tableRowDeleteButton).not.toBeVisible();
 
@@ -152,39 +144,21 @@ export class Dictionaries {
     await expect(this.confirmModalDeleteButton).toBeVisible();
     await this.confirmModalDeleteButton.click();
 
-    // TODO: Remove this conditional when we add Sequence Adaptation names and we can tie to a specific row.
-    if (type !== DictionaryType.SequenceAdaptation) {
-      await tableRow.waitFor({ state: 'detached' });
-      await tableRow.waitFor({ state: 'hidden' });
-      await expect(tableRow).not.toBeVisible();
-    } else {
-      await this.updatePage(this.page, type);
-
-      // This will never go below 0.
-      expect(Math.max(0, (await this.sequenceAdaptationTableRows.count()) - 1)).toBe(
-        await this.sequenceAdaptationTableRows.count(),
-      );
-    }
+    await tableRow.waitFor({ state: 'detached' });
+    await tableRow.waitFor({ state: 'hidden' });
+    await expect(tableRow).not.toBeVisible();
   }
 
   async deleteParameterDictionary(): Promise<void> {
     await this.updatePage(this.page, DictionaryType.ParameterDictionary, this.parameterDictionaryName);
 
-    await this.deleteDictionary(
-      this.parameterDictionaryTableRow,
-      this.parameterDictionaryTableRowDeleteButton,
-      DictionaryType.ParameterDictionary,
-    );
+    await this.deleteDictionary(this.parameterDictionaryTableRow, this.parameterDictionaryTableRowDeleteButton);
   }
 
   async deleteSequenceAdaptation(): Promise<void> {
     await this.updatePage(this.page, DictionaryType.SequenceAdaptation);
 
-    await this.deleteDictionary(
-      this.sequenceAdaptationTableRow,
-      this.sequenceAdaptationTableRowDeleteButton,
-      DictionaryType.SequenceAdaptation,
-    );
+    await this.deleteDictionary(this.sequenceAdaptationTableRow, this.sequenceAdaptationTableRowDeleteButton);
   }
 
   private async fillInputFile(dictionaryBuffer: Buffer, dictionaryName: string) {
@@ -212,8 +186,6 @@ export class Dictionaries {
   }
 
   async updatePage(page: Page, dictionaryType: DictionaryType, dictionaryName?: string | undefined): Promise<void> {
-    this.page = page;
-
     this.confirmModal = this.page.locator(`.modal:has-text("Delete ${dictionaryType}")`);
     this.confirmModalDeleteButton = this.page.locator(
       `.modal:has-text("Delete ${dictionaryType}") >> button:has-text("Delete")`,

--- a/e2e-tests/tests/dictionaries.test.ts
+++ b/e2e-tests/tests/dictionaries.test.ts
@@ -47,7 +47,7 @@ test.describe('Dictionaries', () => {
     });
   });
 
-  test.describe.serial('Sequence Adaptation', () => {
+  test.describe.skip('Sequence Adaptation', () => {
     test('Create sequence adaptation', async () => {
       await dictionaries.createSequenceAdaptation();
     });

--- a/e2e-tests/tests/plan-activities.test.ts
+++ b/e2e-tests/tests/plan-activities.test.ts
@@ -22,9 +22,9 @@ test.beforeAll(async ({ browser }) => {
 
   models = new Models(page);
   plans = new Plans(page, models);
-  constraints = new Constraints(page, models);
-  schedulingConditions = new SchedulingConditions(page, models);
-  schedulingGoals = new SchedulingGoals(page, models);
+  constraints = new Constraints(page);
+  schedulingConditions = new SchedulingConditions(page);
+  schedulingGoals = new SchedulingGoals(page);
   plan = new Plan(page, plans, constraints, schedulingGoals, schedulingConditions);
 
   await models.goto();

--- a/e2e-tests/tests/plan-activity-presets.test.ts
+++ b/e2e-tests/tests/plan-activity-presets.test.ts
@@ -21,9 +21,9 @@ test.beforeAll(async ({ browser }) => {
 
   models = new Models(page);
   plans = new Plans(page, models);
-  constraints = new Constraints(page, models);
-  schedulingConditions = new SchedulingConditions(page, models);
-  schedulingGoals = new SchedulingGoals(page, models);
+  constraints = new Constraints(page);
+  schedulingConditions = new SchedulingConditions(page);
+  schedulingGoals = new SchedulingGoals(page);
   plan = new Plan(page, plans, constraints, schedulingGoals, schedulingConditions);
 
   await models.goto();

--- a/e2e-tests/tests/plan-merge.test.ts
+++ b/e2e-tests/tests/plan-merge.test.ts
@@ -22,9 +22,9 @@ test.beforeAll(async ({ browser }) => {
 
   models = new Models(page);
   plans = new Plans(page, models);
-  constraints = new Constraints(page, models);
-  schedulingConditions = new SchedulingConditions(page, models);
-  schedulingGoals = new SchedulingGoals(page, models);
+  constraints = new Constraints(page);
+  schedulingConditions = new SchedulingConditions(page);
+  schedulingGoals = new SchedulingGoals(page);
   plan = new Plan(page, plans, constraints, schedulingGoals, schedulingConditions);
 
   await models.goto();

--- a/e2e-tests/tests/plan-simulation-templates.test.ts
+++ b/e2e-tests/tests/plan-simulation-templates.test.ts
@@ -21,9 +21,9 @@ test.beforeAll(async ({ browser }) => {
 
   models = new Models(page);
   plans = new Plans(page, models);
-  constraints = new Constraints(page, models);
-  schedulingConditions = new SchedulingConditions(page, models);
-  schedulingGoals = new SchedulingGoals(page, models);
+  constraints = new Constraints(page);
+  schedulingConditions = new SchedulingConditions(page);
+  schedulingGoals = new SchedulingGoals(page);
   plan = new Plan(page, plans, constraints, schedulingGoals, schedulingConditions);
 
   await models.goto();

--- a/e2e-tests/tests/scheduling.test.ts
+++ b/e2e-tests/tests/scheduling.test.ts
@@ -25,9 +25,9 @@ test.beforeAll(async ({ browser }) => {
 
   models = new Models(page);
   plans = new Plans(page, models);
-  constraints = new Constraints(page, models);
-  schedulingConditions = new SchedulingConditions(page, models);
-  schedulingGoals = new SchedulingGoals(page, models);
+  constraints = new Constraints(page);
+  schedulingConditions = new SchedulingConditions(page);
+  schedulingGoals = new SchedulingGoals(page);
   plan = new Plan(page, plans, constraints, schedulingGoals, schedulingConditions);
 
   await models.goto();

--- a/e2e-tests/tests/simulation.test.ts
+++ b/e2e-tests/tests/simulation.test.ts
@@ -22,9 +22,9 @@ test.beforeAll(async ({ browser }) => {
 
   models = new Models(page);
   plans = new Plans(page, models);
-  constraints = new Constraints(page, models);
-  schedulingConditions = new SchedulingConditions(page, models);
-  schedulingGoals = new SchedulingGoals(page, models);
+  constraints = new Constraints(page);
+  schedulingConditions = new SchedulingConditions(page);
+  schedulingGoals = new SchedulingGoals(page);
   plan = new Plan(page, plans, constraints, schedulingGoals, schedulingConditions);
 
   await models.goto();

--- a/e2e-tests/tests/timeline-view-editing.test.ts
+++ b/e2e-tests/tests/timeline-view-editing.test.ts
@@ -22,9 +22,9 @@ test.beforeAll(async ({ browser }) => {
 
   models = new Models(page);
   plans = new Plans(page, models);
-  constraints = new Constraints(page, models);
-  schedulingConditions = new SchedulingConditions(page, models);
-  schedulingGoals = new SchedulingGoals(page, models);
+  constraints = new Constraints(page);
+  schedulingConditions = new SchedulingConditions(page);
+  schedulingGoals = new SchedulingGoals(page);
   plan = new Plan(page, plans, constraints, schedulingGoals, schedulingConditions);
 
   await models.goto();

--- a/e2e-tests/tests/view.test.ts
+++ b/e2e-tests/tests/view.test.ts
@@ -24,9 +24,9 @@ test.beforeAll(async ({ browser }) => {
 
   models = new Models(page);
   plans = new Plans(page, models);
-  constraints = new Constraints(page, models);
-  schedulingConditions = new SchedulingConditions(page, models);
-  schedulingGoals = new SchedulingGoals(page, models);
+  constraints = new Constraints(page);
+  schedulingConditions = new SchedulingConditions(page);
+  schedulingGoals = new SchedulingGoals(page);
   plan = new Plan(page, plans, constraints, schedulingGoals, schedulingConditions);
   view = new View(page);
 

--- a/src/components/parcels/ParcelForm.svelte
+++ b/src/components/parcels/ParcelForm.svelte
@@ -130,7 +130,6 @@
 
   function onToggleParameterDictionary(event: CustomEvent<{ ids: Record<number, boolean> }>) {
     selectedParmeterDictionaries = event.detail.ids;
-    console.log(selectedParmeterDictionaries);
   }
 
   function onToggleSequenceAdaptation(event: CustomEvent<{ id: number | null }>) {

--- a/src/components/plan/PlanMergeReview.test.ts
+++ b/src/components/plan/PlanMergeReview.test.ts
@@ -69,6 +69,7 @@ const mockInitialPlan: Plan = {
     scheduling_specification_conditions: [],
     scheduling_specification_goals: [],
     version: '1.0.0',
+    view: null,
   },
   model_id: 1,
   name: 'Demo Plan',

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -45,7 +45,13 @@ export const load: PageLoad = async ({ parent, params, url }) => {
       const initialActivityTypes = await effects.getActivityTypes(initialPlan.model_id, user);
       const initialResourceTypes = await effects.getResourceTypes(initialPlan.model_id, user, 20);
       const initialPlanTags = await effects.getPlanTags(initialPlan.id, user);
-      const initialView = await effects.getView(url.searchParams, user, initialActivityTypes, initialResourceTypes);
+      const initialView = await effects.getView(
+        url.searchParams,
+        user,
+        initialActivityTypes,
+        initialResourceTypes,
+        initialPlan.model_id,
+      );
       const initialPlanSnapshotId = getSearchParameterNumber(SearchParameters.SNAPSHOT_ID, url.searchParams);
       const extensions = await effects.getExtensions(user);
 

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -42,6 +42,8 @@ export const load: PageLoad = async ({ parent, params, url }) => {
         };
       }
 
+      console.log(initialPlan.model.view);
+
       const initialActivityTypes = await effects.getActivityTypes(initialPlan.model_id, user);
       const initialResourceTypes = await effects.getResourceTypes(initialPlan.model_id, user, 20);
       const initialPlanTags = await effects.getPlanTags(initialPlan.id, user);
@@ -50,7 +52,7 @@ export const load: PageLoad = async ({ parent, params, url }) => {
         user,
         initialActivityTypes,
         initialResourceTypes,
-        initialPlan.model_id,
+        initialPlan.model.view,
       );
       const initialPlanSnapshotId = getSearchParameterNumber(SearchParameters.SNAPSHOT_ID, url.searchParams);
       const extensions = await effects.getExtensions(user);

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -42,8 +42,6 @@ export const load: PageLoad = async ({ parent, params, url }) => {
         };
       }
 
-      console.log(initialPlan.model.view);
-
       const initialActivityTypes = await effects.getActivityTypes(initialPlan.model_id, user);
       const initialResourceTypes = await effects.getResourceTypes(initialPlan.model_id, user, 20);
       const initialPlanTags = await effects.getPlanTags(initialPlan.id, user);

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -2,6 +2,7 @@ import type { UserId } from './app';
 import type { ConstraintModelSpec } from './constraint';
 import type { ParametersMap } from './parameter';
 import type { SchedulingConditionModelSpecification, SchedulingGoalModelSpecification } from './scheduling';
+import type { View } from './view';
 
 export type Model = ModelSchema;
 
@@ -22,6 +23,7 @@ export type ModelSchema = {
   scheduling_specification_conditions: SchedulingConditionModelSpecification[];
   scheduling_specification_goals: SchedulingGoalModelSpecification[];
   version: string;
+  view: View | null;
 };
 
 export type ModelSlim = Pick<

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -3005,22 +3005,6 @@ const effects = {
     }
   },
 
-  async getMissionModelDefaultView(mission_model_id: number, user: User | null): Promise<View | null> {
-    try {
-      const data = await reqHasura<{ view: View }[]>(gql.GET_DEFAULT_VIEW, { mission_model_id }, user);
-      const { defaultView } = data;
-
-      if (defaultView !== null && defaultView.length) {
-        return defaultView[0].view;
-      }
-
-      return null;
-    } catch (e) {
-      catchError(e as Error);
-      return null;
-    }
-  },
-
   async getModel(modelId: number, user: User | null): Promise<Model | null> {
     try {
       const query = convertToQuery(gql.SUB_MODEL);
@@ -3787,7 +3771,7 @@ const effects = {
     user: User | null,
     activityTypes: ActivityType[] = [],
     resourceTypes: ResourceType[] = [],
-    mission_model_id?: number,
+    view: View | null,
   ): Promise<View | null> {
     try {
       if (query !== null) {
@@ -3800,12 +3784,8 @@ const effects = {
           if (view !== null) {
             return view;
           }
-        } else if (mission_model_id !== null && mission_model_id !== undefined) {
-          const missionModelDefaultView = await this.getMissionModelDefaultView(mission_model_id, user);
-
-          if (missionModelDefaultView !== null) {
-            return missionModelDefaultView;
-          }
+        } else if (view !== null) {
+          return view;
         }
       }
       return generateDefaultView(activityTypes, resourceTypes);

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -3771,7 +3771,7 @@ const effects = {
     user: User | null,
     activityTypes: ActivityType[] = [],
     resourceTypes: ResourceType[] = [],
-    view?: View | null,
+    defaultView?: View | null,
   ): Promise<View | null> {
     try {
       if (query !== null) {
@@ -3784,8 +3784,8 @@ const effects = {
           if (view !== null) {
             return view;
           }
-        } else if (view !== null && view !== undefined) {
-          return view;
+        } else if (defaultView !== null && defaultView !== undefined) {
+          return defaultView;
         }
       }
       return generateDefaultView(activityTypes, resourceTypes);

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -3771,7 +3771,7 @@ const effects = {
     user: User | null,
     activityTypes: ActivityType[] = [],
     resourceTypes: ResourceType[] = [],
-    view: View | null,
+    view?: View | null,
   ): Promise<View | null> {
     try {
       if (query !== null) {
@@ -3784,7 +3784,7 @@ const effects = {
           if (view !== null) {
             return view;
           }
-        } else if (view !== null) {
+        } else if (view !== null && view !== undefined) {
           return view;
         }
       }

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -204,7 +204,6 @@ export enum Queries {
   USERS = 'users',
   VALIDATE_ACTIVITY_ARGUMENTS = 'validateActivityArguments',
   VIEW = 'view_by_pk',
-  VIEW_TO_MISSION_MODEL = 'view_to_mission_model',
   VIEWS = 'view',
   WITHDRAW_MERGE_REQUEST = 'withdraw_merge_request',
 }

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -204,6 +204,7 @@ export enum Queries {
   USERS = 'users',
   VALIDATE_ACTIVITY_ARGUMENTS = 'validateActivityArguments',
   VIEW = 'view_by_pk',
+  VIEW_TO_MISSION_MODEL = 'view_to_mission_model',
   VIEWS = 'view',
   WITHDRAW_MERGE_REQUEST = 'withdraw_merge_request',
 }
@@ -1124,6 +1125,21 @@ const gql = {
           updated_at
         }
         name
+      }
+    }
+  `,
+
+  GET_DEFAULT_VIEW: `#graphql
+    query GetDefaultView($mission_model_id: Int!) {
+      defaultView: ${Queries.VIEW_TO_MISSION_MODEL}(where: {mission_model_id: {_eq: $mission_model_id}}) {
+        view {
+          created_at
+          definition
+          id
+          name
+          owner
+          updated_at
+        }
       }
     }
   `,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1129,21 +1129,6 @@ const gql = {
     }
   `,
 
-  GET_DEFAULT_VIEW: `#graphql
-    query GetDefaultView($mission_model_id: Int!) {
-      defaultView: ${Queries.VIEW_TO_MISSION_MODEL}(where: {mission_model_id: {_eq: $mission_model_id}}) {
-        view {
-          created_at
-          definition
-          id
-          name
-          owner
-          updated_at
-        }
-      }
-    }
-  `,
-
   GET_EFFECTIVE_ACTIVITY_ARGUMENTS: `#graphql
     query GetEffectiveActivityArguments($modelId: ID!, $activityTypeName: String!, $arguments: ActivityArguments!) {
       effectiveActivityArguments: ${Queries.GET_ACTIVITY_EFFECTIVE_ARGUMENTS}(
@@ -1390,6 +1375,14 @@ const gql = {
             parameters
           }
           version
+          view {
+            created_at
+            definition
+            id
+            name
+            owner
+            updated_at
+          }
         }
         model_id
         name

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -599,6 +599,7 @@ const queryPermissions = {
   },
   GET_ACTIVITY_DIRECTIVE_CHANGELOG: () => true,
   GET_ACTIVITY_TYPES_EXPANSION_RULES: () => true,
+  GET_DEFAULT_VIEW: () => true,
   GET_EFFECTIVE_ACTIVITY_ARGUMENTS: () => true,
   GET_EFFECTIVE_MODEL_ARGUMENTS: () => true,
   GET_EVENTS: () => true,

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -599,7 +599,6 @@ const queryPermissions = {
   },
   GET_ACTIVITY_DIRECTIVE_CHANGELOG: () => true,
   GET_ACTIVITY_TYPES_EXPANSION_RULES: () => true,
-  GET_DEFAULT_VIEW: () => true,
   GET_EFFECTIVE_ACTIVITY_ARGUMENTS: () => true,
   GET_EFFECTIVE_MODEL_ARGUMENTS: () => true,
   GET_EVENTS: () => true,


### PR DESCRIPTION
Adds default views for a given mission model. Right now there's no UI for creating a default view, so to test you need to manually insert a row using Hasura into the `view_to_mission_model` table.

Associated backend PR: https://github.com/NASA-AMMOS/aerie/pull/1461