### PR TITLE
Import SATF Library Sequence

### DIFF
--- a/src/components/modals/LibrarySequenceModal.svelte
+++ b/src/components/modals/LibrarySequenceModal.svelte
@@ -1,0 +1,67 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import { parcels } from '../../stores/sequencing';
+  import Modal from './Modal.svelte';
+  import ModalContent from './ModalContent.svelte';
+  import ModalFooter from './ModalFooter.svelte';
+  import ModalHeader from './ModalHeader.svelte';
+
+  export let height: number = 200;
+  export let width: number = 380;
+
+  const dispatch = createEventDispatcher<{
+    close: void;
+    save: { library: FileList; parcel: number };
+  }>();
+
+  let saveButtonDisabled: boolean = true;
+  let modalTitle: string;
+  let libraryName: FileList;
+  let parcelId: number;
+
+  $: saveButtonDisabled = parcelId === null || libraryName === undefined;
+  $: modalTitle = 'Import Library';
+
+  function save() {
+    if (!saveButtonDisabled) {
+      dispatch('save', { library: libraryName, parcel: parcelId });
+    }
+  }
+
+  function onKeydown(event: KeyboardEvent) {
+    const { key } = event;
+    if (key === 'Enter') {
+      event.preventDefault();
+      save();
+    }
+  }
+</script>
+
+<svelte:window on:keydown={onKeydown} />
+
+<Modal {height} {width}>
+  <ModalHeader on:close>{modalTitle}</ModalHeader>
+
+  <ModalContent>
+    <div class="st-typography-body">Parcel (required)</div>
+    <select bind:value={parcelId} class="st-select w-100" name="parcel">
+      <option value={null} />
+      {#each $parcels as parcel}
+        <option value={parcel.id}>
+          {parcel.name}
+        </option>
+      {/each}
+    </select>
+    <fieldset>
+      <label for="name">Imported Library</label>
+      <input bind:files={libraryName} class="w-100" name="libraryFile" type="file" accept=".satf" />
+    </fieldset>
+  </ModalContent>
+
+  <ModalFooter>
+    <button class="st-button secondary" on:click={() => dispatch('close')}> Cancel </button>
+    <button class="st-button" disabled={saveButtonDisabled} on:click={save}> Import </button>
+  </ModalFooter>
+</Modal>

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -144,3 +144,11 @@
     {user}
   />
 </CssGrid>
+
+<style>
+  .right {
+    column-gap: 5px;
+    display: flex;
+    flex-wrap: nowrap;
+  }
+</style>

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -9,6 +9,8 @@
   import { parcels, userSequences, userSequencesColumns, workspaces } from '../../stores/sequencing';
   import type { User } from '../../types/app';
   import type { Parcel, UserSequence, Workspace } from '../../types/sequencing';
+  import { satfToSequence } from '../../utilities/codemirror/satf/satf-sasf-utils';
+  import effects from '../../utilities/effects';
   import { getSearchParameterNumber, setQueryParam } from '../../utilities/generic';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
@@ -59,6 +61,28 @@
     const workspaceId = getSearchParameterNumber(SearchParameters.WORKSPACE_ID);
     goto(`${base}/sequencing/new${workspaceId ? `?${SearchParameters.WORKSPACE_ID}=${workspaceId}` : ''}`);
   }
+
+  async function importLibrary(): Promise<void> {
+    const library = await effects.importLibrarySequences(workspaceId);
+    if (!library) {
+      return;
+    }
+
+    const parcel = library.parcel;
+    const sequences = (await satfToSequence(library.fileContents)).sequences;
+    sequences.forEach(async seqN => {
+      await effects.createUserSequence(
+        {
+          definition: seqN.sequence,
+          name: seqN.name,
+          parcel_id: parcel,
+          seq_json: '',
+          workspace_id: workspaceId !== null ? workspaceId : -1,
+        },
+        user,
+      );
+    });
+  }
 </script>
 
 <CssGrid bind:columns={$userSequencesColumns}>
@@ -85,6 +109,18 @@
           on:click={navigateToNewSequence}
         >
           New Sequence
+        </button>
+
+        <button
+          class="st-button secondary ellipsis"
+          use:permissionHandler={{
+            hasPermission: featurePermissions.sequences.canCreate(user),
+            permissionError: 'You do not have permission to upload library sequences',
+          }}
+          disabled={workspace === undefined}
+          on:click|stopPropagation={importLibrary}
+        >
+          Import Library
         </button>
       </div>
     </svelte:fragment>

--- a/src/utilities/codemirror/codemirror-utils.test.ts
+++ b/src/utilities/codemirror/codemirror-utils.test.ts
@@ -356,10 +356,12 @@ describe('getDefaultVariableArgs', () => {
     { allowable_ranges: [{ min: 5 }], type: 'INT' },
     { allowable_ranges: [{ min: 7 }], type: 'UINT' },
     { allowable_values: ['VALUE1'], enum_name: 'ExampleEnum', type: 'ENUM' },
+    { enum_name: 'ExampleEnum2', type: 'ENUM' },
     { type: 'INT' },
+    { name: 'hexValue', type: 'HEX' },
   ] as VariableDeclaration[];
   it('should return default values for different types', () => {
     const result = getDefaultVariableArgs(mockParameters);
-    expect(result).toEqual(['"exampleString"', 1.2, 5, 7, '"VALUE1"', 0]);
+    expect(result).toEqual(['"exampleString"', 1.2, 5, 7, '"VALUE1"', '"ExampleEnum2"', 0, 'ERROR:"hexValue"']);
   });
 });

