### PR TITLE
Added the ability to define multiple output formats for sequence adap…

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -82,6 +82,7 @@ declare global {
         ) => any;
         outputFormat?: [
           {
+            fileExtension: string;
             linter?: (
               diagnostics: Diagnostic[],
               commandDictionary: CommandDictionary,

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -51,50 +51,52 @@ declare global {
 
   var SequenceAdaptation:
     | {
-        ARG_DELEGATOR?: ArgDelegator;
-        CONDITIONAL_KEYWORDS?: { ELSE?: string; ELSE_IF?: string[]; END_IF?: string; IF: string[] };
-        GLOBALS?: GlobalType[];
-        INPUT_FORMAT?: {
-          LINTER?: (
+        argDelegator?: ArgDelegator;
+        conditionalKeywords?: { else?: string; elseIf?: string[]; endIf?: string; if: string[] };
+        globals?: GlobalType[];
+        inputFormat?: {
+          linter?: (
             diagnostics: Diagnostic[],
             commandDictionary: CommandDictionary,
             view: EditorView,
             node: SyntaxNode,
           ) => Diagnostic[];
-          NAME: string;
-          TO_INPUT_FORMAT?: (input: string) => Promise<string>;
+          name: string;
+          toInputFormat?: (input: string) => Promise<string>;
         };
-        LOOP_KEYWORDS?: {
-          BREAK: string;
-          CONTINUE: string;
-          END_WHILE_LOOP: string;
-          WHILE_LOOP: string[];
+        loopKeywords?: {
+          break: string;
+          continue: string;
+          endWhileLoop: string;
+          whileLoop: string[];
         };
-        MODIFY_OUTPUT?: (
+        modifyOutput?: (
           output: SeqJson | any,
           parameterDictionaries: ParameterDictionary[],
           channelDictionary: ChannelDictionary | null,
         ) => any;
-        MODIFY_OUTPUT_PARSE?: (
+        modifyOutputParse?: (
           output: SeqJson | any,
           parameterDictionaries: ParameterDictionary[],
           channelDictionary: ChannelDictionary | null,
         ) => any;
-        OUTPUT_FORMAT?: {
-          LINTER?: (
-            diagnostics: Diagnostic[],
-            commandDictionary: CommandDictionary,
-            view: EditorView,
-            node: SyntaxNode,
-          ) => Diagnostic[];
-          NAME: string;
-          TO_OUTPUT_FORMAT?: (
-            tree: Tree | any,
-            sequence: string,
-            commandDictionary: CommandDictionary | null,
-            sequenceName: string,
-          ) => Promise<string>;
-        };
+        outputFormat?: [
+          {
+            linter?: (
+              diagnostics: Diagnostic[],
+              commandDictionary: CommandDictionary,
+              view: EditorView,
+              node: SyntaxNode,
+            ) => Diagnostic[];
+            name: string;
+            toOutputFormat?: (
+              tree: Tree | any,
+              sequence: string,
+              commandDictionary: CommandDictionary | null,
+              sequenceName: string,
+            ) => Promise<string>;
+          },
+        ];
       }
     | undefined;
 }

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -228,10 +228,7 @@
 
       if (adaptation) {
         try {
-          // This evaluates the custom sequence adaptation that is optionally provided by the user.
-          Function(adaptation.adaptation)();
-
-          setSequenceAdaptation();
+          setSequenceAdaptation(eval(String(adaptation.adaptation)));
         } catch (e) {
           console.error(e);
           showFailureToast('Invalid sequence adaptation');
@@ -243,8 +240,7 @@
   }
 
   function resetSequenceAdaptation(): void {
-    globalThis.SequenceAdaptation = undefined;
-    setSequenceAdaptation();
+    setSequenceAdaptation(undefined);
   }
 
   async function sequenceUpdateListener(viewUpdate: ViewUpdate) {

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -38,6 +38,7 @@
   import type { IOutputFormat, Parcel } from '../../types/sequencing';
   import { setupLanguageSupport } from '../../utilities/codemirror';
   import effects from '../../utilities/effects';
+  import { downloadBlob, downloadJSON } from '../../utilities/generic';
   import { seqJsonLinter } from '../../utilities/sequence-editor/seq-json-linter';
   import { sequenceAutoIndent } from '../../utilities/sequence-editor/sequence-autoindent';
   import { sequenceCompletion } from '../../utilities/sequence-editor/sequence-completion';
@@ -274,25 +275,17 @@
   }
 
   function downloadOutputFormat(outputFormat: IOutputFormat) {
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(
-      new Blob([editorOutputView.state.doc.toString()], {
-        type: outputFormat?.fileExtension === 'json' ? 'application/json' : 'text/plain',
-      }),
-    );
-    a.download = `${sequenceName}.${outputFormat?.fileExtension}`;
-    a.click();
+    const fileExtension = `${sequenceName}.${selectedOutputFormat?.fileExtension}`;
+
+    if (outputFormat?.fileExtension === 'json') {
+      downloadJSON(editorOutputView.state.doc.toJSON(), fileExtension);
+    } else {
+      downloadBlob(new Blob([editorOutputView.state.doc.toString()], { type: 'text/plain' }), fileExtension);
+    }
   }
 
   function downloadInputFormat() {
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(
-      new Blob([editorSequenceView.state.doc.toString()], {
-        type: selectedOutputFormat?.fileExtension === 'json' ? 'application/json' : 'text/plain',
-      }),
-    );
-    a.download = `${sequenceName}.${selectedOutputFormat?.fileExtension}`;
-    a.click();
+    downloadBlob(new Blob([editorOutputView.state.doc.toString()], { type: 'text/plain' }), `${sequenceName}.txt`);
   }
 
   async function copyOutputFormatToClipboard() {

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -277,17 +277,25 @@
     }
   }
 
-  function downloadOutputFormat() {
+  function downloadOutputFormat(outputFormat: IOutputFormat) {
     const a = document.createElement('a');
-    a.href = URL.createObjectURL(new Blob([editorOutputView.state.doc.toString()], { type: 'application/json' }));
-    a.download = `${sequenceName}.json`;
+    a.href = URL.createObjectURL(
+      new Blob([editorOutputView.state.doc.toString()], {
+        type: outputFormat?.fileExtension === 'json' ? 'application/json' : 'text/plain',
+      }),
+    );
+    a.download = `${sequenceName}.${outputFormat?.fileExtension}`;
     a.click();
   }
 
   function downloadInputFormat() {
     const a = document.createElement('a');
-    a.href = URL.createObjectURL(new Blob([editorSequenceView.state.doc.toString()], { type: 'text/plain' }));
-    a.download = `${sequenceName}.txt`;
+    a.href = URL.createObjectURL(
+      new Blob([editorSequenceView.state.doc.toString()], {
+        type: selectedOutputFormat?.fileExtension === 'json' ? 'application/json' : 'text/plain',
+      }),
+    );
+    a.download = `${sequenceName}.${selectedOutputFormat?.fileExtension}`;
     a.click();
   }
 
@@ -364,7 +372,7 @@
                     placement: 'top',
                   }}
                 >
-                  <MenuItem on:click={downloadOutputFormat} disabled={disableCopyAndExport}>
+                  <MenuItem on:click={() => downloadOutputFormat(outputFormatItem)} disabled={disableCopyAndExport}>
                     <DownloadIcon />
                     {outputFormatItem?.name}
                   </MenuItem>

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -172,7 +172,7 @@
 
         // Reconfigure seq JSON editor.
         editorOutputView.dispatch({
-          effects: compartmentSeqJsonLinter.reconfigure(seqJsonLinter(parsedCommandDictionary)),
+          effects: compartmentSeqJsonLinter.reconfigure(seqJsonLinter(parsedCommandDictionary, selectedOutputFormat)),
         });
       });
     }

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -4,7 +4,7 @@
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import type { ParameterDictionary } from '@nasa-jpl/aerie-ampcs';
-  import { sequenceAdaptation } from '../../stores/sequence-adaptation';
+  import { outputFormat } from '../../stores/sequence-adaptation';
   import {
     parameterDictionaries as parameterDictionariesStore,
     parcelToParameterDictionaries,
@@ -269,7 +269,7 @@
       </fieldset>
 
       <fieldset>
-        <label for="outputFile">Create Sequence from {$sequenceAdaptation?.outputFormat.name}</label>
+        <label for="outputFile">Create Sequence from {$outputFormat?.[0].name}</label>
         <input
           bind:files={outputFiles}
           class="w-100"

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -269,7 +269,7 @@
       </fieldset>
 
       <fieldset>
-        <label for="outputFile">Create Sequence from {$outputFormat?.[0].name}</label>
+        <label for="outputFile">Create Sequence from {$outputFormat?.[0]?.name}</label>
         <input
           bind:files={outputFiles}
           class="w-100"

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -233,7 +233,7 @@
       {/if}
 
       <fieldset>
-        <label for="commandDictionary">Parcel (required)</label>
+        <label for="parcel">Parcel (required)</label>
         <select
           bind:value={sequenceParcelId}
           class="st-select w-100"

--- a/src/stores/sequence-adaptation.ts
+++ b/src/stores/sequence-adaptation.ts
@@ -29,30 +29,30 @@ export function getGlobals(): GlobalType[] {
   return get(sequenceAdaptation)?.globals ?? [];
 }
 
-export function setSequenceAdaptation(): void {
+export function setSequenceAdaptation(newSequenceAdaptation: ISequenceAdaptation | undefined): void {
   sequenceAdaptation.set({
-    argDelegator: globalThis.SequenceAdaptation?.argDelegator ?? undefined,
+    argDelegator: newSequenceAdaptation?.argDelegator ?? undefined,
     conditionalKeywords: {
-      else: globalThis.SequenceAdaptation?.conditionalKeywords?.else ?? 'CMD_ELSE',
-      elseIf: globalThis.SequenceAdaptation?.conditionalKeywords?.elseIf ?? ['CMD_ELSE_IF'],
-      endIf: globalThis.SequenceAdaptation?.conditionalKeywords?.endIf ?? 'CMD_END_IF',
-      if: globalThis.SequenceAdaptation?.conditionalKeywords?.if ?? ['CMD_IF'],
+      else: newSequenceAdaptation?.conditionalKeywords?.else ?? 'CMD_ELSE',
+      elseIf: newSequenceAdaptation?.conditionalKeywords?.elseIf ?? ['CMD_ELSE_IF'],
+      endIf: newSequenceAdaptation?.conditionalKeywords?.endIf ?? 'CMD_END_IF',
+      if: newSequenceAdaptation?.conditionalKeywords?.if ?? ['CMD_IF'],
     },
-    globals: globalThis.SequenceAdaptation?.globals ?? [],
+    globals: newSequenceAdaptation?.globals ?? [],
     inputFormat: {
-      linter: globalThis.SequenceAdaptation?.inputFormat?.linter ?? undefined,
-      name: globalThis.SequenceAdaptation?.inputFormat?.name ?? 'SeqN',
-      toInputFormat: globalThis.SequenceAdaptation?.inputFormat?.toInputFormat ?? seqJsonToSequence,
+      linter: newSequenceAdaptation?.inputFormat?.linter ?? undefined,
+      name: newSequenceAdaptation?.inputFormat?.name ?? 'SeqN',
+      toInputFormat: newSequenceAdaptation?.inputFormat?.toInputFormat ?? seqJsonToSequence,
     },
     loopKeywords: {
-      break: globalThis.SequenceAdaptation?.loopKeywords?.break ?? 'CMD_BREAK',
-      continue: globalThis.SequenceAdaptation?.loopKeywords?.continue ?? 'CMD_CONTINUE',
-      endWhileLoop: globalThis.SequenceAdaptation?.loopKeywords?.endWhileLoop ?? 'CMD_END_WHILE_LOOP',
-      whileLoop: globalThis.SequenceAdaptation?.loopKeywords?.whileLoop ?? ['CMD_WHILE_LOOP', 'CMD_WHILE_LOOP_OR'],
+      break: newSequenceAdaptation?.loopKeywords?.break ?? 'CMD_BREAK',
+      continue: newSequenceAdaptation?.loopKeywords?.continue ?? 'CMD_CONTINUE',
+      endWhileLoop: newSequenceAdaptation?.loopKeywords?.endWhileLoop ?? 'CMD_END_WHILE_LOOP',
+      whileLoop: newSequenceAdaptation?.loopKeywords?.whileLoop ?? ['CMD_WHILE_LOOP', 'CMD_WHILE_LOOP_OR'],
     },
-    modifyOutput: globalThis.SequenceAdaptation?.modifyOutput ?? undefined,
-    modifyOutputParse: globalThis.SequenceAdaptation?.modifyOutputParse ?? undefined,
-    outputFormat: globalThis.SequenceAdaptation?.outputFormat ?? [
+    modifyOutput: newSequenceAdaptation?.modifyOutput ?? undefined,
+    modifyOutputParse: newSequenceAdaptation?.modifyOutputParse ?? undefined,
+    outputFormat: newSequenceAdaptation?.outputFormat ?? [
       {
         fileExtension: 'json',
         name: 'Seq JSON',

--- a/src/stores/sequence-adaptation.ts
+++ b/src/stores/sequence-adaptation.ts
@@ -54,6 +54,7 @@ export function setSequenceAdaptation(): void {
     modifyOutputParse: globalThis.SequenceAdaptation?.modifyOutputParse ?? undefined,
     outputFormat: globalThis.SequenceAdaptation?.outputFormat ?? [
       {
+        fileExtension: 'json',
         name: 'Seq JSON',
         toOutputFormat: sequenceToSeqJson,
       },

--- a/src/stores/sequence-adaptation.ts
+++ b/src/stores/sequence-adaptation.ts
@@ -18,7 +18,10 @@ export const sequenceAdaptations = gqlSubscribable<SequenceAdaptation[]>(gql.SUB
 
 export const inputFormat = derived([sequenceAdaptation], ([$sequenceAdaptation]) => $sequenceAdaptation?.inputFormat);
 
-export const outputFormat = derived([sequenceAdaptation], ([$sequenceAdaptation]) => $sequenceAdaptation?.outputFormat);
+export const outputFormat = derived(
+  [sequenceAdaptation],
+  ([$sequenceAdaptation]) => $sequenceAdaptation?.outputFormat ?? [],
+);
 
 /* Helpers */
 
@@ -28,31 +31,32 @@ export function getGlobals(): GlobalType[] {
 
 export function setSequenceAdaptation(): void {
   sequenceAdaptation.set({
-    argDelegator: globalThis.SequenceAdaptation?.ARG_DELEGATOR ?? undefined,
+    argDelegator: globalThis.SequenceAdaptation?.argDelegator ?? undefined,
     conditionalKeywords: {
-      else: globalThis.SequenceAdaptation?.CONDITIONAL_KEYWORDS?.ELSE ?? 'CMD_ELSE',
-      elseIf: globalThis.SequenceAdaptation?.CONDITIONAL_KEYWORDS?.ELSE_IF ?? ['CMD_ELSE_IF'],
-      endIf: globalThis.SequenceAdaptation?.CONDITIONAL_KEYWORDS?.END_IF ?? 'CMD_END_IF',
-      if: globalThis.SequenceAdaptation?.CONDITIONAL_KEYWORDS?.IF ?? ['CMD_IF'],
+      else: globalThis.SequenceAdaptation?.conditionalKeywords?.else ?? 'CMD_ELSE',
+      elseIf: globalThis.SequenceAdaptation?.conditionalKeywords?.elseIf ?? ['CMD_ELSE_IF'],
+      endIf: globalThis.SequenceAdaptation?.conditionalKeywords?.endIf ?? 'CMD_END_IF',
+      if: globalThis.SequenceAdaptation?.conditionalKeywords?.if ?? ['CMD_IF'],
     },
-    globals: globalThis.SequenceAdaptation?.GLOBALS ?? [],
+    globals: globalThis.SequenceAdaptation?.globals ?? [],
     inputFormat: {
-      linter: globalThis.SequenceAdaptation?.INPUT_FORMAT?.LINTER ?? undefined,
-      name: globalThis.SequenceAdaptation?.INPUT_FORMAT?.NAME ?? 'SeqN',
-      toInputFormat: globalThis.SequenceAdaptation?.INPUT_FORMAT?.TO_INPUT_FORMAT ?? seqJsonToSequence,
+      linter: globalThis.SequenceAdaptation?.inputFormat?.linter ?? undefined,
+      name: globalThis.SequenceAdaptation?.inputFormat?.name ?? 'SeqN',
+      toInputFormat: globalThis.SequenceAdaptation?.inputFormat?.toInputFormat ?? seqJsonToSequence,
     },
     loopKeywords: {
-      break: globalThis.SequenceAdaptation?.LOOP_KEYWORDS?.BREAK ?? 'CMD_BREAK',
-      continue: globalThis.SequenceAdaptation?.LOOP_KEYWORDS?.CONTINUE ?? 'CMD_CONTINUE',
-      endWhileLoop: globalThis.SequenceAdaptation?.LOOP_KEYWORDS?.END_WHILE_LOOP ?? 'CMD_END_WHILE_LOOP',
-      whileLoop: globalThis.SequenceAdaptation?.LOOP_KEYWORDS?.WHILE_LOOP ?? ['CMD_WHILE_LOOP', 'CMD_WHILE_LOOP_OR'],
+      break: globalThis.SequenceAdaptation?.loopKeywords?.break ?? 'CMD_BREAK',
+      continue: globalThis.SequenceAdaptation?.loopKeywords?.continue ?? 'CMD_CONTINUE',
+      endWhileLoop: globalThis.SequenceAdaptation?.loopKeywords?.endWhileLoop ?? 'CMD_END_WHILE_LOOP',
+      whileLoop: globalThis.SequenceAdaptation?.loopKeywords?.whileLoop ?? ['CMD_WHILE_LOOP', 'CMD_WHILE_LOOP_OR'],
     },
-    modifyOutput: globalThis.SequenceAdaptation?.MODIFY_OUTPUT ?? undefined,
-    modifyOutputParse: globalThis.SequenceAdaptation?.MODIFY_OUTPUT_PARSE ?? undefined,
-    outputFormat: {
-      linter: globalThis.SequenceAdaptation?.OUTPUT_FORMAT?.LINTER ?? undefined,
-      name: globalThis.SequenceAdaptation?.OUTPUT_FORMAT?.NAME ?? 'Seq JSON',
-      toOutputFormat: globalThis.SequenceAdaptation?.OUTPUT_FORMAT?.TO_OUTPUT_FORMAT ?? sequenceToSeqJson,
-    },
+    modifyOutput: globalThis.SequenceAdaptation?.modifyOutput ?? undefined,
+    modifyOutputParse: globalThis.SequenceAdaptation?.modifyOutputParse ?? undefined,
+    outputFormat: globalThis.SequenceAdaptation?.outputFormat ?? [
+      {
+        name: 'Seq JSON',
+        toOutputFormat: sequenceToSeqJson,
+      },
+    ],
   });
 }

--- a/src/types/sequencing.ts
+++ b/src/types/sequencing.ts
@@ -39,6 +39,7 @@ export type DictionaryType = {
 };
 
 export interface IOutputFormat {
+  fileExtension: string;
   linter?: (
     diagnostics: Diagnostic[],
     commandDictionary: AmpcsCommandDictionary,

--- a/src/types/sequencing.ts
+++ b/src/types/sequencing.ts
@@ -24,7 +24,7 @@ export type ParameterDictionary = {
 } & DictionaryType;
 
 export type SequenceAdaptation = {
-  adaptation: string;
+  adaptation: ISequenceAdaptation;
   name: string;
   type: DictionaryTypes.ADAPTATION;
 } & DictionaryType;

--- a/src/types/sequencing.ts
+++ b/src/types/sequencing.ts
@@ -38,6 +38,22 @@ export type DictionaryType = {
   version: string;
 };
 
+export interface IOutputFormat {
+  linter?: (
+    diagnostics: Diagnostic[],
+    commandDictionary: AmpcsCommandDictionary,
+    view: EditorView,
+    node: SyntaxNode,
+  ) => Diagnostic[];
+  name: string;
+  toOutputFormat?(
+    tree: any,
+    sequence: string,
+    commandDictionary: AmpcsCommandDictionary | null,
+    sequenceName: string,
+  ): Promise<string>;
+}
+
 export interface ISequenceAdaptation {
   argDelegator?: ArgDelegator;
   conditionalKeywords: { else: string; elseIf: string[]; endIf: string; if: string[] };
@@ -50,7 +66,7 @@ export interface ISequenceAdaptation {
       node: SyntaxNode,
     ) => Diagnostic[];
     name: string;
-    toInputFormat(input: string): Promise<string>;
+    toInputFormat?(input: string): Promise<string>;
   };
   loopKeywords: { break: string; continue: string; endWhileLoop: string; whileLoop: string[] };
   modifyOutput?: (
@@ -63,21 +79,7 @@ export interface ISequenceAdaptation {
     parameterDictionaries: AmpcsParameterDictionary[],
     channelDictionary: AmpcsChannelDictionary | null,
   ) => any;
-  outputFormat: {
-    linter?: (
-      diagnostics: Diagnostic[],
-      commandDictionary: AmpcsCommandDictionary,
-      view: EditorView,
-      node: SyntaxNode,
-    ) => Diagnostic[];
-    name: string;
-    toOutputFormat(
-      tree: any,
-      sequence: string,
-      commandDictionary: AmpcsCommandDictionary | null,
-      sequenceName: string,
-    ): Promise<string>;
-  };
+  outputFormat: IOutputFormat[];
 }
 
 export type Parcel = {

--- a/src/utilities/sequence-editor/extension-points.ts
+++ b/src/utilities/sequence-editor/extension-points.ts
@@ -1,12 +1,6 @@
-import type { Tree } from '@lezer/common';
-import {
-  type ChannelDictionary,
-  type CommandDictionary,
-  type FswCommandArgument,
-  type ParameterDictionary,
-} from '@nasa-jpl/aerie-ampcs';
+import { type ChannelDictionary, type FswCommandArgument, type ParameterDictionary } from '@nasa-jpl/aerie-ampcs';
 import { get } from 'svelte/store';
-import { inputFormat, outputFormat, sequenceAdaptation } from '../../stores/sequence-adaptation';
+import { inputFormat, sequenceAdaptation } from '../../stores/sequence-adaptation';
 
 // TODO: serialization
 // replace parameter names with hex ids
@@ -43,24 +37,6 @@ export function getCustomArgDef(
   return delegate?.(dictArg, parameterDictionaries, channelDictionary, precedingArgs) ?? dictArg;
 }
 
-export async function toOutputFormat(
-  node: Tree,
-  sequence: string,
-  commandDictionary: CommandDictionary | null,
-  parameterDictionaries: ParameterDictionary[],
-  channelDictionary: ChannelDictionary | null,
-  sequenceName: string,
-): Promise<string> {
-  const output = await get(outputFormat)?.toOutputFormat(node, sequence, commandDictionary, sequenceName);
-  const modifyOutput = get(sequenceAdaptation)?.modifyOutput;
-
-  if (modifyOutput !== undefined && output !== undefined) {
-    modifyOutput(output, parameterDictionaries, channelDictionary);
-  }
-
-  return output ?? '';
-}
-
 export async function toInputFormat(
   output: string,
   parameterDictionaries: ParameterDictionary[],
@@ -73,7 +49,7 @@ export async function toInputFormat(
     modifiedOutput = await modifyOutputParse(output, parameterDictionaries, channelDictionary);
   }
 
-  const input = await get(inputFormat)?.toInputFormat(modifiedOutput ?? output);
+  const input = await get(inputFormat)?.toInputFormat?.(modifiedOutput ?? output);
 
   return input;
 }

--- a/src/utilities/sequence-editor/seq-json-linter.ts
+++ b/src/utilities/sequence-editor/seq-json-linter.ts
@@ -4,8 +4,7 @@ import type { Extension, Text } from '@codemirror/state';
 import type { CommandDictionary } from '@nasa-jpl/aerie-ampcs';
 // @ts-expect-error library does not include type declarations
 import { parse as jsonSourceMapParse } from 'json-source-map';
-import { get } from 'svelte/store';
-import { sequenceAdaptation } from '../../stores/sequence-adaptation';
+import type { IOutputFormat } from '../../types/sequencing';
 
 type JsonSourceMapPointerPosition = {
   column: number;
@@ -42,7 +41,10 @@ function getErrorPosition(error: SyntaxError, doc: Text): number {
  * Linter function that returns a Code Mirror extension function.
  * Can be optionally called with a command dictionary so it's available during linting.
  */
-export function seqJsonLinter(commandDictionary: CommandDictionary | null = null): Extension {
+export function seqJsonLinter(
+  commandDictionary: CommandDictionary | null = null,
+  outputFormat: IOutputFormat | undefined = undefined,
+): Extension {
   return linter(view => {
     let diagnostics: Diagnostic[] = [];
     const tree = syntaxTree(view.state);
@@ -89,7 +91,7 @@ export function seqJsonLinter(commandDictionary: CommandDictionary | null = null
       });
     }
 
-    const outputLinter = get(sequenceAdaptation)?.outputFormat.linter;
+    const outputLinter = outputFormat?.linter;
 
     if (outputLinter !== undefined && commandDictionary !== null) {
       diagnostics = outputLinter(diagnostics, commandDictionary, view, treeNode);


### PR DESCRIPTION
…tations

Allows sequences to have multiple output formats.

Sample adaptation to test with:
```
(() => {
  globalThis.SequenceAdaptation = {
    outputFormat: [
      {
        linter: function outputLinter(
          diagnostics: Diagnostic[],
          commandDictionary: CommandDictionary,
          view: EditorView,
          node: SyntaxNode,
        ): Diagnostic[] {
          diagnostics = [];

          return diagnostics;
        },
        name: 'Output 1',
        toOutputFormat: async function sequenceToSasf(
          node: Tree,
          sequence: string,
          commandDictionary: CommandDictionary | null,
          sequenceName: string,
        ): Promise<string> {
          return 'Output 1 Format.';
        },
      },
      {
        linter: function outputLinter(
          diagnostics: Diagnostic[],
          commandDictionary: CommandDictionary,
          view: EditorView,
          node: SyntaxNode,
        ): Diagnostic[] {
          diagnostics = [];

          return diagnostics;
        },
        name: 'Output 2',
        toOutputFormat: async function sequenceToSasf(
          node: Tree,
          sequence: string,
          commandDictionary: CommandDictionary | null,
          sequenceName: string,
        ): Promise<string> {
          return 'Output 2 Format';
        },
      },
    ],
  };
})();
```