### PR TITLE
Added an optional flag for command dictionary file saving

### DIFF
--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -133,7 +133,7 @@
             </fieldset>
           {:else if files !== undefined}
             <fieldset class="save-dictionary-fieldset">
-              <label for="Save Dictionary">Save Command Dictionary to filesystem</label>
+              <label for="Save Dictionary">Save Dictionary to the filesystem</label>
               <input
                 bind:checked={persistDictionaryToFilesystem}
                 class="st-input"

--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -27,7 +27,7 @@
   let file: File;
   let fileInput: HTMLInputElement;
   let isSequenceAdaptation: boolean = false;
-  let persistDictionaryToFilesystem: boolean = false;
+  let persistDictionaryToFilesystem: boolean = true;
   let sequenceAdaptationName: string;
 
   $: hasCreatePermission =
@@ -138,7 +138,7 @@
                 bind:checked={persistDictionaryToFilesystem}
                 class="st-input"
                 name="Save Dictionary"
-                on:change={() => (persistDictionaryToFilesystem = true)}
+                on:change={() => (persistDictionaryToFilesystem = !persistDictionaryToFilesystem)}
                 type="checkbox"
               />
             </fieldset>

--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -27,6 +27,7 @@
   let file: File;
   let fileInput: HTMLInputElement;
   let isSequenceAdaptation: boolean = false;
+  let persistDictionaryToFilesystem: boolean = false;
   let sequenceAdaptationName: string;
 
   $: hasCreatePermission =
@@ -49,7 +50,12 @@
     creatingDictionary = true;
 
     try {
-      await effects.uploadDictionaryOrAdaptation(file, data.user, sequenceAdaptationName);
+      await effects.uploadDictionaryOrAdaptation(
+        file,
+        data.user,
+        sequenceAdaptationName,
+        persistDictionaryToFilesystem,
+      );
 
       // Set files to undefined to reset the input form and set the value to empty string to clear the uploaded file.
       files = undefined;
@@ -125,6 +131,17 @@
                 required={isSequenceAdaptation}
               />
             </fieldset>
+          {:else if files !== undefined}
+            <fieldset class="save-dictionary-fieldset">
+              <label for="Save Dictionary">Save Command Dictionary to filesystem</label>
+              <input
+                bind:checked={persistDictionaryToFilesystem}
+                class="st-input"
+                name="Save Dictionary"
+                on:change={() => (persistDictionaryToFilesystem = true)}
+                type="checkbox"
+              />
+            </fieldset>
           {/if}
 
           <fieldset>
@@ -192,5 +209,11 @@
 <style>
   .table-container {
     display: grid;
+  }
+
+  .save-dictionary-fieldset {
+    column-gap: 0.5rem;
+    display: flex;
+    flex-direction: row;
   }
 </style>

--- a/src/routes/dictionaries/+page.svelte
+++ b/src/routes/dictionaries/+page.svelte
@@ -138,7 +138,6 @@
                 bind:checked={persistDictionaryToFilesystem}
                 class="st-input"
                 name="Save Dictionary"
-                on:change={() => (persistDictionaryToFilesystem = !persistDictionaryToFilesystem)}
                 type="checkbox"
               />
             </fieldset>

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -6993,7 +6993,7 @@ const effects = {
     file: File,
     user: User | null,
     sequenceAdaptationName?: string | undefined,
-    persistDictionaryToFilesystem: boolean = false,
+    persistDictionaryToFilesystem: boolean = true,
   ): Promise<void> {
     const text = await file.text();
     if (sequenceAdaptationName) {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -6953,6 +6953,7 @@ const effects = {
   async uploadDictionary(
     dictionary: string,
     user: User | null,
+    persistDictionaryToFilesystem: boolean = false,
   ): Promise<{
     channel?: ChannelDictionaryMetadata;
     command?: CommandDictionaryMetadata;
@@ -6973,7 +6974,7 @@ const effects = {
         channel?: ChannelDictionaryMetadata;
         command?: CommandDictionaryMetadata;
         parameter?: ParameterDictionaryMetadata;
-      }>(gql.CREATE_DICTIONARY, { dictionary }, user);
+      }>(gql.CREATE_DICTIONARY, { dictionary, persistDictionaryToFilesystem }, user);
 
       const { createDictionary: newDictionaries } = data;
 
@@ -6992,6 +6993,7 @@ const effects = {
     file: File,
     user: User | null,
     sequenceAdaptationName?: string | undefined,
+    persistDictionaryToFilesystem: boolean = false,
   ): Promise<void> {
     const text = await file.text();
     if (sequenceAdaptationName) {
@@ -7002,7 +7004,7 @@ const effects = {
       }
       showSuccessToast('Sequence Adaptation Created Successfully');
     } else {
-      const uploadedDictionaries = await this.uploadDictionary(text, user);
+      const uploadedDictionaries = await this.uploadDictionary(text, user, persistDictionaryToFilesystem);
       if (uploadedDictionaries === null) {
         showFailureToast('Failed to upload dictionary file');
         throw Error('Failed to upload dictionary file');

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -6953,7 +6953,7 @@ const effects = {
   async uploadDictionary(
     dictionary: string,
     user: User | null,
-    persistDictionaryToFilesystem: boolean = false,
+    persistDictionaryToFilesystem: boolean = true,
   ): Promise<{
     channel?: ChannelDictionaryMetadata;
     command?: CommandDictionaryMetadata;

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -246,8 +246,8 @@ const gql = {
   `,
 
   CREATE_DICTIONARY: `#graphql
-    mutation CreateDictionary($dictionary: String!) {
-      createDictionary: ${Queries.UPLOAD_DICTIONARY}(dictionary: $dictionary) {
+    mutation CreateDictionary($dictionary: String!, $persistDictionaryToFilesystem: Boolean!) {
+      createDictionary: ${Queries.UPLOAD_DICTIONARY}(dictionary: $dictionary, persistDictionaryToFilesystem: $persistDictionaryToFilesystem) {
         command
         parameter
         channel


### PR DESCRIPTION
Added a checkbox that lets you control if you want to persist the command dictionary to the filesystem or not on upload.

Depending on https://github.com/NASA-AMMOS/aerie/pull/1672

`___REQUIRES_AERIE_PR___="1672"`