### PR TITLE
Propagate disabled flag to ParameterBasePath

### DIFF
--- a/src/components/parameters/ParameterBase.svelte
+++ b/src/components/parameters/ParameterBase.svelte
@@ -61,6 +61,7 @@
   />
 {:else if formParameter.schema.type === 'path'}
   <ParameterBasePath
+    {disabled}
     {hideRightAdornments}
     {labelColumnWidth}
     {level}

--- a/src/components/parameters/ParameterBasePath.svelte
+++ b/src/components/parameters/ParameterBasePath.svelte
@@ -59,7 +59,7 @@
         on:reset={() => dispatch('reset', formParameter)}
       />
     </Input>
-    <input type="file" on:change={onChange} use:useActions={use} />
+    <input {disabled} type="file" on:change={onChange} use:useActions={use} />
   </div>
 </div>
 

--- a/src/components/parameters/ParameterBasePath.svelte
+++ b/src/components/parameters/ParameterBasePath.svelte
@@ -59,7 +59,9 @@
         on:reset={() => dispatch('reset', formParameter)}
       />
     </Input>
-    <input {disabled} type="file" on:change={onChange} use:useActions={use} />
+    {#if !disabled}
+      <input type="file" on:change={onChange} use:useActions={use} />
+    {/if}
   </div>
 </div>
 


### PR DESCRIPTION
While working on https://github.com/NASA-AMMOS/aerie/issues/1525 I noticed that setting `disabled` on a `Parameters` component didn't disable the file upload button

Before:
![Screenshot 2024-09-04 at 12 36 29 PM](https://github.com/user-attachments/assets/a8b51f07-e1b5-4d7c-a470-ece47b40a452)

After:
![Screenshot 2024-09-04 at 12 37 33 PM](https://github.com/user-attachments/assets/0cf705b0-468e-41b3-a529-a16668d599a9)

EDIT:
After Bryan's suggestion:
<img width="277" alt="Screenshot 2024-09-04 at 2 11 04 PM" src="https://github.com/user-attachments/assets/96044656-105c-4956-a1e6-3a92742f0b4a">
