### PR TITLE
Add readonly checkbox to sequences

### DIFF
--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -96,6 +96,7 @@
   export let parcel: Parcel | null;
   export let showCommandFormBuilder: boolean = false;
   export let readOnly: boolean = false;
+  export let previewOnly: boolean = false;
   export let sequenceName: string = '';
   export let sequenceDefinition: string = '';
   export let sequenceOutput: string = '';
@@ -296,7 +297,7 @@
     }
   }
   $: editorSequenceView?.dispatch({
-    effects: compartmentReadonly.reconfigure([EditorState.readOnly.of(readOnly)]),
+    effects: compartmentReadonly.reconfigure([EditorState.readOnly.of(readOnly || previewOnly)]),
   });
 
   $: showOutputs = !isInVmlMode && outputFormats.length > 0;
@@ -362,7 +363,7 @@
         ...($sequenceAdaptation.autoIndent
           ? [compartmentSeqAutocomplete.of(indentService.of($sequenceAdaptation.autoIndent()))]
           : []),
-        compartmentReadonly.of([EditorState.readOnly.of(readOnly)]),
+        compartmentReadonly.of([EditorState.readOnly.of(readOnly || previewOnly)]),
       ],
       parent: editorSequenceDiv,
     });

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -47,6 +47,7 @@
   import { blockTheme } from '../../utilities/codemirror/themes/block';
   import effects from '../../utilities/effects';
   import { downloadBlob, downloadJSON } from '../../utilities/generic';
+  import { permissionHandler } from '../../utilities/permissionHandler';
   import type { CommandInfoMapper } from '../../utilities/sequence-editor/command-info-mapper';
   import { inputLinter, outputLinter } from '../../utilities/sequence-editor/extension-points';
   import { setupLanguageSupport } from '../../utilities/sequence-editor/languages/seq-n/seq-n';
@@ -115,6 +116,7 @@
   let compartmentSeqTooltip: Compartment;
   let compartmentSeqAutocomplete: Compartment;
   let compartmentSeqHighlighter: Compartment;
+  let compartmentReadonly: Compartment;
   let channelDictionary: ChannelDictionary | null;
   let commandDictionary: CommandDictionary | null;
   let disableCopyAndExport: boolean = true;
@@ -293,6 +295,9 @@
       parameterDictionaries = [];
     }
   }
+  $: editorSequenceView?.dispatch({
+    effects: compartmentReadonly.reconfigure([EditorState.readOnly.of(readOnly)]),
+  });
 
   $: showOutputs = !isInVmlMode && outputFormats.length > 0;
   $: {
@@ -329,6 +334,7 @@
   );
 
   onMount(() => {
+    compartmentReadonly = new Compartment();
     compartmentSeqJsonLinter = new Compartment();
     compartmentSeqLanguage = new Compartment();
     compartmentSeqLinter = new Compartment();
@@ -356,7 +362,7 @@
         ...($sequenceAdaptation.autoIndent
           ? [compartmentSeqAutocomplete.of(indentService.of($sequenceAdaptation.autoIndent()))]
           : []),
-        EditorState.readOnly.of(readOnly),
+        compartmentReadonly.of([EditorState.readOnly.of(readOnly)]),
       ],
       parent: editorSequenceDiv,
     });
@@ -591,7 +597,13 @@
       </svelte:fragment>
 
       <svelte:fragment slot="body">
-        <div bind:this={editorSequenceDiv} />
+        <div
+          bind:this={editorSequenceDiv}
+          use:permissionHandler={{
+            hasPermission: !readOnly,
+            permissionError: 'This sequence has been marked as readonly.',
+          }}
+        />
       </svelte:fragment>
     </Panel>
 

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -20,7 +20,7 @@
   import { getSearchParameterNumber } from '../../utilities/generic';
   import { isSaveEvent } from '../../utilities/keyboardEvents';
   import { permissionHandler } from '../../utilities/permissionHandler';
