### PR TITLE
Sequencing command form builder css gutter fix

### DIFF
--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -534,9 +534,8 @@
     {/if}
   </CssGrid>
 
-  <CssGridGutter track={1} type="column" />
-
   {#if showCommandFormBuilder}
+    <CssGridGutter track={1} type="column" />
     {#if !!commandDictionary && !!selectedNode}
       <SelectedCommand
         node={selectedNode}


### PR DESCRIPTION
Only display sequencing command form builder gutter if needed. Previously this gutter would show up on the main sequences page even though unused and if you dragged it you'd get an error. 