--- a/src/utilities/codemirror/codemirror-utils.ts
+++ b/src/utilities/codemirror/codemirror-utils.ts
@@ -120,10 +120,10 @@ export function getDefaultVariableArgs(parameters: VariableDeclaration[]): strin
         return parameter.allowable_values && parameter.allowable_values.length > 0
           ? `"${parameter.allowable_values[0]}"`
           : parameter.enum_name
-            ? `${parameter.enum_name}`
+            ? `"${parameter.enum_name}"`
             : 'UNKNOWN';
       default:
-        throw Error(`unknown argument type ${parameter.type}`);
+        return `ERROR:"${parameter.name}"`;
     }
   }) as string[];
 }

--- a/src/utilities/codemirror/satf/satf-sasf-utils.test.ts
+++ b/src/utilities/codemirror/satf/satf-sasf-utils.test.ts
@@ -91,9 +91,9 @@ describe('satfToSequence', () => {
     expect(result.sequences[0].name).toStrictEqual('test');
     expect(result.sequences[0].sequence).toStrictEqual(`## test
 R00:01:00  01VV param6 10 false "abc" # This command turns, to correct position.
-@MODEL(x,1,"00:00:00")
-@MODEL(z,1.1,"00:00:00")
-@MODEL(y,"abc","00:00:00")`);
+@MODEL "x" 1 "00:00:00"
+@MODEL "z" 1.1 "00:00:00"
+@MODEL "y" "abc" "00:00:00"`);
   });
 
   it('should return multiple sequence with models', async () => {
@@ -127,9 +127,9 @@ R00:01:00  01VV param6 10 false "abc" # This command turns, to correct position.
     expect(result.sequences[0].name).toStrictEqual('test');
     expect(result.sequences[0].sequence).toStrictEqual(`## test
 R00:01:00  01VV param6 10 false "abc" # This command turns, to correct position.
-@MODEL(x,1,"00:00:00")
-@MODEL(z,1.1,"00:00:00")
-@MODEL(y,"abc","00:00:00")`);
+@MODEL "x" 1 "00:00:00"
+@MODEL "z" 1.1 "00:00:00"
+@MODEL "y" "abc" "00:00:00"`);
   });
 });
 

--- a/src/utilities/codemirror/satf/satf-sasf-utils.ts
+++ b/src/utilities/codemirror/satf/satf-sasf-utils.ts
@@ -475,7 +475,15 @@ export function generateSatfVariables(
       return (
         `\t${variable.name}` +
         `(\n\t\tTYPE,${variable.type}${variable.enum_name ? `\n\tENUM,${variable.enum_name}` : ''}` +
-        `${variable.allowable_ranges ? `\n\t\tRANGES,${variable.allowable_ranges}` : ''}` +
+        `${
+          variable.allowable_ranges
+            ? variable.allowable_ranges
+                .map(range => {
+                  return `\n\t\tRANGES,\\${range.min}...${range.max}\\`;
+                })
+                .join(',')
+            : ''
+        }` +
         `${variable.allowable_values ? `\n\t\tVALUES,${variable.allowable_values}` : ''}` +
         `${variable.sc_name ? `\n\t\tSC_NAME,${variable.sc_name}` : ''}\n\t)`
       );
@@ -881,7 +889,7 @@ function parseModel(modelNode: SyntaxNode | null, text: string): string {
       if (!keyNode || !valueNode) {
         return null;
       }
-      return `@MODEL(${text.slice(keyNode.from, keyNode.to)},${text.slice(valueNode.from, valueNode.to)},"00:00:00")`;
+      return `@MODEL "${text.slice(keyNode.from, keyNode.to)}" ${text.slice(valueNode.from, valueNode.to)} "00:00:00"`;
     })
     .filter(model => model !== null)
     .join('\n');

--- a/src/utilities/codemirror/satf/satf-sasf.grammar
+++ b/src/utilities/codemirror/satf/satf-sasf.grammar
@@ -26,7 +26,7 @@
   HeaderPairs { HeaderPair* }
   HeaderPair {Key"="Value ";" newLine}
   Key { (identifier | ":")* }
