### PR TITLE
Small plan export improvements

### DIFF
--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -1,7 +1,6 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import CloseIcon from '@nasa-jpl/stellar/icons/close.svg?component';
   import ExportIcon from '../../assets/export.svg?component';
   import { PlanStatusMessages } from '../../enums/planStatusMessages';
   import { SearchParameters } from '../../enums/searchParameters';
@@ -28,9 +27,9 @@
   import Collapse from '../Collapse.svelte';
   import Field from '../form/Field.svelte';
   import Input from '../form/Input.svelte';
+  import CancellableProgressRadial from '../ui/CancellableProgressRadial.svelte';
   import CardList from '../ui/CardList.svelte';
   import FilterToggleButton from '../ui/FilterToggleButton.svelte';
-  import ProgressRadial from '../ui/ProgressRadial.svelte';
   import PlanCollaboratorInput from '../ui/Tags/PlanCollaboratorInput.svelte';
   import TagsInput from '../ui/Tags/TagsInput.svelte';
   import PlanSnapshot from './PlanSnapshot.svelte';
@@ -189,15 +188,14 @@
         <svelte:fragment slot="right">
           {#if planExportProgress !== null}
             <button
-              class="cancel-button"
+              class="st-button icon cancel-button"
               on:click|stopPropagation={onCancelExportPlan}
               use:tooltip={{
                 content: 'Cancel Plan Export',
                 placement: 'top',
               }}
             >
-              <ProgressRadial progress={planExportProgress} size={16} strokeWidth={1} />
-              <div class="cancel"><CloseIcon /></div>
+              <CancellableProgressRadial progress={planExportProgress} />
             </button>
           {:else}
             <button
@@ -417,31 +415,8 @@
   }
 
   .cancel-button {
-    --progress-radial-background: var(--st-gray-20);
-    background: none;
     border: 0;
     border-radius: 50%;
-    position: relative;
     width: 28px;
-  }
-
-  .cancel-button .cancel {
-    align-items: center;
-    cursor: pointer;
-    display: none;
-    height: 100%;
-    justify-content: center;
-    left: 0;
-    position: absolute;
-    top: 0;
-    width: 100%;
-  }
-
-  .cancel-button .cancel :global(svg) {
-    width: 10px;
-  }
-
-  .cancel-button:hover .cancel {
-    display: flex;
   }
 </style>

