### PR TITLE
[Bug] Boolean args not supported for arguments

### DIFF
--- a/src/components/sequencing/form/ArgEditor.svelte
+++ b/src/components/sequencing/form/ArgEditor.svelte
@@ -5,6 +5,7 @@
   import type { CommandDictionary, FswCommandArgument } from '@nasa-jpl/aerie-ampcs';
   import {
     getMissingArgDefs,
+    isFswCommandArgumentBoolean,
     isFswCommandArgumentRepeat,
     isFswCommandArgumentVarString,
     isNumberArg,
@@ -13,6 +14,7 @@
   } from './../../../utilities/codemirror/codemirror-utils';
   import AddMissingArgsButton from './AddMissingArgsButton.svelte';
   import ArgTitle from './ArgTitle.svelte';
+  import BooleanEditor from './BooleanEditor.svelte';
   import EnumEditor from './EnumEditor.svelte';
   import ExtraArgumentEditor from './ExtraArgumentEditor.svelte';
   import NumEditor from './NumEditor.svelte';
@@ -89,6 +91,16 @@
       />
     {:else if isFswCommandArgumentVarString(argInfo.argDef)}
       <StringEditor
+        argDef={argInfo.argDef}
+        initVal={argInfo.text ?? ''}
+        setInEditor={val => {
+          if (argInfo.node) {
+            setInEditor(argInfo.node, val);
+          }
+        }}
+      />
+    {:else if isFswCommandArgumentBoolean(argInfo.argDef)}
+      <BooleanEditor
         argDef={argInfo.argDef}
         initVal={argInfo.text ?? ''}
         setInEditor={val => {

--- a/src/components/sequencing/form/BooleanEditor.svelte
+++ b/src/components/sequencing/form/BooleanEditor.svelte
@@ -1,0 +1,23 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import type { FswCommandArgumentBoolean } from '@nasa-jpl/aerie-ampcs';
+
+  export let argDef: FswCommandArgumentBoolean;
+  export let initVal: string;
+  export let setInEditor: (val: string) => void;
+
+  let value: string;
+  $: value = initVal;
+  $: {
+    setInEditor(value);
+  }
+</script>
+
+<div>
+  <select class="st-select w-100" required bind:value title={argDef.description}>
+    {#each ['false', 'true'] as ev}
+      <option>{ev}</option>
+    {/each}
+  </select>
+</div>

--- a/src/utilities/codemirror/codemirror-utils.ts
+++ b/src/utilities/codemirror/codemirror-utils.ts
@@ -2,6 +2,7 @@ import type { SyntaxNode } from '@lezer/common';
 import type {
   CommandDictionary,
   FswCommandArgument,
+  FswCommandArgumentBoolean,
   FswCommandArgumentEnum,
   FswCommandArgumentFixedString,
   FswCommandArgumentFloat,
@@ -45,6 +46,10 @@ export function isFswCommandArgumentVarString(arg: FswCommandArgument): arg is F
 
 export function isFswCommandArgumentFixedString(arg: FswCommandArgument): arg is FswCommandArgumentFixedString {
   return arg.arg_type === 'fixed_string';
+}
+
+export function isFswCommandArgumentBoolean(arg: FswCommandArgument): arg is FswCommandArgumentBoolean {
+  return arg.arg_type === 'boolean';
 }
 
 export function isNumberArg(arg: FswCommandArgument): arg is NumberArg {

--- a/src/utilities/codemirror/sequence.grammar
+++ b/src/utilities/codemirror/sequence.grammar
@@ -77,7 +77,7 @@ RepeatArg {
   "[" (whiteSpace? arg)* whiteSpace? "]"
 }
 
-arg[@isGroup=Arguments] { Number | String | Enum }
+arg[@isGroup=Arguments] { Number | String | Boolean | Enum }
 
 Command {
   TimeTag?
@@ -203,8 +203,8 @@ Stem { !stemStart identifier }
     "0x" (hex | "_")+ "n"?
   }
 
-  TRUE { "true" }
-  FALSE { "false" }
+  TRUE { 'true' }
+  FALSE { 'false' }
   Boolean { TRUE | FALSE }
   Null { "null" }
 
@@ -235,7 +235,7 @@ Stem { !stemStart identifier }
 
   @precedence { newLine, whiteSpace }
 
-  @precedence{ TimeAbsolute, TimeRelative, TimeEpoch, TimeComplete, identifier }
+  @precedence{ TimeAbsolute, TimeRelative, TimeEpoch, TimeComplete, Boolean, identifier }
 
   @precedence {
     LoadAndGoDirective,

--- a/src/utilities/sequence-editor/from-seq-json.test.ts
+++ b/src/utilities/sequence-editor/from-seq-json.test.ts
@@ -284,7 +284,7 @@ C FSW_CMD_3
     const sequence = await seqJsonToSequence(JSON.stringify(seqJson));
     const expectedSequence = `@ID "42"
 
-A2024-001T00:00:00 FSW_CMD_0 TRUE 0xFF "Hello" World [FALSE 0xAA "Foo" BAR TRUE 0xBB "Baz" BAT]
+A2024-001T00:00:00 FSW_CMD_0 true 0xFF "Hello" World [false 0xAA "Foo" BAR true 0xBB "Baz" BAT]
 R00:01:00 FSW_CMD_1 22
 E15:00:00 FSW_CMD_2 "Fab"
 C FSW_CMD_3
@@ -348,8 +348,8 @@ C ECHO "test"
 @METADATA "Key1" "Value1"
 @METADATA "Key2" "Value2"
 @MODEL "temp" 0 "00:00:00"
-@MODEL "temp1" TRUE "00:00:01"
-@MODEL "temp2" FALSE "00:00:02"
+@MODEL "temp1" true "00:00:01"
+@MODEL "temp2" false "00:00:02"
 @MODEL "temp4" "NULL" "00:00:03"
 `;
     expect(sequence).toEqual(expectedSequence);
@@ -425,7 +425,7 @@ C ECHO "test"
 
 C ECHO "TEST1" # a description
 R00:00:01 FSW_CMD # fsw command description
-@MODEL "cmd" TRUE "00:00:00"
+@MODEL "cmd" true "00:00:00"
 C FSW_CMD_1
 C FSW_CMD_2 10 "ENUM" # fsw cmd 2 description
 `;
@@ -835,6 +835,46 @@ C FSA_CMD 10 [] "USA" ["96707-898" "92604-623"]
 
 C ECHO "Can this handle \\" Escaped\\" quotes??" # Can this handle "escape"
 C ECHO2 "\\"Can\\" this handle leading and trailing Escaped\\" quotes??\\"" # "Can" "this" handle "escape"
+`;
+    expect(sequence).toEqual(expectedSequence);
+  });
+
+  it('BooleanArguments to sequence', async () => {
+    const seqJson: SeqJson = {
+      id: 'test',
+      metadata: {},
+      steps: [
+        {
+          args: [
+            {
+              type: 'boolean',
+              value: true,
+            },
+            {
+              type: 'boolean',
+              value: false,
+            },
+          ],
+          models: [
+            {
+              offset: '00:00:00',
+              value: true,
+              variable: 'a',
+            },
+          ],
+          stem: 'CMD_0',
+          time: {
+            type: 'COMMAND_COMPLETE',
+          },
+          type: 'command',
+        },
+      ],
+    };
+    const sequence = await seqJsonToSequence(JSON.stringify(seqJson));
+    const expectedSequence = `@ID "test"
+
+C CMD_0 true false
+@MODEL "a" true "00:00:00"
 `;
     expect(sequence).toEqual(expectedSequence);
   });

--- a/src/utilities/sequence-editor/from-seq-json.ts
+++ b/src/utilities/sequence-editor/from-seq-json.ts
@@ -47,8 +47,6 @@ function seqJsonBaseArgToSequence(
   switch (arg.type) {
     case 'string':
       return `${quoteEscape(arg.value)}`;
-    case 'boolean':
-      return arg.value ? 'TRUE' : 'FALSE';
     default:
       return `${arg.value}`;
   }
@@ -93,7 +91,7 @@ function seqJsonModelsToSequence(models: Model[]): string {
       if (typeof model.value === 'string') {
         formattedValue = quoteEscape(model.value);
       } else if (typeof model.value === 'boolean') {
-        formattedValue = model.value.toString().toUpperCase();
+        formattedValue = model.value.toString();
       }
       return `@MODEL ${typeof model.variable === 'string' ? quoteEscape(String(model.variable)) : `"${model.variable}"`} ${formattedValue} ${quoteEscape(model.offset)}`;
     })

--- a/src/utilities/sequence-editor/sequence-linter.ts
+++ b/src/utilities/sequence-editor/sequence-linter.ts
@@ -1051,6 +1051,26 @@ export function sequenceLinter(
           }
         }
         break;
+      case 'boolean':
+        if (argType !== 'Boolean') {
+          diagnostics.push({
+            actions: [],
+            from: argNode.from,
+            message: `Incorrect type - expected 'Boolean' but got ${argType}`,
+            severity: 'error',
+            to: argNode.to,
+          });
+        }
+        if (['true', 'false'].includes(argText) === false) {
+          diagnostics.push({
+            actions: [],
+            from: argNode.from,
+            message: `Incorrect value - expected true or false but got ${argText}`,
+            severity: 'error',
+            to: argNode.to,
+          });
+        }
+        break;
       case 'float':
       case 'integer':
       case 'numeric':

--- a/src/utilities/sequence-editor/to-seq-json.test.ts
+++ b/src/utilities/sequence-editor/to-seq-json.test.ts
@@ -1007,3 +1007,62 @@ A2024-123T12:34:56 @REQUEST_BEGIN("request.name") # Description Text
     });
   });
 });
