### PR TITLE
Sequence Editor Ground epoch time tag

### DIFF
--- a/src/utilities/codemirror/custom-folder.test.ts
+++ b/src/utilities/codemirror/custom-folder.test.ts
@@ -24,7 +24,7 @@ const GROUND_ACTIVITIES = [
 ];
 
 const REQUEST_ACTIVITIES = [
-  `@GROUND_EPOCH("Name", "+0.00") @REQUEST_BEGIN("request.name")
+  `G+00:00:00 "Name" @REQUEST_BEGIN("request.name")
   C SEQ_ECHO ""
   @METADATA "Key" "Value"
   @METADATA "Key1" "Value"

--- a/src/utilities/codemirror/index.ts
+++ b/src/utilities/codemirror/index.ts
@@ -49,6 +49,7 @@ export const SeqLanguage = LRLanguage.define({
         TimeAbsolute: t.className,
         TimeComplete: t.className,
         TimeEpoch: t.className,
+        TimeGroundEpoch: t.className,
         TimeRelative: t.className,
       }),
     ],

--- a/src/utilities/codemirror/sequence.grammar
+++ b/src/utilities/codemirror/sequence.grammar
@@ -67,7 +67,7 @@ HardwareCommands {
   commandBlock
 }
 
-TimeTag { TimeAbsolute | TimeEpoch | TimeRelative  | TimeComplete }
+TimeTag { TimeAbsolute | (TimeGroundEpoch Name { String } whiteSpace)  | TimeEpoch | TimeRelative  | TimeComplete }
 
 Args {
   (whiteSpace (arg | RepeatArg))* whiteSpace?
@@ -118,20 +118,7 @@ commonGround {
 }
 
 Request {
-  (TimeTag | GroundEpoch {
-    groundEpochDirective
-    "("
-      whiteSpace?
-      Name { String }
-      whiteSpace?
-    ","
-      whiteSpace?
-      Delta { String }
-      whiteSpace?
-    ")"
-    // Extra properties are allowed in schema, but not supported by tool chain
-    whiteSpace
-  })
+  TimeTag
   requestStartDirective "(" RequestName { String } ")"
   whiteSpace? LineComment? newLine
   // json schema requires step+, catch error in linter for cleaner message
@@ -190,6 +177,8 @@ Stem { !stemStart identifier }
 
   TimeEpoch { 'E'$[+\-]?(timeSecond | timeDOY | timeHhmmss) whiteSpace}
 
+  TimeGroundEpoch { 'G'$[+\-]?(timeSecond | timeDOY | timeHhmmss) whiteSpace}
+
   TimeComplete { 'C' whiteSpace }
 
   String { '"' (!["\\] | "\\" _)* '"' }
@@ -224,7 +213,6 @@ Stem { !stemStart identifier }
   loadDirective { "@LOAD" }
   engineDirective { "@ENGINE" }
   epochDirective { "@EPOCH" }
-  groundEpochDirective { "@GROUND_EPOCH" }
   groundBlockDirective { "@GROUND_BLOCK" }
   groundEventDirective { "@GROUND_EVENT" }
   requestStartDirective { "@REQUEST_BEGIN" }
@@ -235,7 +223,7 @@ Stem { !stemStart identifier }
 
   @precedence { newLine, whiteSpace }
 
-  @precedence{ TimeAbsolute, TimeRelative, TimeEpoch, TimeComplete, Boolean, identifier }
+  @precedence{ TimeAbsolute, TimeRelative, TimeEpoch, TimeComplete, TimeGroundEpoch, Boolean, identifier }
 
   @precedence {
     LoadAndGoDirective,
@@ -250,7 +238,6 @@ Stem { !stemStart identifier }
     loadDirective,
     groundBlockDirective,
     groundEventDirective,
-    groundEpochDirective,
     requestStartDirective,
     requestEndDirective,
     engineDirective,

--- a/src/utilities/sequence-editor/from-seq-json.test.ts
+++ b/src/utilities/sequence-editor/from-seq-json.test.ts
@@ -783,7 +783,7 @@ C FSA_CMD 10 [] "USA" ["96707-898" "92604-623"]
     const sequence = await seqJsonToSequence(JSON.stringify(seqJson));
     const expectedSequence = `
     @ID "id"
-    @GROUND_EPOCH("GroundEpochName", "+3:00") @REQUEST_BEGIN("request2.name")
+    G+3:00 "GroundEpochName" @REQUEST_BEGIN("request2.name")
       C CMD_0 1 2 3
       @METADATA "cmd_0_meta_name_0" "cmd_0_meta_value_0"
       @MODEL "a" 1 "00:00:00"

--- a/src/utilities/sequence-editor/from-seq-json.ts
+++ b/src/utilities/sequence-editor/from-seq-json.ts
@@ -310,7 +310,7 @@ function requestToString(request: Request) {
   if (request.time) {
     time = seqJsonTimeToSequence(request.time);
   } else if (request.ground_epoch) {
-    time = `@GROUND_EPOCH(${quoteEscape(request.ground_epoch.name ?? '')}, ${quoteEscape(request.ground_epoch.delta ?? '')})`;
+    time = `G${request.ground_epoch.delta ?? ''} ${quoteEscape(request.ground_epoch.name ?? '')}`;
   }
   const reqBegin = `@REQUEST_BEGIN(${quoteEscape(request.name)})`;
   const description = request.description ? seqJsonDescriptionToSequence(request.description) : '';

--- a/src/utilities/sequence-editor/grammar.test.ts
+++ b/src/utilities/sequence-editor/grammar.test.ts
@@ -328,7 +328,7 @@ A2024-321T11:22:33 @LOAD("load.name") # No Args
 @EPOCH "epoch string"
 R123T12:34:56 @LOAD("load2.name") "foo" 1 2 3  # A comment
 @ENGINE -1
-@GROUND_EPOCH("Name","+3:00") @REQUEST_BEGIN("request.name") # Description Text
+G3 "Name" @REQUEST_BEGIN("request.name") # Description Text
   C CMD_0 1 2 3
   @METADATA "foo" "bar"
   @MODEL "a" 1 "00:00:00"
@@ -360,7 +360,7 @@ Sequence(Commands(
   Load(TimeTag(TimeAbsolute),SequenceName(String),Args,LineComment,Engine(Number),Epoch(String)),
   Load(TimeTag(TimeRelative),SequenceName(String),Args(String,Number,Number,Number),LineComment,Engine(Number)),
   Request(
-    GroundEpoch(Name(String),Delta(String)),
+    TimeTag(TimeGroundEpoch,Name(String)),
     RequestName(String),LineComment,
     Steps(
       Command(TimeTag(TimeComplete),Stem,Args(Number,Number,Number),Metadata(MetaEntry(Key(String),Value(String))),Models(Model(Variable(String),Value(Number),Offset(String)))),

--- a/src/utilities/sequence-editor/to-seq-json.test.ts
+++ b/src/utilities/sequence-editor/to-seq-json.test.ts
@@ -747,7 +747,7 @@ A2024-123T12:34:56 @REQUEST_BEGIN("request.name") # Description Text
 
   it('should serialize a request with simple metadata', async () => {
     const input = `
-@GROUND_EPOCH("GroundEpochName","+3:00") @REQUEST_BEGIN("request2.name")
+G+03:00:00 "GroundEpochName" @REQUEST_BEGIN("request2.name")
   C CMD_0 1 2 3
   @METADATA "cmd_0_meta_name_0" "cmd_0_meta_value_0"
   @MODEL "a" 1 "00:00:00"
@@ -764,7 +764,7 @@ A2024-123T12:34:56 @REQUEST_BEGIN("request.name") # Description Text
       requests: [
         {
           ground_epoch: {
-            delta: '+3:00',
+            delta: '03:00:00',
             name: 'GroundEpochName',
           },
           metadata: {
@@ -834,7 +834,7 @@ A2024-123T12:34:56 @REQUEST_BEGIN("request.name") # Description Text
   "boolean": true
 }
 
-@GROUND_EPOCH("GroundEpochName","+3:00") @REQUEST_BEGIN("request2.name")
+G03:00:00 "GroundEpochName" @REQUEST_BEGIN("request2.name")
   C CMD_0 1 2 3
   @METADATA "foo" "bar"
   @MODEL "a" 1 "00:00:00"
@@ -908,7 +908,7 @@ A2024-123T12:34:56 @REQUEST_BEGIN("request.name") # Description Text
 
         {
           ground_epoch: {
-            delta: '+3:00',
+            delta: '03:00:00',
             name: 'GroundEpochName',
           },
           metadata: {
@@ -991,7 +991,7 @@ A2024-123T12:34:56 @REQUEST_BEGIN("request.name") # Description Text
 @METADATA "sub_object" {
   "boolean": true
 }
-@GROUND_EPOCH("GroundEpochName","+3:00") @REQUEST_BEGIN("request2.name")
+G+3 "GroundEpochName" @REQUEST_BEGIN("request2.name")
   C CMD_0 1 2 3
   @METADATA "foo" "bar"
   @MODEL "a" 1 "00:00:00"

--- a/src/utilities/sequence-editor/token.test.ts
+++ b/src/utilities/sequence-editor/token.test.ts
@@ -237,7 +237,7 @@ R123T12:34:56 @GROUND_EVENT("ground_event.name") "foo" 1 2 3  # No Args
   });
 
   it('request', () => {
-    const input = `@GROUND_EPOCH("Name","+3:00") @REQUEST_BEGIN("request.name") # Description Text
+    const input = `G3 "Name" @REQUEST_BEGIN("request.name") # Description Text
   C CMD_0 1 2 3
   @METADATA "foo" "bar"
   @MODEL "a" 1 "00:00:00"
@@ -268,9 +268,9 @@ A2024-123T12:34:56 @REQUEST_BEGIN("request2.name")
 
     assert.equal(getNodeText(requests[0].getChild('RequestName')!, input), '"request.name"');
     assert.equal(getNodeText(requests[0].getChild('LineComment')!, input), '# Description Text');
-    const request0GrondEpoch = requests[0].getChild('GroundEpoch');
+    const request0GrondEpoch = requests[0].getChild('TimeTag');
     assert.equal(getNodeText(request0GrondEpoch!.getChild('Name')!, input), '"Name"');
-    assert.equal(getNodeText(request0GrondEpoch!.getChild('Delta')!, input), '"+3:00"');
+    assert.equal(getNodeText(request0GrondEpoch!.getChild('TimeGroundEpoch')!, input), 'G3 ');
     assert.equal(requests[0].getChild('Steps')?.getChildren('Command').length, 4);
     const request0Meta0 = requests[0].getChild('Metadata')!.getChild('MetaEntry')!;
     assert.deepEqual(JSON.parse(getNodeText(request0Meta0.getChild('Value')!, input)), {


### PR DESCRIPTION
Closes #1368 

A new time tag, 'G', to represent the ground epoch in the sequence 

Reconfigured Ground Epoch: The ground epoch is now represented as a time tag 'G' to better match with existing time tags `R1 A2020-001T00:00:00 E+00:10:00 C`.

Autocompletion support: The 'G' time tag has been added to autocompletion suggestions.

Function refactoring: Time checking logic has been moved to a dedicated function
Linting support: Linting rules have been updated to support the 'G' time tag and ensure correct usage within 'Request' blocks.
SeqJson support: Both export and import functionality for SeqJson include the 'G' time tag, enabling seamless data exchange.
Unit test updates: Unit tests have been modified to cover the new 'G' time tag functionality.


Testing: Make sure you copy-paste this into the editor and export reimport the seqJson for round tripping
```
@ID "G Time Tag"

G-00:00:01 "epoch1" @REQUEST_BEGIN("request1")
  C FSW_CMD_0 "ON" false 1
@REQUEST_END

G+10 "epoch2" @REQUEST_BEGIN("request2")
  C FSW_CMD_0 "ON" false 1
@REQUEST_END

G002T00:01:00 "epoch3" @REQUEST_BEGIN("request3")
  C FSW_CMD_0 "ON" false 1
@REQUEST_END

C @REQUEST_BEGIN("request4")
  C FSW_CMD_0 "ON" false 1
@REQUEST_END


```