### PR TITLE
Parameter info icon misaligned in ParameterRecSeries or ParameterRecStruct (#1473)

### DIFF
--- a/src/components/parameters/ParameterRec.svelte
+++ b/src/components/parameters/ParameterRec.svelte
@@ -7,6 +7,7 @@
   export let disabled: boolean = false;
   export let expanded: boolean = false;
   export let formParameter: FormParameter;
+  export let headerHeight: number = 24;
   export let hideRightAdornments: boolean = false;
   export let labelColumnWidth: number = 200;
   export let level: number = 0;
@@ -31,6 +32,7 @@
   this={component}
   {disabled}
   {expanded}
+  {headerHeight}
   {formParameter}
   {hideRightAdornments}
   {labelColumnWidth}

--- a/src/components/parameters/ParameterRecSeries.svelte
+++ b/src/components/parameters/ParameterRecSeries.svelte
@@ -19,6 +19,7 @@
 
   export let disabled: boolean = false;
   export let expanded: boolean = false;
+  export let headerHeight: number = 24;
   export let formParameter: FormParameter<ValueSchemaSeries>;
   export let hideRightAdornments: boolean = false;
   export let labelColumnWidth: number = 200;
@@ -83,7 +84,7 @@
 </script>
 
 <div class="parameter-rec-series">
-  <Collapse defaultExpanded={expanded}>
+  <Collapse defaultExpanded={expanded} {headerHeight}>
     <div slot="left">
       <ParameterName {formParameter} />
     </div>
@@ -124,6 +125,7 @@
               <ParameterRec
                 {disabled}
                 hideRightAdornments
+                {headerHeight}
                 expanded
                 formParameter={subFormParameter}
                 {labelColumnWidth}

--- a/src/components/parameters/ParameterRecStruct.svelte
+++ b/src/components/parameters/ParameterRecStruct.svelte
@@ -15,6 +15,7 @@
 
   export let disabled: boolean = false;
   export let expanded: boolean = false;
+  export let headerHeight: number = 24;
   export let formParameter: FormParameter<ValueSchemaStruct>;
   export let hideRightAdornments: boolean = false;
   export let labelColumnWidth: number = 200;
@@ -67,7 +68,7 @@
 </script>
 
 <div class="parameter-rec-struct">
-  <Collapse defaultExpanded={expanded}>
+  <Collapse defaultExpanded={expanded} {headerHeight}>
     <div slot="left">
       <ParameterName {formParameter} />
     </div>
@@ -88,6 +89,7 @@
           {#if isRecParameter(subFormParameter)}
             <ParameterRec
               {disabled}
+              {headerHeight}
               {hideRightAdornments}
               formParameter={subFormParameter}
               {labelColumnWidth}
@@ -144,7 +146,6 @@
 
   .parameter-rec-struct :global(.collapse > .collapse-header) {
     gap: 8px;
-    height: 24px;
   }
 
   .parameter-rec-struct :global(.collapse > .content) {


### PR DESCRIPTION
Fixes #1473.

In May there was a major refactor that made the default height of the Collapse widget 32px, likely to fit some other place where Collapse is set, but it seems the Parameters should all be 24px in height. This caused the ParameterRecSeries and ParameterRecStruct to inherit the 32px height, which is inconsistent with the other parameters and then the info icon was then misaligned. 

I can't really find where the height of parameters is set overall so I kept it at the level of ParameterRec but if you can pull this up one level higher we can pass the same height for all parameters widgets. 

Right now other places, like Definition section, uses 32px height. 

To test:
1. Create a plan with banananation model 
2. Add a `ParameterTest` Directive to the plan
3. Click on it and scroll to the parameters that say array, list, struct, etc. basically all the ones you see a collapse arrow
4. Hover over the parameter and check the info icon is aligned