-  import { featurePermissions } from '../../utilities/permissions';
+  import { featurePermissions, isUserAdmin, isUserOwner } from '../../utilities/permissions';
   import { toInputFormat } from '../../utilities/sequence-editor/extension-points';
   import { logError } from '../../utilities/sequence-editor/logger';
   import PageTitle from '../app/PageTitle.svelte';
@@ -336,8 +336,8 @@
           placeholder="Is Sequence Readonly?"
           type="checkbox"
           use:permissionHandler={{
-            hasPermission,
-            permissionError,
+            hasPermission: isUserAdmin(user) || isUserOwner(user, { owner: sequenceOwner }),
+            permissionError: 'Only the owner and admins can toggle readonly',
           }}
         />
       </fieldset>

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -36,6 +36,7 @@
   export let initialSequenceName: string = '';
   export let initialSequenceOwner: UserId = '';
   export let initialSequenceParcelId: number | null = null;
+  export let initialIsSequenceReadonly: boolean = false;
   export let initialSequenceUpdatedAt: string | null = null;
   export let mode: 'create' | 'edit' = 'create';
   export let user: User | null;
@@ -55,6 +56,8 @@
   let sequenceName: string = initialSequenceName;
   let sequenceOwner: UserId = initialSequenceOwner;
   let sequenceParcelId: number | null = initialSequenceParcelId;
+  let isSequenceReadonly: boolean = initialIsSequenceReadonly;
+  let savedIsSequenceReadonly: boolean = initialIsSequenceReadonly;
   let savedSequenceName: string = sequenceName;
   let sequenceOutput: string = 'Output has not been generated yet';
   let sequenceUpdatedAt: string | null = initialSequenceUpdatedAt;
@@ -64,16 +67,27 @@
   let selectedWorkspaceId: number | null;
 
   $: parcel = $parcels.find(p => p.id === sequenceParcelId) ?? null;
+  $: sequenceModified =
+    (!isSequenceReadonly && sequenceDefinition !== savedSequenceDefinition) ||
+    (!isSequenceReadonly && sequenceName !== savedSequenceName) ||
+    savedIsSequenceReadonly !== isSequenceReadonly;
   $: saveButtonClass = sequenceModified && saveButtonEnabled ? 'primary' : 'secondary';
   $: saveButtonEnabled =
-    sequenceParcelId !== null && sequenceDefinition !== '' && sequenceName !== '' && isValidWorkspaceId();
-  $: sequenceModified = sequenceDefinition !== savedSequenceDefinition || sequenceName !== savedSequenceName;
+    sequenceParcelId !== null &&
+    sequenceDefinition !== '' &&
+    sequenceName !== '' &&
+    isValidWorkspaceId() &&
+    sequenceModified;
   $: {
     hasPermission =
       mode === 'edit'
         ? featurePermissions.sequences.canUpdate(user, { owner: sequenceOwner })
         : featurePermissions.sequences.canCreate(user);
-    permissionError = `You do not have permission to ${mode === 'edit' ? 'edit this' : 'create a'} sequence.`;
+    if (isSequenceReadonly) {
+      permissionError = 'This sequence has been marked as readonly.';
+    } else {
+      permissionError = `You do not have permission to ${mode === 'edit' ? 'edit this' : 'create a'} sequence.`;
+    }
     pageTitle = mode === 'edit' ? 'Sequencing' : 'New Sequence';
     pageSubtitle = mode === 'edit' ? savedSequenceName : '';
     saveButtonText = mode === 'edit' && !sequenceModified ? 'Saved' : 'Save';
@@ -181,6 +195,7 @@
         if (mode === 'create') {
           const newSequence: UserSequenceInsertInput = {
             definition: sequenceDefinition,
+            is_locked: isSequenceReadonly,
             name: sequenceName,
             parcel_id: sequenceParcelId,
             seq_json: sequenceOutput,
@@ -194,18 +209,28 @@
             goto(newSequenceUrl + (workspaceId !== null ? `?${SearchParameters.WORKSPACE_ID}=${workspaceId}` : ''));
           }
         } else if (mode === 'edit' && sequenceId !== null) {
-          const updatedSequence: Partial<UserSequence> = {
-            definition: sequenceDefinition,
-            name: sequenceName,
-            parcel_id: sequenceParcelId,
-            seq_json: sequenceOutput,
-          };
+          let updatedSequence: Partial<UserSequence> = {};
+
+          if (isSequenceReadonly) {
+            updatedSequence = {
+              is_locked: true,
+            };
+          } else {
+            updatedSequence = {
+              definition: sequenceDefinition,
+              is_locked: isSequenceReadonly,
+              name: sequenceName,
+              parcel_id: sequenceParcelId,
+              seq_json: sequenceOutput,
+            };
+          }
           const updated_at = await effects.updateUserSequence(sequenceId, updatedSequence, sequenceOwner, user);
           if (updated_at !== null) {
             sequenceUpdatedAt = updated_at;
           }
           savedSequenceDefinition = sequenceDefinition;
           savedSequenceName = sequenceName;
+          savedIsSequenceReadonly = isSequenceReadonly;
         }
       }
       savingSequence = false;
