### PR TITLE
Added back in Chet's hex arg checking that was removed through a rebase

### DIFF
--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -51,7 +51,7 @@
     workspaceId = event.detail;
 
     if (browser) {
-      setQueryParam(SearchParameters.WORKSPACE_ID, `${workspaceId}` ?? null);
+      setQueryParam(SearchParameters.WORKSPACE_ID, `${workspaceId ?? null}`);
     }
   }
 </script>
@@ -78,9 +78,8 @@
           }}
           disabled={workspace === undefined}
           on:click={() => {
-            goto(
-              `${base}/sequencing/new${'?' + SearchParameters.WORKSPACE_ID + '=' + getSearchParameterNumber(SearchParameters.WORKSPACE_ID) ?? ''}`,
-            );
+            const workspaceId = getSearchParameterNumber(SearchParameters.WORKSPACE_ID);
+            goto(`${base}/sequencing/new${workspaceId ? '?' + SearchParameters.WORKSPACE_ID + '=' + workspaceId : ''}`);
           }}
         >
           New Sequence

--- a/src/utilities/sequence-editor/sequence-linter.ts
+++ b/src/utilities/sequence-editor/sequence-linter.ts
@@ -20,7 +20,7 @@ import { TOKEN_COMMAND, TOKEN_ERROR, TOKEN_REPEAT_ARG, TOKEN_REQUEST } from '../
 import { TimeTypes } from '../../enums/time';
 import { getGlobals, sequenceAdaptation } from '../../stores/sequence-adaptation';
 import { CustomErrorCodes } from '../../workers/customCodes';
-import { addDefaultArgs, quoteEscape } from '../codemirror/codemirror-utils';
+import { addDefaultArgs, isHexValue, parseNumericArg, quoteEscape } from '../codemirror/codemirror-utils';
 import { closeSuggestion, computeBlocks, openSuggestion } from '../codemirror/custom-folder';
 import {
   getBalancedDuration,
@@ -1185,13 +1185,15 @@ function validateArgument(
           break;
         }
         const { max, min } = dictArg.range;
-        const nodeTextAsNumber = parseFloat(argText);
+        const nodeTextAsNumber = parseNumericArg(argText, dictArgType);
+        const isHex = isHexValue(argText);
 
         if (nodeTextAsNumber < min || nodeTextAsNumber > max) {
+          const numFormat = (n: number) => (isHex ? `0x${n.toString(16).toUpperCase()}` : n);
           const message =
             max !== min
-              ? `Number out of range. Range is between ${min} and ${max} inclusive.`
-              : `Number out of range. Range is ${min}.`;
+              ? `Number out of range. Range is between ${numFormat(min)} and ${numFormat(max)} inclusive.`
+              : `Number out of range. Range is ${numFormat(min)}.`;
           diagnostics.push({
             actions:
               max === min


### PR DESCRIPTION
I made a big change to `sequence-linter` in https://github.com/NASA-AMMOS/aerie-ui/pull/1446 and accidentally removed some of the code added in Chet's PR here: https://github.com/NASA-AMMOS/aerie-ui/pull/1465

This just adds that back in and fixes another issue I found with null checking on the workspace ids.