### PR TITLE
Fix plan metadata name input reset on snapshot preview

### DIFF
--- a/src/components/activity/ActivityDirectivesTable.svelte
+++ b/src/components/activity/ActivityDirectivesTable.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
   import type { ColDef, ColumnState, ICellRendererParams } from 'ag-grid-community';
+  import { PlanStatusMessages } from '../../enums/planStatusMessages';
   import type { ActivityDirective, ActivityDirectiveId } from '../../types/activity';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef } from '../../types/data-grid';
@@ -58,7 +59,7 @@
               placement: 'bottom',
             },
             hasDeletePermission,
-            planReadOnly,
+            hasDeletePermissionError: planReadOnly ? PlanStatusMessages.READ_ONLY : undefined,
             rowData: params.data,
           },
           target: actionsDiv,
@@ -137,8 +138,8 @@
   columnDefs={completeColumnDefs}
   {columnStates}
   {getRowId}
-  {planReadOnly}
   {hasDeletePermission}
+  hasDeletePermissionError={planReadOnly ? PlanStatusMessages.READ_ONLY : undefined}
   items={activityDirectivesWithErrorCounts}
   pluralItemDisplayText="Activity Directives"
   scrollToSelection={true}

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -80,6 +80,9 @@
       ),
     ]);
   }
+  $: if (plan) {
+    planNameField.validateAndSet(plan?.name ?? '');
+  }
 
   async function onTagsInputChange(event: TagsChangeEvent) {
     const {

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -70,6 +70,9 @@
   $: if (user !== undefined) {
     redrawRows?.();
   }
+  $: if (deletePermission != null) {
+    redrawRows?.();
+  }
 
   onDestroy(() => onBlur());
 

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -11,7 +11,6 @@
   import type { ColDef, ColumnState, IRowNode, RedrawRowsParams } from 'ag-grid-community';
   import { keyBy } from 'lodash-es';
   import { createEventDispatcher, onDestroy, type ComponentEvents } from 'svelte';
-  import { PlanStatusMessages } from '../../../enums/planStatusMessages';
   import type { User } from '../../../types/app';
   import type { Dispatcher } from '../../../types/component';
   import type { RowId, TRowData } from '../../../types/data-grid';
@@ -28,7 +27,7 @@
   export let columnsToForceRefreshOnDataUpdate: (keyof RowData)[] = [];
   export let dataGrid: DataGrid<RowData> | undefined = undefined;
   export let hasDeletePermission: PermissionCheck<RowData> | boolean = true;
-  export let planReadOnly: boolean = false;
+  export let hasDeletePermissionError: string = 'You do not have permission to delete.';
   export let idKey: keyof RowData = 'id';
   export let items: RowData[];
   export let pluralItemDisplayText: string = '';
@@ -55,12 +54,12 @@
     const selectedItem = items.find(item => item.id === selectedItemId) ?? null;
     if (selectedItem) {
       if (typeof hasDeletePermission === 'function') {
-        deletePermission = hasDeletePermission(user, selectedItem) && !planReadOnly;
+        deletePermission = hasDeletePermission(user, selectedItem);
       }
     }
   }
   $: if (typeof hasDeletePermission === 'boolean') {
-    deletePermission = hasDeletePermission && !planReadOnly;
+    deletePermission = hasDeletePermission;
   }
   $: if (selectedItemId != null && !selectedItemIds.includes(selectedItemId)) {
     selectedItemIds = [selectedItemId];
@@ -170,7 +169,7 @@
               permissionHandler,
               {
                 hasPermission: deletePermission,
-                permissionError: planReadOnly ? PlanStatusMessages.READ_ONLY : 'You do not have permission to delete.',
+                permissionError: hasDeletePermissionError,
               },
             ],
           ]}

--- a/src/components/ui/DataGrid/DataGridActions.svelte
+++ b/src/components/ui/DataGrid/DataGridActions.svelte
@@ -1,8 +1,6 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import { PlanStatusMessages } from '../../../enums/planStatusMessages';
-
   import { permissionHandler } from '../../../utilities/permissionHandler';
 
   import DownloadIcon from '@nasa-jpl/stellar/icons/download.svg?component';
@@ -28,7 +26,6 @@
   export let hasDeletePermissionError: string | undefined = undefined;
   export let hasEditPermission: boolean = true;
   export let hasEditPermissionError: string | undefined = undefined;
-  export let planReadOnly: boolean = false;
   export let viewTooltip: Tooltip | undefined = undefined;
 
   export let editCallback: ((data: RowData) => void) | undefined = undefined;
@@ -74,9 +71,7 @@
     use:tooltip={hasEditPermission ? editTooltip : undefined}
     use:permissionHandler={{
       hasPermission: hasEditPermission,
-      permissionError: planReadOnly
-        ? PlanStatusMessages.READ_ONLY
-        : hasEditPermissionError || `You do not have permission to ${editTooltip?.content ?? 'edit'}.`,
+      permissionError: hasEditPermissionError || `You do not have permission to ${editTooltip?.content ?? 'edit'}.`,
     }}
   >
     <PenIcon />
@@ -93,9 +88,8 @@
     use:tooltip={hasDeletePermission ? deleteTooltip : undefined}
     use:permissionHandler={{
       hasPermission: hasDeletePermission,
-      permissionError: planReadOnly
-        ? PlanStatusMessages.READ_ONLY
-        : hasDeletePermissionError || `You do not have permission to ${deleteTooltip?.content ?? 'delete'}.`,
+      permissionError:
+        hasDeletePermissionError || `You do not have permission to ${deleteTooltip?.content ?? 'delete'}.`,
     }}
   >
     <TrashIcon />


### PR DESCRIPTION
This fixes an issue where selecting a snapshot clears out the plan name input field, and fixes another issue where closing a snapshot preview doesn't reenable the delete buttons in the directives table.

This also makes the `BulkActionDataGrid` component a little more reusable outside of plans.

To test:
1. Create a plan
2. Add some directives
3. Open the Plan Metadata panel
4. Create a snapshot
5. Select the snapshot to preview
6. Verify that the plan name input doesn't get cleared out
7. Verify that the delete icons in the table a disabled properly
8. Close the snapshot preview
9. Verify that the delete icons in the table a enabled again