### PR TITLE
Explicitly track offsetX in timeline context menu

### DIFF
--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -263,7 +263,7 @@
 
   export function viewTimeRangeChanged(viewTimeRange: TimeRange, zoomTransform?: ZoomTransform) {
     dispatch('viewTimeRangeChanged', viewTimeRange);
-    // Assign zoom transform if provided to syncronize all d3 zoom handlers
+    // Assign zoom transform if provided to synchronize all d3 zoom handlers
     if (zoomTransform) {
       timelineZoomTransform = zoomTransform;
     } else {

--- a/src/components/timeline/TimelineContextMenu.svelte
+++ b/src/components/timeline/TimelineContextMenu.svelte
@@ -238,7 +238,7 @@
   }
 </script>
 
-<ContextMenu hideAfterClick={false} on:hide bind:this={contextMenuComponent}>
+<ContextMenu hideAfterClick on:hide bind:this={contextMenuComponent}>
   <!-- TODO should we show the row editing menu items when a directive or span is selected? -->
   {#if mouseOverOrigin !== 'row-header'}
     {#if activityDirective}

--- a/src/components/timeline/TimelineViewControls.svelte
+++ b/src/components/timeline/TimelineViewControls.svelte
@@ -69,22 +69,28 @@
     scrollIfOffscreen();
   }
 
-  $: if (
-    typeof window !== 'undefined' &&
-    ($selectedActivityDirective || $selectedSpan || $simulationDatasetId !== null)
-  ) {
-    viewURL = new URL(window.location.href);
-    viewURL.searchParams.set(SearchParameters.START_TIME, new Date(viewTimeRange.start).toISOString());
-    viewURL.searchParams.set(SearchParameters.END_TIME, new Date(viewTimeRange.end).toISOString());
-    if ($selectedActivityDirective) {
-      viewURL.searchParams.set(SearchParameters.ACTIVITY_ID, $selectedActivityDirective.id.toFixed());
+  // The time range can potentially become invalid by zooming out too much which will cause the following to fail
+  // A try/catch is used here to prevent the UI from becoming unresponsive if an invalid time range is provided
+  $: try {
+    if (
+      typeof window !== 'undefined' &&
+      ($selectedActivityDirective || $selectedSpan || $simulationDatasetId !== null)
+    ) {
+      viewURL = new URL(window.location.href);
+      viewURL.searchParams.set(SearchParameters.START_TIME, new Date(viewTimeRange.start).toISOString());
+      viewURL.searchParams.set(SearchParameters.END_TIME, new Date(viewTimeRange.end).toISOString());
+      if ($selectedActivityDirective) {
+        viewURL.searchParams.set(SearchParameters.ACTIVITY_ID, $selectedActivityDirective.id.toFixed());
+      }
+      if ($selectedSpan) {
+        viewURL.searchParams.set(SearchParameters.SPAN_ID, $selectedSpan.span_id.toFixed());
+      }
+      if ($simulationDatasetId) {
+        viewURL.searchParams.set(SearchParameters.SIMULATION_DATASET_ID, $simulationDatasetId.toFixed());
+      }
     }
-    if ($selectedSpan) {
-      viewURL.searchParams.set(SearchParameters.SPAN_ID, $selectedSpan.span_id.toFixed());
-    }
-    if ($simulationDatasetId) {
-      viewURL.searchParams.set(SearchParameters.SIMULATION_DATASET_ID, $simulationDatasetId.toFixed());
-    }
+  } catch (e) {
+    console.log(e);
   }
 
   function onKeydown(e: KeyboardEvent) {

--- a/src/components/timeline/TimelineViewControls.svelte
+++ b/src/components/timeline/TimelineViewControls.svelte
@@ -69,7 +69,7 @@
     scrollIfOffscreen();
   }
 
-  // The time range can potentially become invalid by zooming out too much which will cause the following to fail
+  // The time range can potentially become invalid by zooming in too much which will cause the following to fail
   // A try/catch is used here to prevent the UI from becoming unresponsive if an invalid time range is provided
   $: try {
     if (


### PR DESCRIPTION
This resolves #1399 

To test:
1. In Firefox specifically, open/create a plan
2. Open the simulations panel
3. Hover over the timeline (no activities needed)
4. Right click anywhere on the timeline
5. Click "Set Simulation End"
6. Verify that the simulation end time field now reflects the correct time

The crux of this issue was that (only in Firefox) the X position was being lost between event generation and usage. So this issue was present for any contextmenu event that used cursor positioning after a context menu item was chosen.

Bonus tests:
1. In Firefox, open/create a plan
2. Hover over the timeline
3. Right click anywhere
4. Choose "Place Guide"
5. Verify the guide was placed where you right clicked
6. Right click anywhere again
7. Hover over "Zoom" and click on one of the zoom choices
8. Verify that you zoomed in/out around where you right clicked