### PR TITLE
FPrime Dictionary and Sequence Support

### DIFF
--- a/src/enums/dictionaryHeaders.ts
+++ b/src/enums/dictionaryHeaders.ts
@@ -1,6 +1,0 @@
-export enum DictionaryHeaders {
-  'command_dictionary' = 'command_dictionary',
-  'param_def' = 'param-def',
-  'sequence_adaptation' = 'sequence_adaptation',
-  'telemetry_dictionary' = 'telemetry_dictionary',
-}

--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -9,13 +9,11 @@
   import CssGrid from '../../components/ui/CssGrid.svelte';
   import Panel from '../../components/ui/Panel.svelte';
   import SectionTitle from '../../components/ui/SectionTitle.svelte';
-  import { DictionaryTypes } from '../../enums/dictionaryTypes';
   import { sequenceAdaptations } from '../../stores/sequence-adaptation';
   import { channelDictionaries, commandDictionaries, parameterDictionaries } from '../../stores/sequencing';
   import effects from '../../utilities/effects';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
-  import { showFailureToast, showSuccessToast } from '../../utilities/toast';
   import type { PageData } from './$types';
 
   export let data: PageData;
@@ -51,34 +49,7 @@
     creatingDictionary = true;
 
     try {
-      const uploadedDictionaryOrAdaptation = await effects.uploadDictionaryOrAdaptation(
-        file,
-        data.user,
-        sequenceAdaptationName,
-      );
-
-      if (uploadedDictionaryOrAdaptation === null) {
-        throw Error('Failed to upload file');
-      }
-
-      switch (uploadedDictionaryOrAdaptation.type) {
-        case DictionaryTypes.COMMAND: {
-          showSuccessToast('Command Dictionary Created Successfully');
-          break;
-        }
-        case DictionaryTypes.CHANNEL: {
-          showSuccessToast('Channel Dictionary Created Successfully');
-          break;
-        }
-        case DictionaryTypes.PARAMETER: {
-          showSuccessToast('Parameter Dictionary Created Successfully');
-          break;
-        }
-        case DictionaryTypes.ADAPTATION: {
-          showSuccessToast('Sequence Adaptation Created Successfully');
-          break;
-        }
-      }
+      await effects.uploadDictionaryOrAdaptation(file, data.user, sequenceAdaptationName);
 
       // Set files to undefined to reset the input form and set the value to empty string to clear the uploaded file.
       files = undefined;
@@ -87,7 +58,6 @@
       sequenceAdaptationName = '';
     } catch (e) {
       createDictionaryError = (e as Error).message;
-      showFailureToast('Command Dictionary Create Failed');
     }
 
     creatingDictionary = false;
@@ -130,7 +100,7 @@
           <fieldset>
             <label for="file">AMPCS XML File or Sequence Adaptation</label>
             <input
-              accept=".xml,.js"
+              accept=".xml,.js,.json"
               class="w-100 st-typography-body"
               name="file"
               required

