### PR TITLE
Various aria-label fixes across the app

### DIFF
--- a/src/components/CollapsibleListControls.svelte
+++ b/src/components/CollapsibleListControls.svelte
@@ -19,7 +19,15 @@
 
 <div class="collapsible-list-controls">
   <div class="collapsible-list-controls-top">
-    <input autocomplete="off" bind:value class="st-input w-full" name="filter" {placeholder} on:input={onInput} />
+    <input
+      autocomplete="off"
+      bind:value
+      class="st-input w-full"
+      name="filter"
+      aria-label={placeholder}
+      {placeholder}
+      on:input={onInput}
+    />
     <slot name="right" />
   </div>
   <slot />

--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -537,7 +537,7 @@
                 disabled
                 name="activityName"
                 value={activityDirective.name}
-                aria-label="Activity ID"
+                aria-label="Activity Name"
               />
             </Input>
           </Highlight>
@@ -546,7 +546,7 @@
         <Highlight highlight={highlightKeysMap.id}>
           <Input layout="inline">
             <label use:tooltip={{ content: 'Activity ID', placement: 'top' }} for="id"> ID</label>
-            <input class="st-input w-full" disabled name="id" value={activityDirective.id} />
+            <input class="st-input w-full" disabled name="id" value={activityDirective.id} aria-label="Activity ID" />
           </Input>
         </Highlight>
 
@@ -555,7 +555,13 @@
             <label use:tooltip={{ content: 'Activity Type', placement: 'top' }} for="activity-type">
               Activity Type
             </label>
-            <input class="st-input w-full" disabled name="activity-type" value={activityDirective.type} />
+            <input
+              class="st-input w-full"
+              disabled
+              name="activity-type"
+              value={activityDirective.type}
+              aria-label="Activity Type"
+            />
           </Input>
         </Highlight>
 

--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -535,9 +535,9 @@
               <input
                 class="st-input w-full"
                 disabled
+                id="activityName"
                 name="activityName"
                 value={activityDirective.name}
-                aria-label="Activity Name"
               />
             </Input>
           </Highlight>
@@ -546,7 +546,7 @@
         <Highlight highlight={highlightKeysMap.id}>
           <Input layout="inline">
             <label use:tooltip={{ content: 'Activity ID', placement: 'top' }} for="id"> ID</label>
-            <input class="st-input w-full" disabled name="id" value={activityDirective.id} aria-label="Activity ID" />
+            <input class="st-input w-full" disabled name="id" id="id" value={activityDirective.id} />
           </Input>
         </Highlight>
 
@@ -559,8 +559,8 @@
               class="st-input w-full"
               disabled
               name="activity-type"
+              id="activity-type"
               value={activityDirective.type}
-              aria-label="Activity Type"
             />
           </Input>
         </Highlight>
@@ -612,7 +612,7 @@
               disabled
               name="creationTime"
               value={activityDirective.created_at}
-              aria-label="Creation Time (UTC)"
+              id="creationTime"
             />
           </Input>
         </Highlight>
@@ -626,7 +626,7 @@
               class="st-input w-full"
               disabled
               name="lastModifiedTime"
-              aria-label="Last Modified Time (UTC)"
+              id="lastModifiedTime"
               value={activityDirective.last_modified_at}
             />
           </Input>
@@ -642,7 +642,7 @@
               disabled
               name="modifiedBy"
               value={activityDirective.last_modified_by}
-              aria-label="Last Modified By"
+              id="modifiedBy"
             />
           </Input>
         </Highlight>
@@ -655,7 +655,7 @@
               disabled
               name="createdBy"
               value={activityDirective.created_by}
-              aria-label="Created By"
+              id="createdBy"
             />
           </Input>
         </Highlight>
@@ -672,7 +672,7 @@
               class="st-input w-full"
               disabled
               name="sourceSchedulingGoalId"
-              aria-label="Source Scheduling Goal ID"
+              id="sourceSchedulingGoalId"
               value={activityDirective.source_scheduling_goal_id ?? 'None'}
             />
           </Input>

--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -464,6 +464,7 @@
               class="st-input w-full"
               name="activity-name"
               placeholder="Enter activity name"
+              aria-label="Activity Name"
             />
           </Field>
           <button
