### PR TITLE
Run UI e2e tests with given aerie/gateway docker tags when provided in PR body

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - develop
       - dev-[0-9]+.[0-9]+.[0-9]+
+    types:
+      # defaults + 'edited', to handle changes to flags like ___REQUIRES_AERIE_PR___ in the PR body
+      [opened, synchronize, reopened, edited]
   push:
     branches:
       - develop
@@ -33,6 +36,7 @@ env:
   SCHEDULER_PASSWORD: '${{secrets.SCHEDULER_PASSWORD}}'
   SEQUENCING_USERNAME: '${{secrets.SEQUENCING_USERNAME}}'
   SEQUENCING_PASSWORD: '${{secrets.SEQUENCING_PASSWORD}}'
+  PR_BODY: '${{github.event.pull_request.body}}'
 
 jobs:
   unit-test:
@@ -69,11 +73,25 @@ jobs:
         with:
           node-version: 'lts/*'
           cache: npm
+      - name: Extract Aerie backend docker tag from PR body
+        # look in the PR body for eg. the string ___REQUIRES_AERIE_PR___=9999, extract the number & save to env var
+        # if backend PR is labeled correctly, it will publish a docker tag called 'pr-9999' to use in tests
+        if: ${{ contains(env.PR_BODY, '___REQUIRES_AERIE_PR___=') }}
+        run: |
+          echo "AERIE_IMAGE_TAG=pr-$(echo $PR_BODY | sed -n 's/.*___REQUIRES_AERIE_PR___=\"\([0-9]\+\)\".*/\1/p')" >> $GITHUB_ENV
+      - name: Extract Aerie gateway docker tag from PR body
+        # look in the PR body for eg. the string ___REQUIRES_AERIE_PR___=9999, extract the number & save to env var
+        # if backend PR is labeled correctly, it will publish a docker tag called 'pr-9999' to use in tests
+        if: ${{ contains(env.PR_BODY, '___REQUIRES_GATEWAY_PR___=') }}
+        run: |
+          echo "GATEWAY_IMAGE_TAG=pr-$(echo $PR_BODY | sed -n 's/.*___REQUIRES_GATEWAY_PR___=\"\([0-9]\+\)\".*/\1/p')" >> $GITHUB_ENV
       - name: Start Services (Aerie)
         run: |
-          docker compose -f docker-compose-test.yml up -d
+          echo "AERIE_IMAGE_TAG: $AERIE_IMAGE_TAG"
+          echo "GATEWAY_IMAGE_TAG: $GATEWAY_IMAGE_TAG"
+          docker compose -f docker-compose-test.yml up -d --quiet-pull
           docker images
-          docker ps -a
+          docker ps -a --no-trunc
       - name: Install Dependencies (UI)
         run: npm ci
       - name: Build (UI)

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -19,7 +19,7 @@ services:
       AERIE_DB_PORT: 5432
       GATEWAY_DB_USER: '${GATEWAY_USERNAME}'
       GATEWAY_DB_PASSWORD: '${GATEWAY_PASSWORD}'
-    image: 'ghcr.io/nasa-ammos/aerie-gateway:develop'
+    image: 'ghcr.io/nasa-ammos/aerie-gateway:${GATEWAY_IMAGE_TAG:-develop}'
     ports: ['9000:9000']
     restart: always
     volumes:
@@ -42,7 +42,7 @@ services:
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
       UNTRUE_PLAN_START: '2000-01-01T11:58:55.816Z'
-    image: 'ghcr.io/nasa-ammos/aerie-merlin:develop'
+    image: 'ghcr.io/nasa-ammos/aerie-merlin:${AERIE_IMAGE_TAG:-develop}'
     ports: ['27183:27183']
     restart: always
     volumes:
@@ -62,7 +62,7 @@ services:
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
       UNTRUE_PLAN_START: '2000-01-01T11:58:55.816Z'
-    image: 'ghcr.io/nasa-ammos/aerie-merlin-worker:develop'
+    image: 'ghcr.io/nasa-ammos/aerie-merlin-worker:${AERIE_IMAGE_TAG:-develop}'
     ports: ['27187:8080']
     restart: always
     volumes:
