### PR TITLE
Feature: Show simulation history arguments

### DIFF
--- a/src/components/form/Input.svelte
+++ b/src/components/form/Input.svelte
@@ -93,7 +93,6 @@
       if (right !== null) {
         right.style.right = `${padRight}px`;
 
-        right.style.width = `min(40%, ${right.clientWidth}px)`;
         if (input !== null) {
           input.style.paddingRight = `min(40%, ${padLeft + right.clientWidth + padRight}px)`;
         }

--- a/src/components/parameters/ParameterBase.svelte
+++ b/src/components/parameters/ParameterBase.svelte
@@ -48,8 +48,8 @@
   />
 {:else if formParameter.schema.type === 'int'}
   <ParameterBaseNumber
-    {hideRightAdornments}
     {disabled}
+    {hideRightAdornments}
     {labelColumnWidth}
     {level}
     {levelPadding}

--- a/src/components/parameters/ParameterInfo.svelte
+++ b/src/components/parameters/ParameterInfo.svelte
@@ -8,6 +8,7 @@
   import ValueSourceBadge from './ValueSourceBadge.svelte';
 
   export let formParameter: FormParameter;
+  export let disabled: boolean = false;
 
   const dispatch = createEventDispatcher<{
     reset: FormParameter;
@@ -87,7 +88,9 @@
           {/if}
           {#if source !== 'none'}
             <div class="parameter-info-label">Source</div>
-            <div class="parameter-info-value"><ValueSourceBadge isCompact={false} {source} on:reset={onReset} /></div>
+            <div class="parameter-info-value">
+              <ValueSourceBadge {disabled} isCompact={false} {source} on:reset={onReset} />
+            </div>
           {/if}
         </div>
       </div>

--- a/src/components/parameters/Parameters.svelte
+++ b/src/components/parameters/Parameters.svelte
@@ -58,7 +58,7 @@
           />
         {/if}
         <div class="parameter-info">
-          <ParameterInfo {formParameter} on:reset />
+          <ParameterInfo {disabled} {formParameter} on:reset />
         </div>
       </div>
     </Highlight>

--- a/src/components/parameters/ValueSourceBadge.svelte
+++ b/src/components/parameters/ValueSourceBadge.svelte
@@ -36,9 +36,9 @@
       case 'user on model':
       case 'user on preset':
         showButton = true;
+        tooltipContent = 'Modified';
         tooltipShortcut = `${isMacOs() ? '⌘' : 'CTRL'} Click`;
         tooltipShortcutLabel = `Reset to ${source === 'user on preset' ? presetText : 'Model'}`;
-        tooltipContent = 'Modified';
         break;
       case 'preset':
         tooltipContent = `${presetText} Value`;
@@ -86,8 +86,8 @@
       content: tooltipContent,
       disabled: !isCompact,
       placement: 'top',
-      shortcut: tooltipShortcut,
-      shortcutLabel: tooltipShortcutLabel,
+      shortcut: !disabled ? tooltipShortcut : '',
+      shortcutLabel: !disabled ? tooltipShortcutLabel : '',
     }}
     use:useActions={use}
     on:click={onClick}

--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -22,7 +22,7 @@
   import { viewTogglePanel } from '../../stores/views';
   import type { User } from '../../types/app';
   import type { FieldStore } from '../../types/form';
-  import type { FormParameter, ParametersMap } from '../../types/parameter';
+  import type { ArgumentsMap, FormParameter, ParametersMap } from '../../types/parameter';
   import type {
     Simulation,
     SimulationDataset,
@@ -55,6 +55,7 @@
 
   const updatePermissionError = 'You do not have permission to update this simulation';
 
+  let defaultSimulationArguments: ArgumentsMap = {};
   let simulateButtonTooltip: string = '';
   let reSimulateButtonTooltip: string = '';
   let endTime: string;
@@ -117,7 +118,7 @@
 
   $: modelParametersMap = $plan?.model?.parameters?.parameters ?? {};
   $: if ($simulation && $plan) {
-    effects.getEffectiveModelArguments($plan.model.id, $simulation.arguments, user).then(response => {
+    effects.getEffectiveModelArguments($plan.model.id, {}, user).then(response => {
       if ($simulation !== null && response !== null) {
         const { arguments: defaultArguments } = response;
         // Displayed simulation arguments are either user input arguments,
@@ -128,6 +129,8 @@
           ...defaultArguments,
           ...($simulation?.template?.arguments ?? {}),
         };
+
+        defaultSimulationArguments = defaultArguments;
         formParameters = getFormParameters(
           modelParametersMap,
           $simulation.arguments,
@@ -474,6 +477,8 @@
           {:else}
             {#each filteredSimulationDatasets as simDataset (simDataset.id)}
               <SimulationHistoryDataset
+                {modelParametersMap}
+                {defaultSimulationArguments}
                 queuePosition={getSimulationQueuePosition(simDataset, $simulationDatasetsAll)}
                 simulationDataset={simDataset}
                 planEndTimeMs={$planEndTimeMs}

--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -118,9 +118,7 @@
 
   $: modelParametersMap = $plan?.model?.parameters?.parameters ?? {};
   $: if ($simulation && $plan) {
-    // Because this displays only readonly simulation arguments, there are no overrides present to specify when
-    // invoking `getEffectiveModelArguments`. Thus an empty object is provided in order to get
-    // only the default argument values.
+    // An empty object is provided in order to get only the default argument values to better distinguish overridden arguments
     effects.getEffectiveModelArguments($plan.model.id, {}, user).then(response => {
       if ($simulation !== null && response !== null) {
         const { arguments: defaultArguments } = response;

--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -118,6 +118,9 @@
 
   $: modelParametersMap = $plan?.model?.parameters?.parameters ?? {};
   $: if ($simulation && $plan) {
+    // Because this displays only readonly simulation arguments, there are no overrides present to specify when
+    // invoking `getEffectiveModelArguments`. Thus an empty object is provided in order to get
+    // only the default argument values.
     effects.getEffectiveModelArguments($plan.model.id, {}, user).then(response => {
       if ($simulation !== null && response !== null) {
         const { arguments: defaultArguments } = response;

--- a/src/types/simulation.ts
+++ b/src/types/simulation.ts
@@ -97,6 +97,7 @@ export type Simulation = {
 };
 
 export type SimulationDataset = {
+  arguments: ArgumentsMap;
   canceled: boolean;
   dataset_id: number;
   extent: { extent: string | null } | null;

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -2976,6 +2976,7 @@ const gql = {
     subscription SubSimulationDatasets($planId: Int!) {
       ${Queries.SIMULATIONS}(where: { plan_id: { _eq: $planId } }, order_by: { id: desc }) {
         simulation_datasets(order_by: { id: desc }) {
+          arguments
           canceled
           id
           dataset_id


### PR DESCRIPTION
Resolves #1419 

To test:
1. Create a banananation plan and navigate into it
2. Add some activities
3. Run a simulation
4. Open the simulation panel
5. Verify that there is now a collapsible `Arguments` section for each simulation under "Simulation History"
6. Change some arguments for the simulation
7. Run another simulation
8. Expand each `Arguments` section under the "Simulation History"
9. Verify that the values of the arguments are accurately displayed