### PR TITLE
Fix anchor directive start time computation

### DIFF
--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -572,7 +572,7 @@ export function getActivityDirectiveStartTimeMs(
         activityDirective.start_offset,
       );
 
-      cachedStartTimes[anchor_id] = anchoredStartTimeMs;
+      cachedStartTimes[anchoredSpanId] = anchoredStartTimeMs;
 
       return anchoredStartTimeMs;
     }


### PR DESCRIPTION
Fixes issue where the start time computation for an _anchored_ directive was mistakenly being assigned to the _anchor_ directive.

Closes https://github.com/NASA-AMMOS/aerie-ui/issues/1337

Testing:
 1. Make a plan
 2. Create a chain of anchored activities with varied offsets
 3. Drag activities around and verify that anchored relationships update as expected