### PR TITLE
Fix goal plan specification deletion

### DIFF
--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -185,7 +185,7 @@ export type SchedulingGoalPlanSpecification = {
   enabled: boolean;
   goal_definition?: Pick<SchedulingGoalDefinition, 'analyses'> | null;
   goal_id: number;
-  goal_invocation_id?: number;
+  goal_invocation_id: number;
   goal_metadata:
     | (Pick<SchedulingGoalMetadata, 'name' | 'owner' | 'public'> & {
         versions: Pick<SchedulingGoalDefinition, 'revision' | 'analyses' | 'type' | 'parameter_schema'>[];

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -3815,7 +3815,7 @@ const gql = {
       }
       deleteSchedulingGoalModelSpecifications: ${Queries.DELETE_SCHEDULING_GOAL_MODEL_SPECIFICATIONS}(
         where: {
-          goal_id: { _in: $goalIdsToDelete },
+          goal_invocation_id: { _in: $goalIdsToDelete },
           _and: {
             model_id: { _eq: $modelId }
           }
@@ -3855,7 +3855,7 @@ const gql = {
         }
       }
       deleteSchedulingGoalPlanSpecifications: ${Queries.DELETE_SCHEDULING_SPECIFICATION_GOALS}(
-        where: { goal_id: { _in: $goalSpecIdsToDelete } }
+        where: { goal_invocation_id: { _in: $goalSpecIdsToDelete } }
       ) {
         affected_rows
       }


### PR DESCRIPTION
Resolves #1551 

To test:
1. Create two plans
2. Create a scheduling goal
3. Open one plan
4. Open the `Scheduling Goals` panel
5. Click `Manage Goals`
6. Select the created scheduling goal from step #2
7. Click `Update`
8. Repeat steps 4-7 on the second plan
9. Open the `Manage Goals` modal on either of the plans
10. Deselect the goal
11. Click `Update`
12. Verify that the goal has been removed from the intended plan and is still present on the other plan