### PR TITLE
fix bug where form editor can trigger unneeded editor change

### DIFF
--- a/src/components/sequencing/form/NumEditor.svelte
+++ b/src/components/sequencing/form/NumEditor.svelte
@@ -15,14 +15,15 @@
 
   let max: number = Infinity;
   let min: number = -Infinity;
-  let value: number;
+  let value: number | null = initVal;
+  let valFloat: number = Number(value);
 
   $: max = argDef.range?.max ?? Infinity;
   $: min = argDef.range?.min ?? (isFswCommandArgumentUnsigned(argDef) ? 0 : -Infinity);
   $: value = initVal;
   $: valFloat = Number(value);
   $: {
-    if (typeof value === 'number' && !isNaN(valFloat)) {
+    if (typeof value === 'number' && !isNaN(valFloat) && initVal !== value) {
       setInEditor(value);
     }
   }


### PR DESCRIPTION
ArgEditor makes unnecessary call to edit text editor contents. During initial render of form view this can trigger race condition as multiple changes come through in rapid succession and we're debouncing the updates from the editor. Not observed after initial form view load

https://github.com/user-attachments/assets/fafe6c9c-f4c7-450d-909e-be9d05340b58

