### PR TITLE
Phoenix bugfix for undefined `outputFormat`

### DIFF
--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -100,7 +100,7 @@
   let editorSequenceDiv: HTMLDivElement;
   let editorSequenceView: EditorView;
   let menu: Menu;
-  let outputFormats: IOutputFormat[];
+  let outputFormats: IOutputFormat[] = [];
   let selectedNode: SyntaxNode | null;
   let currentTree: Tree;
   let commandInfoMapper: CommandInfoMapper = new SeqNCommandInfoMapper();


### PR DESCRIPTION
See #1555 

Possible fix seems to work locally for me, but it's unclear whether this is a "bug" or whether I should fix something in my adaptation.