### PR TITLE
Library Sequences from Workspace

### DIFF
--- a/src/components/expansion/ExpansionRuns.svelte
+++ b/src/components/expansion/ExpansionRuns.svelte
@@ -190,6 +190,7 @@
     sequenceOutput={selectedSequence ? JSON.stringify(selectedSequence.expanded_sequence, null, 2) : undefined}
     readOnly={true}
     title="Sequence - Definition Editor (Read-only)"
+    workspaceId={null}
     {user}
   />
 </CssGrid>

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -327,6 +327,7 @@
     title="{mode === 'create' ? 'New' : 'Edit'} Sequence - Definition Editor"
     {user}
     readOnly={!hasPermission}
+    workspaceId={selectedWorkspaceId}
     on:sequence={onSequenceChange}
     on:didChangeModelContent={onDidChangeModelContent}
   />

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -104,6 +104,7 @@
     sequenceOutput={selectedSequence?.seq_json}
     title="Sequence - Definition Editor (Read-only)"
     readOnly={true}
+    {workspaceId}
     {user}
   />
 </CssGrid>

--- a/src/types/sequencing.ts
+++ b/src/types/sequencing.ts
@@ -1,12 +1,13 @@
 import type { CompletionContext, CompletionResult } from '@codemirror/autocomplete';
 import type { IndentContext } from '@codemirror/language';
 import type { Diagnostic } from '@codemirror/lint';
-import type { SyntaxNode } from '@lezer/common';
+import type { SyntaxNode, Tree } from '@lezer/common';
 import type {
   ChannelDictionary as AmpcsChannelDictionary,
   CommandDictionary as AmpcsCommandDictionary,
   ParameterDictionary as AmpcsParameterDictionary,
 } from '@nasa-jpl/aerie-ampcs';
+import type { VariableDeclaration } from '@nasa-jpl/seq-json-schema/types';
 import type { EditorView } from 'codemirror';
 import type { DictionaryTypes } from '../enums/dictionaryTypes';
 import type { ArgDelegator } from '../utilities/sequence-editor/extension-points';
@@ -64,6 +65,7 @@ export interface ISequenceAdaptation {
     channelDictionary: AmpcsChannelDictionary | null,
     commandDictionary: AmpcsCommandDictionary | null,
     parameterDictionaries: AmpcsParameterDictionary[],
+    librarySequences: LibrarySequence[],
   ) => (context: CompletionContext) => CompletionResult | null;
   autoIndent?: () => (context: IndentContext, pos: number) => number | null | undefined;
   globals?: GlobalType[];
@@ -138,6 +140,13 @@ export type UserSequence = {
   parcel_id: number;
   seq_json: SeqJson;
   updated_at: string;
+  workspace_id: number;
+};
+
+export type LibrarySequence = {
+  name: string;
+  parameters: VariableDeclaration[];
+  tree: Tree;
   workspace_id: number;
 };
 

--- a/src/utilities/codemirror/codemirror-utils.test.ts
+++ b/src/utilities/codemirror/codemirror-utils.test.ts
@@ -1,5 +1,7 @@
+import type { VariableDeclaration } from '@nasa-jpl/seq-json-schema/types';
 import { describe, expect, it } from 'vitest';
 import {
+  getDefaultVariableArgs,
   isHexValue,
   isQuoted,
   parseNumericArg,
@@ -115,5 +117,19 @@ describe('isHexValue', function () {
     expect(isHexValue('0xdeadBEEF')).toBe(true);
     expect(isHexValue('0x12ab')).toBe(true);
     expect(isHexValue('0x12xx')).toBe(false);
+  });
+});
+describe('getDefaultVariableArgs', function () {
+  const mockParameters = [
+    { name: 'exampleString', type: 'STRING' },
+    { allowable_ranges: [{ min: 1.2 }], type: 'FLOAT' },
+    { allowable_ranges: [{ min: 5 }], type: 'INT' },
+    { allowable_ranges: [{ min: 7 }], type: 'UINT' },
+    { allowable_values: ['VALUE1'], enum_name: 'ExampleEnum', type: 'ENUM' },
+    { type: 'INT' },
+  ] as VariableDeclaration[];
+  it('should return default values for different types', () => {
+    const result = getDefaultVariableArgs(mockParameters);
+    expect(result).toEqual(['"exampleString"', 1.2, 5, 7, '"VALUE1"', 0]);
   });
 });

--- a/src/utilities/codemirror/codemirror-utils.test.ts
+++ b/src/utilities/codemirror/codemirror-utils.test.ts
@@ -92,15 +92,15 @@ describe('quoteEscape', () => {
   });
 });
 
