### PR TITLE
Allow parsing month of October

### DIFF
--- a/src/utilities/time.test.ts
+++ b/src/utilities/time.test.ts
@@ -282,6 +282,17 @@ test('parseDoyOrYmdTime', () => {
     year: 2022,
   });
 
+  expect(parseDoyOrYmdTime('2022-10-2T00:00:00')).toEqual({
+    day: 2,
+    hour: 0,
+    min: 0,
+    month: 10,
+    ms: 0,
+    sec: 0,
+    time: '00:00:00',
+    year: 2022,
+  });
+
   expect(parseDoyOrYmdTime('012T03:01:30.920')).toEqual({
     days: 12,
     hours: 3,

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -773,7 +773,7 @@ export function parseDoyOrYmdTime(
 ): null | ParsedDoyString | ParsedYmdString | ParsedDurationString {
   const matches = (dateString ?? '').match(
     new RegExp(
-      `^(?<year>\\d{4})-(?:(?<month>(?:[0]?[0-9])|(?:[1][1-2]))-(?<day>(?:[0-2]?[0-9])|(?:[3][0-1]))|(?<doy>\\d{1,3}))(?:T(?<time>(?<hour>[0-9]|[0-2][0-9])(?::(?<min>[0-9]|(?:[0-5][0-9])))?(?::(?<sec>[0-9]|(?:[0-5][0-9]))(?<dec>\\.\\d{1,${numDecimals}})?)?)?)?$`,
+      `^(?<year>\\d{4})-(?:(?<month>(?:[0]?[0-9])|(?:[1][0-2]))-(?<day>(?:[0-2]?[0-9])|(?:[3][0-1]))|(?<doy>\\d{1,3}))(?:T(?<time>(?<hour>[0-9]|[0-2][0-9])(?::(?<min>[0-9]|(?:[0-5][0-9])))?(?::(?<sec>[0-9]|(?:[0-5][0-9]))(?<dec>\\.\\d{1,${numDecimals}})?)?)?)?$`,
       'i',
     ),
   );


### PR DESCRIPTION
Fixes an issue exposed via plan import where a plan file that had a start time in October did not parse the date properly due to dumb regex...