### PR TITLE
Handle Escaped Quotes in Metadata and Models values

### DIFF
--- a/src/tests/mocks/sequencing/grammar-cases/parse_tree.txt
+++ b/src/tests/mocks/sequencing/grammar-cases/parse_tree.txt
@@ -183,6 +183,9 @@ Sequence(
 @ID "big test"
 
 @METADATA "foo" "val foo"
+@METADATA "empty_object" {}
+@METADATA "empty_object_with_space" { }
+@METADATA "level0" { "level1": { "l2obj": { }, "l2empty_arr": [ ], "l2arr": [ 1, 2, 3 ] } }
 
 
 CMD_1 1 2 3
@@ -198,8 +201,18 @@ CMD_2 "hello, it's me"
 Sequence(
   IdDeclaration(String),
   Metadata(
-    MetaEntry(Key(String),Value(String))
+    MetaEntry(Key(String),Value(String)),
+    MetaEntry(Key(String),Value(Object)),
+    MetaEntry(Key(String),Value(Object)),
+    MetaEntry(Key(String),Value(
+      Object(Property(PropertyName(String),Object(
+        Property(PropertyName(String),Object),
+        Property(PropertyName(String),Array),
+        Property(PropertyName(String),Array(Number,Number,Number))
+      ))
+    )))
   ),
+
   Commands(
     Command(
       Stem,

--- a/src/utilities/codemirror/sequence.grammar
+++ b/src/utilities/codemirror/sequence.grammar
@@ -97,8 +97,8 @@ metaValue {
   String | Number | Boolean | Null | Array | Object
 }
 
-Object { "{" list<Property>? "}" }
-Array  { "[" list<metaValue>? "]" }
+Object { "{" (optSpace | list<Property>) "}" }
+Array  { "[" (optSpace | list<metaValue>) "]" }
 
 Property { PropertyName optSpace ":" optSpace metaValue }
 PropertyName[isolate] { String }

--- a/src/utilities/new-sequence-editor/to-seq-json.test.ts
+++ b/src/utilities/new-sequence-editor/to-seq-json.test.ts
@@ -428,4 +428,64 @@ C ECHO L01STR
     };
     expect(actual).toEqual(expected);
   });
+
+  it('Convert quoted metadata and models', () => {
+    const seq = `@ID "escaped_metadata"
+
+R00:00:01 ECHO "Can this handle \\"Escaped\\" quotes??" # and this "too"
+@METADATA "key" "value"
+@METADATA "home" " \\"world\\""
+@METADATA "array" [ "\\" quoted ", 1, true, null, "seq" ]
+@METADATA "object" { "\\"earth\\"" : "green", "array" : [ "\\" quoted ", 1, true, null, "seq" ]}
+@METADATA "this_\\"is\\"_my_key" "This is the value"
+@MODEL "Variable" 0 "Offset"
+@MODEL "Variable \\"Escaped\\"" 0 "Offset \\" \\" \\"\\""`;
+    const id = 'escaped_metadata';
+    const actual = sequenceToSeqJson(SeqLanguage.parser.parse(seq), seq, commandBanana, [], null, id);
+    const expected = {
+      id,
+      metadata: {},
+      steps: [
+        {
+          args: [
+            {
+              name: 'echo_string',
+              type: 'string',
+              value: 'Can this handle "Escaped" quotes??',
+            },
+          ],
+          description: 'and this "too"',
+          metadata: {
+            array: ['" quoted ', 1, true, null, 'seq'],
+            home: ' "world"',
+            key: 'value',
+            object: {
+              '"earth"': 'green',
+              array: ['" quoted ', 1, true, null, 'seq'],
+            },
+            'this_"is"_my_key': 'This is the value',
+          },
+          models: [
+            {
+              offset: 'Offset',
+              value: 0,
+              variable: 'Variable',
+            },
+            {
+              offset: 'Offset " " ""',
+              value: 0,
+              variable: 'Variable "Escaped"',
+            },
+          ],
+          stem: 'ECHO',
+          time: {
+            tag: '00:00:01',
+            type: 'COMMAND_RELATIVE',
+          },
+          type: 'command',
+        },
+      ],
+    };
+    expect(actual).toEqual(expected);
+  });
 });

--- a/src/utilities/new-sequence-editor/to-seq-json.ts
+++ b/src/utilities/new-sequence-editor/to-seq-json.ts
@@ -23,7 +23,7 @@ import type {
   Time,
   VariableDeclaration,
 } from '@nasa-jpl/seq-json-schema/types';
-import { removeEscapedQuotes } from '../codemirror/codemirror-utils';
+import { removeEscapedQuotes, unquoteUnescape } from '../codemirror/codemirror-utils';
 import { customizeSeqJson } from './extension-points';
 import { logInfo } from './logger';
 import { TOKEN_REPEAT_ARG } from './sequencer-grammar-constants';
@@ -374,7 +374,7 @@ function parseModel(node: SyntaxNode, text: string): Model[] | undefined {
     const offsetNode = modelNode.getChild('Offset');
 
     const variable = variableNode
-      ? (removeEscapedQuotes(text.slice(variableNode.from, variableNode.to)) as string)
+      ? (unquoteUnescape(text.slice(variableNode.from, variableNode.to)) as string)
       : 'UNKNOWN';
 
     // Value can be string, number or boolean
@@ -384,7 +384,7 @@ function parseModel(node: SyntaxNode, text: string): Model[] | undefined {
       if (valueChild) {
         const valueText = text.slice(valueChild.from, valueChild.to);
         if (valueChild.name === 'String') {
-          value = removeEscapedQuotes(valueText);
+          value = unquoteUnescape(valueText);
         } else if (valueChild.name === 'Boolean') {
           value = !/^FALSE$/i.test(valueText);
         } else if (valueChild.name === 'Number') {
@@ -392,7 +392,7 @@ function parseModel(node: SyntaxNode, text: string): Model[] | undefined {
         }
       }
     }
-    const offset = offsetNode ? (removeEscapedQuotes(text.slice(offsetNode.from, offsetNode.to)) as string) : 'UNKNOWN';
+    const offset = offsetNode ? (unquoteUnescape(text.slice(offsetNode.from, offsetNode.to)) as string) : 'UNKNOWN';
 
     models.push({ offset, value, variable });
   }
@@ -510,7 +510,7 @@ function parseMetadata(node: SyntaxNode, text: string): Metadata | undefined {
       return; // Skip this entry if either the key or value is missing
     }
 
-    const keyText = removeEscapedQuotes(text.slice(keyNode.from, keyNode.to)) as string;
+    const keyText = unquoteUnescape(text.slice(keyNode.from, keyNode.to)) as string;
 
     let value = text.slice(valueNode.from, valueNode.to);
     try {


### PR DESCRIPTION
Close #1334 

We used the wrong helper function for `metadata` and `model` value parsing. I also included a updated unit test that is pretty detailed. 

TEST:

- Import the seqJson into the SeqN editor. 
- Verify the seqJson output matches the file  input, which means roundtripping is working. 

[escaped_metadata.json](https://github.com/user-attachments/files/15877363/escaped_metadata.json)
