### PR TITLE
More aria/screen reader label fixes

### DIFF
--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -240,17 +240,17 @@
       {#if mode === 'edit'}
         <fieldset>
           <label for="ruleId">Rule ID</label>
-          <input class="st-input w-full" disabled name="ruleId" value={ruleId} />
+          <input class="st-input w-full" disabled name="ruleId" id="ruleId" value={ruleId} />
         </fieldset>
 
         <fieldset>
           <label for="createdAt">Created At</label>
-          <input class="st-input w-full" disabled name="createdAt" value={ruleCreatedAt} />
+          <input class="st-input w-full" disabled name="createdAt" id="createdAt" value={ruleCreatedAt} />
         </fieldset>
 
         <fieldset>
           <label for="updatedAt">Updated At</label>
-          <input class="st-input w-full" disabled name="updatedAt" value={ruleUpdatedAt} />
+          <input class="st-input w-full" disabled name="updatedAt" id="updatedAt" value={ruleUpdatedAt} />
         </fieldset>
       {/if}
 
@@ -260,6 +260,7 @@
           bind:value={parcelId}
           class="st-select w-full"
           name="parcel"
+          id="parcel"
           use:permissionHandler={{
             hasPermission: hasAuthoringPermission,
             permissionError: authoringPermissionError,
@@ -280,6 +281,7 @@
           bind:value={ruleModelId}
           class="st-select w-full"
           name="modelId"
+          id="modelId"
           on:change={() => (ruleActivityType = null)}
           use:permissionHandler={{
             hasPermission: hasAuthoringPermission,
@@ -302,6 +304,7 @@
           bind:value={ruleActivityType}
           class="st-select w-full"
           name="activityType"
+          id="activityType"
           use:permissionHandler={{
             hasPermission: hasAuthoringPermission,
             permissionError: authoringPermissionError,

--- a/src/components/expansion/ExpansionRuleForm.svelte
+++ b/src/components/expansion/ExpansionRuleForm.svelte
@@ -323,6 +323,7 @@
           bind:value={ruleName}
           class="st-input w-full"
           name="name"
+          id="name"
           placeholder="Enter a rule name (required)"
           required
           use:permissionHandler={{
@@ -339,6 +340,7 @@
           autocomplete="off"
           class="st-input w-full"
           name="description"
+          id="description"
           placeholder="Enter a rule description (optional)"
           required
           use:permissionHandler={{
@@ -352,6 +354,7 @@
         <label for="tags">Tags</label>
         <TagsInput
           disabled={!hasPermission}
+          id="tags"
           use={[
             [
               permissionHandler,

--- a/src/components/external-events/ExternalEventsTablePanel.svelte
+++ b/src/components/external-events/ExternalEventsTablePanel.svelte
@@ -31,7 +31,13 @@
   <svelte:fragment slot="header">
     <GridMenu {gridSection} title="External Events Table" />
     <div class="table-menu">
-      <input type="search" bind:value={filterExpression} placeholder="Filter External Events" class="st-input" />
+      <input
+        type="search"
+        bind:value={filterExpression}
+        placeholder="Filter External Events"
+        aria-label="Filter External Events"
+        class="st-input"
+      />
     </div>
   </svelte:fragment>
   <svelte:fragment slot="body">

--- a/src/components/form/ColorPicker.svelte
+++ b/src/components/form/ColorPicker.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <div class={inputClasses} use:tooltip={{ content: tooltipText, placement: 'top' }}>
-  <input {value} class="color-picker-input" on:input on:change type="color" {name} />
+  <input {value} id={name} class="color-picker-input" on:input on:change type="color" {name} />
   {#if !value}
     <div class="color-wheel">
       <div class="color-wheel-hue" />

--- a/src/components/form/ColorPresetsPicker.svelte
+++ b/src/components/form/ColorPresetsPicker.svelte
@@ -43,6 +43,7 @@
       {#each presetColors as color}
         <button
           type="button"
+          aria-label="new color"
           class="st-button tertiary color"
           on:click={() => onInput(color)}
           style="background:{color}"

--- a/src/components/form/ColorPresetsPicker.svelte
+++ b/src/components/form/ColorPresetsPicker.svelte
@@ -43,7 +43,7 @@
       {#each presetColors as color}
         <button
           type="button"
-          aria-label="new color"
+          aria-label="preset color"
           class="st-button tertiary color"
           on:click={() => onInput(color)}
           style="background:{color}"

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -296,6 +296,7 @@
           bind:value={sequenceParcelId}
           class="st-select w-full"
           name="parcel"
+          id="parcel"
           use:permissionHandler={{
             hasPermission: hasPermission && !isSequenceReadonly,
             permissionError,
@@ -317,6 +318,7 @@
           autocomplete="off"
           class="st-input w-full"
           name="sequenceName"
+          id="sequenceName"
           placeholder="Enter Sequence Name"
           required
           use:permissionHandler={{
@@ -333,6 +335,7 @@
           autocomplete="off"
           class="st-input"
           name="sequenceReadonly"
+          id="sequenceReadonly"
           placeholder="Is Sequence Readonly?"
           type="checkbox"
           use:permissionHandler={{
@@ -348,6 +351,7 @@
           bind:files={outputFiles}
           class="w-full"
           name="outputFile"
+          id="outputFile"
           type="file"
           on:change={onOutputFileUpload}
           use:permissionHandler={{

--- a/src/components/sequencing/SequenceForm.svelte
+++ b/src/components/sequencing/SequenceForm.svelte
@@ -276,17 +276,17 @@
       {#if mode === 'edit'}
         <fieldset>
           <label for="ruleId">ID</label>
-          <input class="st-input w-full" disabled name="ruleId" value={sequenceId} />
+          <input class="st-input w-full" disabled name="ruleId" id="ruleId" value={sequenceId} />
         </fieldset>
 
         <fieldset>
           <label for="createdAt">Created At</label>
-          <input class="st-input w-full" disabled name="createdAt" value={sequenceCreatedAt} />
+          <input class="st-input w-full" disabled name="createdAt" id="createdAt" value={sequenceCreatedAt} />
         </fieldset>
 
         <fieldset>
           <label for="updatedAt">Updated At</label>
-          <input class="st-input w-full" disabled name="updatedAt" value={sequenceUpdatedAt} />
+          <input class="st-input w-full" disabled name="updatedAt" id="updatedAt" value={sequenceUpdatedAt} />
         </fieldset>
       {/if}
 

--- a/src/components/ui/Association/AssociationForm.svelte
+++ b/src/components/ui/Association/AssociationForm.svelte
@@ -474,6 +474,7 @@
             <input
               class="w-full"
               name="file"
+              id="file"
               type="file"
               accept={definitionTypeConfigurations?.file.accept ?? 'application/json'}
               bind:files={definitionFiles}
@@ -495,6 +496,7 @@
           class:metadata-form-error={!!nameError}
           class="st-input w-100"
           name="metadata-name"
+          id="metadata-name"
           placeholder={`Enter ${displayName} Name (required)`}
           required
           use:permissionHandler={{
@@ -511,6 +513,7 @@
           bind:value={owner}
           class="st-input w-full"
           name="owner"
+          id="owner"
           placeholder={`Enter ${displayName} Owner Username (required)`}
           use:permissionHandler={{
             hasPermission: hasWriteMetadataPermission,
@@ -526,6 +529,7 @@
           autocomplete="off"
           class="st-input w-full"
           name="metadata-description"
+          id="metadata-description"
           placeholder={`Enter ${displayName} Description (optional)`}
           use:permissionHandler={{
             hasPermission: hasWriteMetadataPermission,
@@ -557,7 +561,7 @@
       {#if mode === 'edit'}
         <fieldset>
           <label for="id">{displayName} ID</label>
-          <input class="st-input w-full" disabled name="id" value={metadataId} />
+          <input class="st-input w-full" disabled name="id" id="id" value={metadataId} />
         </fieldset>
       {/if}
 
@@ -621,6 +625,7 @@
           value={defintionAuthor}
           class="st-input w-full"
           name="definitionAuthor"
+          id="definitionAuthor"
           use:permissionHandler={{
             hasPermission: hasWriteMetadataPermission,
             permissionError,

--- a/src/components/ui/Association/DefinitionEditor.svelte
+++ b/src/components/ui/Association/DefinitionEditor.svelte
@@ -80,7 +80,6 @@
         <SearchableDropdown
           selectedOptionValues={typeof referenceModelId === 'number' ? [referenceModelId] : []}
           placeholder="No Model"
-          id="models"
           name="models"
           options={modelOptions}
           on:change={onSelectReferenceModel}

--- a/src/components/ui/Association/DefinitionEditor.svelte
+++ b/src/components/ui/Association/DefinitionEditor.svelte
@@ -80,6 +80,7 @@
         <SearchableDropdown
           selectedOptionValues={typeof referenceModelId === 'number' ? [referenceModelId] : []}
           placeholder="No Model"
+          id="models"
           name="models"
           options={modelOptions}
           on:change={onSelectReferenceModel}

--- a/src/components/ui/SearchableDropdown.svelte
+++ b/src/components/ui/SearchableDropdown.svelte
@@ -181,7 +181,7 @@
     use:tooltip={{ content: error || selectTooltip, placement: selectTooltipPlacement }}
   >
     <span class="selected-display-value" class:error>{label}</span>
-    <button class="icon st-button icon-right" on:click|stopPropagation={openMenu}>
+    <button class="icon st-button icon-right" aria-label={name} on:click|stopPropagation={openMenu}>
       {#if $$slots.icon}
         <slot name="icon" />
       {:else}

--- a/src/routes/tags/+page.svelte
+++ b/src/routes/tags/+page.svelte
@@ -319,6 +319,7 @@
                 autocomplete="off"
                 sizeVariant="xs"
                 name="name"
+                id="name"
                 placeholder="Enter tag name"
               />
             </div>
@@ -334,7 +335,7 @@
                 }}
                 class="w-full"
               >
-                <Input on:keyup={onColorFieldKeyup} autocomplete="off" name="color" sizeVariant="xs" />
+                <Input on:keyup={onColorFieldKeyup} autocomplete="off" name="color" id="color" sizeVariant="xs" />
               </div>
               <!-- TODO add permission handler here -->
               <div class="size-6">
@@ -442,7 +443,7 @@
             <TagsIcon slot="icon" />
             Tags
           </SectionTitle>
-          <Input bind:value={filterText} placeholder="Filter tags" sizeVariant="xs" />
+          <Input bind:value={filterText} placeholder="Filter tags" aria-label="Filter tags" sizeVariant="xs" />
         </div>
       </svelte:fragment>
 


### PR DESCRIPTION
Similar to the previous PR, here is another set of fixes supporting screen readers.  Testing was a bit deeper this time, created objects (constraints etc.) to get more object editing and metadata forms in view.  With this and the previous PRs that may be 80-90% of the WAVE input/button related issues (need to get yet deeper in testing to find those).  