### PR TITLE
Remove manually specified activities from default view

### DIFF
--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -54,7 +54,6 @@ export const load: PageLoad = async ({ parent, params, url }) => {
         url.searchParams,
         user,
         true,
-        initialActivityTypes,
         initialResourceTypes,
         initialExternalEventTypes,
         initialPlan.model.view,

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -4740,7 +4740,6 @@ const effects = {
     query: URLSearchParams | null,
     user: User | null,
     migrate: boolean = true,
-    activityTypes: ActivityType[] = [],
     resourceTypes: ResourceType[] = [],
     externalEventTypes: ExternalEventType[] = [],
     defaultView?: View | null,
@@ -4785,7 +4784,7 @@ const effects = {
           }
         }
       }
-      return generateDefaultView(activityTypes, resourceTypes, externalEventTypes);
+      return generateDefaultView(resourceTypes, externalEventTypes);
     } catch (e) {
       catchError(e as Error);
       return null;

--- a/src/utilities/view.test.ts
+++ b/src/utilities/view.test.ts
@@ -11,14 +11,11 @@ import {
 
 describe('generateDefaultView', () => {
   test('Should generate a valid view', async () => {
-    const view = generateDefaultView(
-      [],
-      [
-        { name: 'resource1', schema: { type: 'boolean' } },
-        { name: 'resource2', schema: { type: 'int' } },
-        { name: 'resource2', schema: { items: { type: 'boolean' }, type: 'series' } },
-      ],
-    );
+    const view = generateDefaultView([
+      { name: 'resource1', schema: { type: 'boolean' } },
+      { name: 'resource2', schema: { type: 'int' } },
+      { name: 'resource2', schema: { items: { type: 'boolean' }, type: 'series' } },
+    ]);
     const { valid, errors } = validateViewJSONAgainstSchema(view.definition);
     expect(errors).to.deep.equal([]);
     expect(valid).toBe(true);
@@ -27,7 +24,7 @@ describe('generateDefaultView', () => {
 
 describe('generateDefaultViewWithEvents', () => {
   test('Should generate a valid view with events', async () => {
-    const view = generateDefaultView([], [], [{ name: 'external-event-type_1' }, { name: 'external-event-type_2' }]);
+    const view = generateDefaultView([], [{ name: 'external-event-type_1' }, { name: 'external-event-type_2' }]);
 
     // validate against schema
     const { valid, errors } = validateViewJSONAgainstSchema(view.definition);

--- a/src/utilities/view.ts
+++ b/src/utilities/view.ts
@@ -1,7 +1,6 @@
 import Ajv from 'ajv';
 import { ViewDefaultDiscreteOptions, viewSchemaVersion, viewSchemaVersionName } from '../constants/view';
 import jsonSchema from '../schemas';
-import type { ActivityType } from '../types/activity';
 import type { ExternalEventType } from '../types/external-event';
 import type { ResourceType } from '../types/simulation';
 import type { View, ViewDefinition, ViewGridColumns, ViewGridRows } from '../types/view';
@@ -20,19 +19,17 @@ import {
  * Generates a default generic UI view.
  */
 export function generateDefaultView(
-  activityTypes: ActivityType[] = [],
   resourceTypes: ResourceType[] = [],
   externalEventTypes: ExternalEventType[] = [],
 ): View {
   const now = new Date().toISOString();
-  const types: string[] = activityTypes.map(({ name }) => name);
 
   const timeline = createTimeline([], { marginLeft: 250, marginRight: 30 });
   const timelines = [timeline];
 
   // Start with the activity row
   const activityLayer = createTimelineActivityLayer(timelines, {
-    filter: { activity: { static_types: types } },
+    filter: /* { activity: { static_types: types } } */ {},
   });
   const activityRow = createRow(timelines, {
     autoAdjustHeight: true,

--- a/src/utilities/view.ts
+++ b/src/utilities/view.ts
@@ -29,7 +29,7 @@ export function generateDefaultView(
 
   // Start with the activity row
   const activityLayer = createTimelineActivityLayer(timelines, {
-    filter: /* { activity: { static_types: types } } */ {},
+    filter: {},
   });
   const activityRow = createRow(timelines, {
     autoAdjustHeight: true,

--- a/src/utilities/view.ts
+++ b/src/utilities/view.ts
@@ -28,9 +28,7 @@ export function generateDefaultView(
   const timelines = [timeline];
 
   // Start with the activity row
-  const activityLayer = createTimelineActivityLayer(timelines, {
-    filter: {},
-  });
+  const activityLayer = createTimelineActivityLayer(timelines);
   const activityRow = createRow(timelines, {
     autoAdjustHeight: true,
     discreteOptions: { ...ViewDefaultDiscreteOptions, displayMode: 'grouped' },


### PR DESCRIPTION
Remove static activity type filter for default view so that all activities are included dynamically in case of a model change.