@@ -272,7 +297,7 @@
           class="st-select w-100"
           name="parcel"
           use:permissionHandler={{
-            hasPermission,
+            hasPermission: hasPermission && !isSequenceReadonly,
             permissionError,
           }}
         >
@@ -285,7 +310,7 @@
         </select>
       </fieldset>
 
-      <fieldset>
+      <fieldset class="readonly">
         <label for="sequenceName">Name (required)</label>
         <input
           bind:value={sequenceName}
@@ -294,6 +319,22 @@
           name="sequenceName"
           placeholder="Enter Sequence Name"
           required
+          use:permissionHandler={{
+            hasPermission: hasPermission && !isSequenceReadonly,
+            permissionError,
+          }}
+        />
+      </fieldset>
+
+      <fieldset class="readonly-fieldset">
+        <label for="sequenceReadonly">Is Readonly</label>
+        <input
+          bind:checked={isSequenceReadonly}
+          autocomplete="off"
+          class="st-input"
+          name="sequenceReadonly"
+          placeholder="Is Sequence Readonly?"
+          type="checkbox"
           use:permissionHandler={{
             hasPermission,
             permissionError,
@@ -310,7 +351,7 @@
           type="file"
           on:change={onOutputFileUpload}
           use:permissionHandler={{
-            hasPermission,
+            hasPermission: hasPermission && !isSequenceReadonly,
             permissionError,
           }}
         />
@@ -328,9 +369,22 @@
     {sequenceOutput}
     title="{mode === 'create' ? 'New' : 'Edit'} Sequence - Definition Editor"
     {user}
-    readOnly={!hasPermission}
+    readOnly={!hasPermission || isSequenceReadonly}
     workspaceId={selectedWorkspaceId}
     on:sequence={onSequenceChange}
     on:didChangeModelContent={onDidChangeModelContent}
   />
 </CssGrid>
+
+<style>
+  .readonly-fieldset {
+    column-gap: 0.5rem;
+    display: flex;
+    flex-direction: row;
+  }
+
+  .readonly-fieldset > label,
+  input {
+    display: inline;
+  }
+</style>

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -310,7 +310,7 @@
         </select>
       </fieldset>
 
-      <fieldset class="readonly">
+      <fieldset>
         <label for="sequenceName">Name (required)</label>
         <input
           bind:value={sequenceName}

--- a/src/components/sequencing/SequenceTable.svelte
+++ b/src/components/sequencing/SequenceTable.svelte
@@ -90,6 +90,7 @@
             },
             hasDeletePermission: params.data ? hasDeletePermission(user, params.data) : false,
             hasEditPermission: params.data ? hasEditPermission(user, params.data) : false,
+            hasEditPermissionError: params.data ? hasEditPermissionError(user, params.data) : '',
             rowData: params.data,
           },
           target: actionsDiv,