--- a/src/utilities/codemirror/sequence.grammar
+++ b/src/utilities/codemirror/sequence.grammar
@@ -70,14 +70,14 @@ HardwareCommands {
 TimeTag { TimeAbsolute | (TimeGroundEpoch Name { String } whiteSpace)  | TimeEpoch | TimeRelative  | TimeComplete }
 
 Args {
-  (whiteSpace (arg | RepeatArg))* whiteSpace?
+  (whiteSpace (arg))* whiteSpace?
 }
 
 RepeatArg {
   "[" (whiteSpace? arg)* whiteSpace? "]"
 }
 
-arg[@isGroup=Arguments] { Number | String | Boolean | Enum }
+arg[@isGroup=Arguments] { Number | String | Boolean | Enum | RepeatArg }
 
 Command {
   TimeTag?

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -8,7 +8,6 @@ import {
 } from '@nasa-jpl/aerie-ampcs';
 import { get } from 'svelte/store';
 import { SchedulingType } from '../constants/scheduling';
-import { DictionaryHeaders } from '../enums/dictionaryHeaders';
 import { DictionaryTypes } from '../enums/dictionaryTypes';
 import { SearchParameters } from '../enums/searchParameters';
 import { Status } from '../enums/status';
@@ -5667,31 +5666,28 @@ const effects = {
 
   async uploadDictionary(
     dictionary: string,
-    type: DictionaryTypes,
     user: User | null,
-  ): Promise<CommandDictionary | ChannelDictionary | ParameterDictionary | null> {
-    const typeString = type.charAt(0).toUpperCase() + type.slice(1);
-
+  ): Promise<{ channel?: ChannelDictionary; command?: CommandDictionary; parameter?: ParameterDictionary } | null> {
     try {
       if (!queryPermissions.CREATE_DICTIONARY(user)) {
-        throwPermissionError(`upload a ${typeString} dictionary`);
+        throwPermissionError(`upload a dictionary`);
       }
 
-      const data = await reqHasura<CommandDictionary | ChannelDictionary | ParameterDictionary>(
-        gql.CREATE_DICTIONARY,
-        { dictionary, type },
-        user,
-      );
+      const data = await reqHasura<{
+        channel?: ChannelDictionary;
+        command?: CommandDictionary;
+        parameter?: ParameterDictionary;
+      }>(gql.CREATE_DICTIONARY, { dictionary }, user);
 
-      const { createDictionary: newDictionary } = data;
+      const { createDictionary: newDictionaries } = data;
 
-      if (newDictionary === null) {
-        throw Error(`Unable to upload ${typeString} Dictionary`);
+      if (newDictionaries === null) {
+        throw Error(`Unable to upload Dictionary`);
       }
 
-      return newDictionary;
+      return newDictionaries;
     } catch (e) {
-      catchError(`${typeString} Dictionary Upload Failed`, e as Error);
+      catchError(`Dictionary Upload Failed`, e as Error);
       return null;
     }
   },
@@ -5700,40 +5696,34 @@ const effects = {
     file: File,
     user: User | null,
     sequenceAdaptationName?: string | undefined,
-  ): Promise<CommandDictionary | ChannelDictionary | ParameterDictionary | SequenceAdaptation | null> {
+  ): Promise<void> {
     const text = await file.text();
-    const splitLineDictionary = text.split('\n');
-
-    let type: DictionaryTypes = DictionaryTypes.COMMAND;
-
-    switch (splitLineDictionary[1]) {
-      case `<${DictionaryHeaders.command_dictionary}>`: {
-        type = DictionaryTypes.COMMAND;
-        break;
+    if (sequenceAdaptationName) {
+      const seqAdaptation = await this.createCustomAdaptation({ adaptation: text, name: sequenceAdaptationName }, user);
+      if (seqAdaptation === null) {
+        showFailureToast('Unable to upload sequence adaptation');
+        throw Error('Unable to upload sequence adaptation');
       }
-      case `<${DictionaryHeaders.telemetry_dictionary}>`: {
-        type = DictionaryTypes.CHANNEL;
-        break;
+      showSuccessToast('Sequence Adaptation Created Successfully');
+    } else {
+      const uploadedDictionaries = await this.uploadDictionary(text, user);
+      if (uploadedDictionaries === null) {
+        showFailureToast('Failed to upload dictionary file');
+        throw Error('Failed to upload dictionary file');
+      } else if (Object.keys(uploadedDictionaries).length === 0) {
+        showFailureToast('Dictionary Parser return empty data, verify the parser is correctly implemented.');
+        throw Error('Dictionary Parser return empty data, verify the parser is correctly implemented.');
       }
-      case `<${DictionaryHeaders.param_def}>`: {
-        type = DictionaryTypes.PARAMETER;
-        break;
+      if ('channel' in uploadedDictionaries) {
+        showSuccessToast('Channel Dictionary Created Successfully');
       }
-      default: {
-        if (sequenceAdaptationName) {
-          const adaptation = await this.createCustomAdaptation(
-            { adaptation: text, name: sequenceAdaptationName },
-            user,
-          );
-          return adaptation;
-        }
-        break;
+      if ('command' in uploadedDictionaries) {
+        showSuccessToast('Command Dictionary Created Successfully');
+      }
+      if ('parameter' in uploadedDictionaries) {
+        showSuccessToast('Parameter Dictionary Created Successfully');
       }
     }
-
-    const dictionary = await this.uploadDictionary(text, type, user);
-
-    return dictionary;
   },
 
   async uploadFile(file: File, user: User | null): Promise<number | null> {

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -387,15 +387,11 @@ const gql = {
   `,
 
   CREATE_DICTIONARY: `#graphql
-    mutation CreateDictionary($dictionary: String!, $type: String!) {
-      createDictionary: ${Queries.UPLOAD_DICTIONARY}(dictionary: $dictionary, type : $type) {
-        dictionary_path
-        created_at
-        id
-        mission
-        parsed_json
-        version
-        type
+    mutation CreateDictionary($dictionary: String!) {
+      createDictionary: ${Queries.UPLOAD_DICTIONARY}(dictionary: $dictionary) {
+        command
+        parameter
+        channel
       }
     }
   `,

--- a/src/utilities/sequence-editor/command-dictionary.ts
+++ b/src/utilities/sequence-editor/command-dictionary.ts
@@ -35,9 +35,10 @@ export function fswCommandArgDefault(fswCommandArg: FswCommandArgument, enumMap:
       const enumArg = fswCommandArg as FswCommandArgumentEnum;
       const enumSymbolValue =
         enumMap[enumArg.enum_name]?.values[0]?.symbol ?? fswCommandArg.default_value ?? fswCommandArg.name;
-      return `"${enumSymbolValue}"` ?? 'UNKNOWN_ENUM';
+      return enumSymbolValue ? `"${enumSymbolValue}"` : 'UNKNOWN_ENUM';
     }
-    case 'fill' || 'fixed_string':
+    case 'fill':
+    case 'fixed_string':
       return '""';
     case 'float': {
       const floatArg = fswCommandArg as FswCommandArgumentFloat;

--- a/src/utilities/sequence-editor/command-dictionary.ts
+++ b/src/utilities/sequence-editor/command-dictionary.ts
@@ -134,7 +134,7 @@ export function fswCommandArgDefault(fswCommandArg: FswCommandArgument, enumMap:
       const varStringArg = fswCommandArg as FswCommandArgumentVarString;
       const { default_value } = varStringArg;
 
-      if (default_value !== null) {
+      if (default_value) {
         return default_value;
       } else {
         return '""';

--- a/src/utilities/sequence-editor/grammar.test.ts
+++ b/src/utilities/sequence-editor/grammar.test.ts
@@ -417,9 +417,8 @@ Command(Stem,⚠,Args)
 CMD2 [
 CMD3 ]`,
     `Sequence(Commands(
-Command(Stem,Args(RepeatArg(⚠))),
-Command(Stem,Args(RepeatArg(⚠,Enum)))
-))`,
+    Command(Stem,Args(RepeatArg(RepeatArg,⚠))),
+    Command(Stem,Args(RepeatArg(⚠))),Command(Stem,Args(⚠))))`,
   ],
   ['locals with wrong value types', `@LOCALS "string_not_enum"`, `Sequence(LocalDeclaration(⚠(String)))`],
 ];


### PR DESCRIPTION
`___REQUIRES_AERIE_PR___="1542"`

This PR adds support for FPrime dictionary and sequencing. 

**GQL CreateDictionary call update**: The GQL CreateDictionary call has been modified to return information about all three potential dictionaries that the sequencing server could have parsed. 

**Raw dictionary passing:** The logic to determine the type of dictionary being uploaded has been removed. This responsibility is now delegated to the dictionary parser plugin

**Auto-complete bug fix:** The auto-complete feature has been corrected to ensure that variable strings are enclosed in double quotes (""), even when a default value is not provided.

FPrime Sequence Adaptation:
https://github.com/NASA-AMMOS/FPrime-Sequence-Adaptation

The backend PR is here:
https://github.com/NASA-AMMOS/aerie/pull/1542
