### PR TITLE
Copy & Paste of Activity Directives between Plans

### DIFF
--- a/src/components/activity/PasteActivitiesContextMenu.svelte
+++ b/src/components/activity/PasteActivitiesContextMenu.svelte
@@ -1,0 +1,57 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import type { ActivityDirective } from '../../types/activity';
+  import type { Plan } from '../../types/plan';
+  import {
+    getActivityDirectivesClipboardCount,
+    getActivityDirectivesToPaste,
+    getPasteActivityDirectivesText,
+  } from '../../utilities/activities';
+  import { permissionHandler } from '../../utilities/permissionHandler';
+  import ContextMenuItem from '../context-menu/ContextMenuItem.svelte';
+
+  const dispatch = createEventDispatcher<{
+    createActivityDirectives: ActivityDirective[];
+  }>();
+
+  export let atTime: Date | undefined = undefined;
+  export let hasCreatePermission: boolean = false;
+  export let plan: Plan | null;
+  export let planPermissionErrorText: string | null = null;
+
+  async function pasteActivityDirectives(atTime: Date | undefined) {
+    if (plan != null && hasCreatePermission) {
+      const timeValue = atTime && atTime.getTime();
+      const activities = await getActivityDirectivesToPaste(plan, timeValue);
+      dispatch(`createActivityDirectives`, activities);
+    }
+  }
+</script>
+
+{#await getActivityDirectivesClipboardCount() then directivesInClipboard}
+  <ContextMenuItem
+    use={[
+      [
+        permissionHandler,
+        {
+          hasPermission: hasCreatePermission && directivesInClipboard > 0,
+          permissionError: () => {
+            if (planPermissionErrorText !== null) {
+              return planPermissionErrorText;
+            } else if (directivesInClipboard && directivesInClipboard <= 0) {
+              return 'No activity directives in clipboard';
+            } else {
+              return null;
+            }
+          },
+        },
+      ],
+    ]}
+    on:click={() => pasteActivityDirectives(atTime)}
+  >
+    {getPasteActivityDirectivesText(directivesInClipboard)}
+    {atTime === undefined ? `` : `At Time`}
+  </ContextMenuItem>
+{/await}

--- a/src/utilities/clipboard.ts
+++ b/src/utilities/clipboard.ts
@@ -1,0 +1,22 @@
+export function setClipboardContent(content: object, success?: () => void, fail?: () => void) {
+  navigator.clipboard.writeText(JSON.stringify(content)).then(
+    () => {
+      if (success !== undefined) {
+        success(); //optional success callback
+      }
+    },
+    () => {
+      if (fail !== undefined) {
+        fail(); //optional fail callback
+      }
+    },
+  );
+}
+
+export async function getClipboardContent(): Promise<string | void> {
+  try {
+    return await window.navigator.clipboard.readText();
+  } catch (e) {
+    console.error(e);
+  }
+}

--- a/src/utilities/sessionStorageClipboard.ts
+++ b/src/utilities/sessionStorageClipboard.ts
@@ -1,7 +1,0 @@
-export function setSessionStorageClipboard(content: string) {
-  sessionStorage.setItem(`aerie_clipboard`, content);
-}
-
-export function getSessionStorageClipboard(): string | null {
-  return sessionStorage.getItem(`aerie_clipboard`);
-}


### PR DESCRIPTION
Closes #1625 

Extending the original Copy & Paste feature with a few things here...

1. Let's use the system [Clipboard](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard), instead of session storage. This will allow us to deconflict having a separate special clipboard for Aerie, and it enables more features like...
2. Copy & Paste between plans. Open two plans, you can copy from plan A and paste on plan B either on the table or on the timeline at a specific time. 
3. Now that we handle different plans, they can have different boundaries, so if you're pasting and the earliest start is out of bounds, then we're going to paste at the start of the plan. 
