### PR TITLE
Fix incorrect usage of condition plan specs array as dictionary

### DIFF
--- a/src/components/modals/ManagePlanSchedulingConditionsModal.svelte
+++ b/src/components/modals/ManagePlanSchedulingConditionsModal.svelte
@@ -3,6 +3,7 @@
 <script lang="ts">
   import { base } from '$app/paths';
   import type { CellEditingStoppedEvent, ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
+  import { keyBy } from 'lodash-es';
   import { createEventDispatcher } from 'svelte';
   import { PlanStatusMessages } from '../../enums/planStatusMessages';
   import { SearchParameters } from '../../enums/searchParameters';
@@ -100,6 +101,10 @@
 
   let columnDefs = baseColumnDefs;
 
+  let allowedSchedulingConditionSpecsMap: Record<
+    SchedulingConditionPlanSpecification['condition_id'],
+    SchedulingConditionPlanSpecification
+  > = {};
   let dataGrid: DataGrid<SchedulingConditionMetadata> | undefined = undefined;
   let filterText: string = '';
   let filteredConditions: SchedulingConditionMetadata[] = [];
@@ -107,6 +112,7 @@
   let hasEditSpecPermission: boolean = false;
   let selectedConditions: Record<string, boolean> = {};
 
+  $: allowedSchedulingConditionSpecsMap = keyBy($allowedSchedulingConditionSpecs, 'condition_id');
   $: filteredConditions = $schedulingConditions
     // TODO: remove this after db merge as it becomes redundant
     .filter(({ owner, public: isPublic }) => {
@@ -221,7 +227,7 @@
         ) => {
           const conditionId = parseInt(selectedConditionId);
           const isSelected = selectedConditions[conditionId];
-          const conditionPlanSpec = $allowedSchedulingConditionSpecs[conditionId];
+          const conditionPlanSpec = allowedSchedulingConditionSpecsMap[conditionId];
 
           if (isSelected && $schedulingPlanSpecification !== null) {
             if (!conditionPlanSpec || conditionPlanSpec.condition_metadata?.owner === user?.id) {

--- a/src/components/modals/ManagePlanSchedulingConditionsModal.svelte
+++ b/src/components/modals/ManagePlanSchedulingConditionsModal.svelte
@@ -230,7 +230,7 @@
           const conditionPlanSpec = allowedSchedulingConditionSpecsMap[conditionId];
 
           if (isSelected && $schedulingPlanSpecification !== null) {
-            if (!conditionPlanSpec || conditionPlanSpec.condition_metadata?.owner === user?.id) {
+            if (!conditionPlanSpec) {
               return {
                 ...prevConditionPlanSpecUpdates,
                 conditionPlanSpecsToAdd: [


### PR DESCRIPTION
resolves #1596 

This is a little hard to test because effectively it was doing the correct behavior by happenstance, but just using the wrong logic. The background is that users cannot see scheduling conditions that are private that they do not own. It is safe to remove the owner check since users cannot see private conditions to add if they don't own them.

To test:

1. Create a couple of conditions, each one under a different user, and set them to private
2. Create a plan
3. Switch to the "user" role
4. Associate the condition that the current user owns to the plan via the "Scheduling Conditions Panel"
5. Verify that only the conditions that the user owns are visible if they are private
6. Switch to the other user that was used to create the other conditions.
7. Switch to the "user" role
8. Repeat steps 4-5