--- a/src/components/ui/CancellableProgressRadial.svelte
+++ b/src/components/ui/CancellableProgressRadial.svelte
@@ -1,0 +1,44 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import CloseIcon from '@nasa-jpl/stellar/icons/close.svg?component';
+  import ProgressRadial from './ProgressRadial.svelte';
+
+  export { className as class };
+  export let progress: number = 0;
+  export let size: number = 16;
+
+  let className: string = '';
+</script>
+
+<div class:cancel-progress={true} class={className}>
+  <ProgressRadial {progress} {size} strokeWidth={1} />
+  <div class="cancel"><CloseIcon /></div>
+</div>
+
+<style>
+  .cancel-progress {
+    --progress-radial-background: var(--st-gray-20);
+    position: relative;
+  }
+
+  .cancel-progress .cancel {
+    align-items: center;
+    cursor: pointer;
+    display: none;
+    height: 100%;
+    justify-content: center;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
+
+  .cancel-progress .cancel :global(svg) {
+    width: 65%;
+  }
+
+  .cancel-progress:hover .cancel {
+    display: flex;
+  }
+</style>

--- a/src/components/ui/DataGrid/DataGridActions.svelte
+++ b/src/components/ui/DataGrid/DataGridActions.svelte
@@ -3,7 +3,6 @@
 <script lang="ts">
   import { permissionHandler } from '../../../utilities/permissionHandler';
 
-  import CloseIcon from '@nasa-jpl/stellar/icons/close.svg?component';
   import DownloadIcon from '@nasa-jpl/stellar/icons/download.svg?component';
   import ExpandIcon from '@nasa-jpl/stellar/icons/expand.svg?component';
   import PenIcon from '@nasa-jpl/stellar/icons/pen.svg?component';
@@ -12,7 +11,7 @@
   import ExportIcon from '../../../assets/export.svg?component';
   import type { TRowData } from '../../../types/data-grid';
   import { tooltip } from '../../../utilities/tooltip';
-  import ProgressRadial from '../ProgressRadial.svelte';
+  import CancellableProgressRadial from '../CancellableProgressRadial.svelte';
 
   type RowData = $$Generic<TRowData>;
 
@@ -119,8 +118,7 @@
       on:click|stopPropagation={onCancelDownload}
       use:tooltip={{ ...downloadTooltip, content: `Cancel ${downloadTooltip?.content}` }}
     >
-      <ProgressRadial progress={downloadProgress} size={16} strokeWidth={1} />
-      <div class="cancel"><CloseIcon /></div>
+      <CancellableProgressRadial progress={downloadProgress} />
     </button>
   {/if}
 {/if}
@@ -169,25 +167,5 @@
     --progress-radial-background: var(--st-gray-20);
     border-radius: 50%;
     position: relative;
-  }
-
-  .downloading .cancel {
-    align-items: center;
-    cursor: pointer;
-    display: none;
-    height: 100%;
-    justify-content: center;
-    left: 0;
-    position: absolute;
-    top: 0;
-    width: 100%;
-  }
-
-  .downloading .cancel :global(svg) {
-    width: 10px;
-  }
-
-  .downloading:hover .cancel {
-    display: flex;
   }
 </style>

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -19,13 +19,13 @@
   import Input from '../../components/form/Input.svelte';
   import ModelStatusRollup from '../../components/model/ModelStatusRollup.svelte';
   import AlertError from '../../components/ui/AlertError.svelte';
+  import CancellableProgressRadial from '../../components/ui/CancellableProgressRadial.svelte';
   import CssGrid from '../../components/ui/CssGrid.svelte';
   import DataGridActions from '../../components/ui/DataGrid/DataGridActions.svelte';
   import { tagsCellRenderer, tagsFilterValueGetter } from '../../components/ui/DataGrid/DataGridTags';
   import SingleActionDataGrid from '../../components/ui/DataGrid/SingleActionDataGrid.svelte';
   import IconCellRenderer from '../../components/ui/IconCellRenderer.svelte';
   import Panel from '../../components/ui/Panel.svelte';
-  import ProgressRadial from '../../components/ui/ProgressRadial.svelte';
   import SectionTitle from '../../components/ui/SectionTitle.svelte';
   import TagsInput from '../../components/ui/Tags/TagsInput.svelte';
   import { InvalidDate } from '../../constants/time';
@@ -677,8 +677,7 @@
                     placement: 'top',
                   }}
                 >
-                  <ProgressRadial progress={planExportProgress} size={16} strokeWidth={1} />
-                  <div class="cancel"><CloseIcon /></div>
+                  <CancellableProgressRadial progress={planExportProgress} />
                 </button>
               {/if}
               <button
@@ -1009,30 +1008,8 @@
   }
 
   .cancel-button {
-    --progress-radial-background: var(--st-gray-20);
     background: none;
     border: 0;
-    position: relative;
-  }
-
-  .cancel-button .cancel {
-    align-items: center;
-    cursor: pointer;
-    display: none;
-    height: 100%;
-    justify-content: center;
-    left: 0;
-    position: absolute;
-    top: 0;
-    width: 100%;
-  }
-
-  .cancel-button .cancel :global(svg) {
-    width: 10px;
-  }
-
-  .cancel-button:hover .cancel {
-    display: flex;
   }
 
   .import-input-container {


### PR DESCRIPTION
This is to make plan export a little bit DRYer by adding a new component for progress radials that have a cancel icon.

This also fixes a small bug in the Plans table where if a download is in progress in a row, and the row itself is clicked on or another row is selected, the download icon in the table will reset.