### PR TITLE
Fix for when sequencedefinition loads prior to component mount

### DIFF
--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -79,7 +79,7 @@
   }
 
   $: {
-    editorSequenceView.dispatch({
+    editorSequenceView?.dispatch({
       changes: { from: 0, insert: sequenceDefinition, to: editorSequenceView.state.doc.length },
     });
   }


### PR DESCRIPTION
Under some circumstances the sequence editor fails to load with the following stack trace

```
TypeError: Cannot read properties of undefined (reading 'dispatch')
    at /Users/joswig/Workspaces/NASA-AMMOS/aerie-ui/src/components/sequencing/SequenceEditor.svelte:82:24
    at Object.$$render (/Users/joswig/Workspaces/NASA-AMMOS/aerie-ui/node_modules/svelte/src/runtime/internal/ssr.js:156:16)
    at Object.default (/Users/joswig/Workspaces/NASA-AMMOS/aerie-ui/src/components/sequencing/Sequences.svelte:264:26)
    at /Users/joswig/Workspaces/NASA-AMMOS/aerie-ui/src/components/ui/CssGrid.svelte:79:17
    at Object.$$render (/Users/joswig/Workspaces/NASA-AMMOS/aerie-ui/node_modules/svelte/src/runtime/internal/ssr.js:156:16)
    at eval (/Users/joswig/Workspaces/NASA-AMMOS/aerie-ui/src/components/sequencing/Sequences.svelte:270:104)
    at Object.$$render (/Users/joswig/Workspaces/NASA-AMMOS/aerie-ui/node_modules/svelte/src/runtime/internal/ssr.js:156:16)
    at eval (/Users/joswig/Workspaces/NASA-AMMOS/aerie-ui/src/routes/sequencing/+page.svelte:15:239)
    at Object.$$render (/Users/joswig/Workspaces/NASA-AMMOS/aerie-ui/node_modules/svelte/src/runtime/internal/ssr.js:156:16)
    at Object.default (/Users/joswig/Workspaces/NASA-AMMOS/aerie-ui/.svelte-kit/generated/root.svelte:48:43)
```