### PR TITLE
Pull from constraint run table

### DIFF
--- a/src/components/constraints/ConstraintsPanel.svelte
+++ b/src/components/constraints/ConstraintsPanel.svelte
@@ -12,7 +12,7 @@
   import {
     allowedConstraintPlanSpecMap,
     allowedConstraintSpecs,
-    checkConstraintsStatus,
+    cachedConstraintsStatus,
     constraintPlanSpecs,
     constraintResponseMap,
     constraintVisibilityMap,
@@ -326,7 +326,7 @@
       {:else}
         <div class="pt-1 st-typography-label filter-label-row">
           <div class="filter-label">
-            {#if $checkConstraintsStatus}
+            {#if $cachedConstraintsStatus}
               <FilterIcon />
               {filteredConstraints.length} of {$allowedConstraintSpecs.length} constraints, {filteredViolationCount} of
               {totalViolationCount} violations

--- a/src/components/constraints/ConstraintsPanel.svelte
+++ b/src/components/constraints/ConstraintsPanel.svelte
@@ -232,7 +232,7 @@
             permissionHandler,
             {
               hasPermission: $plan
-                ? featurePermissions.constraintsPlanSpec.canCheck(user, $plan, $plan.model) && !$planReadOnly
+                ? featurePermissions.constraintRuns.canCreate(user, $plan, $plan.model) && !$planReadOnly
                 : false,
               permissionError: $planReadOnly
                 ? PlanStatusMessages.READ_ONLY

--- a/src/components/plan/PlanNavButton.svelte
+++ b/src/components/plan/PlanNavButton.svelte
@@ -9,7 +9,7 @@
   import PlayIcon from '@nasa-jpl/stellar/icons/play.svg?component';
   import type { Status } from '../../enums/status';
   import { permissionHandler } from '../../utilities/permissionHandler';
-  import { getHumanReadableStatus } from '../../utilities/simulation';
+  import { getHumanReadableStatus } from '../../utilities/status';
   import { tooltip } from '../../utilities/tooltip';
   import Menu from '../menus/Menu.svelte';
   import MenuHeader from '../menus/MenuHeader.svelte';

--- a/src/components/simulation/SimulationHistoryDataset.svelte
+++ b/src/components/simulation/SimulationHistoryDataset.svelte
@@ -167,9 +167,9 @@
       </div>
       <div>
         {#if extent}
-          <span use:tooltip={{ content: 'Simulation Time', placement: 'top' }} class="simulation-dataset-extent"
-            >{getSimulationTimestamp(simulationDataset)}</span
-          >,
+          <span use:tooltip={{ content: 'Simulation Time', placement: 'top' }} class="simulation-dataset-extent">
+            {getSimulationTimestamp(simulationDataset)}
+          </span>
         {/if}
         {progress.toFixed()}%
       </div>

--- a/src/components/simulation/SimulationHistoryDataset.svelte
+++ b/src/components/simulation/SimulationHistoryDataset.svelte
@@ -11,13 +11,13 @@
   import { hexToRgba } from '../../utilities/color';
   import {
     formatSimulationQueuePosition,
-    getHumanReadableStatus,
     getSimulationExtent,
     getSimulationProgress,
     getSimulationProgressColor,
     getSimulationStatus,
     getSimulationTimestamp,
   } from '../../utilities/simulation';
+  import { getHumanReadableStatus } from '../../utilities/status';
   import { formatDate, getUnixEpochTimeFromInterval, removeDateStringMilliseconds } from '../../utilities/time';
   import { tooltip } from '../../utilities/tooltip';
   import Card from '../ui/Card.svelte';

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -229,7 +229,7 @@
   $: hasUpdateViewPermission = $view !== null ? featurePermissions.view.canUpdate(data.user, $view) : false;
   $: if ($initialPlan) {
     hasCheckConstraintsPermission =
-      featurePermissions.constraintsPlanSpec.canCheck(data.user, $initialPlan, $initialPlan.model) && !$planReadOnly;
+      featurePermissions.constraintRuns.canCreate(data.user, $initialPlan, $initialPlan.model) && !$planReadOnly;
     hasExpandPermission =
       featurePermissions.expansionSequences.canExpand(data.user, $initialPlan, $initialPlan.model) && !$planReadOnly;
     hasScheduleAnalysisPermission =

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -166,6 +166,7 @@
   let compactNavMode = false;
   let errorConsole: Console;
   let consoleHeightString = '36px';
+  let constraintsStatusText: string | undefined;
   let hasCreateViewPermission: boolean = false;
   let hasUpdateViewPermission: boolean = false;
   let hasExpandPermission: boolean = false;
@@ -399,10 +400,16 @@
   $: numConstraintsViolated = Object.values($constraintResponseMap).filter(
     response => response.results.violations?.length,
   ).length;
-
   $: numConstraintsWithErrors = Object.values($constraintResponseMap).filter(
     response => response.errors?.length,
   ).length;
+  $: constraintsStatusText =
+    ($constraintsStatus === Status.Complete ||
+      $constraintsStatus === Status.Failed ||
+      $constraintsStatus === Status.PartialSuccess) &&
+    numConstraintsViolated + numConstraintsWithErrors + $uncheckedConstraintCount > 0
+      ? `${numConstraintsViolated + numConstraintsWithErrors + $uncheckedConstraintCount}`
+      : undefined;
 
   $: if ($initialPlan && browser) {
     // Asynchronously fetch resource types
@@ -699,12 +706,7 @@
           buttonText="Check Constraints"
           hasPermission={hasCheckConstraintsPermission}
           disabled={$simulationStatus !== Status.Complete}
-          statusBadgeText={($constraintsStatus === Status.Complete ||
-            $constraintsStatus === Status.Failed ||
-            $constraintsStatus === Status.PartialSuccess) &&
-          numConstraintsViolated + numConstraintsWithErrors + $uncheckedConstraintCount > 0
-            ? `${numConstraintsViolated + numConstraintsWithErrors + $uncheckedConstraintCount}`
-            : undefined}
+          statusBadgeText={constraintsStatusText}
           buttonTooltipContent={$simulationStatus !== Status.Complete ? 'Completed simulation required' : ''}
           permissionError={$planReadOnly
             ? PlanStatusMessages.READ_ONLY

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -43,9 +43,9 @@
     selectedActivityDirectiveId,
   } from '../../../stores/activities';
   import {
+    cachedConstraintsStatus,
     constraintResponseMap,
     constraintsStatus,
-    constraintsViolationStatus,
     resetConstraintStores,
     resetPlanConstraintStores,
     uncheckedConstraintCount,
@@ -723,7 +723,7 @@
                 </div>
                 {#if $constraintsStatus === Status.Complete || $constraintsStatus === Status.Failed || $constraintsStatus === Status.PartialSuccess}
                   <div class="constraints-status-item">
-                    <StatusBadge status={$constraintsViolationStatus} showTooltip={false} />
+                    <StatusBadge status={$cachedConstraintsStatus} showTooltip={false} />
                     {#if numConstraintsViolated > 0}
                       <div style:color="var(--st-error-red)">
                         {numConstraintsViolated} constraint{pluralize(numConstraintsViolated)}

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -698,7 +698,9 @@
           buttonText="Check Constraints"
           hasPermission={hasCheckConstraintsPermission}
           disabled={$simulationStatus !== Status.Complete}
-          statusBadgeText={($constraintsStatus === Status.Complete || $constraintsStatus === Status.Failed) &&
+          statusBadgeText={($constraintsStatus === Status.Complete ||
+            $constraintsStatus === Status.Failed ||
+            $constraintsStatus === Status.PartialSuccess) &&
           numConstraintsViolated + numConstraintsWithErrors + $uncheckedConstraintCount > 0
             ? `${numConstraintsViolated + numConstraintsWithErrors + $uncheckedConstraintCount}`
             : undefined}

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -43,7 +43,6 @@
     selectedActivityDirectiveId,
   } from '../../../stores/activities';
   import {
-    checkConstraintsStatus,
     constraintResponseMap,
     constraintsStatus,
     constraintsViolationStatus,
@@ -120,6 +119,7 @@
   import type { Extension } from '../../../types/extension';
   import type { PlanSnapshot } from '../../../types/plan-snapshot';
   import type { View, ViewSaveEvent, ViewToggleEvent } from '../../../types/view';
+  import { getConstraintStatus } from '../../../utilities/constraint';
   import effects from '../../../utilities/effects';
   import { getSearchParameterNumber, removeQueryParam, setQueryParam } from '../../../utilities/generic';
   import { isSaveEvent } from '../../../utilities/keyboardEvents';
@@ -128,7 +128,6 @@
   import { featurePermissions } from '../../../utilities/permissions';
   import {
     formatSimulationQueuePosition,
-    getHumanReadableStatus,
     getSimulationExtent,
     getSimulationProgress,
     getSimulationProgressColor,
@@ -136,7 +135,7 @@
     getSimulationStatus,
     getSimulationTimestamp,
   } from '../../../utilities/simulation';
-  import { statusColors } from '../../../utilities/status';
+  import { getHumanReadableStatus, statusColors } from '../../../utilities/status';
   import { pluralize } from '../../../utilities/text';
   import { getUnixEpochTime } from '../../../utilities/time';
   import { tooltip } from '../../../utilities/tooltip';
@@ -699,7 +698,7 @@
           buttonText="Check Constraints"
           hasPermission={hasCheckConstraintsPermission}
           disabled={$simulationStatus !== Status.Complete}
-          statusBadgeText={($checkConstraintsStatus === Status.Complete || $checkConstraintsStatus === Status.Failed) &&
+          statusBadgeText={($constraintsStatus === Status.Complete || $constraintsStatus === Status.Failed) &&
           numConstraintsViolated + numConstraintsWithErrors + $uncheckedConstraintCount > 0
             ? `${numConstraintsViolated + numConstraintsWithErrors + $uncheckedConstraintCount}`
             : undefined}
@@ -715,12 +714,12 @@
           <VerticalCollapseIcon />
           <svelte:fragment slot="metadata">
             <div class="st-typography-body constraints-status">
-              {#if $checkConstraintsStatus}
+              {#if $constraintsStatus}
                 <div class="constraints-status-item">
-                  <StatusBadge status={$checkConstraintsStatus} indeterminate showTooltip={false} />
-                  Check constraints: {getHumanReadableStatus($checkConstraintsStatus)}
+                  <StatusBadge status={$constraintsStatus} indeterminate showTooltip={false} />
+                  Check constraints: {getConstraintStatus($constraintsStatus)}
                 </div>
-                {#if $checkConstraintsStatus === Status.Complete || $checkConstraintsStatus === Status.Failed}
+                {#if $constraintsStatus === Status.Complete || $constraintsStatus === Status.Failed || $constraintsStatus === Status.PartialSuccess}
                   <div class="constraints-status-item">
                     <StatusBadge status={$constraintsViolationStatus} showTooltip={false} />
                     {#if numConstraintsViolated > 0}

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -44,6 +44,7 @@
   } from '../../../stores/activities';
   import {
     cachedConstraintsStatus,
+    checkConstraintsStatus,
     constraintResponseMap,
     constraintsStatus,
     resetConstraintStores,
@@ -718,8 +719,8 @@
             <div class="st-typography-body constraints-status">
               {#if $constraintsStatus}
                 <div class="constraints-status-item">
-                  <StatusBadge status={$constraintsStatus} indeterminate showTooltip={false} />
-                  Check constraints: {getConstraintStatus($constraintsStatus)}
+                  <StatusBadge status={$checkConstraintsStatus} indeterminate showTooltip={false} />
+                  Check constraints: {getConstraintStatus($checkConstraintsStatus)}
                 </div>
                 {#if $constraintsStatus === Status.Complete || $constraintsStatus === Status.Failed || $constraintsStatus === Status.PartialSuccess}
                   <div class="constraints-status-item">

--- a/src/stores/constraints.ts
+++ b/src/stores/constraints.ts
@@ -248,7 +248,6 @@ export const checkConstraintsStatus: Readable<Status | null> = derived(
       return Status.Complete;
     }
 
-    console.log('rawCheckConstraintsStatus :>> ', $rawCheckConstraintsStatus);
     return Status.Unchecked;
   },
 );

--- a/src/stores/constraints.ts
+++ b/src/stores/constraints.ts
@@ -127,7 +127,7 @@ export const constraintResponseMap: Readable<Record<ConstraintDefinition['constr
           run =>
             ({
               constraintId: run.constraint_id,
-              constraintName: '',
+              constraintName: run.constraint_metadata.name,
               errors: [],
               results: {
                 ...run.results,
@@ -208,17 +208,19 @@ export const relevantConstraintRuns: Readable<ConstraintRun[]> = derived(
 );
 
 export const visibleConstraintResults: Readable<ConstraintResultWithName[]> = derived(
-  [constraintRuns, allowedConstraintPlanSpecMap],
-  ([$constraintRuns, $allowedConstraintPlanSpecMap]) =>
-    $constraintRuns
+  [constraintResponseMap, allowedConstraintPlanSpecMap],
+  ([$constraintResponseMap, $allowedConstraintPlanSpecMap]) => {
+    return Object.values($constraintResponseMap)
       .filter(constraintRun => {
-        return (
-          $allowedConstraintPlanSpecMap[constraintRun.constraint_id] &&
-          $allowedConstraintPlanSpecMap[constraintRun.constraint_id].constraint_revision ===
-            constraintRun.constraint_revision
-        );
+        return $allowedConstraintPlanSpecMap[constraintRun.constraintId];
       })
-      .map(constraintRun => constraintRun.results),
+      .map(constraintRun => {
+        return {
+          ...constraintRun.results,
+          constraintName: constraintRun.constraintName,
+        };
+      });
+  },
 );
 
 export const cachedConstraintsStatus: Readable<Status | null> = derived(

--- a/src/stores/constraints.ts
+++ b/src/stores/constraints.ts
@@ -19,10 +19,9 @@ import { gqlSubscribable } from './subscribable';
 
 export const constraintMetadataId: Writable<number> = writable(-1);
 
-export const rawCheckConstraintsStatus: Writable<Status | null> = writable(null);
-
 export const constraintVisibilityMapWritable: Writable<Record<ConstraintMetadata['id'], boolean>> = writable({});
 
+export const rawCheckConstraintsStatus: Writable<Status | null> = writable(null);
 export const rawConstraintResponses: Writable<ConstraintResponse[]> = writable([]);
 
 export const constraintsColumns: Writable<string> = writable('1fr 3px 1fr');
@@ -289,11 +288,11 @@ export function resetPlanConstraintStores() {
 }
 
 export function resetConstraintStores(): void {
-  // cachedConstraintsStatus.set(null);
+  rawCheckConstraintsStatus.set(null);
   rawConstraintResponses.set([]);
 }
 
 export function resetConstraintStoresForSimulation(): void {
-  // cachedConstraintsStatus.set(Status.Unchecked);
+  rawCheckConstraintsStatus.set(Status.Unchecked);
   rawConstraintResponses.set([]);
 }

--- a/src/stores/constraints.ts
+++ b/src/stores/constraints.ts
@@ -173,15 +173,13 @@ export const constraintResponseMap: Readable<Record<ConstraintDefinition['constr
 
 export const uncheckedConstraintCount: Readable<number> = derived(
   [allowedConstraintSpecs, constraintResponseMap],
-  ([$allowedConstraintSpecs, $constraintResponseMap]) => {
-    const foo = $allowedConstraintSpecs.reduce((count, prev) => {
+  ([$allowedConstraintSpecs, $constraintResponseMap]) =>
+    $allowedConstraintSpecs.reduce((count, prev) => {
       if (!(prev.constraint_id in $constraintResponseMap)) {
         count++;
       }
       return count;
-    }, 0);
-    return foo;
-  },
+    }, 0),
 );
 
 export const relevantConstraintRuns: Readable<ConstraintRun[]> = derived(

--- a/src/stores/constraints.ts
+++ b/src/stores/constraints.ts
@@ -222,17 +222,20 @@ export const visibleConstraintResults: Readable<ConstraintResultWithName[]> = de
 );
 
 export const cachedConstraintsStatus: Readable<Status | null> = derived(
-  [relevantConstraintRuns],
-  ([$relevantConstraintRuns]) => {
-    return $relevantConstraintRuns.reduce((status: Status, constraintRun: ConstraintRun) => {
-      if (constraintRun.results.violations?.length) {
-        return Status.Failed;
-      } else if (status !== Status.Failed) {
-        return Status.Complete;
-      }
+  [relevantConstraintRuns, constraintPlanSpecsMap],
+  ([$relevantConstraintRuns, $constraintPlanSpecsMap]) => {
+    return $relevantConstraintRuns.reduce(
+      (status: Status | null, constraintRun: ConstraintRun) => {
+        if (constraintRun.results.violations?.length) {
+          return Status.Failed;
+        } else if (status !== Status.Failed) {
+          return Status.Complete;
+        }
 
-      return status;
-    }, Status.Unchecked);
+        return status;
+      },
+      Object.keys($constraintPlanSpecsMap).length ? Status.Unchecked : null,
+    );
   },
 );
 

--- a/src/stores/simulation.ts
+++ b/src/stores/simulation.ts
@@ -157,6 +157,11 @@ export const selectedSpan = derived([spansMap, selectedSpanId], ([$spansMap, $se
   return null;
 });
 
+export const simulationDatasetLatestId = derived(
+  [simulationDatasetLatest],
+  ([$simulationDatasetLatest]) => $simulationDatasetLatest?.dataset_id ?? -1,
+);
+
 /* Helper Functions. */
 
 export function resetSimulationStores() {

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -84,6 +84,13 @@ export type ConstraintResponse = {
   type: ConstraintType;
 };
 
+export type ConstraintRun = {
+  constraint_id: number;
+  constraint_revision: number;
+  results: ConstraintResultWithName;
+  simulation_data_id: number;
+};
+
 export type UserCodeError = {
   location: CodeLocation;
   message: string;

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -86,6 +86,9 @@ export type ConstraintResponse = {
 
 export type ConstraintRun = {
   constraint_id: number;
+  constraint_metadata: {
+    name: string;
+  };
   constraint_revision: number;
   results: ConstraintResultWithName;
   simulation_data_id: number;

--- a/src/utilities/constraint.test.ts
+++ b/src/utilities/constraint.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest';
+import { Status } from '../enums/status';
+import { getConstraintStatus } from './constraint';
+
+const constraintStatusReadableStatusMap = {
+  [Status.Complete]: Status.Complete,
+  [Status.Failed]: Status.Failed,
+  [Status.Canceled]: Status.Canceled,
+  [Status.PartialSuccess]: 'Partially Checked',
+  [Status.Incomplete]: 'In Progress',
+  [Status.Pending]: 'Queued',
+};
+
+describe.each([
+  ...Object.entries(constraintStatusReadableStatusMap).map(([status, readable]) => ({ readable, status })),
+  { readable: 'Unknown', status: 'Random status' },
+])('getConstraintStatus', ({ readable, status }) => {
+  test(`Should get the readable status ${readable} for the constraint status ${status}`, () => {
+    expect(getConstraintStatus(status as Status)).toEqual(readable);
+  });
+});

--- a/src/utilities/constraint.ts
+++ b/src/utilities/constraint.ts
@@ -1,0 +1,12 @@
+import type { Status } from '../enums/status';
+import { getHumanReadableStatus } from './status';
+
+export function getConstraintStatus(status: Status | null): string {
+  const readableStatus = getHumanReadableStatus(status);
+
+  if (readableStatus === 'Partially Succeeded') {
+    return 'Partially Checked';
+  }
+
+  return readableStatus;
+}

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -413,13 +413,11 @@ const effects = {
 
           if (successfulConstraintResults.length === 0 && data.constraintResponses.length > 0) {
             showFailureToast('All Constraints Failed');
-            // checkConstraintsStatus.set(Status.Failed);
           } else if (successfulConstraintResults.length !== data.constraintResponses.length) {
             showFailureToast('Constraints Partially Checked');
-            // checkConstraintsStatus.set(successfulConstraintResults.length !== 0 ? Status.Failed : Status.Failed);
+            constraintsViolationStatus.set(Status.Failed);
           } else {
             showSuccessToast('All Constraints Checked');
-            // checkConstraintsStatus.set(Status.Complete);
           }
 
           if (failedConstraintResponses.length > 0) {
@@ -437,7 +435,6 @@ const effects = {
       }
     } catch (e) {
       catchError('Check Constraints Failed', e as Error);
-      // checkConstraintsStatus.set(Status.Failed);
       showFailureToast('Check Constraints Failed');
     }
   },

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -13,7 +13,6 @@ import { SearchParameters } from '../enums/searchParameters';
 import { Status } from '../enums/status';
 import { activityDirectivesDB, selectedActivityDirectiveId } from '../stores/activities';
 import {
-  checkConstraintsStatus,
   constraintsViolationStatus,
   rawConstraintResponses,
   resetConstraintStoresForSimulation,
@@ -381,7 +380,7 @@ const effects = {
 
   async checkConstraints(plan: Plan, user: User | null): Promise<void> {
     try {
-      checkConstraintsStatus.set(Status.Incomplete);
+      // checkConstraintsStatus.set(Status.Incomplete);
       constraintsViolationStatus.set(null);
       if (plan !== null) {
         const { id: planId } = plan;
@@ -414,13 +413,13 @@ const effects = {
 
           if (successfulConstraintResults.length === 0 && data.constraintResponses.length > 0) {
             showFailureToast('All Constraints Failed');
-            checkConstraintsStatus.set(Status.Failed);
+            // checkConstraintsStatus.set(Status.Failed);
           } else if (successfulConstraintResults.length !== data.constraintResponses.length) {
             showFailureToast('Constraints Partially Checked');
-            checkConstraintsStatus.set(successfulConstraintResults.length !== 0 ? Status.Failed : Status.Failed);
+            // checkConstraintsStatus.set(successfulConstraintResults.length !== 0 ? Status.Failed : Status.Failed);
           } else {
             showSuccessToast('All Constraints Checked');
-            checkConstraintsStatus.set(Status.Complete);
+            // checkConstraintsStatus.set(Status.Complete);
           }
 
           if (failedConstraintResponses.length > 0) {
@@ -438,7 +437,7 @@ const effects = {
       }
     } catch (e) {
       catchError('Check Constraints Failed', e as Error);
-      checkConstraintsStatus.set(Status.Failed);
+      // checkConstraintsStatus.set(Status.Failed);
       showFailureToast('Check Constraints Failed');
     }
   },

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -12,11 +12,7 @@ import { DictionaryTypes } from '../enums/dictionaryTypes';
 import { SearchParameters } from '../enums/searchParameters';
 import { Status } from '../enums/status';
 import { activityDirectivesDB, selectedActivityDirectiveId } from '../stores/activities';
-import {
-  constraintsViolationStatus,
-  rawConstraintResponses,
-  resetConstraintStoresForSimulation,
-} from '../stores/constraints';
+import { rawConstraintResponses, resetConstraintStoresForSimulation } from '../stores/constraints';
 import { catchError, catchSchedulingError } from '../stores/errors';
 import {
   createExpansionRuleError,
@@ -380,8 +376,6 @@ const effects = {
 
   async checkConstraints(plan: Plan, user: User | null): Promise<void> {
     try {
-      // checkConstraintsStatus.set(Status.Incomplete);
-      constraintsViolationStatus.set(null);
       if (plan !== null) {
         const { id: planId } = plan;
         const data = await reqHasura<ConstraintResponse[]>(
@@ -402,20 +396,10 @@ const effects = {
           const failedConstraintResponses = data.constraintResponses.filter(
             constraintResponse => !constraintResponse.success,
           );
-
-          const anyViolations = successfulConstraintResults.reduce((bool, prev) => {
-            if (prev.violations && prev.violations.length > 0) {
-              bool = true;
-            }
-            return bool;
-          }, false);
-          constraintsViolationStatus.set(anyViolations ? Status.Failed : Status.Complete);
-
           if (successfulConstraintResults.length === 0 && data.constraintResponses.length > 0) {
             showFailureToast('All Constraints Failed');
           } else if (successfulConstraintResults.length !== data.constraintResponses.length) {
             showFailureToast('Constraints Partially Checked');
-            constraintsViolationStatus.set(Status.Failed);
           } else {
             showSuccessToast('All Constraints Checked');
           }

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -2115,6 +2115,9 @@ const gql = {
         constraint_id
         constraint_revision
         results
+        constraint_metadata {
+          name
+        }
       }
     }
   `,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -16,6 +16,7 @@ export enum Queries {
   CONSTRAINT_DEFINITION = 'constraint_definition_by_pk',
   CONSTRAINT_METADATA = 'constraint_metadata_by_pk',
   CONSTRAINT_METADATAS = 'constraint_metadata',
+  CONSTRAINT_RUN = 'constraint_run',
   CONSTRAINT_SPECIFICATIONS = 'constraint_specification',
   CONSTRAINT_VIOLATIONS = 'constraintViolations',
   CREATE_EXPANSION_SET = 'createExpansionSet',
@@ -2104,6 +2105,16 @@ const gql = {
           }
         }
         plan_id
+      }
+    }
+  `,
+
+  SUB_CONSTRAINT_RUNS: `#graphql
+    subscription SubConstraintRuns($simulationDatasetId: Int!) {
+      constraintRuns: ${Queries.CONSTRAINT_RUN}(where: { simulation_dataset_id: { _eq: $simulationDatasetId }}) {
+        constraint_id
+        constraint_revision
+        results
       }
     }
   `,

--- a/src/utilities/simulation.ts
+++ b/src/utilities/simulation.ts
@@ -60,29 +60,6 @@ export function getSimulationTimestamp(simulationDataset: SimulationDataset): st
 }
 
 /**
- * Returns a human readable string representing a Status
- */
-export function getHumanReadableStatus(status: Status | null): string {
-  if (!status) {
-    return 'Unknown';
-  }
-  if (status === Status.Complete) {
-    return Status.Complete;
-  } else if (status === Status.PartialSuccess) {
-    return 'Partially Succeeded';
-  } else if (status === Status.Failed) {
-    return Status.Failed;
-  } else if (status === Status.Incomplete) {
-    return 'In Progress';
-  } else if (status === Status.Pending) {
-    return 'Queued';
-  } else if (status === Status.Canceled) {
-    return 'Canceled';
-  }
-  return 'Unknown';
-}
-
-/**
  * Returns a Status for a simulation dataset
  */
 export function getSimulationStatus(simulationDataset: SimulationDatasetSlim | null): Status | null {

--- a/src/utilities/status.test.ts
+++ b/src/utilities/status.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+import { Status } from '../enums/status';
+import { getColorForStatus, getHumanReadableStatus, statusColors } from './status';
+
+const statusColorMap = {
+  [Status.Complete]: statusColors.green,
+  [Status.Failed]: statusColors.red,
+  [Status.Canceled]: statusColors.red,
+  [Status.Incomplete]: statusColors.blue,
+  [Status.Unchecked]: statusColors.yellow,
+  [Status.Modified]: statusColors.yellow,
+  [Status.Pending]: statusColors.gray,
+  [Status.PartialSuccess]: statusColors.orange,
+};
+const statusReadableStatusMap = {
+  [Status.Complete]: Status.Complete,
+  [Status.Failed]: Status.Failed,
+  [Status.Canceled]: Status.Canceled,
+  [Status.PartialSuccess]: 'Partially Succeeded',
+  [Status.Incomplete]: 'In Progress',
+  [Status.Pending]: 'Queued',
+};
+
+describe.each([
+  ...Object.entries(statusColorMap).map(([status, color]) => ({ color, status })),
+  { color: statusColors.gray, status: 'Random' },
+])('getColorForStatus', ({ status, color }) => {
+  test(`Should get the color ${color} for the status ${status}`, () => {
+    expect(getColorForStatus(status as Status)).toEqual(color);
+  });
+});
+
+describe.each([
+  ...Object.entries(statusReadableStatusMap).map(([status, readable]) => ({ readable, status })),
+  { readable: 'Unknown', status: 'Random status' },
+])('getHumanReadableStatus', ({ readable, status }) => {
+  test(`Should get the readable status ${readable} for the status ${status}`, () => {
+    expect(getHumanReadableStatus(status as Status)).toEqual(readable);
+  });
+});

--- a/src/utilities/status.ts
+++ b/src/utilities/status.ts
@@ -31,3 +31,23 @@ export function getColorForStatus(status: Status | null): string {
     return statusColors.gray;
   }
 }
+
+/**
+ * Returns a human readable string representing a Status
+ */
+export function getHumanReadableStatus(status: Status | null): string {
+  switch (status) {
+    case Status.Complete:
+    case Status.Failed:
+    case Status.Canceled:
+      return status;
+    case Status.PartialSuccess:
+      return 'Partially Succeeded';
+    case Status.Incomplete:
+      return 'In Progress';
+    case Status.Pending:
+      return 'Queued';
+    default:
+      return 'Unknown';
+  }
+}


### PR DESCRIPTION
Resolves #770 

This PR introduces a subscription to the `constraint_run` table to pull the last cached constraint check status for the latest simulation dataset.

Ideally the behavior should be exactly the same for displaying constraint statuses, but the only difference would be that the last constraint status is persisted between reloads.

To test:
1. Create a constraint `export default (): Constraint => Real.Resource("/fruit").lessThan(4)`
2. Create banananation plan
3. Add a `GrowBanana`
4. Associate the constraint created in step 1 to the plan
5. Simulate
6. Check constraints
7. Verify that the constraint status is all green
8. Refresh and verify that it still shows as all green
9. Add another `GrowBanana`
10. Simulate again
11. Check constraints again
12. Verify that a validation error shows
13. Refresh and verify that it still shows the validation error