@@ -531,7 +532,13 @@
               <label use:tooltip={{ content: 'Activity Name', placement: 'top' }} for="activityName">
                 Activity Name
               </label>
-              <input class="st-input w-full" disabled name="activityName" value={activityDirective.name} />
+              <input
+                class="st-input w-full"
+                disabled
+                name="activityName"
+                value={activityDirective.name}
+                aria-label="Activity ID"
+              />
             </Input>
           </Highlight>
         {/if}
@@ -594,7 +601,13 @@
             <label use:tooltip={{ content: 'Creation Time (UTC)', placement: 'top' }} for="creationTime">
               Creation Time (UTC)
             </label>
-            <input class="st-input w-full" disabled name="creationTime" value={activityDirective.created_at} />
+            <input
+              class="st-input w-full"
+              disabled
+              name="creationTime"
+              value={activityDirective.created_at}
+              aria-label="Creation Time (UTC)"
+            />
           </Input>
         </Highlight>
 
@@ -607,6 +620,7 @@
               class="st-input w-full"
               disabled
               name="lastModifiedTime"
+              aria-label="Last Modified Time (UTC)"
               value={activityDirective.last_modified_at}
             />
           </Input>
@@ -617,14 +631,26 @@
             <label use:tooltip={{ content: 'Last Modified By', placement: 'top' }} for="modifiedBy">
               Last Modified By
             </label>
-            <input class="st-input w-full" disabled name="modifiedBy" value={activityDirective.last_modified_by} />
+            <input
+              class="st-input w-full"
+              disabled
+              name="modifiedBy"
+              value={activityDirective.last_modified_by}
+              aria-label="Last Modified By"
+            />
           </Input>
         </Highlight>
 
         <Highlight highlight={highlightKeysMap.last_modified_by}>
           <Input layout="inline">
             <label use:tooltip={{ content: 'Created By', placement: 'top' }} for="createdBy"> Created By </label>
-            <input class="st-input w-full" disabled name="createdBy" value={activityDirective.created_by} />
+            <input
+              class="st-input w-full"
+              disabled
+              name="createdBy"
+              value={activityDirective.created_by}
+              aria-label="Created By"
+            />
           </Input>
         </Highlight>
 
@@ -640,6 +666,7 @@
               class="st-input w-full"
               disabled
               name="sourceSchedulingGoalId"
+              aria-label="Source Scheduling Goal ID"
               value={activityDirective.source_scheduling_goal_id ?? 'None'}
             />
           </Input>

--- a/src/components/constraints/Constraints.svelte
+++ b/src/components/constraints/Constraints.svelte
@@ -211,7 +211,13 @@
       <SectionTitle>Constraints</SectionTitle>
 
       <Input>
-        <input bind:value={filterText} class="st-input" placeholder="Filter constraints" style="width: 100%;" />
+        <input
+          bind:value={filterText}
+          class="st-input"
+          aria-label="Filter constraints"
+          placeholder="Filter constraints"
+          style="width: 100%;"
+        />
       </Input>
 
       <div class="right">

--- a/src/components/modals/ManagePlanConstraintsModal.svelte
+++ b/src/components/modals/ManagePlanConstraintsModal.svelte
@@ -269,7 +269,13 @@
       <div class="constraints-modal-filter-container">
         <div class="constraints-modal-title">Constraints</div>
         <Input>
-          <input bind:value={filterText} class="st-input" placeholder="Filter constraints" style="width: 100%;" />
+          <input
+            bind:value={filterText}
+            class="st-input"
+            aria-label="Filter constraints"
+            placeholder="Filter constraints"
+            style="width: 100%;"
+          />
         </Input>
         <button
           class="st-button secondary ellipsis"

--- a/src/components/model/Models.svelte
+++ b/src/components/model/Models.svelte
@@ -283,6 +283,7 @@
                 name="name"
                 use:tooltip={{ content: name, placement: 'top' }}
                 value={selectedModel.name}
+                aria-label="Model Name"
               />
             </Input>
             <Input layout="inline">
@@ -295,15 +296,27 @@
             </Input>
             <Input layout="inline">
               <label class="model-metadata-item-label" for="version">Model Version</label>
