### PR TITLE
simplify logic on no arg commands

### DIFF
--- a/src/utilities/codemirror/custom-folder.ts
+++ b/src/utilities/codemirror/custom-folder.ts
@@ -127,7 +127,10 @@ export function foldVariables(containerNode: SyntaxNode, state: EditorState): { 
 
   // Calculate the length of the directive (e.g. "@INPUT_PARAMETERS_BEGIN" or "@LOCALS_BEGIN")
   const directiveLength = state
-    .sliceDoc(containerNode.from, containerNode.to - variablesNodes.length ? getFromAndTo([...variablesNodes]).from : 0)
+    .sliceDoc(
+      containerNode.from,
+      containerNode.to - (variablesNodes.length > 0 ? getFromAndTo([...variablesNodes]).from : 0),
+    )
     .split('\n')[0].length;
 
   // Calculate the start of the fold range after the directive

--- a/src/utilities/sequence-editor/sequence-linter.ts
+++ b/src/utilities/sequence-editor/sequence-linter.ts
@@ -1226,79 +1226,56 @@ function validateAndLintArguments(
  * Validates the command structure.
  * @param stemNode - The SyntaxNode representing the command stem.
  * @param argsNode - The SyntaxNode representing the command arguments.
- * @param exactArgSize - The expected number of arguments.
+ * @param expectedArgSize - The expected number of arguments.
  * @param addDefault - The function to add default arguments.
  * @returns A Diagnostic object representing the validation error, or undefined if there is no error.
  */
 function validateCommandStructure(
   stemNode: SyntaxNode,
   argsNode: SyntaxNode[] | null,
-  exactArgSize: number,
+  expectedArgSize: number,
   addDefault: (view: any) => any,
 ): Diagnostic | undefined {
-  if (arguments.length > 0) {
-    if (!argsNode || argsNode.length === 0) {
-      return {
-        actions: [],
-        from: stemNode.from,
-        message: `The stem is missing arguments.`,
-        severity: 'error',
-        to: stemNode.to,
-      };
-    }
-    if (argsNode.length > exactArgSize) {
-      const extraArgs = argsNode.slice(exactArgSize);
-      const { from, to } = getFromAndTo(extraArgs);
-      return {
-        actions: [
-          {
-            apply(view, from, to) {
-              view.dispatch({ changes: { from, to } });
-            },
-            name: `Remove ${extraArgs.length} extra argument${extraArgs.length > 1 ? 's' : ''}`,
-          },
-        ],
-        from,
-        message: `Extra arguments, definition has ${exactArgSize}, but ${argsNode.length} are present`,
-        severity: 'error',
-        to,
-      };
-    }
-    if (argsNode.length < exactArgSize) {
-      const { from, to } = getFromAndTo(argsNode);
-      const pluralS = exactArgSize > argsNode.length + 1 ? 's' : '';
-      return {
-        actions: [
-          {
-            apply(view) {
-              addDefault(view);
-            },
-            name: `Add default missing argument${pluralS}`,
-          },
-        ],
-        from,
-        message: `Missing argument${pluralS}, definition has ${argsNode.length}, but ${exactArgSize} are present`,
-        severity: 'error',
-        to,
-      };
-    }
-  } else if (argsNode && argsNode.length > 0) {
-    const { from, to } = getFromAndTo(argsNode);
+  if ((!argsNode || argsNode.length === 0) && expectedArgSize === 0) {
+    return undefined;
+  }
+  if (argsNode && argsNode.length > expectedArgSize) {
+    const extraArgs = argsNode.slice(expectedArgSize);
+    const { from, to } = getFromAndTo(extraArgs);
     return {
       actions: [
         {
           apply(view, from, to) {
             view.dispatch({ changes: { from, to } });
           },
-          name: `Remove argument${argsNode.length > 1 ? 's' : ''}`,
+          name: `Remove ${extraArgs.length} extra argument${extraArgs.length > 1 ? 's' : ''}`,
         },
       ],
-      from: from,
-      message: 'The command should not have arguments',
+      from,
+      message: `Extra arguments, definition has ${expectedArgSize}, but ${argsNode.length} are present`,
       severity: 'error',
-      to: to,
+      to,
     };
   }
+  if ((argsNode && argsNode.length < expectedArgSize) || (!argsNode && expectedArgSize > 0)) {
+    const { from, to } = getFromAndTo(argsNode ?? [stemNode]);
+    const pluralS = expectedArgSize - (argsNode?.length ?? 0) > 1 ? 's' : '';
+    return {
+      actions: [
+        {
+          apply(view) {
+            addDefault(view);
+          },
+          name: `Add default missing argument${pluralS}`,
+        },
+      ],
+      from,
+      message: `Missing argument${pluralS}, definition has ${expectedArgSize}, but ${argsNode?.length ?? 0} are present`,
+      severity: 'error',
+      to,
+    };
+  }
+
   return undefined;
 }
 

--- a/src/utilities/sequence-editor/sequence-linter.ts
+++ b/src/utilities/sequence-editor/sequence-linter.ts
@@ -38,6 +38,7 @@ import {
 } from '../codemirror/codemirror-utils';
 import { closeSuggestion, computeBlocks, openSuggestion } from '../codemirror/custom-folder';
 import { SeqNCommandInfoMapper } from '../codemirror/seq-n-tree-utils';
+import { pluralize } from '../text';
 import {
   getBalancedDuration,
   getDoyTime,
@@ -1242,35 +1243,36 @@ function validateCommandStructure(
   if (argsNode && argsNode.length > expectedArgSize) {
     const extraArgs = argsNode.slice(expectedArgSize);
     const { from, to } = getFromAndTo(extraArgs);
+    const commandArgs = `argument${pluralize(extraArgs.length)}`;
     return {
       actions: [
         {
           apply(view, from, to) {
             view.dispatch({ changes: { from, to } });
           },
-          name: `Remove ${extraArgs.length} extra argument${extraArgs.length > 1 ? 's' : ''}`,
+          name: `Remove ${extraArgs.length} extra ${commandArgs}`,
         },
       ],
       from,
-      message: `Extra arguments, definition has ${expectedArgSize}, but ${argsNode.length} are present`,
+      message: `Extra ${commandArgs}, definition has ${expectedArgSize}, but ${argsNode.length} are present`,
       severity: 'error',
       to,
     };
   }
   if ((argsNode && argsNode.length < expectedArgSize) || (!argsNode && expectedArgSize > 0)) {
     const { from, to } = getFromAndTo(argsNode ?? [stemNode]);
-    const pluralS = expectedArgSize - (argsNode?.length ?? 0) > 1 ? 's' : '';
+    const commandArgs = `argument${pluralize(expectedArgSize - (argsNode?.length ?? 0))}`;
     return {
       actions: [
         {
           apply(view) {
             addDefault(view);
           },
-          name: `Add default missing argument${pluralS}`,
+          name: `Add default missing ${commandArgs}`,
         },
       ],
       from,
-      message: `Missing argument${pluralS}, definition has ${expectedArgSize}, but ${argsNode?.length ?? 0} are present`,
+      message: `Missing ${commandArgs}, definition has ${expectedArgSize}, but ${argsNode?.length ?? 0} are present`,
       severity: 'error',
       to,
     };
@@ -1475,7 +1477,7 @@ function validateArgument(
             diagnostics.push({
               actions: [],
               from: argNode.from,
-              message: `Repeat argument should have at least ${minCount} value${minCount !== 0 ? 's' : ''} but has ${
+              message: `Repeat argument should have at least ${minCount} value${pluralize(minCount)} but has ${
                 repeatNodes.length
               }`,
               severity: 'error',
@@ -1485,7 +1487,7 @@ function validateArgument(
             diagnostics.push({
               actions: [],
               from: argNode.from,
-              message: `Repeat argument should have at most ${maxCount} value${maxCount !== 0 ? 's' : ''} but has ${
+              message: `Repeat argument should have at most ${maxCount} value${pluralize(maxCount)} but has ${
                 repeatNodes.length
               }`,
               severity: 'error',

--- a/src/utilities/sequence-editor/tree-utils.ts
+++ b/src/utilities/sequence-editor/tree-utils.ts
@@ -42,7 +42,7 @@ export function getFromAndTo(nodes: (SyntaxNode | null)[]): { from: number; to: 
         to: Math.max(acc.to, node.to),
       };
     },
-    { from: Number.MAX_VALUE, to: Number.MIN_VALUE },
+    { from: nodes[0]?.from ?? 0, to: nodes[0]?.to ?? 0 },
   );
 }
 


### PR DESCRIPTION
I am not clear on the rationale for making a distinction on whether or not an arguments node is present, I don't expect the user to know and what is important is that the argument counts match. Let me know if I'm missing some nuance here.