### PR TITLE
Prefer using the arg delegate for enum args if its provided over the …

### DIFF
--- a/src/components/sequencing/form/EnumEditor.svelte
+++ b/src/components/sequencing/form/EnumEditor.svelte
@@ -18,7 +18,7 @@
   let value: string;
 
   $: value = initVal;
-  $: enumValues = commandDictionary?.enumMap[argDef.enum_name]?.values?.map(v => v.symbol) ?? argDef.range ?? [];
+  $: enumValues = argDef.range ?? commandDictionary?.enumMap[argDef.enum_name]?.values?.map(v => v.symbol) ?? [];
   $: isValueInEnum = !!enumValues.find(ev => ev === value);
   $: setInEditor(value);
   $: options = enumValues.map(ev => ({


### PR DESCRIPTION
…command dictionary values

Closes #1575 .

This code used to work as intended but was changed at some point, go back to preferring the enum values that come from the arg delegate if they exist, otherwise fallback to the command dictionary if none are provided for enum arguments.