### PR TITLE
Fix aerie-action container name in docker-compose-test

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -20,7 +20,7 @@ services:
       ACTION_LOCAL_STORE: /usr/src/app/action_file_store
       ACTION_WORKER_NUM: 8
       ACTION_MAX_WORKER_NUM: 8
-    image: 'ghcr.io/nasa-ammos/aerie-actions:${AERIE_IMAGE_TAG:-develop}'
+    image: 'ghcr.io/nasa-ammos/aerie-action:${AERIE_IMAGE_TAG:-develop}'
     ports: ['27186:27186']
     restart: always
     volumes:


### PR DESCRIPTION
Causing e2e failures due to using wrong Docker container (aerie-actions - now unpublished/deleted)