### PR TITLE
UI for Plan Model Migration

### DIFF
--- a/src/components/form/Input.svelte
+++ b/src/components/form/Input.svelte
@@ -4,7 +4,7 @@
   import { onDestroy, onMount } from 'svelte';
   import { classNames, filterEmpty } from '../../utilities/generic';
 
-  export let layout: 'inline' | 'stacked' | null = 'stacked';
+  export let layout: 'inline' | 'inline-with-button' | 'stacked' | null = 'stacked';
   export { className as class };
 
   const padLeft = 5;
@@ -29,6 +29,7 @@
   $: inputClasses = classNames('input', {
     [className]: !!className,
     'input-inline': layout === 'inline',
+    'input-inline-with-button': layout === 'inline-with-button',
     'input-stacked': layout === 'stacked',
   });
 
@@ -180,6 +181,13 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .input-inline-with-button {
+    display: grid;
+    gap: 4px;
+    padding: 4px 0px;
+    grid-template-columns: 40% auto 1fr;
   }
 
   .input-stacked {

--- a/src/components/form/Input.svelte
+++ b/src/components/form/Input.svelte
@@ -4,7 +4,7 @@
   import { onDestroy, onMount } from 'svelte';
   import { classNames, filterEmpty } from '../../utilities/generic';
 
-  export let layout: 'inline' | 'inline-with-button' | 'stacked' | null = 'stacked';
+  export let layout: 'inline' | 'stacked' | null = 'stacked';
   export { className as class };
 
   const padLeft = 5;
@@ -29,7 +29,6 @@
   $: inputClasses = classNames('input', {
     [className]: !!className,
     'input-inline': layout === 'inline',
-    'input-inline-with-button': layout === 'inline-with-button',
     'input-stacked': layout === 'stacked',
   });
 
@@ -174,20 +173,13 @@
     display: grid;
     gap: 8px;
     grid-template-columns: 40% auto;
-    padding: 4px 0px;
+    padding: 4px 0;
   }
 
   .input-inline :global(label) {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-  }
