### PR TITLE
Add "scroll to activity" to activity directive table context menu (#1433)

### DIFF
--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -14,7 +14,7 @@
   import { InvalidDate } from '../../constants/time';
   import { activityDirectivesMap, selectActivity, selectedActivityDirectiveId } from '../../stores/activities';
   import { activityErrorRollupsMap } from '../../stores/errors';
-  import { plan, planReadOnly } from '../../stores/plan';
+  import { maxTimeRange, plan, planReadOnly, viewTimeRange } from '../../stores/plan';
   import { plugins } from '../../stores/plugins';
   import { view, viewTogglePanel, viewUpdateActivityDirectivesTable } from '../../stores/views';
   import type { ActivityDirective } from '../../types/activity';
@@ -30,6 +30,8 @@
   import Panel from '../ui/Panel.svelte';
   import ActivityDirectivesTable from './ActivityDirectivesTable.svelte';
   import ActivityTableMenu from './ActivityTableMenu.svelte';
+  import { get } from 'svelte/store';
+  import { getTimeRangeAroundTime } from '../../utilities/timeline';
 
   export let gridSection: ViewGridSection;
   export let user: User | null;
@@ -364,6 +366,16 @@
       viewUpdateActivityDirectivesTable({ autoSizeColumns: 'off' });
     }
   }
+
+  function scrollTimelineToTime({ detail }: CustomEvent<number>) {
+    const currentTimeRange = get(viewTimeRange);
+    const centeredTimeRange = getTimeRangeAroundTime(
+      detail,
+      currentTimeRange.end - currentTimeRange.start,
+      get(maxTimeRange),
+    );
+    viewTimeRange.set(centeredTimeRange);
+  }
 </script>
 
 <Panel padBody={false}>
@@ -417,6 +429,7 @@
       on:gridSizeChanged={onGridSizeChangedDebounced}
       on:rowDoubleClicked={onRowDoubleClicked}
       on:selectionChanged={onSelectionChanged}
+      on:scrollTimelineToTime={scrollTimelineToTime}
     />
   </svelte:fragment>
 </Panel>

--- a/src/components/timeline/TimelineViewControls.svelte
+++ b/src/components/timeline/TimelineViewControls.svelte
@@ -27,13 +27,8 @@
   } from '../../stores/simulation';
   import { timelineInteractionMode, timelineLockStatus, viewIsModified } from '../../stores/views';
   import type { TimeRange } from '../../types/timeline';
-  import {
-    getActivityDirectiveStartTimeMs,
-    getDoyTimeFromInterval,
-    getIntervalInMs,
-    getUnixEpochTime,
-  } from '../../utilities/time';
-  import { TimelineLockStatus } from '../../utilities/timeline';
+  import { getActivityDirectiveStartTimeMs, getDoyTimeFromInterval, getUnixEpochTime } from '../../utilities/time';
+  import { getTimeRangeAroundTime, TimelineLockStatus } from '../../utilities/timeline';
   import { showFailureToast, showSuccessToast } from '../../utilities/toast';
   import { tooltip } from '../../utilities/tooltip';
   import Input from '../form/Input.svelte';
@@ -217,13 +212,9 @@
   function scrollToSelection() {
     const time = getSelectionTime();
     if (!isNaN(time) && (time < viewTimeRange.start || time > viewTimeRange.end)) {
-      const midSpan = time + getIntervalInMs($selectedSpan?.duration) / 2;
-      const start = Math.max(maxTimeRange.start, midSpan - viewDuration / 2);
-      const end = Math.min(maxTimeRange.end, midSpan + viewDuration / 2);
-      dispatch('viewTimeRangeChanged', {
-        end,
-        start,
-      });
+      const currentTimeRangeSpan = viewTimeRange.end - viewTimeRange.start;
+      const centeredTimeRange = getTimeRangeAroundTime(time, currentTimeRangeSpan, maxTimeRange);
+      dispatch('viewTimeRangeChanged', centeredTimeRange);
     }
   }
 

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -33,6 +33,7 @@
   export let pluralItemDisplayText: string = '';
   export let scrollToSelection: boolean = false;
   export let selectedItemId: RowId | null = null;
+  export let selectedItemIds: RowId[] = [];
   export let showContextMenu: boolean = true;
   export let singleItemDisplayText: string = '';
   export let suppressDragLeaveHidesColumns: boolean = true;
@@ -48,7 +49,6 @@
 
   let isFiltered: boolean = false;
   let deletePermission: boolean = true;
-  let selectedItemIds: RowId[] = [];
 
   $: if (typeof hasDeletePermission === 'function' && user) {
     if (selectedItemIds.length > 0) {
@@ -172,6 +172,8 @@
 >
   <svelte:fragment slot="context-menu">
     {#if showContextMenu}
+      <!-- to further extend context menu -->
+      <slot name="context-menu" />
       <ContextMenuHeader>Bulk Actions</ContextMenuHeader>
       <ContextMenuItem on:click={selectAllItems}>
         Select All {isFiltered ? 'Visible ' : ''}{pluralItemDisplayText}

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -428,6 +428,30 @@ export function getUniqueColorForLineLayer(row?: Row): string {
   return color;
 }
 
+export function getTimeRangeAroundTime(time: number, timeRangeSpan: number, maxTimeRange?: TimeRange): TimeRange {
+  const padding = timeRangeSpan / 2;
+  let start = time - padding;
+  let end = time + padding;
+
+  // optional maxTimeRange for bounding the results bounds
+  if (maxTimeRange !== undefined && maxTimeRange !== null) {
+    //span is larger than the max time range, well it can't get larger than that
+    if (timeRangeSpan >= maxTimeRange.end - maxTimeRange.start) {
+      return maxTimeRange;
+    }
+
+    //bound the start or end of the TimeRange, but keep the timeRangeSpan the same
+    if (time - padding < maxTimeRange.start) {
+      start = maxTimeRange.start;
+      end = maxTimeRange.start + timeRangeSpan;
+    } else if (time + padding > maxTimeRange.end) {
+      start = maxTimeRange.end - timeRangeSpan;
+      end = maxTimeRange.end;
+    }
+  }
+  return { end, start };
+}
+
 /**
  * Returns a new vertical guide
  */


### PR DESCRIPTION
Resolves #1433 

This one is my first substantial task so please check me I didn't do anything too crazy 😄 


To test:
1. Open a Plan, go to the Activity Directives Table
2. Right Click on a single activity directive, you should see "Scroll to Activity"
3. Select a few items in the table, and right click, you should NOT see "Scroll to Activity"
4. In the Timeline Histogram select a smaller time range
5. From the Activity Directives Table, right click on activities at the start, middle and end of plan and click on "Scroll to Activity" in the context menu, it should scroll to show them if it is not visible, otherwise it just selects it in the timeline! 


![Screenshot 2024-11-05 at 3 42 22 PM](https://github.com/user-attachments/assets/abe7177a-7d4b-45bc-99c7-8374c3ce4d24)