### PR TITLE
Ensures that only one context menu is open at a time

### DIFF
--- a/src/components/context-menu/ContextMenu.svelte
+++ b/src/components/context-menu/ContextMenu.svelte
@@ -1,7 +1,19 @@
 <svelte:options accessors={true} immutable={true} />
 
+<script lang="ts" context="module">
+  type HideFns = Set<() => void>;
+  const hideFns: HideFns = new Set<() => void>();
+
+  export function hideAllMenus() {
+    // TODO: https://github.com/sveltejs/language-tools/issues/1229
+    hideFns.forEach(hideFn => {
+      hideFn();
+    });
+  }
+</script>
+
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, onDestroy, onMount } from 'svelte';
   import { fade } from 'svelte/transition';
 
   const dispatch = createEventDispatcher<{
@@ -33,6 +45,7 @@
   }
 
   export function show(e: MouseEvent): void {
+    hideAllMenus();
     e.preventDefault();
     shown = true;
     x = e.clientX;
@@ -43,6 +56,14 @@
   let shown: boolean = false;
   let x: number;
   let y: number;
+
+  onMount(() => {
+    hideFns.add(hide);
+  });
+
+  onDestroy(() => {
+    hideFns.delete(hide);
+  });
 
   $: if (div) {
     const rect = div.getBoundingClientRect();

--- a/src/components/context-menu/ContextMenu.svelte
+++ b/src/components/context-menu/ContextMenu.svelte
@@ -5,7 +5,6 @@
   const hideFns: HideFns = new Set<() => void>();
 
   export function hideAllMenus() {
-    // TODO: https://github.com/sveltejs/language-tools/issues/1229
     hideFns.forEach(hideFn => {
       hideFn();
     });

--- a/src/components/menus/Menu.svelte
+++ b/src/components/menus/Menu.svelte
@@ -12,7 +12,6 @@
   };
 
   export function hideAllMenus(type?: MenuType) {
-    // TODO: https://github.com/sveltejs/language-tools/issues/1229
     if (type) {
       hideFns[type].forEach(hide => {
         hide();


### PR DESCRIPTION
This fixes an issue where right clicking on multiple components with the custom context menu component results in multiple context menus can appear.

To test:
1. Open a plan
2. Switch two panels to be the activity directives table.
3. Right click on one panel's table
4. Right click on the other panel's table
5. Verify that only the last context menu to be opened is visible.