### PR TITLE
Fix plan name from being reset while editing if other plans are updated at the same time

### DIFF
--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -529,7 +529,7 @@ export class Plan {
   }
 
   async waitForActivityCheckingStatus(status: Status) {
-    await expect(this.page.locator(this.activityCheckingStatusSelector(status))).toBeAttached();
+    await expect(this.page.locator(this.activityCheckingStatusSelector(status))).toBeAttached({ timeout: 10000 });
     await expect(this.page.locator(this.activityCheckingStatusSelector(status))).toBeVisible();
   }
 
@@ -538,17 +538,17 @@ export class Plan {
   }
 
   async waitForSchedulingStatus(status: Status) {
-    await expect(this.page.locator(this.schedulingStatusSelector(status))).toBeAttached();
+    await expect(this.page.locator(this.schedulingStatusSelector(status))).toBeAttached({ timeout: 10000 });
     await expect(this.page.locator(this.schedulingStatusSelector(status))).toBeVisible();
   }
 
   async waitForSimulationStatus(status: Status) {
-    await expect(this.page.locator(this.simulationStatusSelector(status))).toBeAttached();
+    await expect(this.page.locator(this.simulationStatusSelector(status))).toBeAttached({ timeout: 10000 });
     await expect(this.page.locator(this.simulationStatusSelector(status))).toBeVisible();
   }
 
   async waitForToast(message: string) {
-    await this.page.waitForSelector(`.toastify:has-text("${message}")`, { timeout: 3000 });
+    await this.page.waitForSelector(`.toastify:has-text("${message}")`, { timeout: 10000 });
   }
 }
 

