### PR TITLE
Added names to sequence adaptations

### DIFF
--- a/e2e-tests/fixtures/Dictionaries.ts
+++ b/e2e-tests/fixtures/Dictionaries.ts
@@ -35,6 +35,8 @@ export class Dictionaries {
   parameterDictionaryTableRow: Locator;
   parameterDictionaryTableRowDeleteButton: Locator;
   sequenceAdaptationBuffer: Buffer;
+  sequenceAdaptationName: string;
+  sequenceAdaptationNameInputField: Locator;
   sequenceAdaptationPath: string = 'e2e-tests/data/sequence-adaptation.js';
   sequenceAdaptationTable: Locator;
   sequenceAdaptationTableRow: Locator;
@@ -48,7 +50,8 @@ export class Dictionaries {
     this.commandDictionaryBuffer = this.readDictionary(this.commandDictionaryName, COMMAND_DICTIONARY_PATH);
     this.parameterDictionaryName = uniqueNamesGenerator({ dictionaries: [adjectives, colors, animals] });
     this.parameterDictionaryBuffer = this.readDictionary(this.parameterDictionaryName, this.parameterDictionaryPath);
-    this.sequenceAdaptationBuffer = this.readDictionary(DictionaryType.SequenceAdaptation, this.sequenceAdaptationPath);
+    this.sequenceAdaptationName = uniqueNamesGenerator({ dictionaries: [adjectives, colors, animals] });
+    this.sequenceAdaptationBuffer = this.readDictionary(this.sequenceAdaptationName, this.sequenceAdaptationPath);
 
     this.page = page;
   }
@@ -84,12 +87,13 @@ export class Dictionaries {
     tableRow: Locator,
     type: DictionaryType,
   ): Promise<void> {
-    // TODO: Remove this conditional when we add Sequence Adaptation names and we can tie to a specific row.
-    if (type !== DictionaryType.SequenceAdaptation) {
-      await expect(tableRow).not.toBeVisible();
+    await this.fillInputFile(dictionaryBuffer, dictionaryName, type);
+
+    if (type === DictionaryType.SequenceAdaptation) {
+      await expect(this.sequenceAdaptationNameInputField).toBeVisible();
+      await this.sequenceAdaptationNameInputField.fill(this.sequenceAdaptationName);
     }
 
-    await this.fillInputFile(dictionaryBuffer, dictionaryName);
     await this.createButton.click();
     await this.filterTable(table, dictionaryName);
     await tableRow.waitFor({ state: 'attached' });
@@ -110,7 +114,7 @@ export class Dictionaries {
   }
 
   async createSequenceAdaptation(): Promise<void> {
-    await this.updatePage(this.page, DictionaryType.SequenceAdaptation);
+    await this.updatePage(this.page, DictionaryType.SequenceAdaptation, this.sequenceAdaptationName);
 
     await this.createDictionary(
       this.sequenceAdaptationBuffer,
@@ -169,17 +173,28 @@ export class Dictionaries {
   }
 
   async deleteSequenceAdaptation(): Promise<void> {
-    await this.updatePage(this.page, DictionaryType.SequenceAdaptation);
+    await this.updatePage(this.page, DictionaryType.SequenceAdaptation, this.sequenceAdaptationName);
 
     await this.deleteDictionary(this.sequenceAdaptationTableRow, this.sequenceAdaptationTableRowDeleteButton);
   }
 
-  private async fillInputFile(dictionaryBuffer: Buffer, dictionaryName: string) {
+  private async fillInputFile(dictionaryBuffer: Buffer, dictionaryName: string, type: DictionaryType) {
+    let mimeType: string;
+    let name: string;
+
+    if (type === DictionaryType.SequenceAdaptation) {
+      mimeType = 'application/x-javascript';
+      name = dictionaryName + '.js';
+    } else {
+      mimeType = 'application/xml';
+      name = dictionaryName + '.xml';
+    }
+
     await this.inputFile.focus();
     await this.inputFile.setInputFiles({
       buffer: dictionaryBuffer,
-      mimeType: 'application/xml',
-      name: dictionaryName,
+      mimeType,
+      name,
     });
     await this.inputFile.evaluate(e => e.blur());
   }
@@ -221,36 +236,31 @@ export class Dictionaries {
     this.createButton = this.page.locator(`button:has-text("Create")`);
     this.inputFile = this.page.locator('input[name="file"]');
 
-    // TODO: Sequence Adaptations don't have a name, so skip this for these tests. Can be cleaned up when we add names.
-    if (dictionaryName !== undefined) {
-      this.channelDictionaryTable = this.page.locator('.panel:has-text("Channel Dictionaries")').getByRole('treegrid');
-      this.channelDictionaryTableRow = this.channelDictionaryTable.getByRole('row', { name: dictionaryName });
-      this.channelDictionaryTableRowDeleteButton = this.channelDictionaryTableRow
-        .getByRole('gridcell')
-        .getByRole('button', { name: `Delete ${DictionaryType.ChannelDictionary}` });
+    this.channelDictionaryTable = this.page.locator('.panel:has-text("Channel Dictionaries")').getByRole('treegrid');
+    this.channelDictionaryTableRow = this.channelDictionaryTable.getByRole('row', { name: dictionaryName });
+    this.channelDictionaryTableRowDeleteButton = this.channelDictionaryTableRow
+      .getByRole('gridcell')
+      .getByRole('button', { name: `Delete ${DictionaryType.ChannelDictionary}` });
 
-      this.commandDictionaryTable = this.page.locator('.panel:has-text("Command Dictionaries")').getByRole('treegrid');
-      this.commandDictionaryTableRow = this.commandDictionaryTable.getByRole('row', { name: dictionaryName });
-      this.commandDictionaryTableRowDeleteButton = this.commandDictionaryTable
-        .getByRole('gridcell')
-        .getByRole('button', { name: `Delete ${DictionaryType.CommandDictionary}` });
+    this.commandDictionaryTable = this.page.locator('.panel:has-text("Command Dictionaries")').getByRole('treegrid');
+    this.commandDictionaryTableRow = this.commandDictionaryTable.getByRole('row', { name: dictionaryName });
+    this.commandDictionaryTableRowDeleteButton = this.commandDictionaryTable
+      .getByRole('gridcell')
+      .getByRole('button', { name: `Delete ${DictionaryType.CommandDictionary}` });
 
-      this.parameterDictionaryTable = this.page
-        .locator('.panel:has-text("Parameter Dictionaries")')
-        .getByRole('treegrid');
-      this.parameterDictionaryTableRow = this.parameterDictionaryTable.getByRole('row', { name: dictionaryName });
-      this.parameterDictionaryTableRowDeleteButton = this.parameterDictionaryTable
-        .getByRole('gridcell')
-        .getByRole('button', { name: `Delete ${DictionaryType.ParameterDictionary}` });
-    } else {
-      this.sequenceAdaptationTable = this.page.locator('.panel:has-text("Sequence Adaptations")').getByRole('treegrid');
-      this.sequenceAdaptationTableRows = this.page
-        .locator('.panel', { hasText: 'Sequence Adaptations' })
-        .locator('.body .ag-row');
-      this.sequenceAdaptationTableRow = this.sequenceAdaptationTableRows.first();
-      this.sequenceAdaptationTableRowDeleteButton = this.sequenceAdaptationTableRow.locator(
-        `button[aria-label="Delete ${DictionaryType.SequenceAdaptation}"]`,
-      );
-    }
+    this.parameterDictionaryTable = this.page
+      .locator('.panel:has-text("Parameter Dictionaries")')
+      .getByRole('treegrid');
+    this.parameterDictionaryTableRow = this.parameterDictionaryTable.getByRole('row', { name: dictionaryName });
+    this.parameterDictionaryTableRowDeleteButton = this.parameterDictionaryTable
+      .getByRole('gridcell')
+      .getByRole('button', { name: `Delete ${DictionaryType.ParameterDictionary}` });
+
+    this.sequenceAdaptationTable = this.page.locator('.panel:has-text("Sequence Adaptations")').getByRole('treegrid');
+    this.sequenceAdaptationTableRow = this.sequenceAdaptationTable.getByRole('row', { name: dictionaryName });
+    this.sequenceAdaptationTableRowDeleteButton = this.sequenceAdaptationTable
+      .getByRole('gridcell')
+      .getByRole('button', { name: `Delete ${DictionaryType.SequenceAdaptation}` });
+    this.sequenceAdaptationNameInputField = this.page.locator(`input[name="sequenceAdaptationName"]`);
   }
 }

--- a/e2e-tests/fixtures/Dictionaries.ts
+++ b/e2e-tests/fixtures/Dictionaries.ts
@@ -95,7 +95,7 @@ export class Dictionaries {
     }
 
     await this.createButton.click();
-    await this.filterTable(table, dictionaryName);
+    await this.filterTable(table, dictionaryName, type);
     await tableRow.waitFor({ state: 'attached' });
     await tableRow.waitFor({ state: 'visible' });
     await expect(tableRow).toBeVisible();
@@ -118,7 +118,7 @@ export class Dictionaries {
 
     await this.createDictionary(
       this.sequenceAdaptationBuffer,
-      'Sequence Adaptation',
+      this.sequenceAdaptationName,
       this.sequenceAdaptationTable,
       this.sequenceAdaptationTableRow,
       DictionaryType.SequenceAdaptation,
@@ -128,13 +128,13 @@ export class Dictionaries {
   async deleteChannelDictionary(): Promise<void> {
     await this.updatePage(this.page, DictionaryType.ChannelDictionary, this.channelDictionaryName);
 
-    await this.filterTable(this.channelDictionaryTable, this.channelDictionaryName);
+    await this.filterTable(this.channelDictionaryTable, this.channelDictionaryName, DictionaryType.ChannelDictionary);
     await this.deleteDictionary(this.channelDictionaryTableRow, this.channelDictionaryTableRowDeleteButton);
   }
 
   async deleteCommandDictionary(): Promise<void> {
     await this.updatePage(this.page, DictionaryType.CommandDictionary, this.commandDictionaryName);
-    await this.filterTable(this.commandDictionaryTable, this.commandDictionaryName);
+    await this.filterTable(this.commandDictionaryTable, this.commandDictionaryName, DictionaryType.CommandDictionary);
 
     await this.deleteDictionary(this.commandDictionaryTableRow, this.commandDictionaryTableRowDeleteButton);
   }
@@ -168,13 +168,22 @@ export class Dictionaries {
   async deleteParameterDictionary(): Promise<void> {
     await this.updatePage(this.page, DictionaryType.ParameterDictionary, this.parameterDictionaryName);
 
-    await this.filterTable(this.parameterDictionaryTable, this.parameterDictionaryName);
+    await this.filterTable(
+      this.parameterDictionaryTable,
+      this.parameterDictionaryName,
+      DictionaryType.ParameterDictionary,
+    );
     await this.deleteDictionary(this.parameterDictionaryTableRow, this.parameterDictionaryTableRowDeleteButton);
   }
 
   async deleteSequenceAdaptation(): Promise<void> {
     await this.updatePage(this.page, DictionaryType.SequenceAdaptation, this.sequenceAdaptationName);
 
+    await this.filterTable(
+      this.sequenceAdaptationTable,
+      this.sequenceAdaptationName,
+      DictionaryType.SequenceAdaptation,
+    );
     await this.deleteDictionary(this.sequenceAdaptationTableRow, this.sequenceAdaptationTableRowDeleteButton);
   }
 
@@ -199,11 +208,17 @@ export class Dictionaries {
     await this.inputFile.evaluate(e => e.blur());
   }
 
-  private async filterTable(table: Locator, dictionaryName: string) {
+  private async filterTable(table: Locator, dictionaryName: string, type: DictionaryType) {
     await table.waitFor({ state: 'attached' });
     await table.waitFor({ state: 'visible' });
+    let nameColumnHeader: Locator | undefined = undefined;
 
-    const nameColumnHeader = await table.getByRole('columnheader', { name: 'Mission' });
+    if (type === DictionaryType.SequenceAdaptation) {
+      nameColumnHeader = table.getByRole('columnheader', { name: 'Name' });
+    } else {
+      nameColumnHeader = table.getByRole('columnheader', { name: 'Mission' });
+    }
+
     await nameColumnHeader.hover();
 
     const filterIcon = await nameColumnHeader.locator('.ag-icon-menu');

--- a/e2e-tests/fixtures/Parcels.ts
+++ b/e2e-tests/fixtures/Parcels.ts
@@ -2,7 +2,6 @@ import { Locator, Page, expect } from '@playwright/test';
 import { adjectives, animals, colors, uniqueNamesGenerator } from 'unique-names-generator';
 
 export class Parcels {
-  cancelButton: Locator;
   closeButton: Locator;
   confirmModal: Locator;
   confirmModalDeleteButton: Locator;
@@ -107,7 +106,6 @@ export class Parcels {
   updatePage(page: Page): void {
     this.page = page;
 
-    this.cancelButton = page.locator(`button:has-text("Cancel")`);
     this.closeButton = page.locator(`button:has-text("Close")`);
     this.confirmModal = page.locator(`.modal:has-text("Delete Parcel")`);
     this.confirmModalDeleteButton = this.confirmModal.getByRole('button', { name: 'Delete' });

--- a/e2e-tests/tests/dictionaries.test.ts
+++ b/e2e-tests/tests/dictionaries.test.ts
@@ -47,7 +47,7 @@ test.describe('Dictionaries', () => {
     });
   });
 
-  test.describe.skip('Sequence Adaptation', () => {
+  test.describe('Sequence Adaptation', () => {
     test('Create sequence adaptation', async () => {
       await dictionaries.createSequenceAdaptation();
     });

--- a/e2e-tests/tests/parcels.test.ts
+++ b/e2e-tests/tests/parcels.test.ts
@@ -24,7 +24,7 @@ test.beforeAll(async ({ browser }) => {
   );
 
   await dictionaries.goto();
-  await dictionaries.updatePage(page, DictionaryType.CommandDictionary, firstCommandDictionaryName);
+  await dictionaries.updatePage(DictionaryType.CommandDictionary, firstCommandDictionaryName);
   await dictionaries.createDictionary(
     firstCommandDictionaryBuffer,
     firstCommandDictionaryName,
@@ -32,7 +32,7 @@ test.beforeAll(async ({ browser }) => {
     dictionaries.commandDictionaryTableRow,
     DictionaryType.CommandDictionary,
   );
-  await dictionaries.updatePage(page, DictionaryType.CommandDictionary, secondCommandDictionaryName);
+  await dictionaries.updatePage(DictionaryType.CommandDictionary, secondCommandDictionaryName);
   await dictionaries.createDictionary(
     secondCommandDictionaryBuffer,
     secondCommandDictionaryName,

--- a/e2e-tests/tests/parcels.test.ts
+++ b/e2e-tests/tests/parcels.test.ts
@@ -24,7 +24,7 @@ test.beforeAll(async ({ browser }) => {
   );
 
   await dictionaries.goto();
-  await dictionaries.updatePage(DictionaryType.CommandDictionary, firstCommandDictionaryName);
+  await dictionaries.updatePage(page, DictionaryType.CommandDictionary, firstCommandDictionaryName);
   await dictionaries.createDictionary(
     firstCommandDictionaryBuffer,
     firstCommandDictionaryName,
@@ -32,7 +32,7 @@ test.beforeAll(async ({ browser }) => {
     dictionaries.commandDictionaryTableRow,
     DictionaryType.CommandDictionary,
   );
-  await dictionaries.updatePage(DictionaryType.CommandDictionary, secondCommandDictionaryName);
+  await dictionaries.updatePage(page, DictionaryType.CommandDictionary, secondCommandDictionaryName);
   await dictionaries.createDictionary(
     secondCommandDictionaryBuffer,
     secondCommandDictionaryName,

--- a/src/components/parcels/DictionaryTable.svelte
+++ b/src/components/parcels/DictionaryTable.svelte
@@ -93,6 +93,7 @@
 
   $: sequenceAdaptationColumDefs = [
     ...(isEditingParcel ? editingColumnDefs : []),
+    { field: 'name', filter: 'text', headerName: 'Name', sortable: true, width: 100 },
     {
       field: 'id',
       filter: 'number',

--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -36,9 +36,9 @@
   let sequenceAdaptationName: string;
 
   $: hasCreatePermission = featurePermissions.commandDictionary.canCreate(data.user);
-  $: createButtonDisabled = !files || (isSequenceAdaptation && sequenceAdaptationName === '');
+  $: createButtonDisabled = !files || files?.length === 0 || (isSequenceAdaptation && sequenceAdaptationName === '');
   $: {
-    if (files) {
+    if (files && files.length > 0) {
       file = files[0];
 
       isSequenceAdaptation = file.name.substring(file.name.lastIndexOf('.')) === '.js';

--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -31,16 +31,17 @@
   let creatingDictionary: boolean = false;
   let files: FileList;
   let file: File;
+  let fileInput: HTMLInputElement;
   let isSequenceAdaptation: boolean = false;
   let sequenceAdaptationName: string;
 
   $: hasCreatePermission = featurePermissions.commandDictionary.canCreate(data.user);
-  $: createButtonDisabled = !files;
+  $: createButtonDisabled = !files || (isSequenceAdaptation && sequenceAdaptationName === '');
   $: {
     if (files) {
       file = files[0];
 
-      isSequenceAdaptation = file.type === 'application/x-javascript';
+      isSequenceAdaptation = file.name.substring(file.name.lastIndexOf('.')) === '.js';
       sequenceAdaptationName = '';
     }
   }
@@ -73,11 +74,15 @@
           showSuccessToast('Parameter Dictionary Created Successfully');
           break;
         }
-        case 'ADAPTATION': {
+        case DictionaryTypes.ADAPTATION: {
           showSuccessToast('Sequence Adaptation Created Successfully');
           break;
         }
       }
+
+      fileInput.value = '';
+      isSequenceAdaptation = false;
+      sequenceAdaptationName = '';
     } catch (e) {
       createDictionaryError = (e as Error).message;
       showFailureToast('Command Dictionary Create Failed');
@@ -129,6 +134,7 @@
               required
               type="file"
               bind:files
+              bind:this={fileInput}
               use:permissionHandler={{
                 hasPermission: hasCreatePermission,
                 permissionError: createPermissionError,

--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -30,16 +30,31 @@
   let createDictionaryError: string | null = null;
   let creatingDictionary: boolean = false;
   let files: FileList;
+  let file: File;
+  let isSequenceAdaptation: boolean = false;
+  let sequenceAdaptationName: string;
 
   $: hasCreatePermission = featurePermissions.commandDictionary.canCreate(data.user);
   $: createButtonDisabled = !files;
+  $: {
+    if (files) {
+      file = files[0];
 
-  async function uploadDictionaryOrAdaptation(files: FileList) {
+      isSequenceAdaptation = file.type === 'application/x-javascript';
+      sequenceAdaptationName = '';
+    }
+  }
+
+  async function uploadDictionaryOrAdaptation() {
     createDictionaryError = null;
     creatingDictionary = true;
 
     try {
-      const uploadedDictionaryOrAdaptation = await effects.uploadDictionaryOrAdaptation(files, data.user);
+      const uploadedDictionaryOrAdaptation = await effects.uploadDictionaryOrAdaptation(
+        file,
+        data.user,
+        sequenceAdaptationName,
+      );
 
       if (uploadedDictionaryOrAdaptation === null) {
         throw Error('Failed to upload file');
@@ -102,12 +117,13 @@
       </svelte:fragment>
 
       <svelte:fragment slot="body">
-        <form on:submit|preventDefault={() => uploadDictionaryOrAdaptation(files)}>
+        <form on:submit|preventDefault={uploadDictionaryOrAdaptation}>
           <AlertError class="m-2" error={createDictionaryError} />
 
           <fieldset>
             <label for="file">AMPCS XML File or Sequence Adaptation</label>
             <input
+              accept=".xml,.js"
               class="w-100 st-typography-body"
               name="file"
               required
@@ -119,6 +135,19 @@
               }}
             />
           </fieldset>
+
+          {#if isSequenceAdaptation}
+            <fieldset>
+              <input
+                bind:value={sequenceAdaptationName}
+                autocomplete="off"
+                class="st-input w-100"
+                name="sequenceAdaptationName"
+                placeholder="Enter Sequence Adaptation Name"
+                required={isSequenceAdaptation}
+              />
+            </fieldset>
+          {/if}
 
           <fieldset>
             <button

--- a/src/types/sequencing.ts
+++ b/src/types/sequencing.ts
@@ -15,6 +15,7 @@ export type ParameterDictionary = {
 
 export type SequenceAdaptation = {
   adaptation: string;
+  name: string;
   type: DictionaryTypes.ADAPTATION;
 } & DictionaryType;
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -663,7 +663,7 @@ const effects = {
   },
 
   async createCustomAdaptation(
-    adaptation: { adaptation: string },
+    adaptation: { adaptation: string; name: string },
     user: User | null,
   ): Promise<SequenceAdaptation | null> {
     try {
@@ -5301,10 +5301,10 @@ const effects = {
   },
 
   async uploadDictionaryOrAdaptation(
-    files: FileList,
+    file: File,
     user: User | null,
+    sequenceAdaptationName?: string | undefined,
   ): Promise<CommandDictionary | ChannelDictionary | ParameterDictionary | SequenceAdaptation | null> {
-    const file: File = files[0];
     const text = await file.text();
     const splitLineDictionary = text.split('\n');
 
@@ -5323,8 +5323,14 @@ const effects = {
         break;
       }
       default: {
-        const adaptation = await this.createCustomAdaptation({ adaptation: text }, user);
-        return adaptation;
+        if (sequenceAdaptationName) {
+          const adaptation = await this.createCustomAdaptation(
+            { adaptation: text, name: sequenceAdaptationName },
+            user,
+          );
+          return adaptation;
+        }
+        break;
       }
     }
     const dictionary = await this.uploadDictionary(text, type, user);

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -640,6 +640,7 @@ const gql = {
     mutation CreateCustomAdaptation($adaptation: sequence_adaptation_insert_input!) {
       createSequenceAdaptation: ${Queries.INSERT_SEQUENCE_ADAPTATION}(object: $adaptation) {
         adaptation
+        name
         created_at
       }
     }
@@ -1596,6 +1597,7 @@ const gql = {
     query GetSequenceAdaptation($sequence_adaptation_id: Int!) {
       ${Queries.SEQUENCE_ADAPTATION}(where: { id: { _eq: $sequence_adaptation_id }}) {
         adaptation
+        name
       }
     }
   `,
@@ -2825,6 +2827,7 @@ const gql = {
         adaptation
         created_at
         id
+        name
         updated_by
       }
     }


### PR DESCRIPTION
Adds unique sequence adaptation names to conform to the standard of our other dictionary types.

To test:
When uploading a `.js` file on the Dictionaries page a new name field appears where a required name is needed for Sequence Adaptations. This was done because the adaptations are built files and don't contain metadata like the other dictionaries.

Backend PR: https://github.com/NASA-AMMOS/aerie/pull/1469