### PR TITLE
Fix SeqN @NOTE to match SeqJSON schema properties

### DIFF
--- a/src/utilities/sequence-editor/grammar.test.ts
+++ b/src/utilities/sequence-editor/grammar.test.ts
@@ -318,6 +318,7 @@ Command(Stem,Args(String),Models(Model(Variable(String),Value(String),Offset(Str
     `Seq.Json comprehension`,
     `A2024-123T12:34:56 @GROUND_BLOCK("ground_block.name") # No Args
 C @NOTE("note_value")
+@MODEL "my:attribute" 123 "00:00:00"
 R123T12:34:56 @GROUND_EVENT("ground_event.name") "foo" 1 2 3
 A2024-123T12:34:56 @ACTIVATE("activate.name") # No Args
 @ENGINE 10
@@ -356,7 +357,7 @@ A2024-123T12:34:56 @REQUEST_BEGIN("request2.name")
     `
 Sequence(Commands(
   GroundBlock(TimeTag(TimeAbsolute),GroundName(String),Args,LineComment),
-  Note(TimeTag(TimeComplete),NoteValue(String)Args),
+  Note(TimeTag(TimeComplete),NoteValue(String),Models(Model(Variable(String),Value(Number),Offset(String)))),
   GroundEvent(TimeTag(TimeRelative),GroundName(String),Args(String,Number,Number,Number)),
   Activate(TimeTag(TimeAbsolute),SequenceName(String),Args,LineComment,Engine(Number),Epoch(String)),
   Activate(TimeTag(TimeRelative),SequenceName(String),Args(String,Number,Number,Number),LineComment,Engine(Number)),

--- a/src/utilities/sequence-editor/languages/seq-n/seq-n.grammar
+++ b/src/utilities/sequence-editor/languages/seq-n/seq-n.grammar
@@ -28,12 +28,12 @@ IdDeclaration {
 
 ParameterDeclaration {
   (parameterDirective whiteSpace Variable{((Enum whiteSpace?) | (Enum whiteSpace? Object whiteSpace?))}+ newLine) |
-  (parameterStartDirective newLine (whiteSpace? Variable{((Enum whiteSpace?) | (Enum whiteSpace? Type { identifier } whiteSpace? ( (EnumName { identifier}) | (Range { String } (whiteSpace Values {String})? ) |  (EnumName { identifier} whiteSpace (Range { String } (whiteSpace Values {String})?) )? whiteSpace?)) )} newLine)* parameterEndDirective newLine ) 
+  (parameterStartDirective newLine (whiteSpace? Variable{((Enum whiteSpace?) | (Enum whiteSpace? Type { identifier } whiteSpace? ( (EnumName { identifier}) | (Range { String } (whiteSpace Values {String})? ) |  (EnumName { identifier} whiteSpace (Range { String } (whiteSpace Values {String})?) )? whiteSpace?)) )} newLine)* parameterEndDirective newLine )
 }
 
 LocalDeclaration {
   (localsDirective whiteSpace Variable{((Enum whiteSpace?) | (Enum whiteSpace? Object whiteSpace?))}+ newLine) |
-  (localsStartDirective newLine (whiteSpace? Variable{((Enum whiteSpace?) | (Enum whiteSpace? Type { identifier } whiteSpace? ( (EnumName { identifier}) | (Range { String } (whiteSpace Values {String})? ) |  (EnumName { identifier} whiteSpace (Range { String } (whiteSpace Values {String})?) )? whiteSpace?)) )} newLine)* localsEndDirective newLine ) 
+  (localsStartDirective newLine (whiteSpace? Variable{((Enum whiteSpace?) | (Enum whiteSpace? Type { identifier } whiteSpace? ( (EnumName { identifier}) | (Range { String } (whiteSpace Values {String})? ) |  (EnumName { identifier} whiteSpace (Range { String } (whiteSpace Values {String})?) )? whiteSpace?)) )} newLine)* localsEndDirective newLine )
 
 }
 
@@ -123,10 +123,10 @@ commonGround {
 Note {
   TimeTag
   noteDirective "(" NoteValue { String } ")"
-  Args
   LineComment?
   newLine
   Metadata?
+  Models?
 }
 
 Request {


### PR DESCRIPTION
SeqJSON v1.3.1 allows models and not args for @NOTE. Remove args and add models to comply.

Closes #1643 