-describe('parseNumericArg', function () {
-  it("should parse 'float' and 'numeric' args as floats", function () {
+describe('parseNumericArg', () => {
+  it("should parse 'float' and 'numeric' args as floats", () => {
     expect(parseNumericArg('1.23', 'float')).toEqual(1.23);
     expect(parseNumericArg('2.34', 'numeric')).toEqual(2.34);
     expect(parseNumericArg('bad', 'float')).toEqual(NaN);
     // can't parse hex numbers as float
     expect(parseNumericArg('0xabc', 'float')).toEqual(0);
   });
-  it("should parse 'integer' and 'unsigned' args as integers", function () {
+  it("should parse 'integer' and 'unsigned' args as integers", () => {
     expect(parseNumericArg('123', 'integer')).toEqual(123);
     expect(parseNumericArg('234', 'unsigned')).toEqual(234);
     expect(parseNumericArg('234.567', 'integer')).toEqual(234);
@@ -109,8 +109,8 @@ describe('parseNumericArg', function () {
     expect(parseNumericArg('0x1f', 'unsigned')).toEqual(31);
   });
 });
-describe('isHexValue', function () {
-  it('should correctly identify a hex number string', function () {
+describe('isHexValue', () => {
+  it('should correctly identify a hex number string', () => {
     expect(isHexValue('12')).toBe(false);
     expect(isHexValue('ff')).toBe(false);
     expect(isHexValue('0x99')).toBe(true);
@@ -119,7 +119,7 @@ describe('isHexValue', function () {
     expect(isHexValue('0x12xx')).toBe(false);
   });
 });
-describe('getDefaultVariableArgs', function () {
+describe('getDefaultVariableArgs', () => {
   const mockParameters = [
     { name: 'exampleString', type: 'STRING' },
     { allowable_ranges: [{ min: 1.2 }], type: 'FLOAT' },

--- a/src/utilities/codemirror/seq-n-tree-utils.ts
+++ b/src/utilities/codemirror/seq-n-tree-utils.ts
@@ -58,7 +58,11 @@ export class SeqNCommandInfoMapper implements CommandInfoMapper {
   }
 
   getArgumentAppendPosition(commandOrRepeatArgNode: SyntaxNode | null): number | undefined {
-    if (commandOrRepeatArgNode?.name === RULE_COMMAND) {
+    if (
+      commandOrRepeatArgNode?.name === RULE_COMMAND ||
+      commandOrRepeatArgNode?.name === TOKEN_ACTIVATE ||
+      commandOrRepeatArgNode?.name === TOKEN_LOAD
+    ) {
       const argsNode = commandOrRepeatArgNode.getChild('Args');
       const stemNode = commandOrRepeatArgNode.getChild('Stem');
       return getFromAndTo([stemNode, argsNode]).to;

--- a/src/utilities/sequence-editor/extension-points.ts
+++ b/src/utilities/sequence-editor/extension-points.ts
@@ -9,7 +9,7 @@ import {
 } from '@nasa-jpl/aerie-ampcs';
 import { get } from 'svelte/store';
 import { inputFormat, sequenceAdaptation } from '../../stores/sequence-adaptation';
-import type { IOutputFormat } from '../../types/sequencing';
+import type { IOutputFormat, LibrarySequence } from '../../types/sequencing';
 import { seqJsonLinter } from './seq-json-linter';
 import { sequenceLinter } from './sequence-linter';
 
@@ -81,6 +81,7 @@ export function inputLinter(
   channelDictionary: ChannelDictionary | null = null,
   commandDictionary: CommandDictionary | null = null,
   parameterDictionaries: ParameterDictionary[] = [],
+  librarySequences: LibrarySequence[] = [],
 ): Extension {
   return linter(view => {
     const inputLinter = get(sequenceAdaptation).inputFormat.linter;
@@ -88,7 +89,7 @@ export function inputLinter(
     const treeNode = tree.topNode;
     let diagnostics: Diagnostic[];
 
-    diagnostics = sequenceLinter(view, channelDictionary, commandDictionary, parameterDictionaries);
+    diagnostics = sequenceLinter(view, channelDictionary, commandDictionary, parameterDictionaries, librarySequences);
 
     if (inputLinter !== undefined && commandDictionary !== null) {
       diagnostics = inputLinter(diagnostics, commandDictionary, view, treeNode);

--- a/src/utilities/sequence-editor/to-seq-json.ts
+++ b/src/utilities/sequence-editor/to-seq-json.ts
@@ -442,7 +442,7 @@ function parseTime(commandNode: SyntaxNode, text: string): Time {
 // min length of one
 type VariableDeclarationArray = [VariableDeclaration, ...VariableDeclaration[]];
 
-function parseVariables(
+export function parseVariables(
   node: SyntaxNode,
   text: string,
   type: 'LocalDeclaration' | 'ParameterDeclaration' = 'LocalDeclaration',


### PR DESCRIPTION
This pull request introduces support for library sequences, which allow users to use sequences within their workspaces. Closes #1501 

### Key Changes:

**WorkspaceID Passthrough:** The workspaceID is now passed to the SequenceEditor, enabling it to work with sequences from the selected workspace.
**Library Sequence Library Type**: A new library sequence type has been created, and the Adaptation object has been updated accordingly.
**Workspace Sequence Mapping:** All sequences in the selected workspace are automatically recognized as library sequences.
**Linter Integration:** The linter now checks the syntax and semantics of library sequence arguments.
**Selected Command Panel Enhancements:** The Selected Command panel now displays `load` and `activate` arguments for library sequences.
**Autocompletion Support:** Autocompletion is available for library sequence identifiers.

### How to test

* Create a new workspace
* Create `SeqA` with the below content
```
@INPUT_PARAMS_BEGIN
VARIABLE INT "10...20"
LOCATION STRING
NAMES ENUM person_name "" "BOB, TOM"
tmp3 UINT
@INPUT_PARAMS_END
C ECHO "A library Sequence" 
```
* Create `SeqB` in the same workspace
* Type in `@ACTIVATE` or `@LOAD,` autocomplete should appear for these `Directives`
* Change 'Sequence.Name' and autocomplete should show `SeqA` as an option

```
C @ACTIVATE("seqA")
```

* Verify that autocomplete will add default values
* Tweak the values and test the linter
* Modify the arguments in the Command Panel off to the right