@@ -142,7 +143,7 @@
 
   function editSequence({ id }: Pick<UserSequence, 'id'>) {
     goto(
-      `${base}/sequencing/edit/${id}${'?' + SearchParameters.WORKSPACE_ID + '=' + getSearchParameterNumber(SearchParameters.WORKSPACE_ID) ?? ''}`,
+      `${base}/sequencing/edit/${id}${`?${SearchParameters.WORKSPACE_ID}=${getSearchParameterNumber(SearchParameters.WORKSPACE_ID) ?? ''}`}`,
     );
   }
 
@@ -156,6 +157,14 @@
 
   function hasEditPermission(user: User | null, sequence: UserSequence) {
     return featurePermissions.sequences.canUpdate(user, sequence);
+  }
+
+  function hasEditPermissionError(_user: User | null, sequence: UserSequence) {
+    if (sequence.is_locked) {
+      return 'This sequence has been marked as readonly.';
+    } else {
+      return 'You do not have permission to edit.';
+    }
   }
 
   function onFilterToUsersSequences(event: Event) {
@@ -218,6 +227,7 @@
     {columnDefs}
     hasEdit={true}
     {hasEditPermission}
+    {hasEditPermissionError}
     {hasDeletePermission}
     itemDisplayText="Sequence"
     items={filteredSequences}

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -86,6 +86,7 @@
       await effects.createUserSequence(
         {
           definition: seqN.sequence,
+          is_locked: false,
           name: seqN.name,
           parcel_id: parcel,
           seq_json: '',

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -163,7 +163,7 @@
     sequenceName={selectedSequence?.name}
     sequenceOutput={selectedSequence?.seq_json}
     title="Sequence - Definition Editor (Read-only)"
-    readOnly={true}
+    previewOnly={true}
     {workspaceId}
     {user}
   />

--- a/src/components/ui/DataGrid/SingleActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/SingleActionDataGrid.svelte
@@ -20,6 +20,9 @@
   import ContextMenuItem from '../../context-menu/ContextMenuItem.svelte';
   import DataGrid from '../../ui/DataGrid/DataGrid.svelte';
 
+  const defaultDeletePermissionError: string = 'You do not have permission to delete.';
+  const defaultEditPermissionError: string = 'You do not have permission to edit.';
+
   export let autoSizeColumnsToFit: boolean = true;
   export let columnDefs: ColDef[];
   export let columnStates: ColumnState[] = [];
@@ -27,8 +30,12 @@
   export let dataGrid: DataGrid<RowData> | undefined = undefined;
   export let filterExpression: string = '';
   export let hasDeletePermission: PermissionCheck<RowData> | boolean = true;
+  export let hasDeletePermissionError: string | ((user: User, data: RowData) => string) | undefined =
+    defaultDeletePermissionError;
   export let hasEdit: boolean = false;
   export let hasEditPermission: PermissionCheck<RowData> | boolean = true;
+  export let hasEditPermissionError: string | ((user: User, data: RowData) => string) | undefined =
+    defaultEditPermissionError;
   export let idKey: keyof RowData = 'id';
   export let items: RowData[];
   export let itemDisplayText: string;
@@ -45,7 +52,9 @@
   const dispatch = createEventDispatcher<Dispatcher<$$Events>>();
 
   let deletePermission: boolean = true;
+  let deletePermissionError: string = defaultDeletePermissionError;
   let editPermission: boolean = true;
+  let editPermissionError: string = defaultEditPermissionError;
   let selectedItemIds: RowId[] = [];
 
   $: if ((typeof hasDeletePermission === 'function' || typeof hasEditPermission === 'function') && user) {
@@ -54,16 +63,28 @@
       if (typeof hasDeletePermission === 'function') {
         deletePermission = hasDeletePermission(user, selectedItem);
       }
+      if (typeof hasDeletePermissionError === 'function') {
+        deletePermissionError = hasDeletePermissionError(user, selectedItem);
+      }
       if (typeof hasEditPermission === 'function') {
         editPermission = hasEditPermission(user, selectedItem);
+      }
+      if (typeof hasEditPermissionError === 'function') {
+        editPermissionError = hasEditPermissionError(user, selectedItem);
       }
     }
   }
   $: if (typeof hasDeletePermission === 'boolean') {
     deletePermission = hasDeletePermission;
   }
+  $: if (typeof hasDeletePermissionError === 'string') {
+    deletePermissionError = hasDeletePermissionError;
+  }
   $: if (typeof hasEditPermission === 'boolean') {
     editPermission = hasEditPermission;
+  }
+  $: if (typeof hasEditPermissionError === 'string') {
+    editPermissionError = hasEditPermissionError;
   }
   $: if (selectedItemId != null && !selectedItemIds.includes(selectedItemId)) {
     selectedItemIds = [selectedItemId];
@@ -148,7 +169,7 @@
             permissionHandler,
             {
               hasPermission: editPermission,
-              permissionError: 'You do not have permission to edit.',
+              permissionError: editPermissionError,
             },
           ],
         ]}