+
+it('should serialize a boolean arg', async () => {
+  const input = `
+
+C CMD_0 true false [ false true ]
+@METADATA "foo" "bar"
+@MODEL "a" true "00:00:00"
+  `;
+  const actual = JSON.parse(await sequenceToSeqJson(SeqLanguage.parser.parse(input), input, commandBanana, 'id'));
+  const expected = {
+    id: 'id',
+    metadata: {},
+    steps: [
+      {
+        args: [
+          {
+            type: 'boolean',
+            value: true,
+          },
+          {
+            type: 'boolean',
+            value: false,
+          },
+          {
+            type: 'repeat',
+            value: [
+              [
+                {
+                  type: 'boolean',
+                  value: false,
+                },
+                {
+                  type: 'boolean',
+                  value: true,
+                },
+              ],
+            ],
+          },
+        ],
+        metadata: {
+          foo: 'bar',
+        },
+        models: [
+          {
+            offset: '00:00:00',
+            value: true,
+            variable: 'a',
+          },
+        ],
+        stem: 'CMD_0',
+        time: {
+          type: 'COMMAND_COMPLETE',
+        },
+        type: 'command',
+      },
+    ],
+  };
+  expect(actual).toEqual(expected);
+});

--- a/src/utilities/sequence-editor/to-seq-json.ts
+++ b/src/utilities/sequence-editor/to-seq-json.ts
@@ -245,7 +245,7 @@ function parseArg(
   const nodeValue = text.slice(node.from, node.to);
 
   if (node.name === 'Boolean') {
-    const value = nodeValue === 'TRUE' ? true : false;
+    const value = nodeValue === 'true' ? true : false;
     const booleanArg: BooleanArgument = { type: 'boolean', value };
     if (dictionaryArg) {
       booleanArg.name = dictionaryArg.name;


### PR DESCRIPTION
Closes #1395 

Previously missing boolean argument support has been added to args, along with corresponding updates to seqJSON and seqN import/export functions. I have updated the e2e test as well