### PR TITLE
Fix sequencing page resizing behavior (#1457)

### DIFF
--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -94,7 +94,7 @@
     </svelte:fragment>
   </Panel>
 
-  <CssGridGutter track={1} type="column" />
+  <CssGridGutter track={3} type="column" />
 
   <SequenceEditor
     {parcel}


### PR DESCRIPTION
Fixes #1457 

To test:
1. Navigate to /sequencing
2. Attempt to resize the workspaces panel by dragging the left resize handle - the left and middle should update widths
3. Attempt to resize the sequences panel by dragging the right resize handle  - the middle and right panel should update widths