@@ -164,7 +185,7 @@
             permissionHandler,
             {
               hasPermission: deletePermission,
-              permissionError: 'You do not have permission to delete.',
+              permissionError: deletePermissionError,
             },
           ],
         ]}

--- a/src/routes/sequencing/edit/[id]/+page.svelte
+++ b/src/routes/sequencing/edit/[id]/+page.svelte
@@ -15,6 +15,7 @@
   initialSequenceParcelId={data.initialSequence.parcel_id}
   initialSequenceId={data.initialSequence.id}
   initialSequenceUpdatedAt={data.initialSequence.updated_at}
+  initialIsSequenceReadonly={data.initialSequence.is_locked}
   mode="edit"
   user={data.user}
 />

--- a/src/stores/sequencing.ts
+++ b/src/stores/sequencing.ts
@@ -100,7 +100,7 @@ export const workspaces = gqlSubscribable<Workspace[]>(gql.SUB_WORKSPACES, {}, [
 
 /* Writeable. */
 
-export const userSequencesColumns: Writable<string> = writable('.75fr 3px 1.5fr 3px 1fr');
+export const userSequencesColumns: Writable<string> = writable('1.5fr 3px 1.5fr 3px 1fr');
 
 export const userSequenceFormColumns: Writable<string> = writable('1fr 3px 2fr');
 

--- a/src/types/sequencing.ts
+++ b/src/types/sequencing.ts
@@ -144,6 +144,7 @@ export type UserSequence = {
   created_at: string;
   definition: string;
   id: number;
+  is_locked: boolean;
   name: string;
   owner: UserId;
   parcel_id: number;

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -3439,6 +3439,7 @@ const gql = {
         created_at
         definition
         id
+        is_locked
         name
         owner
         parcel_id

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1816,9 +1816,11 @@ const gql = {
         created_at
         definition
         id
+        is_locked
         name
         owner
         parcel_id
+        seq_json
         updated_at
         workspace_id
       }


### PR DESCRIPTION
resolves #1633 

This PR disables the ability to edit any part of a user sequence when the `Is Readonly` checkbox is marked.

To test:
1. Navigate to http://localhost:3000/dictionaries
2. Upload a command dictionary
3. Navigate to http://localhost:3000/parcels/new
4. Create a new parcel with the uploaded command dictionary
5. Navigate to http://localhost:3000/sequencing
6. Create a new workspace
7. Create a new sequence using the new workspace
8. Verify that toggling the `Is Readonly` checkbox on should disable everything but the checkbox