-  Value { headerValue+ }
+  Value { (headerValue | "/")+ }
   SfduHeader { headerMarker newLine HeaderPairs headerMarker}
 
   Start { "$$"identifier identifier* newLine}

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -226,6 +226,7 @@ import {
   showDeleteActivitiesModal,
   showDeleteExternalSourceModal,
   showEditViewModal,
+  showLibrarySequenceModel,
   showManageGroupsAndTypes,
   showManagePlanConstraintsModal,
   showManagePlanDerivationGroups,
@@ -4788,6 +4789,28 @@ const effects = {
     } catch (e) {
       catchError(e as Error);
       return null;
+    }
+  },
+
+  async importLibrarySequences(
+    workspaceId: number | null,
+  ): Promise<{ fileContents: string; parcel: number } | undefined> {
+    if (workspaceId === null) {
+      showFailureToast("Library Import: Workspace doesn't exist");
+      return undefined;
+    }
+    const { confirm, value } = await showLibrarySequenceModel();
+
+    if (!confirm || !value) {
+      return undefined;
+    }
+
+    try {
+      const contents = await value.libraryFile.text();
+      return { fileContents: contents, parcel: value.parcel };
+    } catch (e) {
+      showFailureToast('Library Import: Unable to open file');
+      return undefined;
     }
   },
 

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -12,6 +12,7 @@ import DeleteExternalEventSourceTypeModal from '../components/modals/DeleteExter
 import DeleteExternalSourceModal from '../components/modals/DeleteExternalSourceModal.svelte';
 import EditViewModal from '../components/modals/EditViewModal.svelte';
 import ExpansionSequenceModal from '../components/modals/ExpansionSequenceModal.svelte';
+import LibrarySequenceModal from '../components/modals/LibrarySequenceModal.svelte';
 import ManageGroupsAndTypesModal from '../components/modals/ManageGroupsAndTypesModal.svelte';
 import ManagePlanConstraintsModal from '../components/modals/ManagePlanConstraintsModal.svelte';
 import ManagePlanDerivationGroupsModal from '../components/modals/ManagePlanDerivationGroupsModal.svelte';
@@ -547,6 +548,39 @@ export async function showWorkspaceModal(
           target.replaceChildren();
           target.resolve = null;
           resolve({ confirm: true, value: e.detail });
+          workspaceModal.$destroy();
+        });
+      }
+    } else {
+      resolve({ confirm: false });
+    }
+  });
+}
+
+export async function showLibrarySequenceModel(): Promise<ModalElementValue<{ libraryFile: File; parcel: number }>> {
+  return new Promise(resolve => {
+    if (browser) {
+      const target: ModalElement | null = document.querySelector('#svelte-modal');
+
+      if (target) {
+        const workspaceModal = new LibrarySequenceModal({
+          target,
+        });
+        target.resolve = resolve;
+
+        workspaceModal.$on('close', () => {
+          target.replaceChildren();
+          target.resolve = null;
+          resolve({ confirm: false });
+          workspaceModal.$destroy();
+        });
+
+        workspaceModal.$on('save', (e: CustomEvent<{ library: FileList; parcel: number }>) => {
+          const library = e.detail.library[0];
+          const parcel = e.detail.parcel;
+          target.replaceChildren();
+          target.resolve = null;
+          resolve({ confirm: true, value: { libraryFile: library, parcel } });
           workspaceModal.$destroy();
         });
       }

--- a/src/utilities/sequence-editor/sequence-linter.ts
+++ b/src/utilities/sequence-editor/sequence-linter.ts
@@ -567,16 +567,24 @@ function validateActivateLoad(
               } else {
                 value = parseInt(num);
               }
-              parameter.allowable_ranges?.forEach(range => {
-                if (value < range.min || value > range.max) {
+
+              if (parameter.allowable_ranges) {
+                const invalidRanges = parameter.allowable_ranges.filter(range => {
+                  return value < range.min || value > range.max;
+                });
+                if (invalidRanges.length === parameter.allowable_ranges.length) {
                   diagnostics.push({
                     from: arg.from,
-                    message: `Value must be between ${range.min} and ${range.max}`,
+                    message: `Value must be between ${parameter.allowable_ranges
+                      .map(range => {
+                        return `[${range.min} and ${range.max}]`;
+                      })
+                      .join(' or ')}`,
                     severity: 'error',
                     to: arg.to,
                   });
                 }
-              });
+              }
 
               if (parameter.type === 'UINT') {
                 if (value < 0) {


### PR DESCRIPTION
Closes #1591 

**Library Sequence Modal:**

- Introduced a new modal for importing a library sequence file.
- Integrated the library modal with workspaces for seamless interaction.

**Linting Bugfix:**
- Fixed an issue where the linter incorrectly reported errors for values within a valid range when multiple ranges were defined.
- Fixed an issue where the linter incorrectly reported errors for command stems with no arguments. 


**Autocomplete Bugfix:**
- Improved autocomplete functionality to allow completion even with invalid variable types. The user will be notified of the invalid type within the editor and will need to manually correct it. 

**SATF/SASF Library**
- Fixed an issue where we were not generating the @MODEL correctly. 

**TESTING**
- Download the attach file (banana_library.txt)
- Rename it to banana_library.satf
- Create a new workspace
- In the middle panel underneath the 'create sequence' you should see a 'import library'
- Click on 'import library' and select a parcel and library file ex. banana_library.satf
- Verify the library gets imported and you see 3 sequences created

[banana_library.txt](https://github.com/user-attachments/files/18426366/banana_library.txt)
