### PR TITLE
External Event Timeline Filtering

### DIFF
--- a/e2e-tests/tests/timeline-view-editing.test.ts
+++ b/e2e-tests/tests/timeline-view-editing.test.ts
@@ -324,7 +324,6 @@ test.describe.serial('Timeline View Editing', () => {
     expect(newLayerCount - existingLayerCount).toEqual(1);
 
     // Expect the external event layer to include all external events
-    // TODO: create a schema + upload a source before this, but still I don't think all show by default?
   });
 
   test('Edit an external event layer', async () => {
@@ -340,9 +339,6 @@ test.describe.serial('Timeline View Editing', () => {
     // Expect that the modal is present
     const modal = externalEventLayerEditor.getByRole('dialog');
     expect(modal).toBeDefined();
-
-    // Expect that layer name is showing in the name input
-    // expect(modal.locator('input[name="layer-name"]')).toHaveValue('Events Layer');
 
     // Expect that the resulting types list is not empty
     const resultingTypesList = modal.locator('.resulting-types-list');
@@ -365,29 +361,7 @@ test.describe.serial('Timeline View Editing', () => {
     // Ensure that only one instance (ExampleEvent) is listed
     expect(await resultingTypesList.locator('.filter-type-result').count()).toEqual(1);
 
-    // Expect that attribute filters can be added
-    await modal.getByLabel('other-filters').getByRole('button', { name: 'Add Filter' }).click();
-    expect(await modal.getByLabel('other-filters').getByRole('listitem').count()).toBe(1);
-    await modal.getByLabel('other-filters').locator("select[aria-label='field']").selectOption('Attribute');
-    await modal.getByLabel('other-filters').getByText('Select Attribute').click();
-    await modal.getByLabel('other-filters').getByText('example2 (number)').click();
-    await modal.getByLabel('other-filters').locator("select[aria-label='operator']").selectOption('equals');
-    await modal.getByLabel('other-filters').getByRole('listitem').locator("input[name='filter-value']").fill('1');
-
     expect(await modal.getByText('1 instance')).toBeVisible();
-
-    // Clear all filters
-    await modal.getByLabel('other-filters').getByRole('button', { name: 'Remove filter' }).click();
-    await modal.getByLabel('dynamic-types').getByRole('button', { name: 'Remove filter' }).click();
-    await modal.getByRole('button', { name: 'Remove Types' }).click();
-    expect(await modal.getByText('0 instances')).toBeDefined();
-    expect(await resultingTypesList.locator('.filter-type-result').count()).toEqual(allExternalEventTypesCount);
-
-    // Re-add manual filter for future testing
-    await modal.locator("input[name='manual-types-filter-input']").click();
-    expect(await modal.locator('.manual-types-menu').first()).toBeDefined();
-    await modal.getByRole('menuitem', { name: 'ExampleEvent' }).click();
-    await page.keyboard.press('Escape');
 
     // Give the layer a new name
     await modal.locator('input[name="layer-name"]').fill('Foo');
@@ -396,7 +370,7 @@ test.describe.serial('Timeline View Editing', () => {
     await modal.getByRole('button', { name: 'close' }).click();
 
     // Expect name to match given name
-    expect(await externalEventLayerEditor.locator('.timeline-layer-editor').first()).toHaveText('  Foo 1        ');
+    expect(await externalEventLayerEditor.locator('.timeline-layer-editor').first()).toHaveText(/\s+Foo\s/);
   });
 
   test('Change external event layer settings', async () => {
@@ -412,7 +386,7 @@ test.describe.serial('Timeline View Editing', () => {
     expect(
       await page
         .locator('.timeline-row-wrapper', { hasText: rowName })
-        .locator('.collapse', { hasText: 'ExampleEvent' })
+        .locator('.collapse-root', { hasText: 'ExampleEvent' })
         .count(),
     ).toBe(1);
 

--- a/e2e-tests/tests/timeline-view-editing.test.ts
+++ b/e2e-tests/tests/timeline-view-editing.test.ts
@@ -1,6 +1,7 @@
 import test, { expect, type BrowserContext, type Page } from '@playwright/test';
 import { adjectives, animals, colors, uniqueNamesGenerator } from 'unique-names-generator';
 import { Constraints } from '../fixtures/Constraints.js';
+import { ExternalSources } from '../fixtures/ExternalSources.js';
 import { Models } from '../fixtures/Models.js';
 import { PanelNames, Plan } from '../fixtures/Plan.js';
 import { Plans } from '../fixtures/Plans.js';
@@ -9,6 +10,7 @@ import { SchedulingGoals } from '../fixtures/SchedulingGoals.js';
 
 let constraints: Constraints;
 let context: BrowserContext;
+let externalSources: ExternalSources;
 let models: Models;
 let page: Page;
 let plan: Plan;
@@ -21,6 +23,7 @@ test.beforeAll(async ({ baseURL, browser }) => {
   page = await context.newPage();
 
   models = new Models(page);
+  externalSources = new ExternalSources(page);
   plans = new Plans(page, models);
   constraints = new Constraints(page);
   schedulingConditions = new SchedulingConditions(page);
@@ -29,8 +32,20 @@ test.beforeAll(async ({ baseURL, browser }) => {
 
   await models.goto();
   await models.createModel(baseURL);
+  await externalSources.goto();
+  await externalSources.createTypes(
+    externalSources.exampleTypeSchema,
+    externalSources.exampleTypeSchemaExpectedSourceTypes,
+    externalSources.exampleTypeSchemaExpectedEventTypes,
+  );
+  await externalSources.uploadExternalSource();
   await plans.goto();
   await plans.createPlan();
+  await plan.goto();
+  await plan.showPanel(PanelNames.EXTERNAL_SOURCES);
+  await plan.externalSourceManageButton.click();
+  await page.getByText('No Derivation Groups Found').waitFor({ state: 'hidden' });
+  await externalSources.linkDerivationGroup(externalSources.exampleDerivationGroup, externalSources.exampleSourceType);
   await plan.goto();
 });
 
@@ -39,6 +54,12 @@ test.afterAll(async () => {
   await plans.deletePlan();
   await models.goto();
   await models.deleteModel();
+  await externalSources.goto();
+  await externalSources.deleteSource(externalSources.externalSourceFileName);
+  await externalSources.gotoTypeManager();
+  await externalSources.deleteDerivationGroup(externalSources.exampleDerivationGroup);
+  await externalSources.deleteExternalSourceType(externalSources.exampleSourceType);
+  await externalSources.deleteExternalEventType(externalSources.exampleEventType);
   await page.close();
   await context.close();
 });
@@ -143,7 +164,7 @@ test.describe.serial('Timeline View Editing', () => {
 
     // Expect that the resulting types list is not empty
     const resultingTypesList = modal.locator('.resulting-types-list');
-    const allActivityTypesCount = await resultingTypesList.locator('.activity-type-result').count();
+    const allActivityTypesCount = await resultingTypesList.locator('.filter-type-result').count();
     expect(allActivityTypesCount).toBeGreaterThan(0);
 
     // Expect that manually selecting types cause the types to appear in the resulting types list
@@ -160,7 +181,7 @@ test.describe.serial('Timeline View Editing', () => {
     await modal.getByLabel('dynamic-types').getByRole('button', { name: 'Add Filter' }).click();
     expect(await modal.getByLabel('dynamic-types').getByRole('listitem').count()).toBe(1);
     await modal.getByLabel('dynamic-types').getByRole('listitem').locator("input[name='filter-value']").fill('banana');
-    expect(await resultingTypesList.locator('.activity-type-result').count()).toEqual(11);
+    expect(await resultingTypesList.locator('.filter-type-result').count()).toEqual(11);
 
     // Expect that other filters can be added
     await modal.getByLabel('other-filters').getByRole('button', { name: 'Add Filter' }).click();
@@ -178,7 +199,7 @@ test.describe.serial('Timeline View Editing', () => {
     expect(await modal.getByText('1 instance')).toBeDefined();
 
     // Expect that type subfilters can be added
-    const activityResult = resultingTypesList.getByRole('listitem', { name: 'activity-type-result-PickBanana' });
+    const activityResult = resultingTypesList.getByRole('listitem', { name: 'filter-type-result-PickBanana' });
     await activityResult.getByRole('button', { name: 'Add Filter' }).click();
     expect(await activityResult.getByRole('listitem').count()).toBe(1);
     // Select name field
@@ -200,14 +221,14 @@ test.describe.serial('Timeline View Editing', () => {
 
     // Expect that dynamic types can be removed
     await modal.getByLabel('dynamic-types').getByRole('button', { name: 'Remove filter' }).click();
-    expect(await resultingTypesList.locator('.activity-type-result').count()).toEqual(2);
+    expect(await resultingTypesList.locator('.filter-type-result').count()).toEqual(2);
 
     // Expect that manual types can be cleared
     await modal.locator("input[name='manual-types-filter-input']").click();
     await modal.getByRole('menuitem', { name: 'ChangeProducer' }).click();
     await page.keyboard.press('Escape');
     await modal.getByRole('button', { name: 'Remove Types' }).click();
-    expect(await resultingTypesList.locator('.activity-type-result').count()).toEqual(allActivityTypesCount);
+    expect(await resultingTypesList.locator('.filter-type-result').count()).toEqual(allActivityTypesCount);
 
     // Give the layer a new name
     await modal.locator('input[name="layer-name"]').fill('Foo');
@@ -291,6 +312,117 @@ test.describe.serial('Timeline View Editing', () => {
     // Delete a resource layer
     await resourceLayerEditor.locator('.timeline-layer-editor').first().getByRole('button', { name: 'Delete' }).click();
     expect(await resourceLayerEditor.locator('.timeline-layer-editor').count()).toBe(1);
+  });
+
+  test('Add an external event layer', async () => {
+    const externalEventLayerEditor = page.getByLabel('Event Layer-editor');
+    const existingLayerCount = await externalEventLayerEditor.locator('.timeline-layer-editor').count();
+
+    // Add an external event layer
+    await externalEventLayerEditor.getByRole('button', { name: 'New Event Layer' }).click();
+    const newLayerCount = await externalEventLayerEditor.locator('.timeline-layer-editor').count();
+    expect(newLayerCount - existingLayerCount).toEqual(1);
+
+    // Expect the external event layer to include all external events
+    // TODO: create a schema + upload a source before this, but still I don't think all show by default?
+  });
+
+  test('Edit an external event layer', async () => {
+    const externalEventLayerEditor = page.getByLabel('Event Layer-editor');
+
+    // Open the external event filter builder
+    await externalEventLayerEditor
+      .locator('.timeline-layer-editor')
+      .first()
+      .getByLabel('Toggle external event filter builder modal')
+      .click();
+
+    // Expect that the modal is present
+    const modal = externalEventLayerEditor.getByRole('dialog');
+    expect(modal).toBeDefined();
+
+    // Expect that layer name is showing in the name input
+    // expect(modal.locator('input[name="layer-name"]')).toHaveValue('Events Layer');
+
+    // Expect that the resulting types list is not empty
+    const resultingTypesList = modal.locator('.resulting-types-list');
+    const allExternalEventTypesCount = await resultingTypesList.locator('.filter-type-result').count();
+    expect(allExternalEventTypesCount).toBeGreaterThan(0);
+
+    // Expect that manually selecting types cause the types to appear in the resulting types list
+    await modal.locator("input[name='manual-types-filter-input']").click();
+    expect(await modal.locator('.manual-types-menu').first()).toBeDefined();
+    await modal.getByRole('menuitem', { name: 'ExampleEvent' }).click();
+    await page.keyboard.press('Escape');
+
+    expect(await resultingTypesList.getByText('ExampleEvent')).toBeDefined();
+
+    // Expect that dynamic types can be added
+    await modal.getByLabel('dynamic-types').getByRole('button', { name: 'Add Filter' }).click();
+    expect(await modal.getByLabel('dynamic-types').getByRole('listitem').count()).toBe(1);
+    // Fill filter value input
+    await modal.getByLabel('dynamic-types').getByRole('listitem').locator("input[name='filter-value']").fill('Example');
+    // Ensure that only one instance (ExampleEvent) is listed
+    expect(await resultingTypesList.locator('.filter-type-result').count()).toEqual(1);
+
+    // Expect that attribute filters can be added
+    await modal.getByLabel('other-filters').getByRole('button', { name: 'Add Filter' }).click();
+    expect(await modal.getByLabel('other-filters').getByRole('listitem').count()).toBe(1);
+    await modal.getByLabel('other-filters').locator("select[aria-label='field']").selectOption('Attribute');
+    await modal.getByLabel('other-filters').getByText('Select Attribute').click();
+    await modal.getByLabel('other-filters').getByText('example2 (number)').click();
+    await modal.getByLabel('other-filters').locator("select[aria-label='operator']").selectOption('equals');
+    await modal.getByLabel('other-filters').getByRole('listitem').locator("input[name='filter-value']").fill('1');
+
+    expect(await modal.getByText('1 instance')).toBeVisible();
+
+    // Clear all filters
+    await modal.getByLabel('other-filters').getByRole('button', { name: 'Remove filter' }).click();
+    await modal.getByLabel('dynamic-types').getByRole('button', { name: 'Remove filter' }).click();
+    await modal.getByRole('button', { name: 'Remove Types' }).click();
+    expect(await modal.getByText('0 instances')).toBeDefined();
+    expect(await resultingTypesList.locator('.filter-type-result').count()).toEqual(allExternalEventTypesCount);
+
+    // Re-add manual filter for future testing
+    await modal.locator("input[name='manual-types-filter-input']").click();
+    expect(await modal.locator('.manual-types-menu').first()).toBeDefined();
+    await modal.getByRole('menuitem', { name: 'ExampleEvent' }).click();
+    await page.keyboard.press('Escape');
+
+    // Give the layer a new name
+    await modal.locator('input[name="layer-name"]').fill('Foo');
+
+    // Close the modal
+    await modal.getByRole('button', { name: 'close' }).click();
+
+    // Expect name to match given name
+    expect(await externalEventLayerEditor.locator('.timeline-layer-editor').first()).toHaveText('  Foo 1        ');
+  });
+
+  test('Change external event layer settings', async () => {
+    const externalEventLayerEditor = await page.getByLabel('Event Layer-editor');
+
+    // Expect to not see an external event tree group in this row
+    expect(await page.locator('.timeline-row-wrapper', { hasText: rowName }).locator('.event-tree').count()).toBe(0);
+
+    // Switch to grouped display mode
+    await page.locator('button', { hasText: 'Grouped' }).click();
+
+    // Expect to see an external event tree group for this event in this row
+    expect(
+      await page
+        .locator('.timeline-row-wrapper', { hasText: rowName })
+        .locator('.collapse', { hasText: 'ExampleEvent' })
+        .count(),
+    ).toBe(1);
+
+    // Delete an external event layer
+    await externalEventLayerEditor
+      .locator('.timeline-layer-editor')
+      .first()
+      .getByRole('button', { name: 'Delete' })
+      .click();
+    expect(await externalEventLayerEditor.locator('.timeline-layer-editor').count()).toBe(0);
   });
 
   test('Open and close the row header context menu', async () => {

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -4,7 +4,6 @@
   import type { ScaleTime } from 'd3-scale';
   import { select, type Selection } from 'd3-selection';
   import { zoom as d3Zoom, zoomIdentity, type D3ZoomEvent, type ZoomBehavior, type ZoomTransform } from 'd3-zoom';
-  import { groupBy } from 'lodash-es';
   import { createEventDispatcher } from 'svelte';
   import FilterWithXIcon from '../../assets/filter-with-x.svg?component';
   import { ViewDefaultDiscreteOptions } from '../../constants/view';
@@ -65,7 +64,7 @@
   import { getAllSpansForActivityDirective } from '../../utilities/activities';
   import effects from '../../utilities/effects';
   import { getExternalEventRowId } from '../../utilities/externalEvents';
-  import { classNames, unique } from '../../utilities/generic';
+  import { classNames } from '../../utilities/generic';
   import { showConfirmActivityCreationModal } from '../../utilities/modal';
   import { sampleProfiles } from '../../utilities/resources';
   import { getSimulationStatus } from '../../utilities/simulation';
@@ -74,6 +73,7 @@
   import {
     TimelineInteractionMode,
     applyActivityLayerFilter,
+    applyExternalEventLayerFilter,
     directiveInView,
     externalEventInView,
     generateDiscreteTreeUtil,
@@ -367,12 +367,13 @@
 
   // helper for hasExternalEventsLayer; counts how many external event types are associated with this row
   // (if all layers have 0 event types, we don't want to allocate any canvas space in the row for the layer)
-  $: associatedEventTypes = externalEventLayers
-    .map(layer => (layer.filter.externalEvent ? layer.filter.externalEvent.event_types.length : 0))
-    .reduce((currentSum, newValue) => currentSum + newValue, 0);
+  // TODO: Update for new filtering
+  // $: associatedEventTypes = externalEventLayers
+  //   .map(layer => (layer.filter.externalEvent ? layer.filter.externalEvent.event_types.length : 0))
+  //   .reduce((currentSum, newValue) => currentSum + newValue, 0);
 
   // only consider a layer to be present if it is defined AND it actually has types/values selected.
-  $: hasExternalEventsLayer = externalEventLayers.length > 0 && associatedEventTypes > 0;
+  $: hasExternalEventsLayer = externalEventLayers.length > 0; // && associatedEventTypes > 0;
   $: hasResourceLayer = lineLayers.length + xRangeLayers.length > 0;
 
   $: if (discreteTreeExpansionMap === undefined) {
@@ -433,15 +434,16 @@
 
   $: if ((activityLayers && spansMap && activityDirectives) || hasExternalEventsLayer) {
     discreteTree = [];
-    let updatedIdToColorMaps: {
-      directives: Record<ActivityDirectiveId, string>;
-      external_events: Record<ExternalEventId, string>;
-      spans: Record<SpanId, string>;
-    } = {
-      directives: { ...idToColorMaps.directives },
-      external_events: { ...idToColorMaps.external_events },
-      spans: { ...idToColorMaps.spans },
-    };
+    // TODO: What was this used for previously?
+    // let updatedIdToColorMaps: {
+    //   directives: Record<ActivityDirectiveId, string>;
+    //   external_events: Record<ExternalEventId, string>;
+    //   spans: Record<SpanId, string>;
+    // } = {
+    //   directives: { ...idToColorMaps.directives },
+    //   external_events: { ...idToColorMaps.external_events },
+    //   spans: { ...idToColorMaps.spans },
+    // };
     if (activityLayers && spansMap && activityDirectives) {
       let spansList = Object.values(spansMap);
       if (activityLayers.length) {
@@ -511,50 +513,44 @@
       } else {
         hasActivityLayer = false;
       }
+    }
 
-      if (hasExternalEventsLayer) {
-        let externalEventsFilteredByDG = [];
-        filteredExternalEvents = [];
+    if (hasExternalEventsLayer) {
+      filteredExternalEvents = [];
 
-        let filteredDerivationGroups = $planDerivationGroupLinks
-          .filter(
-            link => link.plan_id === plan?.id && !($derivationGroupVisibilityMap[link.derivation_group_name] ?? true),
-          )
-          .map(link => link.derivation_group_name);
+      // Filter what LINKED Derivation Groups are to be shown
+      let filteredDerivationGroups = $planDerivationGroupLinks
+        .filter(
+          link => link.plan_id === plan?.id && !($derivationGroupVisibilityMap[link.derivation_group_name] ?? true),
+        )
+        .map(link => link.derivation_group_name);
 
-        // Apply filter for hiding derivation groups
-        externalEventsFilteredByDG = externalEvents.filter(ee => {
-          let derivationGroup =
-            $externalSources.find(
-              externalSource =>
-                externalSource.derivation_group_name === ee.pkey.derivation_group_name &&
-                externalSource.key === ee.pkey.source_key,
-            )?.derivation_group_name ?? undefined;
-          // the statement below says return true (keep) if the plan is not null and if the filter for this plan does not include this derivation group
-          return plan && derivationGroup ? !filteredDerivationGroups.includes(derivationGroup) : false;
-        });
-        // Filter by external event type
-        const externalEventsByType = groupBy(externalEventsFilteredByDG, 'pkey.event_type_name');
-        externalEventLayers.forEach(layer => {
-          if (layer.filter && layer.filter.externalEvent !== undefined) {
-            const event_types = layer.filter.externalEvent.event_types || [];
-            event_types.forEach(type => {
-              const matchingEvents = externalEventsByType[type];
-              if (matchingEvents) {
-                matchingEvents.forEach(
-                  event =>
-                    (updatedIdToColorMaps.external_events[getExternalEventRowId(event.pkey)] =
-                      layer.externalEventColor),
-                );
-                filteredExternalEvents = filteredExternalEvents.concat(unique(matchingEvents));
-              }
-            });
-          }
-        });
-        filteredExternalEvents.sort((a, b) => (a.start_ms < b.start_ms ? -1 : 1));
+      // Apply filter for hiding derivation groups
+      let externalEventsFilteredByDG = externalEvents.filter(ee => {
+        let derivationGroup =
+          $externalSources.find(
+            externalSource =>
+              externalSource.derivation_group_name === ee.pkey.derivation_group_name &&
+              externalSource.key === ee.pkey.source_key,
+          )?.derivation_group_name ?? undefined;
+        // the statement below says return true (keep) if the plan is not null and if the filter for this plan does not include this derivation group
+        return plan && derivationGroup ? !filteredDerivationGroups.includes(derivationGroup) : false;
+      });
 
-        timeFilteredExternalEvents = filteredExternalEvents; // if not actively filtering by time
-      }
+      externalEventLayers.forEach(layer => {
+        if (layer.filter) {
+          const { externalEvents: matchingExternalEvents } = applyExternalEventLayerFilter(
+            layer.filter.externalEvent,
+            externalEventsFilteredByDG,
+          );
+          matchingExternalEvents.forEach(externalEvent => {
+            idToColorMaps.external_events[getExternalEventRowId(externalEvent.pkey)] = layer.externalEventColor;
+          });
+          filteredExternalEvents = [...filteredExternalEvents, ...matchingExternalEvents];
+          filteredExternalEvents.sort((a, b) => (a.start_ms < b.start_ms ? -1 : 1));
+          timeFilteredExternalEvents = filteredExternalEvents; // if not actively filtering by time
+        }
+      });
     }
   }
 

--- a/src/components/timeline/form/TimelineEditor/DynamicFilter.svelte
+++ b/src/components/timeline/form/TimelineEditor/DynamicFilter.svelte
@@ -4,11 +4,14 @@
   import ChevronDownIcon from '@nasa-jpl/stellar/icons/chevron_down.svg?component';
   import CloseIcon from '@nasa-jpl/stellar/icons/close.svg?component';
   import { createEventDispatcher } from 'svelte';
-  import { ActivityFilterField, FilterOperator } from '../../../../enums/filter';
+  import { ActivityFilterField, ExternalEventFilterField, FilterOperator } from '../../../../enums/filter';
   import type { SelectedDropdownOptionValue } from '../../../../types/dropdown';
   import type { DynamicFilter, DynamicFilterDataType } from '../../../../types/filter';
   import type { TagsChangeEvent } from '../../../../types/tags';
-  import { type ActivityLayerFilterSubfieldSchema } from '../../../../types/timeline';
+  import {
+    type ActivityLayerFilterSubfieldSchema,
+    type ExternalEventLayerFilterSubfieldSchema,
+  } from '../../../../types/timeline';
   import { getTarget } from '../../../../utilities/generic';
   import { tooltip } from '../../../../utilities/tooltip';
   import Input from '../../../form/Input.svelte';
@@ -23,6 +26,7 @@
 
   export let filter: DynamicFilter<any>;
   export let schema: Partial<Record<keyof typeof ActivityFilterField, Partial<OperatorSchema>>> & {
+    Attribute?: { subfields: ExternalEventLayerFilterSubfieldSchema[] };
     Parameter?: { subfields: ActivityLayerFilterSubfieldSchema[] };
   } = {};
   export let verb: string = 'Where';
@@ -33,11 +37,16 @@
   }>();
 
   let dirtyFilter: DynamicFilter<any> = structuredClone(filter);
-  let currentField: keyof typeof ActivityFilterField = dirtyFilter.field as keyof typeof ActivityFilterField;
+  let currentField: keyof typeof ActivityFilterField | ExternalEventFilterField = dirtyFilter.field as
+    | keyof typeof ActivityFilterField
+    | ExternalEventFilterField;
   let currentOperator: keyof typeof FilterOperator | null = dirtyFilter.operator;
-  let subfields: ActivityLayerFilterSubfieldSchema[] | undefined = undefined;
+  let subfields: Array<ActivityLayerFilterSubfieldSchema | ExternalEventLayerFilterSubfieldSchema> | undefined =
+    undefined;
   let currentSubfieldLabel =
-    dirtyFilter.field === 'Parameter' ? `${dirtyFilter.subfield?.name} (${dirtyFilter.subfield?.type})` : '';
+    dirtyFilter.field === 'Parameter' || dirtyFilter.field === 'Attribute'
+      ? `${dirtyFilter.subfield?.name} (${dirtyFilter.subfield?.type})`
+      : '';
   let currentType: DynamicFilterDataType = 'string';
   let currentValue = dirtyFilter.value;
   let currentValueAsStringOrNumber: string | number = '';
@@ -46,9 +55,9 @@
   let currentValuePossibilities: Array<any> = [];
 
   $: dirtyFilter = structuredClone(filter);
-  $: subfields = schema.Parameter?.subfields;
+  $: subfields = 'Parameter' in schema ? schema.Parameter?.subfields : schema.Attribute?.subfields;
 
-  $: if (currentField !== 'Parameter') {
+  $: if (currentField !== 'Parameter' && currentField !== 'Attribute') {
     currentSubfieldLabel = '';
     currentUnit = '';
     const schemaField = schema[currentField];
@@ -68,7 +77,11 @@
     }
   }
 
-  $: if (currentField === 'Parameter' && currentSubfieldLabel !== undefined && subfields) {
+  $: if (
+    (currentField === 'Attribute' || currentField === 'Parameter') &&
+    currentSubfieldLabel !== undefined &&
+    subfields
+  ) {
     const matchingSubfield = subfields.find(subfield => subfield.label === currentSubfieldLabel);
     if (matchingSubfield) {
       // Map subfield type to filter type
@@ -168,6 +181,10 @@
     return s as keyof typeof ActivityFilterField;
   }
 
+  function asExternalEventFilterField(s: string): keyof typeof ExternalEventFilterField {
+    return s as keyof typeof ExternalEventFilterField;
+  }
+
   function getDefaultCurrentValue() {
     if (currentOperator === 'is_within' || currentOperator === 'is_not_within') {
       return [];
@@ -182,15 +199,20 @@
   {/if}
   <select aria-label="field" class="st-select" on:change={onFieldChange} value={currentField}>
     {#each Object.keys(schema) as key}
-      <option value={key}>{ActivityFilterField[asActivityLayerFilterField(key)]}</option>
+      {#if key in ActivityFilterField}
+        <option value={key}>{ActivityFilterField[asActivityLayerFilterField(key)]}</option>
+      {:else}
+        <option value={key}>{ExternalEventFilterField[asExternalEventFilterField(key)]}</option>
+      {/if}
     {/each}
   </select>
-  {#if currentField === 'Parameter' && subfields}
+  {#if (currentField === 'Parameter' || currentField === 'Attribute') && subfields}
+    {@const parameterOrAttribute = currentField === 'Parameter' ? 'Parameter' : 'Attribute'}
     <SearchableDropdown
       className="dynamic-filter-searchable-dropdown-hide-overflow"
-      placeholder="Select Parameter"
-      selectTooltip="Select Parameter"
-      searchPlaceholder="Filter parameters"
+      placeholder={`Select ${parameterOrAttribute}`}
+      selectTooltip={`Select ${parameterOrAttribute}`}
+      searchPlaceholder={`Filter ${parameterOrAttribute}`}
       on:change={onSelectParameter}
       selectedOptionValues={[currentSubfieldLabel]}
       options={subfields.map(subfield => ({ display: subfield.label, value: subfield.label }))}

--- a/src/components/timeline/form/TimelineEditor/ExternalEventFilterBuilder.svelte
+++ b/src/components/timeline/form/TimelineEditor/ExternalEventFilterBuilder.svelte
@@ -395,7 +395,7 @@
   }
 </script>
 
-<div bind:this={rootRef} class="w-100" style:display="grid">
+<div bind:this={rootRef} class="w-full" style:display="grid">
   <slot name="trigger" />
   {#if shown}
     <Draggable
@@ -446,7 +446,7 @@
                       autocomplete="off"
                       bind:this={manualInputRef}
                       name="manual-types-filter-input"
-                      class="st-input w-100 manual-types-filter-input"
+                      class="st-input w-full manual-types-filter-input"
                       placeholder="Select types"
                       bind:value={manualInputValue}
                       on:click={() => {
@@ -597,7 +597,7 @@
             </div>
             <Input>
               <div class="search-icon" slot="left"><SearchIcon /></div>
-              <input class="st-input w-100" placeholder="Filter types" bind:value={resultingTypesInputValue} />
+              <input class="st-input w-full" placeholder="Filter types" bind:value={resultingTypesInputValue} />
             </Input>
             <div class="resulting-types-list">
               {#each filteredMatchingTypes as type}

--- a/src/components/timeline/form/TimelineEditor/ExternalEventFilterBuilder.svelte
+++ b/src/components/timeline/form/TimelineEditor/ExternalEventFilterBuilder.svelte
@@ -3,21 +3,18 @@
 <script lang="ts">
   import CloseIcon from '@nasa-jpl/stellar/icons/close.svg?component';
   import SearchIcon from '@nasa-jpl/stellar/icons/search.svg?component';
+  import TagIcon from '@nasa-jpl/stellar/icons/tag.svg?component';
   import { createEventDispatcher } from 'svelte';
+  import ExternalEventIcon from '../../../../assets/external-event-box-with-arrow.svg?component';
   import FilterWithPlusIcon from '../../../../assets/filter-with-plus.svg?component';
-  import DirectiveIcon from '../../../../assets/timeline-directive.svg?component';
-  import SpanIcon from '../../../../assets/timeline-span.svg?component';
-  import { activityArgumentDefaultsMap, activityDirectivesMap } from '../../../../stores/activities';
-  import { planModelActivityTypes, subsystemTags } from '../../../../stores/plan';
-  import { spans, spanUtilityMaps } from '../../../../stores/simulation';
-  import { tags } from '../../../../stores/tags';
-  import type { ValueSchemaVariant } from '../../../../types/schema';
-  import type { ActivityLayerFilter, ActivityLayerFilterSubfieldSchema } from '../../../../types/timeline';
+  import { externalEventsMap, externalEventTypes } from '../../../../stores/external-event';
+  import type { ExternalEventType } from '../../../../types/external-event';
+  import type { ExternalEventLayerFilter, ExternalEventLayerFilterSubfieldSchema } from '../../../../types/timeline';
   import { compare, getTarget, lowercase } from '../../../../utilities/generic';
   import { pluralize } from '../../../../utilities/text';
   import {
-    applyActivityLayerFilter,
-    getMatchingTypesForActivityLayerFilter,
+    applyExternalEventLayerFilter,
+    getMatchingTypesForExternalEventLayerFilter,
     getNextThingID,
   } from '../../../../utilities/timeline';
   import { tooltip } from '../../../../utilities/tooltip';
@@ -27,17 +24,18 @@
   import MenuItem from '../../../menus/MenuItem.svelte';
   import CssGrid from '../../../ui/CssGrid.svelte';
   import CssGridGutter from '../../../ui/CssGridGutter.svelte';
-  import ActivityTypeResult from './FilterTypeResult.svelte';
   import Draggable from './Draggable.svelte';
   import DynamicFilter from './DynamicFilter.svelte';
+  import FilterTypeResult from './FilterTypeResult.svelte';
 
-  export let filter: ActivityLayerFilter | undefined = undefined;
+  export let filter: ExternalEventLayerFilter | undefined;
   export const filterWidth = 1000;
   export const filterHeight = 500;
   export let layerName: string = '';
 
-  let parameterSubfields: ActivityLayerFilterSubfieldSchema[] = [];
-  let dirtyFilter: ActivityLayerFilter = {
+  let parameterSubfields: ExternalEventLayerFilterSubfieldSchema[] = [];
+  // TODO: Match this type to the activities one?
+  let dirtyFilter: ExternalEventLayerFilter = {
     dynamic_type_filters: [],
     other_filters: [],
     static_types: [],
@@ -55,14 +53,9 @@
   let instanceCount: number = 0;
 
   const dispatch = createEventDispatcher<{
-    filterChange: { filter: ActivityLayerFilter };
+    filterChange: { filter: ExternalEventLayerFilter };
     rename: { name: string };
-    visibilityChange: { isShown: boolean };
   }>();
-
-  export function setActiveFilter(newFilter: ActivityLayerFilter) {
-    dirtyFilter = newFilter;
-  }
 
   export function toggle() {
     if (shown) {
@@ -70,17 +63,14 @@
     } else {
       show();
     }
-    dispatch('visibilityChange', { isShown: shown });
   }
 
   export function show() {
     shown = true;
-    dispatch('visibilityChange', { isShown: shown });
   }
 
   export function hide() {
     shown = false;
-    dispatch('visibilityChange', { isShown: shown });
   }
 
   function onManualTypeToggled(name: string) {
@@ -97,7 +87,7 @@
   }
 
   function onAddAllManualTypes() {
-    dirtyFilter = { ...dirtyFilter, static_types: filteredActivityTypes.map(t => t.name) };
+    dirtyFilter = { ...dirtyFilter, static_types: filteredExternalEventTypes.map(t => t.name) };
     dispatch('filterChange', { filter: dirtyFilter });
   }
 
@@ -133,7 +123,7 @@
   }
 
   function onDynamicFilterRemove(list: 'dynamic_type_filters' | 'other_filters', id: number) {
-    const currentFilters: ActivityLayerFilter['dynamic_type_filters'] | ActivityLayerFilter['other_filters'] =
+    const currentFilters: ExternalEventLayerFilter['dynamic_type_filters'] | ExternalEventLayerFilter['other_filters'] =
       Array.isArray(dirtyFilter[list]) ? dirtyFilter[list] : [];
     dirtyFilter = {
       ...dirtyFilter,
@@ -201,33 +191,15 @@
     dirtyFilter = structuredClone(filter);
   }
 
-  $: activityDirectives = Object.values($activityDirectivesMap || {});
-  $: appliedFilter = applyActivityLayerFilter(
-    dirtyFilter,
-    activityDirectives,
-    $spans || [],
-    $planModelActivityTypes,
-    $activityArgumentDefaultsMap,
-  );
+  $: externalEvents = Object.values($externalEventsMap || {});
+  $: appliedFilter = applyExternalEventLayerFilter(dirtyFilter, externalEvents);
 
+  // TODO: This was doing a lot before and I don't think it needs to be
   $: if (appliedFilter) {
-    const seenSpans: Record<number, boolean> = {};
-    let count = appliedFilter.directives.length;
-    appliedFilter.directives.forEach(directive => {
-      const matchingSpanId = $spanUtilityMaps.directiveIdToSpanIdMap[directive.id];
-      if (typeof matchingSpanId === 'number') {
-        seenSpans[matchingSpanId] = true;
-      }
-    });
-    appliedFilter.spans.forEach(span => {
-      if (!seenSpans[span.span_id]) {
-        count++;
-      }
-    });
-    instanceCount = count;
+    instanceCount = appliedFilter.externalEvents.length;
   }
 
-  $: matchingTypes = getMatchingTypesForActivityLayerFilter(dirtyFilter, $planModelActivityTypes);
+  $: matchingTypes = getMatchingTypesForExternalEventLayerFilter(dirtyFilter, $externalEventTypes);
   $: filteredMatchingTypes = matchingTypes.filter(type => {
     if (!resultingTypesInputValue) {
       return true;
@@ -237,43 +209,54 @@
   });
 
   $: {
-    const allParameterTypes = (matchingTypes.length ? matchingTypes : $planModelActivityTypes).reduce(
-      (acc: Record<string, ActivityLayerFilterSubfieldSchema>, activityType) => {
-        Object.entries(activityType.parameters).forEach(([parameterName, parameter]) => {
-          const parameterType = parameter.schema.type;
-          // TODO support series and struct?
-          if (parameterType === 'series' || parameterType === 'struct') {
-            return;
-          }
-          const key = `${parameterName} (${parameterType})`;
-          const matchingName = !!acc[key];
-          const matchingEntry = matchingName && acc[key].type === parameterType;
-          const isVariant = parameterType === 'variant';
-          let values = null;
-          if (matchingEntry) {
-            acc[key].activityTypes.push(activityType.name);
-            if (isVariant) {
-              // If we have a matching variant, add unique variants to the list
-              const variantValues = (parameter.schema as ValueSchemaVariant).variants.map(variant => variant.key);
-              values = Array.from(new Set([...variantValues, ...(acc[key].values || [])]));
-              acc[key].values = values;
+    const allParameterTypes = (matchingTypes.length ? matchingTypes : $externalEventTypes).reduce(
+      (acc: Record<string, ExternalEventLayerFilterSubfieldSchema>, externalEventType) => {
+        Object.entries(externalEventType.attribute_schema.properties).forEach(
+          ([parameterName, parameterDefinition]) => {
+            const casted: any = parameterDefinition as any; // it has to be casted _somehow_, because it comes in necessarily as unknown but at most it is an any
+            let parameterType = casted.type;
+            // TODO support series and struct?
+            if (parameterType === 'series' || parameterType === 'struct') {
+              return;
             }
-          }
-          if (!matchingEntry) {
-            const values = isVariant
-              ? (parameter.schema as ValueSchemaVariant).variants.map(variant => variant.key)
-              : null;
-            const unit = parameter.schema.metadata?.unit?.value ?? null;
-            acc[key] = {
-              activityTypes: [activityType.name],
-              name: parameterName,
-              type: parameterType,
-              ...(values ? { values } : null),
-              ...(unit ? { unit } : null),
-              label: `${parameterName} (${parameterType})`,
-            };
-          }
-        });
+            if (parameterType === undefined && !!casted.enum) {
+              parameterType = 'enum';
+            }
+            const key = `${parameterName} (${parameterType})`;
+            const matchingName = !!acc[key];
+            const matchingEntry = matchingName && acc[key].type === parameterType;
+            if (matchingEntry) {
+              acc[key].externalEventTypes.push(externalEventType.name);
+              switch (parameterType) {
+                case 'enum':
+                  handleEnumAttribute(acc, parameterName, parameterDefinition, externalEventType);
+                  break;
+                case 'object':
+                  recurseObjectAttributeProperties(acc, casted.properties, parameterName, externalEventType);
+                  break;
+                default:
+                  acc[key].externalEventTypes.push(externalEventType.name);
+              }
+            }
+            if (!matchingEntry) {
+              switch (parameterType) {
+                case 'enum':
+                  handleEnumAttribute(acc, parameterName, parameterDefinition, externalEventType);
+                  break;
+                case 'object':
+                  recurseObjectAttributeProperties(acc, casted.properties, parameterName, externalEventType);
+                  break;
+                default:
+                  acc[key] = {
+                    externalEventTypes: [externalEventType.name],
+                    label: `${parameterName} (${parameterType})`,
+                    name: parameterName,
+                    type: parameterType,
+                  };
+              }
+            }
+          },
+        );
         return acc;
       },
       {},
@@ -282,7 +265,7 @@
     parameterSubfields = Object.values(allParameterTypes).sort((a, b) => compare(a.label, b.label));
   }
 
-  $: filteredActivityTypes = $planModelActivityTypes.filter(type => {
+  $: filteredExternalEventTypes = $externalEventTypes.filter(type => {
     if (!manualInputValue) {
       return true;
     }
@@ -308,6 +291,67 @@
     } else {
       resultingTypesMessage = '';
     }
+  }
+
+  function handleEnumAttribute(
+    acc: Record<string, ExternalEventLayerFilterSubfieldSchema>,
+    parameterName: string,
+    variants: any,
+    externalEventType: ExternalEventType,
+  ) {
+    const matchingName = !!acc[parameterName];
+    const matchingEntry = matchingName && acc[parameterName].type === 'variant';
+    if (matchingEntry) {
+      // handle enums too?
+      acc[parameterName].externalEventTypes.push(externalEventType.name);
+    }
+    if (!matchingEntry) {
+      acc[parameterName] = {
+        externalEventTypes: [externalEventType.name],
+        label: parameterName,
+        name: parameterName,
+        type: 'variant',
+        values: variants.enum,
+      };
+    }
+  }
+
+  function recurseObjectAttributeProperties(
+    acc: Record<string, ExternalEventLayerFilterSubfieldSchema>,
+    properties: any,
+    parameterName: string,
+    externalEventType: ExternalEventType,
+  ) {
+    let props: [string, any][] = Object.entries(properties);
+    props.forEach(prop => {
+      if (prop[1].properties) {
+        recurseObjectAttributeProperties(acc, prop[1].properties, `${parameterName} -> ${prop[0]}`, externalEventType);
+      } else {
+        const key = `${parameterName} -> ${prop[0]}`;
+        let type = prop[1].type;
+        if (type === undefined && !!prop[1].enum) {
+          type = 'enum';
+        }
+        const matchingName = !!acc[key];
+        const matchingEntry = matchingName && acc[key].type === type;
+        if (matchingEntry) {
+          // handle enums too?
+          acc[key].externalEventTypes.push(externalEventType.name);
+        }
+        if (!matchingEntry) {
+          if (type !== 'enum') {
+            acc[key] = {
+              externalEventTypes: [externalEventType.name],
+              label: `${key} (${type})`,
+              name: key,
+              type: type,
+            };
+          } else {
+            handleEnumAttribute(acc, `${parameterName} -> ${prop[0]}`, prop[1], externalEventType);
+          }
+        }
+      }
+    });
   }
 
   function onLayerNameChange(event: Event) {
@@ -351,17 +395,17 @@
   }
 </script>
 
-<div bind:this={rootRef} class="w-full" style:display="grid">
+<div bind:this={rootRef} class="w-100" style:display="grid">
   <slot name="trigger" />
   {#if shown}
     <Draggable
-      className="st-menu activity-filter-builder"
+      className="st-menu external-event-filter-builder"
       initialWidth={filterWidth}
       initialHeight={filterHeight}
       dragOptions={{ defaultPosition: getDefaultPosition() }}
     >
       <div slot="handle">
-        <MenuHeader title="Activity Filtering">
+        <MenuHeader title="External Event Filtering">
           <input
             slot="left"
             value={layerName}
@@ -379,7 +423,7 @@
         </MenuHeader>
       </div>
       <div class="body">
-        <CssGrid columns="0.7fr 3px 0.3fr" columnMinSizes={{ 0: 500, 1: 3, 2: 300 }} class="activity-filter-grid">
+        <CssGrid columns="0.7fr 3px 0.3fr" columnMinSizes={{ 0: 500, 1: 3, 2: 300 }} class="external-event-filter-grid">
           <div class="filters">
             <div class="filter-section" aria-label="manual-types">
               <div class="filter-section-header st-typography-medium">
@@ -402,7 +446,7 @@
                       autocomplete="off"
                       bind:this={manualInputRef}
                       name="manual-types-filter-input"
-                      class="st-input manual-types-filter-input w-full"
+                      class="st-input w-100 manual-types-filter-input"
                       placeholder="Select types"
                       bind:value={manualInputValue}
                       on:click={() => {
@@ -424,13 +468,13 @@
                     on:hide={() => (manualInputOpen = false)}
                   >
                     <div class="manual-types-menu">
-                      {#if filteredActivityTypes.length > 0}
+                      {#if filteredExternalEventTypes.length > 0}
                         <MenuItem on:click={() => onAddAllManualTypes()}>
                           <div class="st-typography-bold manual-types-add-all">
-                            Add {filteredActivityTypes.length !== $planModelActivityTypes.length ? 'Matching' : 'All'} +
+                            Add {filteredExternalEventTypes.length !== $externalEventTypes.length ? 'Matching' : 'All'} +
                           </div>
                         </MenuItem>
-                        {#each filteredActivityTypes as type}
+                        {#each filteredExternalEventTypes as type}
                           <MenuItem on:click={() => onManualTypeToggled(type.name)}>
                             <input
                               type="checkbox"
@@ -442,7 +486,7 @@
                           </MenuItem>
                         {/each}
                       {:else}
-                        <MenuItem disabled>No activities matching your filter</MenuItem>
+                        <MenuItem disabled>No external events matching your filter</MenuItem>
                       {/if}
                     </div>
                   </Menu>
@@ -450,7 +494,8 @@
                 {#if dirtyFilter.static_types?.length}
                   <div class="manual-types-results">
                     {#each dirtyFilter.static_types as name}
-                      <ActivityTypeResult {name} on:remove={() => onManualTypeToggled(name)} />
+                      <!-- TODO: Implement for EE -->
+                      <FilterTypeResult {name} activityOrEvent="event" on:remove={() => onManualTypeToggled(name)} />
                     {/each}
                   </div>
                 {/if}
@@ -481,14 +526,10 @@
                         on:change={event => onDynamicFilterChange('dynamic_type_filters', event)}
                         verb={i === 0 ? 'Where' : 'and'}
                         schema={{
-                          Subsystem: {
-                            does_not_include: { type: 'tag', values: $subsystemTags },
-                            includes: { type: 'tag', values: $subsystemTags },
-                          },
                           Type: {
-                            does_not_equal: { type: 'variant', values: $planModelActivityTypes.map(type => type.name) },
+                            does_not_equal: { type: 'variant', values: $externalEventTypes.map(type => type.name) },
                             does_not_include: { type: 'string' },
-                            equals: { type: 'variant', values: $planModelActivityTypes.map(type => type.name) },
+                            equals: { type: 'variant', values: $externalEventTypes.map(type => type.name) },
                             includes: { type: 'string' },
                           },
                         }}
@@ -502,7 +543,7 @@
               <div class="filter-section-header st-typography-medium">
                 <div class="filter-section-title">
                   Other Filters
-                  <div class="hint st-typography-body">Tags, parameter, scheduling goal, etc...</div>
+                  <div class="hint st-typography-body">Names, attributes</div>
                 </div>
                 <button
                   class="st-button icon"
@@ -517,28 +558,21 @@
                 <div class="filter-section-content">
                   <div class="dynamic-filter-content" role="list">
                     {#each dirtyFilter.other_filters as filter, i (filter.id)}
+                      <!-- TODO: Implement for EE -->
                       <DynamicFilter
                         {filter}
                         on:remove={() => onDynamicFilterRemove('other_filters', filter.id)}
                         on:change={event => onDynamicFilterChange('other_filters', event)}
                         verb={i === 0 ? 'Where' : 'and'}
                         schema={{
+                          Attribute: {
+                            subfields: parameterSubfields,
+                          },
                           Name: {
                             does_not_equal: { type: 'string' },
                             does_not_include: { type: 'string' },
                             equals: { type: 'string' },
                             includes: { type: 'string' },
-                          },
-                          Parameter: {
-                            subfields: parameterSubfields,
-                          },
-                          SchedulingGoalId: {
-                            does_not_equal: { type: 'int' },
-                            equals: { type: 'int' },
-                          },
-                          Tags: {
-                            does_not_include: { type: 'tag', values: $tags },
-                            includes: { type: 'tag', values: $tags },
                           },
                         }}
                       />
@@ -555,17 +589,20 @@
             <div class="resulting-types-title st-typography-medium">
               Resulting Types
               <div class="resulting-types-info-container">
-                <div class="resulting-types-info"><DirectiveIcon /> {matchingTypes.length} types</div>
-                <div class="resulting-types-info"><SpanIcon /> {instanceCount} instance{pluralize(instanceCount)}</div>
+                <div class="resulting-types-info"><TagIcon />{matchingTypes.length} types</div>
+                <div class="resulting-types-info">
+                  <ExternalEventIcon />{instanceCount} instance{pluralize(instanceCount)}
+                </div>
               </div>
             </div>
             <Input>
               <div class="search-icon" slot="left"><SearchIcon /></div>
-              <input class="st-input w-full" placeholder="Filter types" bind:value={resultingTypesInputValue} />
+              <input class="st-input w-100" placeholder="Filter types" bind:value={resultingTypesInputValue} />
             </Input>
             <div class="resulting-types-list">
               {#each filteredMatchingTypes as type}
-                <ActivityTypeResult name={type.name} removable={false}>
+                <!-- TODO: Implement for EE -->
+                <FilterTypeResult activityOrEvent="event" name={type.name} removable={false}>
                   <button
                     slot="right"
                     on:click={() => onAddTypeSubfilter(type.name)}
@@ -585,25 +622,17 @@
                             on:change={event => onTypeSubfilterChange(type.name, event)}
                             verb={''}
                             schema={{
+                              Attribute: {
+                                // Filter subfields to only those matching this type
+                                subfields: parameterSubfields.filter(subfield => {
+                                  return subfield.externalEventTypes.indexOf(type.name) > -1;
+                                }),
+                              },
                               Name: {
                                 does_not_equal: { type: 'string' },
                                 does_not_include: { type: 'string' },
                                 equals: { type: 'string' },
                                 includes: { type: 'string' },
-                              },
-                              Parameter: {
-                                // Filter subfields to only those matching this type
-                                subfields: parameterSubfields.filter(subfield => {
-                                  return subfield.activityTypes.indexOf(type.name) > -1;
-                                }),
-                              },
-                              SchedulingGoalId: {
-                                does_not_equal: { type: 'int' },
-                                equals: { type: 'int' },
-                              },
-                              Tags: {
-                                does_not_include: { type: 'tag', values: $tags },
-                                includes: { type: 'tag', values: $tags },
                               },
                             }}
                           />
@@ -611,7 +640,7 @@
                       </div>
                     {/if}
                   </svelte:fragment>
-                </ActivityTypeResult>
+                </FilterTypeResult>
               {/each}
               {#if resultingTypesMessage}
                 <div class="st-typography-label p-1">{resultingTypesMessage}</div>
@@ -620,13 +649,12 @@
           </div>
         </CssGrid>
       </div>
-      <slot name="footer" />
     </Draggable>
   {/if}
 </div>
 
 <style>
-  :global(.activity-filter-builder) {
+  :global(.external-event-filter-builder) {
     display: flex;
     flex-direction: column;
     height: 100%;
@@ -637,7 +665,7 @@
     width: 100%;
   }
 
-  :global(.activity-filter-builder .header) {
+  :global(.external-event-filter-builder .header) {
     cursor: inherit;
   }
 
@@ -769,7 +797,7 @@
     display: flex;
   }
 
-  :global(.activity-filter-grid) {
+  :global(.external-event-filter-grid) {
     width: 100%;
   }
 

--- a/src/components/timeline/form/TimelineEditor/ExternalEventFilterBuilder.svelte
+++ b/src/components/timeline/form/TimelineEditor/ExternalEventFilterBuilder.svelte
@@ -446,7 +446,7 @@
                       autocomplete="off"
                       bind:this={manualInputRef}
                       name="manual-types-filter-input"
-                      class="st-input w-full manual-types-filter-input"
+                      class="st-input manual-types-filter-input w-full"
                       placeholder="Select types"
                       bind:value={manualInputValue}
                       on:click={() => {

--- a/src/components/timeline/form/TimelineEditor/FilterTypeResult.svelte
+++ b/src/components/timeline/form/TimelineEditor/FilterTypeResult.svelte
@@ -3,11 +3,13 @@
 <script lang="ts">
   import CloseIcon from '@nasa-jpl/stellar/icons/close.svg?component';
   import { createEventDispatcher } from 'svelte';
+  import ExternalEventIcon from '../../../../assets/external-event-box-with-arrow.svg?component';
   import DirectiveIcon from '../../../../assets/timeline-directive.svg?component';
   import { tooltip } from '../../../../utilities/tooltip';
 
   export let name: string;
   export let removable: boolean = true;
+  export let activityOrEvent: 'activity' | 'event' = 'activity';
 
   const dispatch = createEventDispatcher<{
     addFilter: void;
@@ -15,10 +17,14 @@
   }>();
 </script>
 
-<div class="activity-type-result" role="listitem" aria-label="activity-type-result-{name}">
+<div class="filter-type-result" role="listitem" aria-label="filter-type-result-{name}">
   <div class="top-row">
     <div class="title st-typography-medium">
-      <DirectiveIcon />
+      {#if activityOrEvent === 'activity'}
+        <DirectiveIcon />
+      {:else}
+        <ExternalEventIcon />
+      {/if}
       <div class="title-text">{name}</div>
     </div>
     <slot name="right" />
@@ -36,7 +42,7 @@
 </div>
 
 <style>
-  .activity-type-result {
+  .filter-type-result {
     box-shadow: 0px 0px 0px 1px var(--st-gray-20);
     display: flex;
     flex-direction: column;

--- a/src/components/timeline/form/TimelineEditor/TimelineLayerEditor.svelte
+++ b/src/components/timeline/form/TimelineEditor/TimelineLayerEditor.svelte
@@ -201,7 +201,7 @@
           aria-label="Toggle external event filter builder modal"
           slot="trigger"
           on:click|stopPropagation={toggleExternalEventFilterMenu}
-          class="st-button icon w-100"
+          class="st-button icon w-full"
           style:position="relative"
           use:tooltip={{
             content: `Filter External Events${filterCount > 0 ? ` (${filterCount} applied)` : ''}`,
@@ -221,21 +221,6 @@
           </div></button
         >
       </ExternalEventFilterBuilder>
-
-      <!-- <SearchableDropdown
-        allowMultiple
-        selectedOptionLabel={layer.name}
-        showPlaceholderOption={false}
-        className="w-full"
-        placeholder="Select Event Types"
-        selectTooltip="Select Event Types"
-        searchPlaceholder="Filter event types"
-        selectedOptionValues={layer.filter.externalEvent?.event_types ?? []}
-        options={$externalEventTypes.map(type => ({ display: type.name, value: type.name }))}
-        on:change={({ detail: values }) => dispatch('filterChange', { filter: { event_types: values } })}
-      >
-        <ChevronDownIcon slot="icon" />
-      </SearchableDropdown> -->
     {/if}
   </div>
   <div class="actions">
@@ -249,7 +234,7 @@
         </RadioButton>
       </RadioButtons>
     {/if}
-    {#if !isActivityLayer(layer)}
+    {#if !isActivityLayer(layer) && !isExternalEventLayer(layer)}
       <TimelineEditorLayerSettings
         {layer}
         on:input={event => dispatch('updateLayer', { property: event.detail.name, value: event.detail.value })}

--- a/src/components/timeline/form/TimelineEditor/TimelineLayerEditor.svelte
+++ b/src/components/timeline/form/TimelineEditor/TimelineLayerEditor.svelte
@@ -9,13 +9,13 @@
   import TimelineLineLayerIcon from '../../../../assets/timeline-line-layer.svg?component';
   import TimelineXRangeLayerIcon from '../../../../assets/timeline-x-range-layer.svg?component';
   import { ViewDiscreteLayerColorPresets, ViewLineLayerColorPresets } from '../../../../constants/view';
-  import { externalEventTypes } from '../../../../stores/external-event';
   import { externalResourceNames, resourceTypes } from '../../../../stores/simulation';
   import type { RadioButtonId } from '../../../../types/radio-buttons';
   import type {
     ActivityLayer,
     Axis,
     ChartType,
+    ExternalEventLayer,
     ExternalEventLayerFilter,
     Layer,
     ResourceLayerFilter,
@@ -29,13 +29,15 @@
   import SearchableDropdown from '../../../ui/SearchableDropdown.svelte';
   import TimelineEditorLayerSettings from '../TimelineEditorLayerSettings.svelte';
   import ActivityFilterBuilder from './ActivityFilterBuilder.svelte';
+  import ExternalEventFilterBuilder from './ExternalEventFilterBuilder.svelte';
 
   export let layer: Layer;
   export let yAxes: Axis[] = [];
 
-  let filterMenu: ActivityFilterBuilder;
+  let activityFilterMenu: ActivityFilterBuilder;
   let color: string = '';
   let colorPresets: string[] = [];
+  let externalEventFilterMenu: ExternalEventFilterBuilder;
   let isColorScheme: boolean = false;
   let name: string = '';
 
@@ -88,8 +90,12 @@
     return name;
   }
 
-  function toggleFilterMenu() {
-    filterMenu.toggle();
+  function toggleActivityFilterMenu() {
+    activityFilterMenu.toggle();
+  }
+
+  function toggleExternalEventFilterMenu() {
+    externalEventFilterMenu.toggle();
   }
 
   function getActivityLayerFilterCount(layer: ActivityLayer) {
@@ -98,6 +104,17 @@
       (layer.filter.activity?.dynamic_type_filters?.length ?? 0) +
       (layer.filter.activity?.other_filters?.length ?? 0) +
       (layer.filter.activity?.type_subfilters ? Object.keys(layer.filter.activity?.type_subfilters).length : 0)
+    );
+  }
+
+  function getExternalEventLayerFilterCount(layer: ExternalEventLayer) {
+    return (
+      (layer.filter.externalEvent?.static_types?.length ?? 0) +
+      (layer.filter.externalEvent?.dynamic_type_filters?.length ?? 0) +
+      (layer.filter.externalEvent?.other_filters?.length ?? 0) +
+      (layer.filter.externalEvent?.type_subfilters
+        ? Object.keys(layer.filter.externalEvent?.type_subfilters).length
+        : 0)
     );
   }
 
@@ -130,12 +147,12 @@
         filter={layer.filter.activity}
         on:filterChange
         on:rename={({ detail: { name: newName } }) => dispatch('updateLayer', { property: 'name', value: newName })}
-        bind:this={filterMenu}
+        bind:this={activityFilterMenu}
       >
         <button
           aria-label="Toggle activity filter builder modal"
           slot="trigger"
-          on:click|stopPropagation={toggleFilterMenu}
+          on:click|stopPropagation={toggleActivityFilterMenu}
           class="st-button icon w-full"
           style:position="relative"
           use:tooltip={{
@@ -143,11 +160,11 @@
             placement: 'top',
           }}
         >
-          <div class="activity-layer-name st-select">
-            <div class="activity-layer-name-text">
+          <div class="layer-name st-select">
+            <div class="layer-name-text">
               {name || 'Activity Layer'}
             </div>
-            <div class="activity-layer-name-badge">
+            <div class="layer-name-badge">
               {#if filterCount > 0}
                 <div>{filterCount}</div>
               {/if}
@@ -172,7 +189,40 @@
         <ChevronDownIcon slot="icon" />
       </SearchableDropdown>
     {:else if isExternalEventLayer(layer)}
-      <SearchableDropdown
+      {@const filterCount = getExternalEventLayerFilterCount(layer)}
+      <ExternalEventFilterBuilder
+        layerName={layer.name}
+        filter={layer.filter.externalEvent}
+        on:filterChange
+        on:rename={({ detail: { name: newName } }) => dispatch('updateLayer', { property: 'name', value: newName })}
+        bind:this={externalEventFilterMenu}
+      >
+        <button
+          aria-label="Toggle external event filter builder modal"
+          slot="trigger"
+          on:click|stopPropagation={toggleExternalEventFilterMenu}
+          class="st-button icon w-100"
+          style:position="relative"
+          use:tooltip={{
+            content: `Filter External Events${filterCount > 0 ? ` (${filterCount} applied)` : ''}`,
+            placement: 'top',
+          }}
+        >
+          <div class="layer-name st-select">
+            <div class="layer-name-text">
+              {name || 'External Event Layer'}
+            </div>
+            <div class="layer-name-badge">
+              {#if filterCount > 0}
+                <div>{filterCount}</div>
+              {/if}
+              <FilterIcon />
+            </div>
+          </div></button
+        >
+      </ExternalEventFilterBuilder>
+
+      <!-- <SearchableDropdown
         allowMultiple
         selectedOptionLabel={layer.name}
         showPlaceholderOption={false}
@@ -185,7 +235,7 @@
         on:change={({ detail: values }) => dispatch('filterChange', { filter: { event_types: values } })}
       >
         <ChevronDownIcon slot="icon" />
-      </SearchableDropdown>
+      </SearchableDropdown> -->
     {/if}
   </div>
   <div class="actions">
@@ -258,7 +308,7 @@
     height: min-content;
   }
 
-  .activity-layer-name {
+  .layer-name {
     align-items: center;
     display: flex;
     flex: 1;
@@ -268,19 +318,19 @@
     padding: 0px 4px;
   }
 
-  .activity-layer-name-text {
+  .layer-name-text {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
-  .activity-layer-name-badge {
+  .layer-name-badge {
     align-items: center;
     display: flex;
     gap: 4px;
   }
 
-  .activity-layer-name-badge > div {
+  .layer-name-badge > div {
     background: var(--st-gray-15);
     border-radius: 2px;
     min-width: 16px;

--- a/src/constants/view.ts
+++ b/src/constants/view.ts
@@ -72,6 +72,6 @@ export const ViewXRangeLayerSchemePresets: Record<XRangeLayerColorScheme, readon
 
 export const ViewTimelineResourceRowsLimit = 20;
 
-export const viewSchemaVersion = 2;
+export const viewSchemaVersion = 3;
 
 export const viewSchemaVersionName = `v${viewSchemaVersion}`;

--- a/src/enums/filter.ts
+++ b/src/enums/filter.ts
@@ -17,3 +17,9 @@ export enum ActivityFilterField {
   Parameter = 'Parameter',
   SchedulingGoalId = 'Scheduling Goal Id',
 }
+
+export enum ExternalEventFilterField {
+  Type = 'Type',
+  Name = 'Name',
+  Attribute = 'Attribute',
+}

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,9 +1,11 @@
 import * as v0 from './ui-view-schema-v0.json';
 import * as v1 from './ui-view-schema-v1.json';
 import * as v2 from './ui-view-schema-v2.json';
+import * as v3 from './ui-view-schema-v3.json';
 
 export default {
   v0,
   v1,
   v2,
+  v3,
 };

--- a/src/schemas/ui-view-schema-v3.json
+++ b/src/schemas/ui-view-schema-v3.json
@@ -1,0 +1,726 @@
+{
+  "$id": "https://github.com/NASA-AMMOS/aerie-ui/blob/develop/src/schemas/ui-view-schema-v1.json",
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "additionalProperties": false,
+  "definitions": {
+    "color": {
+      "description": "RGB color in hex format",
+      "pattern": "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$",
+      "type": "string"
+    },
+    "dynamicFilter": {
+      "additionalProperties": false,
+      "properties": {
+        "field": {
+          "description": "Type of the filter (Type, Tag, etc)",
+          "type": "string"
+        },
+        "id": {
+          "$ref": "#/definitions/id"
+        },
+        "operator": {
+          "oneOf": [
+            {
+              "const": "equals"
+            },
+            {
+              "const": "does_not_equal"
+            },
+            {
+              "const": "includes"
+            },
+            {
+              "const": "does_not_include"
+            },
+            {
+              "const": "is_greater_than"
+            },
+            {
+              "const": "is_less_than"
+            },
+            {
+              "const": "is_within"
+            },
+            {
+              "const": "is_not_within"
+            }
+          ]
+        },
+        "subfield": {
+          "additionalProperties": false,
+          "description": "Array of activity or external event types to display in this layer",
+          "properties": {
+            "name": {
+              "description": "Subfield name",
+              "type": "string"
+            },
+            "type": {
+              "oneOf": [
+                {
+                  "const": "string"
+                },
+                {
+                  "const": "boolean"
+                },
+                {
+                  "const": "duration"
+                },
+                {
+                  "const": "int"
+                },
+                {
+                  "const": "path"
+                },
+                {
+                  "const": "real"
+                },
+                {
+                  "const": "series"
+                },
+                {
+                  "const": "struct"
+                },
+                {
+                  "const": "variant"
+                },
+                {
+                  "const": "tag"
+                }
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "value": {
+          "description": "Value of the filter",
+          "type": ["string", "integer", "array", "boolean"]
+        }
+      },
+      "required": ["field", "id", "operator", "value"]
+    },
+    "filterActivity": {
+      "additionalProperties": false,
+      "properties": {
+        "activity": {
+          "additionalProperties": false,
+          "properties": {
+            "static_types": {
+              "description": "Array of activity types to display in this layer",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "dynamic_type_filters": {
+              "description": "Array of filters with which to dynamically select activity types for display in this layer",
+              "items": {
+                "$ref": "#/definitions/dynamicFilter"
+              },
+              "type": "array"
+            },
+            "other_filters": {
+              "description": "Array of filters with which to globally filter activities for display in this layer",
+              "items": {
+                "$ref": "#/definitions/dynamicFilter"
+              },
+              "type": "array"
+            },
+            "type_subfilters": {
+              "description": "Map of types, each with an array of filters with which to subfilter activities of that type for display in this layer",
+              "additionalProperties": {
+                "$ref": "#/definitions/dynamicFilter"
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "filterExternalEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "externalEvent": {
+          "additionalProperties": false,
+          "properties": {
+            "static_types": {
+              "description": "Array of external event types to display in this layer",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "dynamic_type_filters": {
+              "description": "Array of filters with which to dynamically select external event types for display in this layer",
+              "items": {
+                "$ref": "#/definitions/dynamicFilter"
+              },
+              "type": "array"
+            },
+            "other_filters": {
+              "description": "Array of filters with which to globally filter external events for display in this layer",
+              "items": {
+                "$ref": "#/definitions/dynamicFilter"
+              },
+              "type": "array"
+            }
+          }
+        }
+      },
+      "type": "object"
+    },
+    "filterResource": {
+      "additionalProperties": false,
+      "properties": {
+        "resource": {
+          "additionalProperties": false,
+          "description": "Resource to display in this layer",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "id": {
+      "description": "Numeric unique id >= 0",
+      "minimum": 0,
+      "type": "number"
+    },
+    "label": {
+      "additionalProperties": false,
+      "description": "Generic label object",
+      "properties": {
+        "color": {
+          "$ref": "#/definitions/color"
+        },
+        "text": {
+          "description": "Label text content",
+          "type": "string"
+        }
+      },
+      "required": ["text"],
+      "type": "object"
+    },
+    "table": {
+      "additionalProperties": false,
+      "description": "Table specification for visualizing tabular data via ag-grid",
+      "properties": {
+        "autoSizeColumns": {
+          "default": "fill",
+          "description": "The state of which the table should resize automatically",
+          "type": "string"
+        },
+        "columnDefs": {
+          "description": "Array of column definition objects that conform to the ag-grid ColumnDef type",
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "columnStates": {
+          "description": "Array of column state objects that conform to the ag-grid ColumnState type",
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "required": ["columnDefs", "columnStates"],
+      "type": "object"
+    },
+    "viewGridComponent": {
+      "description": "Set of components available to view in a grid section",
+      "enum": [
+        "ActivityDirectivesTablePanel",
+        "ActivityFormPanel",
+        "ActivitySpansTablePanel",
+        "TimelineItemsPanel",
+        "ConstraintsPanel",
+        "ExpansionPanel",
+        "IFramePanel",
+        "PlanMetadataPanel",
+        "SchedulingConditionsPanel",
+        "SchedulingGoalsPanel",
+        "SimulationEventsPanel",
+        "SimulationPanel",
+        "TimelineEditorPanel",
+        "ExternalSourcesPanel"
+      ]
+    },
+    "yAxisId": {
+      "description": "Id of the associated y-axis. Can be null for no association.",
+      "type": ["number", "null"]
+    }
+  },
+  "description": "JSON schema definition used for configuring the Aerie UI",
+  "properties": {
+    "version": {
+      "type": "number"
+    },
+    "plan": {
+      "additionalProperties": false,
+      "description": "View configuration for a plan",
+      "properties": {
+        "activityDirectivesTable": {
+          "$ref": "#/definitions/table"
+        },
+        "activitySpansTable": {
+          "$ref": "#/definitions/table"
+        },
+        "simulationEventsTable": {
+          "$ref": "#/definitions/table"
+        },
+        "grid": {
+          "additionalProperties": false,
+          "description": "Defines the different visible sections for a plan",
+          "properties": {
+            "columnSizes": {
+              "description": "Size of each column and gutter using CSS grid notation",
+              "type": "string"
+            },
+            "leftComponentBottom": {
+              "$ref": "#/definitions/viewGridComponent"
+            },
+            "leftComponentTop": {
+              "$ref": "#/definitions/viewGridComponent"
+            },
+            "leftHidden": {
+              "description": "If true hide the left panel, if false show the left panel",
+              "type": "boolean"
+            },
+            "leftRowSizes": {
+              "description": "Size of each left row and gutter using CSS grid notation",
+              "type": "string"
+            },
+            "leftSplit": {
+              "description": "If true the left panel is split into two, if false show single left panel",
+              "type": "boolean"
+            },
+            "middleComponentBottom": {
+              "$ref": "#/definitions/viewGridComponent"
+            },
+            "middleRowSizes": {
+              "description": "Size of each middle row and gutter using CSS grid notation",
+              "type": "string"
+            },
+            "middleSplit": {
+              "description": "If true the middle panel is split into two, if false show single middle panel",
+              "type": "boolean"
+            },
+            "rightComponentBottom": {
+              "$ref": "#/definitions/viewGridComponent"
+            },
+            "rightComponentTop": {
+              "$ref": "#/definitions/viewGridComponent"
+            },
+            "rightHidden": {
+              "description": "If true hide the right panel, if false show the right panel",
+              "type": "boolean"
+            },
+            "rightRowSizes": {
+              "description": "Size of each right row and gutter using CSS grid notation",
+              "type": "string"
+            },
+            "rightSplit": {
+              "description": "If true the right panel is split into two, if false show single right panel",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "columnSizes",
+            "leftComponentBottom",
+            "leftComponentTop",
+            "leftHidden",
+            "leftRowSizes",
+            "leftSplit",
+            "middleComponentBottom",
+            "middleRowSizes",
+            "middleSplit",
+            "rightComponentBottom",
+            "rightComponentTop",
+            "rightHidden",
+            "rightRowSizes",
+            "rightSplit"
+          ],
+          "type": "object"
+        },
+        "iFrames": {
+          "description": "IFrame specifications for embedding other web pages",
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "id": {
+                "$ref": "#/definitions/id"
+              },
+              "src": {
+                "description": "The URL of the page to embed",
+                "type": "string"
+              },
+              "title": {
+                "description": "The title attribute of the iframe",
+                "type": "string"
+              }
+            },
+            "required": ["id", "src", "title"],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "timelines": {
+          "description": "Timeline specifications for visualizing activities or resources in a timeline",
+          "items": {
+            "additionalProperties": false,
+            "description": "Displays a timeline in the section",
+            "properties": {
+              "id": {
+                "$ref": "#/definitions/id"
+              },
+              "marginLeft": {
+                "description": "Left margin of the timeline in pixels",
+                "minimum": 0,
+                "type": "number"
+              },
+              "marginRight": {
+                "description": "Right margin of the timeline in pixels",
+                "minimum": 0,
+                "type": "number"
+              },
+              "rows": {
+                "description": "Timeline row definitions",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "autoAdjustHeight": {
+                      "description": "If true the row height is set automatically to fit the row content",
+                      "type": "boolean"
+                    },
+                    "expanded": {
+                      "description": "Expanded state of the timeline row",
+                      "type": "boolean"
+                    },
+                    "discreteOptions": {
+                      "additionalProperties": false,
+                      "description": "Defines the options used for rendering external events on the timeline",
+                      "properties": {
+                        "activityOptions": {
+                          "description": "Options for activity layers in the row",
+                          "properties": {
+                            "composition": {
+                              "description": "Whether or not to display only directives, only spans, or both in the row",
+                              "enum": ["directives", "spans", "both"]
+                            },
+                            "hierarchyMode": {
+                              "description": "If 'directive' the activities are grouped starting with directive types, if 'flat' activities are grouped by type regardless of hierarchy",
+                              "enum": ["directive", "flat"]
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "displayMode": {
+                          "description": "Describes the display mode to use for rendering external events",
+                          "enum": ["compact", "grouped"]
+                        },
+                        "externalEventOptions": {
+                          "description": "Options for external event layers in the row",
+                          "properties": {
+                            "groupBy": {
+                              "description": "Determines whether to group the external events by their event type, or their external source",
+                              "enum": ["event_type_name", "source_key"]
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "height": {
+                          "description": "Height of timeline rows",
+                          "type": "number",
+                          "minimum": 16
+                        },
+                        "labelVisibility": {
+                          "description": "External event text label behavior",
+                          "enum": ["on", "off", "auto"]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "height": {
+                      "description": "Height of the row in pixels",
+                      "minimum": 0,
+                      "type": "number"
+                    },
+                    "horizontalGuides": {
+                      "description": "Row horizontal guide definitions",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "id": {
+                            "$ref": "#/definitions/id"
+                          },
+                          "label": {
+                            "$ref": "#/definitions/label"
+                          },
+                          "y": {
+                            "description": "Y value the horizontal guide anchors to",
+                            "type": "number"
+                          },
+                          "yAxisId": {
+                            "$ref": "#/definitions/id"
+                          }
+                        },
+                        "required": ["id", "label", "y", "yAxisId"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "id": {
+                      "$ref": "#/definitions/id"
+                    },
+                    "layers": {
+                      "description": "Row layer definitions",
+                      "items": {
+                        "oneOf": [
+                          {
+                            "additionalProperties": false,
+                            "description": "Activity layer",
+                            "properties": {
+                              "activityColor": {
+                                "$ref": "#/definitions/color"
+                              },
+                              "chartType": {
+                                "const": "activity",
+                                "description": "Layer that visualizes activities"
+                              },
+                              "filter": {
+                                "$ref": "#/definitions/filterActivity"
+                              },
+                              "id": {
+                                "$ref": "#/definitions/id"
+                              },
+                              "name": {
+                                "description": "Name of the layer",
+                                "type": "string"
+                              },
+                              "yAxisId": {
+                                "$ref": "#/definitions/yAxisId"
+                              }
+                            },
+                            "required": ["activityColor", "chartType", "filter", "id", "yAxisId"],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "description": "Line layer",
+                            "properties": {
+                              "chartType": {
+                                "const": "line",
+                                "description": "Layer that visualizes points and a line"
+                              },
+                              "filter": {
+                                "$ref": "#/definitions/filterResource"
+                              },
+                              "id": {
+                                "$ref": "#/definitions/id"
+                              },
+                              "lineColor": {
+                                "$ref": "#/definitions/color"
+                              },
+                              "lineWidth": {
+                                "description": "Width of the line",
+                                "type": "number"
+                              },
+                              "name": {
+                                "description": "Name of the layer",
+                                "type": "string"
+                              },
+                              "pointRadius": {
+                                "description": "Radius of the points",
+                                "type": "number"
+                              },
+                              "yAxisId": {
+                                "$ref": "#/definitions/yAxisId"
+                              }
+                            },
+                            "required": [
+                              "chartType",
+                              "filter",
+                              "id",
+                              "lineColor",
+                              "lineWidth",
+                              "pointRadius",
+                              "yAxisId"
+                            ],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "description": "X-range layer",
+                            "properties": {
+                              "chartType": {
+                                "const": "x-range",
+                                "description": "Layer that visualizes range data as full-height colored rectangles"
+                              },
+                              "colorScheme": {
+                                "description": "https://github.com/d3/d3-scale-chromatic/blob/main/README.md#api-reference",
+                                "enum": [
+                                  "schemeAccent",
+                                  "schemeCategory10",
+                                  "schemeDark2",
+                                  "schemePaired",
+                                  "schemePastel1",
+                                  "schemePastel2",
+                                  "schemeSet1",
+                                  "schemeSet2",
+                                  "schemeSet3",
+                                  "schemeTableau10"
+                                ],
+                                "type": "string"
+                              },
+                              "filter": {
+                                "$ref": "#/definitions/filterResource"
+                              },
+                              "id": {
+                                "$ref": "#/definitions/id"
+                              },
+                              "name": {
+                                "description": "Name of the layer",
+                                "type": "string"
+                              },
+                              "opacity": {
+                                "type": "number"
+                              },
+                              "showAsLinePlot": {
+                                "type": "boolean"
+                              },
+                              "yAxisId": {
+                                "$ref": "#/definitions/yAxisId"
+                              }
+                            },
+                            "required": ["chartType", "colorScheme", "filter", "id", "opacity", "yAxisId"],
+                            "type": "object"
+                          },
+                          {
+                            "additionalProperties": false,
+                            "description": "External event layer",
+                            "properties": {
+                              "externalEventColor": {
+                                "$ref": "#/definitions/color"
+                              },
+                              "chartType": {
+                                "const": "externalEvent",
+                                "description": "Layer that visualizes external events"
+                              },
+                              "filter": {
+                                "$ref": "#/definitions/filterExternalEvent"
+                              },
+                              "id": {
+                                "$ref": "#/definitions/id"
+                              },
+                              "name": {
+                                "description": "Name of the layer",
+                                "type": "string"
+                              },
+                              "yAxisId": {
+                                "$ref": "#/definitions/yAxisId"
+                              }
+                            },
+                            "type": "object"
+                          }
+                        ]
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "description": "Name of the row",
+                      "type": "string"
+                    },
+                    "yAxes": {
+                      "description": "Row y-axes definitions",
+                      "items": {
+                        "additionalProperties": false,
+                        "properties": {
+                          "color": {
+                            "$ref": "#/definitions/color"
+                          },
+                          "domainFitMode": {
+                            "description": "Describes the domain fitting behavior for the axis",
+                            "enum": ["fitPlan", "fitTimeWindow", "manual"],
+                            "type": "string"
+                          },
+                          "id": {
+                            "$ref": "#/definitions/id"
+                          },
+                          "label": {
+                            "$ref": "#/definitions/label"
+                          },
+                          "renderTickLines": {
+                            "description": "If true render horizontal lines for each y axis tick, if false do not render them",
+                            "type": "boolean"
+                          },
+                          "scaleDomain": {
+                            "description": "Min and max values of the axis domain: [min, max], only used if domainFitMode is set to manual",
+                            "items": {
+                              "type": "number"
+                            },
+                            "type": "array"
+                          },
+                          "tickCount": {
+                            "description": "Number of ticks on the axis",
+                            "minimum": 0,
+                            "type": "number"
+                          }
+                        },
+                        "required": ["color", "id", "label", "tickCount"],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "autoAdjustHeight",
+                    "expanded",
+                    "height",
+                    "horizontalGuides",
+                    "id",
+                    "layers",
+                    "name",
+                    "yAxes"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "verticalGuides": {
+                "description": "Timeline vertical guide definitions",
+                "items": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "id": {
+                      "$ref": "#/definitions/id"
+                    },
+                    "label": {
+                      "$ref": "#/definitions/label"
+                    },
+                    "timestamp": {
+                      "description": "DOY timestamp (YYYY-DDDThh:mm:ss) of the vertical guide",
+                      "type": "string"
+                    }
+                  },
+                  "required": ["id", "label", "timestamp"],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": ["id", "marginLeft", "marginRight", "rows", "verticalGuides"],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "required": ["activityDirectivesTable", "activitySpansTable", "grid", "iFrames", "timelines"],
+      "type": "object"
+    }
+  },
+  "required": ["plan", "version"],
+  "title": "View",
+  "type": "object"
+}

--- a/src/stores/views.ts
+++ b/src/stores/views.ts
@@ -635,7 +635,7 @@ export function getUpdatedLayerWithFilters(
     } else if (type === 'externalEvent') {
       return {
         layer: createTimelineExternalEventLayer(timelines, {
-          filter: { externalEvent: { event_types: itemNames } },
+          filter: { externalEvent: { static_types: itemNames } },
         }),
       };
     } else {
@@ -666,7 +666,7 @@ export function getUpdatedLayerWithFilters(
       updatedFilter.activity = getUpdatedActivityLayerFilter(items, metadata, layer.filter.activity);
     } else if (type === 'externalEvent') {
       updatedFilter.externalEvent = {
-        event_types: Array.from(new Set([...(updatedFilter.externalEvent?.event_types || []), ...itemNames])),
+        static_types: Array.from(new Set([...(updatedFilter.externalEvent?.static_types || []), ...itemNames])),
       };
     }
 

--- a/src/tests/mocks/view/v2/view.json
+++ b/src/tests/mocks/view/v2/view.json
@@ -404,6 +404,41 @@
             },
             "autoAdjustHeight": false,
             "horizontalGuides": []
+          },
+          {
+            "id": 8,
+            "name": "External Events",
+            "yAxes": [],
+            "height": 160,
+            "layers": [
+              {
+                "id": 0,
+                "name": "",
+                "filter": {
+                  "externalEvent": {
+                    "event_types": ["BananaSale", "RainStorm"]
+                  }
+                },
+                "yAxisId": null,
+                "chartType": "externalEvent",
+                "externalEventColor": "#fcdd8f"
+              }
+            ],
+            "expanded": true,
+            "discreteOptions": {
+              "height": 16,
+              "displayMode": "grouped",
+              "activityOptions": {
+                "composition": "both",
+                "hierarchyMode": "flat"
+              },
+              "labelVisibility": "auto",
+              "externalEventOptions": {
+                "groupBy": "event_type_name"
+              }
+            },
+            "autoAdjustHeight": true,
+            "horizontalGuides": []
           }
         ],
         "marginLeft": 250,

--- a/src/tests/mocks/view/v3/view.json
+++ b/src/tests/mocks/view/v3/view.json
@@ -38,7 +38,7 @@
                 "name": "",
                 "filter": {
                   "activity": {
-                    "types": [
+                    "static_types": [
                       "BakeBananaBread",
                       "BananaNap",
                       "BiteBanana",
@@ -104,9 +104,7 @@
                 "id": 1,
                 "name": "",
                 "filter": {
-                  "resource": {
-                    "names": ["/data/line_count"]
-                  }
+                  "resource": "/data/line_count"
                 },
                 "yAxisId": 0,
                 "chartType": "line",
@@ -152,9 +150,7 @@
                 "id": 2,
                 "name": "",
                 "filter": {
-                  "resource": {
-                    "names": ["/flag"]
-                  }
+                  "resource": "/flag"
                 },
                 "opacity": 0.8,
                 "yAxisId": 1,
@@ -200,9 +196,7 @@
                 "id": 3,
                 "name": "",
                 "filter": {
-                  "resource": {
-                    "names": ["/flag/conflicted"]
-                  }
+                  "resource": "/flag/conflicted"
                 },
                 "opacity": 0.8,
                 "yAxisId": 2,
@@ -248,9 +242,7 @@
                 "id": 4,
                 "name": "",
                 "filter": {
-                  "resource": {
-                    "names": ["/fruit"]
-                  }
+                  "resource": "/fruit"
                 },
                 "yAxisId": 3,
                 "chartType": "line",
@@ -296,9 +288,7 @@
                 "id": 5,
                 "name": "",
                 "filter": {
-                  "resource": {
-                    "names": ["/peel"]
-                  }
+                  "resource": "/peel"
                 },
                 "yAxisId": 4,
                 "chartType": "line",
@@ -344,9 +334,7 @@
                 "id": 6,
                 "name": "",
                 "filter": {
-                  "resource": {
-                    "names": ["/plant"]
-                  }
+                  "resource": "/plant"
                 },
                 "yAxisId": 5,
                 "chartType": "line",
@@ -392,9 +380,7 @@
                 "id": 7,
                 "name": "",
                 "filter": {
-                  "resource": {
-                    "names": ["/producer"]
-                  }
+                  "resource": "/producer"
                 },
                 "opacity": 0.8,
                 "yAxisId": 6,
@@ -430,7 +416,7 @@
                 "name": "",
                 "filter": {
                   "externalEvent": {
-                    "event_types": ["BananaSale", "RainStorm"]
+                    "static_types": ["BananaSale", "RainStorm"]
                   }
                 },
                 "yAxisId": null,
@@ -971,5 +957,5 @@
       "autoSizeColumns": "fill"
     }
   },
-  "version": 1
+  "version": 3
 }

--- a/src/types/external-event.ts
+++ b/src/types/external-event.ts
@@ -43,7 +43,7 @@ export type ExternalEventJson = {
 // no analogue to ExternalSourceSlim as we have no subevents or anything of the sort that we may elect to exclude
 
 export type ExternalEvent = {
-  attributes: object;
+  attributes: { [name: string]: any };
   duration: string;
   duration_ms: number;
   pkey: ExternalEventPkey;

--- a/src/types/timeline.ts
+++ b/src/types/timeline.ts
@@ -1,10 +1,10 @@
 import type { Selection } from 'd3-selection';
+import type { ActivityFilterField, ExternalEventFilterField } from '../enums/filter';
 import type { ActivityDirective, ActivityDirectiveId, ActivityType } from './activity';
 import type { ConstraintResultWithName } from './constraint';
 import type { ExternalEvent, ExternalEventId, ExternalEventType } from './external-event';
 import type { DynamicFilter, DynamicFilterDataType } from './filter';
 import type { ResourceType, Span, SpanId } from './simulation';
-import type { ActivityFilterField } from '../enums/filter';
 
 export type DiscreteTree = DiscreteTreeNode[];
 
@@ -41,13 +41,26 @@ export type ActivityLayerFilter = {
     DynamicFilter<Pick<typeof ActivityFilterField, 'Tags' | 'Parameter' | 'SchedulingGoalId' | 'Name'>>[]
   >;
 };
+
 export type ExternalEventLayerFilter = {
-  event_types: string[];
+  dynamic_type_filters?: DynamicFilter<Pick<typeof ExternalEventFilterField, 'Type'>>[];
+  other_filters?: DynamicFilter<Pick<typeof ExternalEventFilterField, 'Attribute' | 'Name'>>[];
+  static_types?: string[];
+  type_subfilters?: Record<string, DynamicFilter<Pick<typeof ExternalEventFilterField, 'Attribute' | 'Name'>>[]>;
 };
 
 export type ActivityLayerFilterSubfield = { name: string; type: DynamicFilterDataType };
 export type ActivityLayerFilterSubfieldSchema = ActivityLayerFilterSubfield & {
   activityTypes: string[];
+  label: string;
+  unit?: string;
+  values?: string[];
+};
+
+// TODO: Is this still valid for External Events?
+export type ExternalEventLayerFilterSubfield = { name: string; type: DynamicFilterDataType };
+export type ExternalEventLayerFilterSubfieldSchema = ExternalEventLayerFilterSubfield & {
+  externalEventTypes: string[];
   label: string;
   unit?: string;
   values?: string[];

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -20,9 +20,9 @@ import {
   ViewLineLayerColorPresets,
   ViewXRangeLayerSchemePresets,
 } from '../constants/view';
-import type { ActivityFilterField } from '../enums/filter';
+import type { ActivityFilterField, ExternalEventFilterField } from '../enums/filter';
 import type { ActivityDirective, ActivityType } from '../types/activity';
-import type { ExternalEvent } from '../types/external-event';
+import type { ExternalEvent, ExternalEventType } from '../types/external-event';
 import type { DynamicFilter } from '../types/filter';
 import type { DefaultEffectiveArgumentsMap } from '../types/parameter';
 import type { Resource, ResourceType, ResourceValue, Span, SpanUtilityMaps, SpansMap } from '../types/simulation';
@@ -36,6 +36,7 @@ import type {
   DiscreteTreeNode,
   DiscreteTreeNodeItem,
   ExternalEventLayer,
+  ExternalEventLayerFilter,
   ExternalEventOptions,
   HorizontalGuide,
   Layer,
@@ -613,9 +614,7 @@ export function createTimelineExternalEventLayer(
     chartType: 'externalEvent',
     externalEventColor: '#fcdd8f',
     filter: {
-      externalEvent: {
-        event_types: [],
-      },
+      externalEvent: {},
     },
     id,
     name: '',
@@ -1435,6 +1434,35 @@ export function applyActivityLayerFilter(
   return { directives: filteredDirectives, spans: filteredSpans };
 }
 
+export function applyExternalEventLayerFilter(
+  filter: ExternalEventLayerFilter | undefined,
+  externalEvents: ExternalEvent[],
+): { externalEvents: ExternalEvent[] } {
+  if (
+    !filter ||
+    (!filter.dynamic_type_filters?.length &&
+      !filter.other_filters?.length &&
+      !filter.static_types?.length &&
+      (!filter.type_subfilters || !Object.keys(filter.type_subfilters).length))
+  ) {
+    return { externalEvents: [] };
+  }
+
+  const staticTypeMap: Record<string, boolean> = (filter.static_types || []).reduce(
+    (acc: Record<string, boolean>, cur: string) => {
+      acc[cur] = true;
+      return acc;
+    },
+    {},
+  );
+
+  const filteredExternalEvents: ExternalEvent[] = externalEvents.filter(externalEvent => {
+    return applyFiltersToExternalEvent(externalEvent, filter, staticTypeMap);
+  });
+
+  return { externalEvents: filteredExternalEvents };
+}
+
 function applyFiltersToDirectiveOrSpan(
   directiveOrSpan: ActivityDirective | Span,
   filter: ActivityLayerFilter,
@@ -1486,6 +1514,47 @@ function applyFiltersToDirectiveOrSpan(
   return included;
 }
 
+function applyFiltersToExternalEvent(
+  externalEvent: ExternalEvent,
+  filter: ExternalEventLayerFilter,
+  staticTypeMap: Record<string, boolean>,
+) {
+  const anyTypeFiltersSpecified = !!(filter.static_types?.length || filter.dynamic_type_filters?.length);
+  const anyMainFiltersSpecified = anyTypeFiltersSpecified || !!filter.other_filters?.length;
+  let included = !anyMainFiltersSpecified;
+
+  // Check to see if external event is included in static list
+  if (filter.static_types?.length) {
+    included = !!staticTypeMap[externalEvent.pkey.event_type_name];
+  }
+
+  // Check if necessary to see if directive is included in dynamic list
+  if ((!filter.static_types?.length || !included) && filter.dynamic_type_filters?.length) {
+    included = externalEventMatchesDynamicFilters(externalEvent, filter.dynamic_type_filters);
+  }
+
+  // Apply other filters on top of the types
+  if (filter.other_filters?.length) {
+    included =
+      externalEventMatchesDynamicFilters(externalEvent, filter.other_filters) &&
+      (anyTypeFiltersSpecified ? included : true);
+  }
+
+  // Apply type specific filters if found and if the type is already included or
+  // if no other filters were specified (case where all types are included by default)
+  if (
+    filter.type_subfilters &&
+    filter.type_subfilters[externalEvent.pkey.event_type_name] &&
+    filter.type_subfilters[externalEvent.pkey.event_type_name].length
+  ) {
+    included =
+      externalEventMatchesDynamicFilters(externalEvent, filter.type_subfilters[externalEvent.pkey.event_type_name]) &&
+      (anyMainFiltersSpecified ? included : true);
+  }
+
+  return included;
+}
+
 export function getMatchingTypesForActivityLayerFilter(filter: ActivityLayerFilter | undefined, types: ActivityType[]) {
   if (
     !filter ||
@@ -1518,6 +1587,46 @@ export function getMatchingTypesForActivityLayerFilter(filter: ActivityLayerFilt
     // Check if necessary to see if type is included in dynamic list
     if ((!filter.static_types?.length || !included) && filter.dynamic_type_filters?.length) {
       included = typeMatchesDynamicFilters(type, filter.dynamic_type_filters);
+    }
+    return included;
+  });
+}
+
+export function getMatchingTypesForExternalEventLayerFilter(
+  filter: ExternalEventLayerFilter | undefined,
+  types: ExternalEventType[],
+) {
+  if (
+    !filter ||
+    (!filter.dynamic_type_filters?.length &&
+      !filter.other_filters?.length &&
+      !filter.static_types?.length &&
+      (!filter.type_subfilters || !Object.keys(filter.type_subfilters).length))
+  ) {
+    return types;
+  }
+
+  const staticTypeMap: Record<string, boolean> = (filter.static_types || []).reduce(
+    (acc: Record<string, boolean>, cur: string) => {
+      acc[cur] = true;
+      return acc;
+    },
+    {},
+  );
+
+  const anyTypeFiltersSpecified = !!(filter.static_types?.length || filter.dynamic_type_filters?.length);
+
+  return types.filter(type => {
+    let included = !anyTypeFiltersSpecified;
+
+    // Check to see if type is included in static list
+    if (filter.static_types?.length) {
+      included = !!staticTypeMap[type.name];
+    }
+
+    // Check if necessary to see if type is included in dynamic list
+    if ((!filter.static_types?.length || !included) && filter.dynamic_type_filters?.length) {
+      included = externalEventTypeMatchesDynamicFilters(type, filter.dynamic_type_filters);
     }
     return included;
   });
@@ -1571,6 +1680,49 @@ function directiveOrSpanMatchesDynamicFilters(
   }, true);
 }
 
+// TODO: Does typeDefMap have any use for External Events?
+function externalEventMatchesDynamicFilters(
+  externalEvent: ExternalEvent,
+  dynamicFilters: DynamicFilter<typeof ExternalEventFilterField>[],
+): boolean {
+  return dynamicFilters.reduce((acc, curr) => {
+    let matches = false;
+    if (curr.field === 'Type') {
+      matches = matchesDynamicFilter(externalEvent.pkey.event_type_name, curr.operator, curr.value);
+    } else if (curr.field === 'Name') {
+      matches = matchesDynamicFilter(externalEvent.pkey.key, curr.operator, curr.value);
+    } else if (curr.field === 'Attribute' && curr.subfield) {
+      const subfield = curr.subfield;
+      const attributeKey: string = subfield.name;
+      if (attributeKey.includes('->')) {
+        const split = attributeKey.split(' -> ');
+        let attribute = externalEvent.attributes;
+        let failed = false;
+        for (const subKey of split) {
+          if (attribute === undefined) {
+            failed = true;
+            break;
+          }
+          attribute = attribute[subKey];
+        }
+        if (!failed || attribute !== undefined) {
+          matches = matchesDynamicFilter(
+            attribute as string | number | boolean | string[] | number[],
+            curr.operator,
+            curr.value,
+          );
+        }
+      } else {
+        const attribute = externalEvent.attributes[attributeKey];
+        if (attribute !== undefined) {
+          matches = matchesDynamicFilter(attribute, curr.operator, curr.value);
+        }
+      }
+    }
+    return acc && matches;
+  }, true);
+}
+
 // TODO try consolidating with the function above
 function typeMatchesDynamicFilters(
   type: ActivityType,
@@ -1582,6 +1734,20 @@ function typeMatchesDynamicFilters(
       matches = matchesDynamicFilter(type.name, curr.operator, curr.value);
     } else if (curr.field === 'Subsystem') {
       matches = matchesDynamicFilter(type.subsystem_tag?.id ?? -1, curr.operator, curr.value);
+    }
+    return acc && matches;
+  }, true);
+}
+
+// TODO consolidate to Activity function
+function externalEventTypeMatchesDynamicFilters(
+  type: ExternalEventType,
+  dynamicFilters: DynamicFilter<typeof ExternalEventFilterField>[],
+): boolean {
+  return dynamicFilters.reduce((acc, curr) => {
+    let matches = false;
+    if (curr.field === 'Type') {
+      matches = matchesDynamicFilter(type.name, curr.operator, curr.value);
     }
     return acc && matches;
   }, true);

--- a/src/utilities/view.test.ts
+++ b/src/utilities/view.test.ts
@@ -67,7 +67,7 @@ describe('generateDefaultViewWithEvents', () => {
     const layers = timelines[0].rows[1].layers;
     expect(layers.length).toBe(1);
     expect(layers[0].filter.externalEvent).toBeDefined();
-    expect(layers[0].filter.externalEvent?.event_types).toEqual(['external-event-type_1', 'external-event-type_2']);
+    expect(layers[0].filter.externalEvent?.static_types).toEqual(['external-event-type_1', 'external-event-type_2']);
   });
 });
 

--- a/src/utilities/view.test.ts
+++ b/src/utilities/view.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'vitest';
 import viewV0Migrated from '../tests/mocks/view/v0/view-migrated.json';
 import viewV0 from '../tests/mocks/view/v0/view.json';
-import viewV2 from '../tests/mocks/view/v2/view.json';
+import viewV1 from '../tests/mocks/view/v1/view.json';
+import viewV3 from '../tests/mocks/view/v3/view.json';
 import {
   applyViewDefinitionMigrations,
   generateDefaultView,
@@ -80,16 +81,16 @@ describe('applyViewDefinitionMigrations', () => {
 
 describe('migrateViewDefinition', () => {
   test('Should apply view migrations to an old view', async () => {
-    const { anyMigrationsApplied, error, migratedViewDefinition } = applyViewDefinitionMigrations(viewV0 as any);
+    const { anyMigrationsApplied, error, migratedViewDefinition } = applyViewDefinitionMigrations(viewV1 as any);
     expect(anyMigrationsApplied).toBeTruthy();
     expect(error).toBeNull();
-    expect(migratedViewDefinition).to.deep.eq(viewV2);
+    expect(migratedViewDefinition).to.deep.eq(viewV3);
   });
   test('Should apply no view migrations to a migration matching current version', async () => {
-    const { anyMigrationsApplied, error, migratedViewDefinition } = applyViewDefinitionMigrations(viewV2 as any);
+    const { anyMigrationsApplied, error, migratedViewDefinition } = applyViewDefinitionMigrations(viewV3 as any);
     expect(anyMigrationsApplied).toBeFalsy();
     expect(error).toBeNull();
-    expect(migratedViewDefinition).to.deep.eq(viewV2);
+    expect(migratedViewDefinition).to.deep.eq(viewV3);
   });
   test('Should return errors if migration fails', async () => {
     const invalidView = structuredClone(viewV0);

--- a/src/utilities/view.ts
+++ b/src/utilities/view.ts
@@ -525,6 +525,7 @@ export function applyViewDefinitionMigrations(viewDefinition: ViewDefinition): {
     const upMigrations: Record<number, (view: ViewDefinition) => ViewDefinition> = {
       0: migrateViewDefinitionV0toV1,
       1: migrateViewDefinitionV1toV2,
+      2: migrateViewDefinitionV2toV3,
     };
 
     // Iterate through versions between view version and latest view version
@@ -664,5 +665,38 @@ export function migrateViewDefinitionV1toV2(viewDefinition: ViewDefinition) {
       }),
     },
     version: 2,
+  };
+}
+
+export function migrateViewDefinitionV2toV3(viewDefinition: ViewDefinition) {
+  /*
+    Summary of migrations:
+    - Convert prior 'event_types' filter field for External Event layers to 'static_types'
+  */
+  return {
+    ...viewDefinition,
+    plan: {
+      ...viewDefinition.plan,
+      timelines: viewDefinition.plan.timelines.map(timeline => {
+        return {
+          ...timeline,
+          rows: timeline.rows.map(row => {
+            const newRow = structuredClone(row);
+            newRow.layers = newRow.layers.map(layer => {
+              const newLayer = structuredClone(layer);
+              if (newLayer.filter.externalEvent) {
+                // @ts-expect-error deprecated type def
+                newLayer.filter.externalEvent.static_types = newLayer.filter.externalEvent.event_types;
+                // @ts-expect-error deprecated type def
+                delete newLayer.filter.externalEvent.event_types;
+              }
+              return newLayer;
+            });
+            return newRow;
+          }),
+        };
+      }),
+    },
+    version: 3,
   };
 }

--- a/src/utilities/view.ts
+++ b/src/utilities/view.ts
@@ -49,7 +49,11 @@ export function generateDefaultView(
   //     return type, so they can be checked as well).
   if (externalEventTypes.length) {
     const externalEventLayer = createTimelineExternalEventLayer(timelines, {
-      filter: { externalEvent: { event_types: externalEventTypes.map(e => e.name) } },
+      filter: {
+        externalEvent: {
+          static_types: externalEventTypes.map(externalEventType => externalEventType.name),
+        },
+      },
     });
     const externalEventRow = createRow(timelines, {
       autoAdjustHeight: false,


### PR DESCRIPTION
This PR adds external events to the advanced timeline filtering capability (see: https://github.com/NASA-AMMOS/aerie-ui/pull/1535). The filtering capability allows filtering based on external event type and any attributes defined for the events.

![image](https://github.com/user-attachments/assets/bc5ae243-db0b-4bc2-9bd0-e35f2adf9391)

The filtering essentially works the same as the aforementioned activity filtering capability by exposing the following filters for external events:

1. Manually selected/Static external event type(s)
2. Dynamically selected by external event type(s) name
3. Dynamically selected by external event name(s)
4. Dynamically selected by external event attributes

Attribute filtering supports simple and complex types, including nested objects. For example, the filter below accesses a field `complex` that is nested underneath two other parent objects.

![image](https://github.com/user-attachments/assets/b3eb0de3-2bba-4d47-b494-19777376734c)

The feature can be accessed through clicking the filter icon/bar inside an 'Events Layer' within the Timeline Editor panel - the same way a user accesses the filtering for activities within an 'Activity Layer'.

![image](https://github.com/user-attachments/assets/39f270e3-33ba-4f72-87c9-3d9e89745f6b)
 
