### PR TITLE
Decouples scan / publish for UI Docker image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,14 +49,6 @@ jobs:
           context: .
           load: true
           tags: ${{ env.REGISTRY }}/nasa-ammos/aerie-ui:${{ github.sha }}
-      - name: Scan aerie-ui Docker image
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ env.REGISTRY }}/nasa-ammos/aerie-ui:${{ github.sha }}
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          severity: 'CRITICAL'
       - name: Push Docker Image
         uses: docker/build-push-action@v5
         with:
@@ -65,3 +57,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - name: Scan aerie-ui Docker image
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.REGISTRY }}/nasa-ammos/aerie-ui:${{ github.sha }}
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: 'CRITICAL'


### PR DESCRIPTION
- Condenses docker build into one step (was separated so we could build -> scan -> publish, now it's just build+publish, then scan separately)
- Moves scan into separate GHA job so it can fail independently