-
-  .input-inline-with-button {
-    display: grid;
-    gap: 4px;
-    padding: 4px 0px;
-    grid-template-columns: 40% auto 1fr;
   }
 
   .input-stacked {

--- a/src/components/modals/UpdatePlanMissionModelModal.svelte
+++ b/src/components/modals/UpdatePlanMissionModelModal.svelte
@@ -18,17 +18,13 @@
   import type { ActivityErrorCounts } from '../../types/errors';
   import ActivityErrorsRollup from '../ui/ActivityErrorsRollup.svelte';
   import { createEventDispatcher } from 'svelte';
+  import type { PlanSlim } from '../../types/plan';
 
-  export let planId: number | null = null;
+  export let plan: PlanSlim;
 
-  let modelMigrationPreviewErrorCounts: ActivityErrorCounts;
-  let isRowSelectable: ((node: IRowNode) => boolean) | undefined = undefined;
-  let filterExpression: string = '';
-  let height: number = 500;
-  let selectedItemId: RowId | null = null;
-  let selectedMissionModel: ModelSlim | null = null;
-  let width: number = 800;
-  let columnDefs: ColDef[] = [
+  const height: number = 500;
+  const width: number = 800;
+  const columnDefs: ColDef[] = [
     {
       field: 'name',
       headerName: 'Name',
@@ -46,6 +42,15 @@
     confirm: ModelSlim;
   }>();
 
+  let isRowSelectable: ((node: IRowNode) => boolean) | undefined = undefined;
+  let modelMigrationPreviewErrorCounts: ActivityErrorCounts;
+  let filterExpression: string = '';
+  let selectedItemId: RowId | null = null;
+  let selectedMissionModel: ModelSlim | null = null;
+
+  $: previewMissionModelMigration(selectedMissionModel);
+  $: otherModels = $models.filter(m => m.id !== plan.model_id);
+
   function onFiltering(event: Event) {
     const { value } = getTarget(event);
     filterExpression = value as string;
@@ -57,22 +62,21 @@
     } = event;
     if (isSelected) {
       selectedMissionModel = model;
-      previewMissionModelMigration();
     }
   }
 
-  function previewMissionModelMigration() {
-    if (selectedMissionModel !== null) {
+  function previewMissionModelMigration(missionModel: ModelSlim | null) {
+    if (missionModel !== null) {
       //TODO do the preview of migration, result saved in this object...
       modelMigrationPreviewErrorCounts = {
-        all: selectedMissionModel.id * 7,
-        extra: selectedMissionModel.id,
-        invalidAnchor: selectedMissionModel.id,
-        invalidParameter: selectedMissionModel.id,
-        missing: selectedMissionModel.id,
-        outOfBounds: selectedMissionModel.id,
-        pending: selectedMissionModel.id,
-        wrongType: selectedMissionModel.id,
+        all: missionModel.id * 7,
+        extra: missionModel.id,
+        invalidAnchor: missionModel.id,
+        invalidParameter: missionModel.id,
+        missing: missionModel.id,
+        outOfBounds: missionModel.id,
+        pending: missionModel.id,
+        wrongType: missionModel.id,
       };
     }
   }
@@ -109,7 +113,7 @@
           <DataGrid
             bind:currentSelectedRowId={selectedItemId}
             {columnDefs}
-            rowData={$models}
+            rowData={otherModels}
             rowSelection="single"
             on:rowSelected={onClickMissionModel}
             {isRowSelectable}

--- a/src/components/modals/UpdatePlanMissionModelModal.svelte
+++ b/src/components/modals/UpdatePlanMissionModelModal.svelte
@@ -1,0 +1,160 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import ModalHeader from './ModalHeader.svelte';
+  import Modal from './Modal.svelte';
+  import ModalContent from './ModalContent.svelte';
+  import ModalFooter from './ModalFooter.svelte';
+  import CssGrid from '../ui/CssGrid.svelte';
+  import Input from '../form/Input.svelte';
+  import SearchIcon from '@nasa-jpl/stellar/icons/search.svg?component';
+  import CssGridGutter from '../ui/CssGridGutter.svelte';
+  import DataGrid from '../ui/DataGrid/DataGrid.svelte';
+  import type { ColDef, IRowNode } from 'ag-grid-community';
+  import { models } from '../../stores/model';
+  import type { DataGridRowSelection, RowId } from '../../types/data-grid';
+  import type { ModelSlim } from '../../types/model';
+  import { getTarget } from '../../utilities/generic';
+  import type { ActivityErrorCounts } from '../../types/errors';
+  import ActivityErrorsRollup from '../ui/ActivityErrorsRollup.svelte';
+  import { createEventDispatcher } from 'svelte';
+
+  export let planId: number | null = null;
+
+  let modelMigrationPreviewErrorCounts: ActivityErrorCounts;
+  let isRowSelectable: ((node: IRowNode) => boolean) | undefined = undefined;
+  let filterExpression: string = '';
+  let height: number = 500;
+  let selectedItemId: RowId | null = null;
+  let selectedMissionModel: ModelSlim | null = null;
+  let width: number = 800;
+  let columnDefs: ColDef[] = [
+    {
+      field: 'name',
+      headerName: 'Name',
+    },
+    {
+      field: 'created_at',
+      headerName: 'Created',
+      sort: 'desc',
+      width: 80,
+    },
+  ];
+
+  const dispatch = createEventDispatcher<{
+    close: void;
+    confirm: ModelSlim;
+  }>();
+
+  function onFiltering(event: Event) {
+    const { value } = getTarget(event);
+    filterExpression = value as string;
+  }
+
+  function onClickMissionModel(event: CustomEvent<DataGridRowSelection<ModelSlim>>) {
+    const {
+      detail: { data: model, isSelected },
+    } = event;
+    if (isSelected) {
+      selectedMissionModel = model;
+      previewMissionModelMigration();
+    }
+  }
+
+  function previewMissionModelMigration() {
+    if (selectedMissionModel !== null) {
+      //TODO do the preview of migration, result saved in this object...
+      modelMigrationPreviewErrorCounts = {
+        all: selectedMissionModel.id * 7,
+        extra: selectedMissionModel.id,
+        invalidAnchor: selectedMissionModel.id,
+        invalidParameter: selectedMissionModel.id,
+        missing: selectedMissionModel.id,
+        outOfBounds: selectedMissionModel.id,
+        pending: selectedMissionModel.id,
+        wrongType: selectedMissionModel.id,
+      };
+    }
+  }
+
+  function close() {
+    dispatch(`close`);
+  }
+
+  function confirm() {
+    if (selectedMissionModel !== null) {
+      dispatch(`confirm`, selectedMissionModel);
+    }
+  }
+</script>
+
+<Modal {height} {width}>
+  <ModalHeader on:close>Change Mission Model</ModalHeader>
+  <ModalContent>
+    <div class="body">
+      <Input>
+        <div class="search-icon" slot="left">
+          <SearchIcon />
+        </div>
+        <input
+          autocomplete="off"
+          name=""
+          class="st-input w-100"
+          placeholder="Search mission models"
+          on:input={onFiltering}
+        />
+      </Input>
+      <CssGrid columns="60% 2px 40%">
+        <div class="mission-model-column">
+          <DataGrid
+            bind:currentSelectedRowId={selectedItemId}
+            {columnDefs}
+            rowData={$models}
+            rowSelection="single"
+            on:rowSelected={onClickMissionModel}
+            {isRowSelectable}
+            {filterExpression}
+          ></DataGrid>
+        </div>
+        <CssGridGutter track={1} type="column" />
+        <div class="model-migration-preview mission-model-column">
+          {#if selectedMissionModel === null}
+            <div class="st-typography-label">Select mission model for expected conflicts...</div>
+          {:else}
+            <div class="st-typography-label st-typography-bold">Expected conflicts</div>
+            <ActivityErrorsRollup selectable={true} counts={modelMigrationPreviewErrorCounts} showTotalCount={true} />
+          {/if}
+        </div>
+      </CssGrid>
+    </div>
+  </ModalContent>
+  <ModalFooter>
+    <div class="st-typography-label">Snapshot will be automatically created</div>
+    <button class="st-button secondary" on:click={close}>Cancel</button>
+    <button class="st-button" on:click={confirm}>Change Mission Model</button>
+  </ModalFooter>
+</Modal>
+
+<style>
+  .search-icon {
+    align-items: center;
+    color: var(--st-gray-50);
+    display: flex;
+  }
+
+  .mission-model-column {
+    flex-direction: column;
+    gap: 8px;
+    height: 400px;
+    overflow: auto;
+    padding: 8px 8px 0 0;
+  }
+
+  .model-migration-preview {
+    padding: 8px;
+  }
+
+  .model-migration-preview div:first-child {
+    height: 20px;
+  }
+</style>

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -12,6 +12,7 @@
   import { onDestroy, onMount } from 'svelte';
   import ExportIcon from '../../assets/export.svg?component';
   import ImportIcon from '../../assets/import.svg?component';
+  import SwapIcon from 'bootstrap-icons/icons/arrow-left-right.svg?component';
   import Nav from '../../components/app/Nav.svelte';
   import PageTitle from '../../components/app/PageTitle.svelte';
   import DatePickerField from '../../components/form/DatePickerField.svelte';
@@ -630,6 +631,12 @@
   function selectPlan(planId: number | null) {
     selectedPlanId = planId;
   }
+
+  async function openChangePlanMissionModelModal() {
+    if (selectedPlanId !== null) {
+      await effects.updatePlanMissionModel(selectedPlanId, user);
+    }
+  }
 </script>
 
 <PageTitle title="Plans" />
@@ -682,7 +689,7 @@
         {#if selectedPlan}
           <div class="plan-metadata">
             <fieldset>
-              <Input layout="inline">
+              <Input layout="inline-with-button">
                 <label class="plan-metadata-item-label" for="name">Model</label>
                 <input
                   disabled
@@ -691,6 +698,13 @@
                   use:tooltip={{ content: selectedPlanModelName, placement: 'top' }}
                   value={selectedPlanModelName}
                 />
+                <button
+                  class="st-button secondary"
+                  use:tooltip={{ content: 'Change Plan Model', placement: 'top' }}
+                  on:click|stopPropagation={openChangePlanMissionModelModal}
+                >
+                  <SwapIcon />
+                </button>
               </Input>
               <Input layout="inline">
                 <label class="plan-metadata-item-label" for="id">Name</label>

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -633,8 +633,8 @@
   }
 
   async function openChangePlanMissionModelModal() {
-    if (selectedPlanId !== null) {
-      await effects.updatePlanMissionModel(selectedPlanId, user);
+    if (selectedPlan !== undefined) {
+      await effects.updatePlanMissionModel(selectedPlan, user);
     }
   }
 </script>
@@ -689,7 +689,7 @@
         {#if selectedPlan}
           <div class="plan-metadata">
             <fieldset>
-              <Input layout="inline-with-button">
+              <Input layout="inline" class="with-button">
                 <label class="plan-metadata-item-label" for="name">Model</label>
                 <input
                   disabled
@@ -1018,5 +1018,9 @@
 
   .plan-metadata-item-label {
     white-space: nowrap;
+  }
+
+  .plan-metadata :global(.with-button) {
+    grid-template-columns: 40% auto 1fr;
   }
 </style>

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -6008,16 +6008,16 @@ const effects = {
     }
   },
 
-  async updatePlanMissionModel(planId: number, user: User | null): Promise<void> {
+  async updatePlanMissionModel(plan: PlanSlim, user: User | null): Promise<void> {
     try {
-      if (!queryPermissions.UPDATE_PLAN(user, planId)) {
+      if (!queryPermissions.UPDATE_PLAN(user, plan)) {
         throwPermissionError('update plan');
       }
       if (!queryPermissions.CREATE_PLAN_SNAPSHOT(user)) {
         throwPermissionError('create a snapshot');
       }
 
-      const { confirm, value } = await showUpdatePlanMissionModelModal(planId);
+      const { confirm, value } = await showUpdatePlanMissionModelModal(plan);
       if (confirm) {
         //TODO do the migration!
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -243,6 +243,7 @@ import { ActivityDeletionAction } from './activities';
 import { compare, convertToQuery, getSearchParameterNumber, setQueryParam } from './generic';
 import gql, { convertToGQLArray } from './gql';
 import {
+  showUpdatePlanMissionModelModal,
   showConfirmModal,
   showCreateGroupsOrTypes,
   showCreatePlanBranchModal,
@@ -6003,6 +6004,28 @@ const effects = {
     } catch (e) {
       catchError('Plan Update Failed', e as Error);
       showFailureToast('Plan Update Failed');
+      return;
+    }
+  },
+
+  async updatePlanMissionModel(planId: number, user: User | null): Promise<void> {
+    try {
+      if (!queryPermissions.UPDATE_PLAN(user, planId)) {
+        throwPermissionError('update plan');
+      }
+      if (!queryPermissions.CREATE_PLAN_SNAPSHOT(user)) {
+        throwPermissionError('create a snapshot');
+      }
+
+      const { confirm, value } = await showUpdatePlanMissionModelModal(planId);
+      if (confirm) {
+        //TODO do the migration!
+
+        showSuccessToast('Model Migration Success');
+      }
+    } catch (e) {
+      catchError('Model Migration Failed', e as Error);
+      showFailureToast('Model Migration Failed');
       return;
     }
   },

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -7,6 +7,7 @@ import CreateGroupsOrTypesModal from '../components/modals/CreateGroupsOrTypesMo
 import CreatePlanBranchModal from '../components/modals/CreatePlanBranchModal.svelte';
 import CreatePlanSnapshotModal from '../components/modals/CreatePlanSnapshotModal.svelte';
 import CreateViewModal from '../components/modals/CreateViewModal.svelte';
+import ChangePlanMissionModelModal from '../components/modals/UpdatePlanMissionModelModal.svelte';
 import DeleteActivitiesModal from '../components/modals/DeleteActivitiesModal.svelte';
 import DeleteDerivationGroupModal from '../components/modals/DeleteDerivationGroupModal.svelte';
 import DeleteExternalEventSourceTypeModal from '../components/modals/DeleteExternalEventSourceTypeModal.svelte';
@@ -1096,6 +1097,37 @@ export async function showUploadViewModal(): Promise<ModalElementValue<{ definit
           target.resolve = null;
           resolve({ confirm: true, value: e.detail });
           uploadViewModal.$destroy();
+        });
+      }
+    } else {
+      resolve({ confirm: false });
+    }
+  });
+}
+
+export async function showUpdatePlanMissionModelModal(planId: number): Promise<ModalElementValue> {
+  return new Promise(resolve => {
+    if (browser) {
+      const target: ModalElement | null = document.querySelector('#svelte-modal');
+      if (target) {
+        const modal = new ChangePlanMissionModelModal({
+          props: { planId },
+          target,
+        });
+        target.resolve = resolve;
+
+        modal.$on('close', () => {
+          target.replaceChildren();
+          target.resolve = null;
+          resolve({ confirm: false });
+          modal.$destroy();
+        });
+
+        modal.$on('confirm', (e: CustomEvent) => {
+          target.replaceChildren();
+          target.resolve = null;
+          resolve({ confirm: true, value: e.detail });
+          modal.$destroy();
         });
       }
     } else {

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -47,6 +47,7 @@ import type {
   PlanForMerging,
   PlanMergeRequestStatus,
   PlanMergeRequestTypeFilter,
+  PlanSlim,
 } from '../types/plan';
 import type { PlanSnapshot } from '../types/plan-snapshot';
 import type { Tag } from '../types/tags';
@@ -1105,13 +1106,13 @@ export async function showUploadViewModal(): Promise<ModalElementValue<{ definit
   });
 }
 
-export async function showUpdatePlanMissionModelModal(planId: number): Promise<ModalElementValue> {
+export async function showUpdatePlanMissionModelModal(plan: PlanSlim): Promise<ModalElementValue> {
   return new Promise(resolve => {
     if (browser) {
       const target: ModalElement | null = document.querySelector('#svelte-modal');
       if (target) {
         const modal = new ChangePlanMissionModelModal({
-          props: { planId },
+          props: { plan },
           target,
         });
         target.resolve = resolve;


### PR DESCRIPTION
#1631 - but needs integration with backend when it's ready 

In parallel with the work being done for the backend for model migration, let's make a UI to allow previewing the expected conflicts and also selecting the model that you want to migrate to.

THIS DOES NOT DO THE ACTUAL MIGRATION.

Design: https://www.figma.com/design/dNrdkpcAobXVqj97JaSm1l/AERIE-Mission-Model-Migration?node-id=177-3478&t=5oKczCtT7cZwANFG-0

Got it as close as I could using features that allowed me to build it faster like Data Grid.

Preview:
![Screenshot 2025-03-26 at 4 48 05 PM](https://github.com/user-attachments/assets/40011abe-1e3b-440f-b0b9-f0a9f065423c)
