### PR TITLE
Double click plan row to open plan

### DIFF
--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -970,6 +970,7 @@
             selectedItemId={selectedPlanId ?? null}
             on:deleteItem={event => deletePlanContext(event, filteredPlans)}
             on:rowClicked={({ detail }) => selectPlan(detail.data.id)}
+            on:rowDoubleClicked={({ detail }) => openPlan(detail.data.id)}
           />
         {:else}
           No Plans Found


### PR DESCRIPTION
Resolves: [#1438](https://github.com/NASA-AMMOS/aerie-ui/issues/1438)

To test:
1. Have a plans table that has a few plans on it
2. Double click on a plan row
3. Give it a second and the plan should open up in the same tab