--- a/e2e-tests/tests/plan-activities.test.ts
+++ b/e2e-tests/tests/plan-activities.test.ts
@@ -52,18 +52,18 @@ test.describe.serial('Plan Activities', () => {
     await plan.addActivity('GrowBanana');
     await plan.addActivity('PickBanana');
     await plan.addActivity('ThrowBanana');
-    await plan.panelActivityDirectivesTable.getByRole('gridcell', { name: 'PickBanana' }).first().click();
+    await plan.panelActivityDirectivesTable.getByRole('row', { name: 'PickBanana' }).first().click();
     await plan.panelActivityForm.getByRole('button', { name: 'Is Relative To Another Activity Directive' }).click();
     await plan.selectActivityAnchorByIndex(1);
 
-    await plan.panelActivityDirectivesTable.getByRole('gridcell', { name: 'GrowBanana' }).nth(1).click();
+    await plan.panelActivityDirectivesTable.getByRole('row', { name: 'GrowBanana' }).first().click();
     await plan.panelActivityDirectivesTable.getByRole('button', { name: 'Delete Activity Directive' }).click();
     await page.locator('.modal-content select').nth(1).selectOption('anchor-plan');
     await page.getByRole('button', { name: 'Confirm' }).click();
     await plan.panelActivityDirectivesTable
       .getByRole('row', { name: 'GrowBanana' })
       .waitFor({ state: 'detached', timeout: 2000 });
-    await plan.panelActivityDirectivesTable.getByRole('gridcell', { name: 'PickBanana' }).nth(1).click();
+    await plan.panelActivityDirectivesTable.getByRole('row', { name: 'PickBanana' }).first().click();
     await plan.panelActivityForm.getByRole('button', { name: 'Is Relative To Another Activity Directive' }).click();
     await page.waitForFunction(
       () => document.querySelector('.anchor-form .selected-display-value')?.innerHTML === 'To Plan',
@@ -76,21 +76,21 @@ test.describe.serial('Plan Activities', () => {
     await plan.addActivity('GrowBanana');
     await plan.addActivity('PickBanana');
     await plan.addActivity('ThrowBanana');
-    await plan.panelActivityDirectivesTable.getByRole('gridcell', { name: 'PickBanana' }).first().click();
+    await plan.panelActivityDirectivesTable.getByRole('row', { name: 'PickBanana' }).first().click();
     await plan.panelActivityForm.getByRole('button', { name: 'Is Relative To Another Activity Directive' }).click();
     await plan.selectActivityAnchorByIndex(1);
 
-    await plan.panelActivityDirectivesTable.getByRole('gridcell', { name: 'ThrowBanana' }).nth(1).click();
+    await plan.panelActivityDirectivesTable.getByRole('row', { name: 'ThrowBanana' }).first().click();
     await plan.selectActivityAnchorByIndex(2);
 
-    await plan.panelActivityDirectivesTable.getByRole('gridcell', { name: 'GrowBanana' }).nth(1).click();
+    await plan.panelActivityDirectivesTable.getByRole('row', { name: 'GrowBanana' }).first().click();
     await plan.panelActivityDirectivesTable
-      .getByRole('gridcell', { name: 'PickBanana' })
-      .nth(1)
+      .getByRole('row', { name: 'PickBanana' })
+      .first()
       .click({
         modifiers: ['Meta'],
       });
-    await plan.panelActivityDirectivesTable.getByRole('gridcell', { name: 'GrowBanana' }).nth(1).click({
+    await plan.panelActivityDirectivesTable.getByRole('row', { name: 'GrowBanana' }).first().click({
       button: 'right',
     });
     await page.getByText('Delete 2 Activity Directives').click();
@@ -128,8 +128,8 @@ test.describe.serial('Plan Activities', () => {
     await expect(plan.navButtonActivityCheckingMenu).toContainText('1 activity has problems');
     await expect(plan.navButtonActivityCheckingMenu).toContainText('2 missing parameters');
     await plan.navButtonActivityCheckingMenu.getByRole('button', { name: 'View in console' }).click();
-    await plan.consoleContainer.getByRole('gridcell', { name: 'BakeBananaBread' }).first().click();
-    const tbSugar = await plan.panelActivityForm.locator('.parameter', { hasText: 'tbSugar' }).locator('input');
+    await plan.consoleContainer.getByRole('row', { name: 'BakeBananaBread' }).first().click();
+    const tbSugar = plan.panelActivityForm.locator('.parameter', { hasText: 'tbSugar' }).locator('input');
     await tbSugar.fill('100');
     await tbSugar.evaluate(e => e.blur());
     await plan.panelActivityForm.locator('.parameter', { hasText: 'glutenFree' }).getByRole('checkbox').click();

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -41,6 +41,13 @@
   let hasCreateSnapshotPermission: boolean = false;
   let hasPlanUpdatePermission: boolean = false;
   let hasPlanCollaboratorsUpdatePermission: boolean = false;
+  let planNameField = field<string>('', [
+    required,
+    unique(
+      $plans.filter(p => p.id !== plan?.id).map(p => p.name),
+      'Plan name already exists',
+    ),
+  ]);
 
   $: permissionError = $planReadOnly ? PlanStatusMessages.READ_ONLY : 'You do not have permission to edit this plan.';
   $: if (plan) {
@@ -64,14 +71,15 @@
   } else {
     filteredPlanSnapshots = $planSnapshotsWithSimulations;
   }
-
-  $: planNameField = field<string>(plan?.name ?? '', [
-    required,
-    unique(
-      $plans.filter(p => p.id !== plan?.id).map(p => p.name),
-      'Plan name already exists',
-    ),
-  ]);
+  $: if ($plans) {
+    planNameField.updateValidators([
+      required,
+      unique(
+        $plans.filter(p => p.id !== plan?.id).map(p => p.name),
+        'Plan name already exists',
+      ),
+    ]);
+  }
 
   async function onTagsInputChange(event: TagsChangeEvent) {
     const {


### PR DESCRIPTION
This is a little difficult to test, but it fixes the same issue that was present on the plan creation form where the inputted name was being reset if any of the plans were updated. This was due to a reactive statement that was resetting the field because it took the plans list as a dependency. This was only rarely observable during the e2e tests as they run multiple tests at the same time that affects the plans.

This also probably actually maybe fixes all the flaky tests?