@@ -82,7 +82,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
-    image: 'ghcr.io/nasa-ammos/aerie-scheduler:develop'
+    image: 'ghcr.io/nasa-ammos/aerie-scheduler:${AERIE_IMAGE_TAG:-develop}'
     ports: ['27185:27185']
     restart: always
     volumes:
@@ -105,7 +105,7 @@ services:
         -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
         -Dorg.slf4j.simpleLogger.log.com.zaxxer.hikari=INFO
         -Dorg.slf4j.simpleLogger.logFile=System.err
-    image: 'ghcr.io/nasa-ammos/aerie-scheduler-worker:develop'
+    image: 'ghcr.io/nasa-ammos/aerie-scheduler-worker:${AERIE_IMAGE_TAG:-develop}'
     ports: ['27189:8080']
     restart: always
     volumes:
@@ -124,7 +124,7 @@ services:
       SEQUENCING_DB_PASSWORD: '${SEQUENCING_PASSWORD}'
       SEQUENCING_LOCAL_STORE: /usr/src/app/sequencing_file_store
       SEQUENCING_SERVER_PORT: 27184
-    image: 'ghcr.io/nasa-ammos/aerie-sequencing:develop'
+    image: 'ghcr.io/nasa-ammos/aerie-sequencing:${AERIE_IMAGE_TAG:-develop}'
     ports: ['27184:27184']
     restart: always
     volumes:
@@ -146,7 +146,7 @@ services:
       HASURA_GRAPHQL_LOG_LEVEL: info
       HASURA_GRAPHQL_METADATA_DATABASE_URL: 'postgres://${AERIE_USERNAME}:${AERIE_PASSWORD}@postgres:5432/aerie_hasura'
       HASURA_GRAPHQL_METADATA_DIR: /hasura-metadata
-    image: 'ghcr.io/nasa-ammos/aerie-hasura:develop'
+    image: 'ghcr.io/nasa-ammos/aerie-hasura:${AERIE_IMAGE_TAG:-develop}'
     ports: ['8080:8080']
     restart: always
   postgres:
@@ -165,7 +165,7 @@ services:
       SCHEDULER_DB_PASSWORD: '${SCHEDULER_PASSWORD}'
       SEQUENCING_DB_USER: '${SEQUENCING_USERNAME}'
       SEQUENCING_DB_PASSWORD: '${SEQUENCING_PASSWORD}'
-    image: 'ghcr.io/nasa-ammos/aerie-postgres:develop'
+    image: 'ghcr.io/nasa-ammos/aerie-postgres:${AERIE_IMAGE_TAG:-develop}'
     ports: ['5432:5432']
     restart: always
     volumes:


### PR DESCRIPTION
`___REQUIRES_AERIE_PR___="1540"`
`___REQUIRES_GATEWAY_PR___="107"`

### Description
Supporting this issue: https://github.com/NASA-AMMOS/aerie/issues/1538

This PR allows the `aerie-ui` PR e2e test suite to use different Docker image tags, published by PR(s) on their respective repos, for the `aerie` & `aerie-gateway` containers when testing, instead of `develop` as they usually do. The aerie/gateway PR(s) must first be opened and labeled with the "publish" label in github, which will cause them to publish images tagged eg. `pr-1540`. (see https://github.com/NASA-AMMOS/aerie/pull/1540 & https://github.com/NASA-AMMOS/aerie-gateway/pull/107 )

Once this is done, you can add the flag(s) at the top of this PR (`___REQUIRES_AERIE_PR___` and/or `___REQUIRES_GATEWAY_PR___`) to your aerie-ui PR to indicate the PR branches to be tested with.

### Verification
This PR itself demonstrates the workflow:
* The Test workflow re-runs when the PR body is modified (to check for flags)
* The flags in the PR body are parsed by the workflow
* You can see in the workflow logs that the correct docker image tags were pulled (`pr-1540` for aerie and `pr-107` for gateway)
* I've also tested removing these flags to make sure the workflow still works correctly for PRs not passing them