### PR TITLE
Added better linting support inside of the sequence adaptation

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,6 +1,10 @@
 /* eslint-disable no-var */
 /* eslint @typescript-eslint/no-unused-vars: 0 */
 
+import type { Diagnostic } from '@codemirror/lint';
+import type { CommandDictionary } from '@nasa-jpl/aerie-ampcs';
+import type { EditorView } from 'codemirror';
+
 declare global {
   namespace App {
     interface Locals {
@@ -51,10 +55,15 @@ declare global {
         CONDITIONAL_KEYWORDS?: { ELSE?: string; ELSE_IF?: string[]; END_IF?: string; IF: string[] };
         GLOBALS?: GlobalType[];
         INPUT_FORMAT?: {
+          LINTER?: (
+            diagnostics: Diagnostic[],
+            commandDictionary: CommandDictionary,
+            view: EditorView,
+            node: SyntaxNode,
+          ) => Diagnostic[];
           NAME: string;
           TO_INPUT_FORMAT?: (input: string) => Promise<string>;
         };
-        LINT?: (commandDictionary, view, node) => any;
         LOOP_KEYWORDS?: {
           BREAK: string;
           CONTINUE: string;
@@ -72,6 +81,12 @@ declare global {
           channelDictionary: ChannelDictionary | null,
         ) => any;
         OUTPUT_FORMAT?: {
+          LINTER?: (
+            diagnostics: Diagnostic[],
+            commandDictionary: CommandDictionary,
+            view: EditorView,
+            node: SyntaxNode,
+          ) => Diagnostic[];
           NAME: string;
           TO_OUTPUT_FORMAT?: (
             tree: Tree | any,

--- a/src/stores/sequence-adaptation.ts
+++ b/src/stores/sequence-adaptation.ts
@@ -1,6 +1,6 @@
 import { derived, get, writable, type Writable } from 'svelte/store';
 import type { GlobalType } from '../types/global-type';
-import type { SequenceAdaptation, SequenceAdaptationI } from '../types/sequencing';
+import type { ISequenceAdaptation, SequenceAdaptation } from '../types/sequencing';
 import gql from '../utilities/gql';
 import { seqJsonToSequence } from '../utilities/sequence-editor/from-seq-json';
 import { sequenceToSeqJson } from '../utilities/sequence-editor/to-seq-json';
@@ -8,7 +8,7 @@ import { gqlSubscribable } from './subscribable';
 
 /* Writeable */
 
-export const sequenceAdaptation: Writable<SequenceAdaptationI | undefined> = writable(undefined);
+export const sequenceAdaptation: Writable<ISequenceAdaptation | undefined> = writable(undefined);
 
 /* Subscriptions. */
 

--- a/src/stores/sequence-adaptation.ts
+++ b/src/stores/sequence-adaptation.ts
@@ -37,10 +37,10 @@ export function setSequenceAdaptation(): void {
     },
     globals: globalThis.SequenceAdaptation?.GLOBALS ?? [],
     inputFormat: {
+      linter: globalThis.SequenceAdaptation?.INPUT_FORMAT?.LINTER ?? undefined,
       name: globalThis.SequenceAdaptation?.INPUT_FORMAT?.NAME ?? 'SeqN',
       toInputFormat: globalThis.SequenceAdaptation?.INPUT_FORMAT?.TO_INPUT_FORMAT ?? seqJsonToSequence,
     },
-    lint: globalThis.SequenceAdaptation?.LINT ?? undefined,
     loopKeywords: {
       break: globalThis.SequenceAdaptation?.LOOP_KEYWORDS?.BREAK ?? 'CMD_BREAK',
       continue: globalThis.SequenceAdaptation?.LOOP_KEYWORDS?.CONTINUE ?? 'CMD_CONTINUE',
@@ -50,6 +50,7 @@ export function setSequenceAdaptation(): void {
     modifyOutput: globalThis.SequenceAdaptation?.MODIFY_OUTPUT ?? undefined,
     modifyOutputParse: globalThis.SequenceAdaptation?.MODIFY_OUTPUT_PARSE ?? undefined,
     outputFormat: {
+      linter: globalThis.SequenceAdaptation?.OUTPUT_FORMAT?.LINTER ?? undefined,
       name: globalThis.SequenceAdaptation?.OUTPUT_FORMAT?.NAME ?? 'Seq JSON',
       toOutputFormat: globalThis.SequenceAdaptation?.OUTPUT_FORMAT?.TO_OUTPUT_FORMAT ?? sequenceToSeqJson,
     },

--- a/src/types/sequencing.ts
+++ b/src/types/sequencing.ts
@@ -1,8 +1,11 @@
+import type { Diagnostic } from '@codemirror/lint';
+import type { SyntaxNode } from '@lezer/common';
 import type {
   ChannelDictionary as AmpcsChannelDictionary,
   CommandDictionary as AmpcsCommandDictionary,
   ParameterDictionary as AmpcsParameterDictionary,
 } from '@nasa-jpl/aerie-ampcs';
+import type { EditorView } from 'codemirror';
 import type { DictionaryTypes } from '../enums/dictionaryTypes';
 import type { ArgDelegator } from '../utilities/sequence-editor/extension-points';
 import type { UserId } from './app';
@@ -40,10 +43,15 @@ export interface SequenceAdaptationI {
   conditionalKeywords: { else: string; elseIf: string[]; endIf: string; if: string[] };
   globals?: GlobalType[];
   inputFormat: {
+    linter?: (
+      diagnostics: Diagnostic[],
+      commandDictionary: AmpcsCommandDictionary,
+      view: EditorView,
+      node: SyntaxNode,
+    ) => Diagnostic[];
     name: string;
     toInputFormat(input: string): Promise<string>;
   };
-  lint?: (commandDictionary: AmpcsCommandDictionary, view: any, node: any) => any;
   loopKeywords: { break: string; continue: string; endWhileLoop: string; whileLoop: string[] };
   modifyOutput?: (
     output: string,
@@ -56,6 +64,12 @@ export interface SequenceAdaptationI {
     channelDictionary: AmpcsChannelDictionary | null,
   ) => any;
   outputFormat: {
+    linter?: (
+      diagnostics: Diagnostic[],
+      commandDictionary: AmpcsCommandDictionary,
+      view: EditorView,
+      node: SyntaxNode,
+    ) => Diagnostic[];
     name: string;
     toOutputFormat(
       tree: any,

--- a/src/types/sequencing.ts
+++ b/src/types/sequencing.ts
@@ -38,7 +38,7 @@ export type DictionaryType = {
   version: string;
 };
 
-export interface SequenceAdaptationI {
+export interface ISequenceAdaptation {
   argDelegator?: ArgDelegator;
   conditionalKeywords: { else: string; elseIf: string[]; endIf: string; if: string[] };
   globals?: GlobalType[];

--- a/src/utilities/sequence-editor/sequence-linter.ts
+++ b/src/utilities/sequence-editor/sequence-linter.ts
@@ -145,10 +145,10 @@ export function sequenceLinter(
       ...conditionalAndLoopKeywordsLinter(treeNode.getChild('Commands')?.getChildren(TOKEN_COMMAND) || [], docText),
     );
 
-    const lint = get(sequenceAdaptation)?.lint;
+    const inputLinter = get(sequenceAdaptation)?.inputFormat.linter;
 
-    if (lint !== undefined && commandDictionary !== null) {
-      diagnostics = [...diagnostics, ...lint(commandDictionary, view, treeNode)];
+    if (inputLinter !== undefined && commandDictionary !== null) {
+      diagnostics = inputLinter(diagnostics, commandDictionary, view, treeNode);
     }
 
     return diagnostics;


### PR DESCRIPTION
This PR changes the sequence adaptation API in the following way to add linting to both the input and output format.
It also changes the diagnostics to now work as intended so that the adaptation can fully overwrite existing diagnostics rather than them always being appended.

```
   inputFormat: {
+   linter: globalThis.SequenceAdaptation?.INPUT_FORMAT?.LINTER ?? undefined,
   },
- lint: globalThis.SequenceAdaptation?.LINT ?? undefined,
   outputFormat: {
+   linter: globalThis.SequenceAdaptation?.OUTPUT_FORMAT?.LINTER ?? undefined,
   },
```

Here's a custom adaptation that you can fiddle with to test the input / output linting:
```
(() => {
  globalThis.SequenceAdaptation = {
    INPUT_FORMAT: {
      LINTER: inputLinter,
      NAME: "Input Format",
    },
    OUTPUT_FORMAT: {
      LINTER: outputLinter,
      NAME: "Output Format",
    },
  };
})();

function inputLinter(diagnostics, commandDictionary, view, node) {
  diagnostics.push({
    actions: [],
    from: 0,
    message: `This is a custom linting error that appears at 0,0`,
    severity: 'error',
    to: 0,
  });

  return diagnostics;
}

function outputLinter(diagnostics, commandDictionary, view, node) {
  // This is an example of overwriting all of the existing lint errors from native Aerie.
  diagnostics = [];

  return diagnostics;
}
```