-              <input disabled class="st-input w-full" name="version" value={selectedModel.version} />
+              <input
+                disabled
+                class="st-input w-full"
+                name="version"
+                value={selectedModel.version}
+                aria-label="Model Version"
+              />
             </Input>
             <Input layout="inline">
               <label class="model-metadata-item-label" for="owner">Owner</label>
-              <input disabled class="st-input w-full" name="owner" value={selectedModel.owner} />
+              <input disabled class="st-input w-full" name="owner" value={selectedModel.owner} aria-label="Owner" /> />
             </Input>
             <Input layout="inline">
               <label class="model-metadata-item-label" for="defaultView">Default View</label>
-              <input disabled class="st-input w-full" name="defaultView" value={selectedModelDefaultViewName} />
+              <input
+                disabled
+                class="st-input w-full"
+                name="defaultView"
+                value={selectedModelDefaultViewName}
+                aria-label="Default View"
+              />
             </Input>
             <Input layout="inline">
               <label class="model-metadata-item-label" for="created">Date Created</label>
@@ -311,6 +324,7 @@
                 disabled
                 class="st-input w-full"
                 name="created"
+                aria-label="Date Created"
                 value={getShortISOForDate(new Date(selectedModel.created_at))}
               />
             </Input>
@@ -320,6 +334,7 @@
                 {#if modelHasExtractionError}
                   <button
                     class="icon-button"
+                    aria-label="Jar File Status"
                     on:click={onRetriggerModelExtraction}
                     use:permissionHandler={{
                       hasPermission: hasExtractionPermission,
@@ -374,6 +389,7 @@
               autocomplete="off"
               class="st-input w-full"
               name="name"
+              aria-label="Name"
               required
               use:permissionHandler={{
                 hasPermission: hasCreateModelPermission,
@@ -390,6 +406,7 @@
               class="st-input w-full"
               name="version"
               placeholder="0.0.0"
+              aria-label="Version"
               required
               use:permissionHandler={{
                 hasPermission: hasCreateModelPermission,
@@ -405,6 +422,7 @@
               autocomplete="off"
               class="st-input w-full"
               name="description"
+              aria-label="Description"
               placeholder="Enter Model Description (optional)"
             />
           </fieldset>
@@ -413,6 +431,7 @@
             <label for="file">Jar File</label>
             <input
               class="w-full"
+              aria-label="Jar File"
               name="file"
               required
               type="file"

--- a/src/components/model/Models.svelte
+++ b/src/components/model/Models.svelte
@@ -276,7 +276,7 @@
         <div class="model-metadata">
           <fieldset>
             <Input layout="inline">
-              <label class="model-metadata-item-label" for="name">Model Name</label>
+              <label class="" for="name">Model Name</label>
               <input
                 disabled
                 class="st-input w-full"
@@ -292,11 +292,17 @@
             </Input>
             <Input layout="inline">
               <label class="model-metadata-item-label" for="description">Model Description</label>
-              <textarea disabled class="st-input w-full" name="description" value={selectedModel.description} />
+              <textarea
+                disabled
+                class="st-input w-full"
+                name="description"
+                id="description"
+                value={selectedModel.description}
+              />
             </Input>
             <Input layout="inline">
               <label class="model-metadata-item-label" for="version">Model Version</label>
-              <input disabled class="st-input w-full" name="version" value={selectedModel.version} id="version" />
+              <input disabled class="st-input w-full" name="version" id="version" value={selectedModel.version} />
             </Input>
             <Input layout="inline">
               <label class="model-metadata-item-label" for="owner">Owner</label>
@@ -324,11 +330,10 @@
             </Input>
             <Input layout="inline">
               <div class="model-jar-label">
-                <label class="model-metadata-item-label">Jar File Status</label>
+                <label class="model-metadata-item-label" for="status">Jar File Status</label>
                 {#if modelHasExtractionError}
                   <button
                     class="icon-button"
-                    id="status"
                     on:click={onRetriggerModelExtraction}
                     use:permissionHandler={{
                       hasPermission: hasExtractionPermission,

--- a/src/components/model/Models.svelte
+++ b/src/components/model/Models.svelte
@@ -283,7 +283,7 @@
                 name="name"
                 use:tooltip={{ content: name, placement: 'top' }}
                 value={selectedModel.name}
-                aria-label="Model Name"
+                id="name"
               />
             </Input>
             <Input layout="inline">
@@ -296,17 +296,11 @@
             </Input>
             <Input layout="inline">
               <label class="model-metadata-item-label" for="version">Model Version</label>
-              <input
-                disabled
-                class="st-input w-full"
-                name="version"
-                value={selectedModel.version}
-                aria-label="Model Version"
-              />
+              <input disabled class="st-input w-full" name="version" value={selectedModel.version} id="version" />
             </Input>
             <Input layout="inline">
               <label class="model-metadata-item-label" for="owner">Owner</label>
-              <input disabled class="st-input w-full" name="owner" value={selectedModel.owner} aria-label="Owner" /> />
+              <input disabled class="st-input w-full" name="owner" value={selectedModel.owner} id="owner" /> />
             </Input>
             <Input layout="inline">
               <label class="model-metadata-item-label" for="defaultView">Default View</label>
@@ -315,7 +309,7 @@
                 class="st-input w-full"
                 name="defaultView"
                 value={selectedModelDefaultViewName}
-                aria-label="Default View"
+                id="defaultView"
               />
             </Input>
             <Input layout="inline">
@@ -324,7 +318,7 @@
                 disabled
                 class="st-input w-full"
                 name="created"
-                aria-label="Date Created"
+                id="created"
                 value={getShortISOForDate(new Date(selectedModel.created_at))}
               />
             </Input>
@@ -334,7 +328,7 @@
                 {#if modelHasExtractionError}
                   <button
                     class="icon-button"
-                    aria-label="Jar File Status"
+                    id="status"
                     on:click={onRetriggerModelExtraction}
                     use:permissionHandler={{
                       hasPermission: hasExtractionPermission,
@@ -389,7 +383,7 @@
               autocomplete="off"
               class="st-input w-full"
               name="name"
-              aria-label="Name"
+              id="name"
               required
               use:permissionHandler={{
                 hasPermission: hasCreateModelPermission,
@@ -406,7 +400,7 @@
               class="st-input w-full"
               name="version"
               placeholder="0.0.0"
-              aria-label="Version"
+              id="version"
               required
               use:permissionHandler={{
                 hasPermission: hasCreateModelPermission,
@@ -422,7 +416,7 @@
               autocomplete="off"
               class="st-input w-full"
               name="description"
-              aria-label="Description"
+              id="description"
               placeholder="Enter Model Description (optional)"
             />
           </fieldset>
@@ -431,7 +425,7 @@
             <label for="file">Jar File</label>
             <input
               class="w-full"
-              aria-label="Jar File"
+              id="file"
               name="file"
               required
               type="file"

--- a/src/components/model/Models.svelte
+++ b/src/components/model/Models.svelte
@@ -300,7 +300,7 @@
             </Input>
             <Input layout="inline">
               <label class="model-metadata-item-label" for="owner">Owner</label>
-              <input disabled class="st-input w-full" name="owner" value={selectedModel.owner} id="owner" /> />
+              <input disabled class="st-input w-full" name="owner" value={selectedModel.owner} id="owner" />
             </Input>
             <Input layout="inline">
               <label class="model-metadata-item-label" for="defaultView">Default View</label>
@@ -324,7 +324,7 @@
             </Input>
             <Input layout="inline">
               <div class="model-jar-label">
-                <label class="model-metadata-item-label" for="status">Jar File Status</label>
+                <label class="model-metadata-item-label">Jar File Status</label>
                 {#if modelHasExtractionError}
                   <button
                     class="icon-button"

--- a/src/components/parameters/ParameterBaseBoolean.svelte
+++ b/src/components/parameters/ParameterBaseBoolean.svelte
@@ -39,6 +39,7 @@
     <input
       bind:this={checkboxRef}
       bind:checked={formParameter.value}
+      aria-label={formParameter.name}
       {disabled}
       type="checkbox"
       on:change={() => dispatch('change', formParameter)}

--- a/src/components/parameters/ParameterBaseDuration.svelte
+++ b/src/components/parameters/ParameterBaseDuration.svelte
@@ -45,6 +45,7 @@
     <input
       bind:value={durationString}
       class="st-input w-full"
+      aria-label={formParameter.name}
       class:error={formParameter.errors !== null || durationStringFormatError !== null}
       {disabled}
       type="text"

--- a/src/components/parameters/ParameterBaseNumber.svelte
+++ b/src/components/parameters/ParameterBaseNumber.svelte
@@ -45,6 +45,7 @@
       class:error={formParameter.errors !== null}
       {disabled}
       type="number"
+      aria-label={formParameter.name}
       use:useActions={use}
       on:change={debouncedOnChange}
     />

--- a/src/components/parameters/ParameterBasePath.svelte
+++ b/src/components/parameters/ParameterBasePath.svelte
@@ -45,6 +45,7 @@
         bind:value={formParameter.value}
         class="st-input w-full"
         class:error={formParameter.errors !== null}
+        aria-label={formParameter.name}
         disabled
         use:useActions={use}
         type="text"

--- a/src/components/parameters/ParameterBaseString.svelte
+++ b/src/components/parameters/ParameterBaseString.svelte
@@ -33,6 +33,7 @@
       bind:value={formParameter.value}
       class="st-input w-full"
       class:error={formParameter.errors !== null}
+      aria-label={formParameter.name}
       {disabled}
       type="text"
       use:useActions={use}

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -193,7 +193,7 @@
                 class="st-input w-full"
                 name="plan-name"
                 placeholder="Enter a plan name"
-                aria-label="Plan Name"
+                id="plan-name"
                 use:permissionHandler={{
                   hasPermission: hasPlanUpdatePermission,
                   permissionError,
@@ -204,25 +204,19 @@
         </div>
         <Input layout="inline">
           <label use:tooltip={{ content: 'ID', placement: 'top' }} for="id">Plan ID</label>
-          <input class="st-input w-full" disabled name="id" value={plan.id} aria-label="Plan ID" />
+          <input class="st-input w-full" disabled name="id" value={plan.id} id="id" />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Model Name', placement: 'top' }} for="modelName">Model Name</label>
-          <input class="st-input w-full" disabled name="modelName" value={plan.model.name} aria-label="Model Name" />
+          <input class="st-input w-full" disabled name="modelName" value={plan.model.name} id="modelName" />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Model ID', placement: 'top' }} for="modelId">Model ID</label>
-          <input class="st-input w-full" disabled name="modelId" value={plan.model_id} aria-label="Model ID" />
+          <input class="st-input w-full" disabled name="modelId" value={plan.model_id} id="modelId" />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Model Version', placement: 'top' }} for="modelVersion">Model Version</label>
-          <input
-            class="st-input w-full"
-            disabled
-            name="modelVersion"
-            value={plan.model.version}
-            aria-label="Model Version"
-          />
+          <input class="st-input w-full" disabled name="modelVersion" value={plan.model.version} id="modelVersion" />
         </Input>
         <Input layout="inline">
           <label
@@ -231,29 +225,17 @@
           >
             Start Time ({$plugins.time.primary.label})
           </label>
-          <input
-            class="st-input w-full"
-            disabled
-            name="startTime"
-            value={planStartTime}
-            aria-label="Start Time (${$plugins.time.primary.label})"
-          />
+          <input class="st-input w-full" disabled name="startTime" value={planStartTime} id="startTime" />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: `End Time (${$plugins.time.primary.label})`, placement: 'top' }} for="endTime">
             End Time ({$plugins.time.primary.label})
           </label>
-          <input
-            class="st-input w-full"
-            disabled
-            name="endTime"
-            value={planEndTime}
-            aria-label="End Time (${$plugins.time.primary.label})"
-          />
+          <input class="st-input w-full" disabled name="endTime" value={planEndTime} id="endTime" />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Owner', placement: 'top' }} for="owner">Owner</label>
-          <input class="st-input w-full" disabled name="owner" value={plan.owner} aria-label="Owner" />
+          <input class="st-input w-full" disabled name="owner" value={plan.owner} id="owner" />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Date Created', placement: 'top' }} for="createdAt">Date Created</label>
@@ -261,7 +243,7 @@
             class="st-input w-full"
             disabled
             name="createdAt"
-            aria-label="Created At"
+            id="createdAt"
             value={getShortISOForDate(new Date(plan.created_at))}
           />
         </Input>
@@ -271,17 +253,17 @@
             class="st-input w-full"
             disabled
             name="updatedAt"
-            aria-label="Updated At"
+            id="updatedAt"
             value={getShortISOForDate(new Date(plan.updated_at))}
           />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Updated By', placement: 'top' }} for="updatedBy">Updated By</label>
-          <input class="st-input w-full" disabled name="updatedBy" value={plan.updated_by} aria-label="Updated By" />
+          <input class="st-input w-full" disabled name="updatedBy" value={plan.updated_by} id="updatedBy" />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Revision', placement: 'top' }} for="revision">Revision</label>
-          <input class="st-input w-full" disabled name="revision" value={plan.revision} aria-label="Revision" />
+          <input class="st-input w-full" disabled name="revision" value={plan.revision} id="revision" />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Collaborators', placement: 'top' }} for="collaborators">Collaborators</label>

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -193,6 +193,7 @@
                 class="st-input w-full"
                 name="plan-name"
                 placeholder="Enter a plan name"
+                aria-label="Plan Name"
                 use:permissionHandler={{
                   hasPermission: hasPlanUpdatePermission,
                   permissionError,
@@ -203,19 +204,25 @@
         </div>
         <Input layout="inline">
           <label use:tooltip={{ content: 'ID', placement: 'top' }} for="id">Plan ID</label>
-          <input class="st-input w-full" disabled name="id" value={plan.id} />
+          <input class="st-input w-full" disabled name="id" value={plan.id} aria-label="Plan ID" />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Model Name', placement: 'top' }} for="modelName">Model Name</label>
-          <input class="st-input w-full" disabled name="modelName" value={plan.model.name} />
+          <input class="st-input w-full" disabled name="modelName" value={plan.model.name} aria-label="Model Name" />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Model ID', placement: 'top' }} for="modelId">Model ID</label>
-          <input class="st-input w-full" disabled name="modelId" value={plan.model_id} />
+          <input class="st-input w-full" disabled name="modelId" value={plan.model_id} aria-label="Model ID" />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Model Version', placement: 'top' }} for="modelVersion">Model Version</label>
-          <input class="st-input w-full" disabled name="modelVersion" value={plan.model.version} />
+          <input
+            class="st-input w-full"
+            disabled
+            name="modelVersion"
+            value={plan.model.version}
+            aria-label="Model Version"
+          />
         </Input>
         <Input layout="inline">
           <label
@@ -224,17 +231,29 @@
           >
             Start Time ({$plugins.time.primary.label})
           </label>
-          <input class="st-input w-full" disabled name="startTime" value={planStartTime} />
+          <input
+            class="st-input w-full"
+            disabled
+            name="startTime"
+            value={planStartTime}
+            aria-label="Start Time (${$plugins.time.primary.label})"
+          />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: `End Time (${$plugins.time.primary.label})`, placement: 'top' }} for="endTime">
             End Time ({$plugins.time.primary.label})
           </label>
-          <input class="st-input w-full" disabled name="endTime" value={planEndTime} />
+          <input
+            class="st-input w-full"
+            disabled
+            name="endTime"
+            value={planEndTime}
+            aria-label="End Time (${$plugins.time.primary.label})"
+          />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Owner', placement: 'top' }} for="owner">Owner</label>
-          <input class="st-input w-full" disabled name="owner" value={plan.owner} />
+          <input class="st-input w-full" disabled name="owner" value={plan.owner} aria-label="Owner" />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Date Created', placement: 'top' }} for="createdAt">Date Created</label>
@@ -242,6 +261,7 @@
             class="st-input w-full"
             disabled
             name="createdAt"
+            aria-label="Created At"
             value={getShortISOForDate(new Date(plan.created_at))}
           />
         </Input>
@@ -251,16 +271,17 @@
             class="st-input w-full"
             disabled
             name="updatedAt"
+            aria-label="Updated At"
             value={getShortISOForDate(new Date(plan.updated_at))}
           />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Updated By', placement: 'top' }} for="updatedBy">Updated By</label>
-          <input class="st-input w-full" disabled name="updatedBy" value={plan.updated_by} />
+          <input class="st-input w-full" disabled name="updatedBy" value={plan.updated_by} aria-label="Updated By" />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Revision', placement: 'top' }} for="revision">Revision</label>
-          <input class="st-input w-full" disabled name="revision" value={plan.revision} />
+          <input class="st-input w-full" disabled name="revision" value={plan.revision} aria-label="Revision" />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Collaborators', placement: 'top' }} for="collaborators">Collaborators</label>

--- a/src/components/scheduling/conditions/SchedulingConditions.svelte
+++ b/src/components/scheduling/conditions/SchedulingConditions.svelte
@@ -186,7 +186,13 @@
     <SectionTitle>Scheduling Conditions</SectionTitle>
 
     <Input>
-      <input bind:value={filterText} class="st-input" placeholder="Filter conditions" style="width: 100%;" />
+      <input
+        bind:value={filterText}
+        class="st-input"
+        placeholder="Filter conditions"
+        aria-label="Filter Conditions"
+        style="width: 100%;"
+      />
     </Input>
 
     <div class="right">

--- a/src/components/scheduling/goals/SchedulingGoals.svelte
+++ b/src/components/scheduling/goals/SchedulingGoals.svelte
@@ -188,7 +188,13 @@
     <SectionTitle>Scheduling Goals</SectionTitle>
 
     <Input>
-      <input bind:value={filterText} class="st-input" placeholder="Filter goals" style="width: 100%;" />
+      <input
+        bind:value={filterText}
+        class="st-input"
+        placeholder="Filter goals"
+        aria-label="Filter goals"
+        style="width: 100%;"
+      />
     </Input>
 
     <div class="right">

--- a/src/components/sequencing/SequenceTable.svelte
+++ b/src/components/sequencing/SequenceTable.svelte
@@ -217,7 +217,7 @@
   </div>
 
   <div>
-    <input type="checkbox" on:change={onFilterToUsersSequences} />
+    <input type="checkbox" on:change={onFilterToUsersSequences} aria-label="Filter to my sequences" />
     <span class=" st-typography-body">Filter to my sequences</span>
   </div>
 </div>

--- a/src/components/sequencing/Sequences.svelte
+++ b/src/components/sequencing/Sequences.svelte
@@ -108,7 +108,13 @@
       <SectionTitle>Sequences</SectionTitle>
 
       <Input>
-        <input bind:value={filterText} class="st-input" placeholder="Filter sequences" style="width: 100%;" />
+        <input
+          bind:value={filterText}
+          class="st-input"
+          placeholder="Filter sequences"
+          aria-label="Filter sequences"
+          style="width: 100%;"
+        />
       </Input>
 
       <div class="right">

--- a/src/components/timeline/TimelineCursor.svelte
+++ b/src/components/timeline/TimelineCursor.svelte
@@ -16,6 +16,7 @@
   <div class="timeline-cursor-line" style="background: {color}" />
   <button
     class="timeline-cursor-icon"
+    aria-label="Timeline Cursor"
     style="color: {color}"
     on:click
     on:mouseenter={() => (hovered = true)}

--- a/src/components/timeline/form/TimelineEditorPanel.svelte
+++ b/src/components/timeline/form/TimelineEditorPanel.svelte
@@ -494,7 +494,7 @@
                   min={ViewConstants.MIN_MARGIN_LEFT}
                   class="st-input w-full"
                   name="marginLeft"
-                  aria-label="Margin Left"
+                  id="marginLeft"
                   type="number"
                   value={selectedTimeline.marginLeft}
                   on:input|stopPropagation={updateTimelineMarginLeft}
@@ -507,7 +507,7 @@
                 min={0}
                 class="st-input w-full"
                 name="marginRight"
-                aria-label="Margin Right"
+                id="marginRight"
                 type="number"
                 value={selectedTimeline.marginRight}
                 on:input|stopPropagation={updateTimelineEvent}

--- a/src/components/timeline/form/TimelineEditorPanel.svelte
+++ b/src/components/timeline/form/TimelineEditorPanel.svelte
@@ -494,6 +494,7 @@
                   min={ViewConstants.MIN_MARGIN_LEFT}
                   class="st-input w-full"
                   name="marginLeft"
+                  aria-label="Margin Left"
                   type="number"
                   value={selectedTimeline.marginLeft}
                   on:input|stopPropagation={updateTimelineMarginLeft}
@@ -506,6 +507,7 @@
                 min={0}
                 class="st-input w-full"
                 name="marginRight"
+                aria-label="Margin Right"
                 type="number"
                 value={selectedTimeline.marginRight}
                 on:input|stopPropagation={updateTimelineEvent}

--- a/src/components/ui/EditableDropdown.svelte
+++ b/src/components/ui/EditableDropdown.svelte
@@ -160,6 +160,7 @@
       <input
         class="st-input w-full"
         placeholder={`Enter ${optionLabel.toLowerCase()} name`}
+        aria-label={`Enter ${optionLabel.toLowerCase()} name`}
         value={optionName}
         on:input={onUpdateOptionName}
       />

--- a/src/components/ui/SearchableDropdown.svelte
+++ b/src/components/ui/SearchableDropdown.svelte
@@ -210,6 +210,7 @@
             <input
               class="st-input w-full"
               placeholder={searchPlaceholder}
+              aria-label={searchPlaceholder}
               value={searchFilter}
               on:input={onSearchPresets}
             />

--- a/src/components/ui/SearchableDropdown.svelte
+++ b/src/components/ui/SearchableDropdown.svelte
@@ -181,7 +181,7 @@
     use:tooltip={{ content: error || selectTooltip, placement: selectTooltipPlacement }}
   >
     <span class="selected-display-value" class:error>{label}</span>
-    <button class="icon st-button icon-right" aria-label={label} on:click|stopPropagation={openMenu}>
+    <button class="icon st-button icon-right" on:click|stopPropagation={openMenu}>
       {#if $$slots.icon}
         <slot name="icon" />
       {:else}

--- a/src/components/ui/SearchableDropdown.svelte
+++ b/src/components/ui/SearchableDropdown.svelte
@@ -181,7 +181,7 @@
     use:tooltip={{ content: error || selectTooltip, placement: selectTooltipPlacement }}
   >
     <span class="selected-display-value" class:error>{label}</span>
-    <button class="icon st-button icon-right" on:click|stopPropagation={openMenu}>
+    <button class="icon st-button icon-right" aria-label={label} on:click|stopPropagation={openMenu}>
       {#if $$slots.icon}
         <slot name="icon" />
       {:else}

--- a/src/components/ui/Tags/TagsInput.svelte
+++ b/src/components/ui/Tags/TagsInput.svelte
@@ -256,7 +256,7 @@
         <Input
           {id}
           {disabled}
-          aria-label="Tags"
+          aria-label={name}
           sizeVariant="xs"
           autocomplete="off"
           placeholder={disabled && !showPlaceholderIfDisabled ? '' : placeholder}

--- a/src/components/ui/Tags/TagsInput.svelte
+++ b/src/components/ui/Tags/TagsInput.svelte
@@ -256,7 +256,7 @@
         <Input
           {id}
           {disabled}
-          aria-label={name}
+          aria-label="Tags"
           sizeVariant="xs"
           autocomplete="off"
           placeholder={disabled && !showPlaceholderIfDisabled ? '' : placeholder}

--- a/src/components/workspace/WorkspaceTable.svelte
+++ b/src/components/workspace/WorkspaceTable.svelte
@@ -139,7 +139,13 @@
     <SectionTitle>Sequence Workspaces</SectionTitle>
 
     <Input>
-      <input bind:value={filterText} class="st-input" placeholder="Filter workspaces" style="width: 100%;" />
+      <input
+        bind:value={filterText}
+        class="st-input"
+        placeholder="Filter workspaces"
+        aria-label="Filter workspaces"
+        style="width: 100%;"
+      />
     </Input>
 
     <div class="right">


### PR DESCRIPTION
This PR addresses a variety of aria label issues found by WAVE.  Placeholders are untouched, most of the time aria-label matches the placeholder except leaving out 'Enter...' when that is present.  For this pass, started with my small plan on the Plans page and tested WAVE against each of the pulldown forms (Activity Types, Simulation etc.).  Some fixes are in shared classes and for those attempted to make dynamic to the input.  

Noting in general we may want to take a pass on making the placeholders more consistent.  
