### PR TITLE
Decouple ActionParameter from Parameter

### DIFF
--- a/src/components/modals/RunActionModal.svelte
+++ b/src/components/modals/RunActionModal.svelte
@@ -71,7 +71,10 @@
         valueSchemaRecordToParametersMap(actionDefinition.parameter_schema),
         argumentsMap,
         [],
+        undefined,
+        undefined,
         getUserSequencesInWorkspace($userSequences, actionDefinition.workspace_id),
+        'sequence',
       )}
       parameterType="action"
       hideRightAdornments

--- a/src/components/modals/RunActionModal.svelte
+++ b/src/components/modals/RunActionModal.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import { userSequences } from '../../stores/sequencing';
   import type { ActionDefinition } from '../../types/actions';
   import type { User } from '../../types/app';
   import type { ArgumentsMap, FormParameter } from '../../types/parameter';
@@ -13,7 +14,6 @@
   import ModalContent from './ModalContent.svelte';
   import ModalFooter from './ModalFooter.svelte';
   import ModalHeader from './ModalHeader.svelte';
-  import { userSequences } from '../../stores/sequencing';
 
   export let actionDefinition: ActionDefinition;
   export let user: User | null;
@@ -40,11 +40,11 @@
 
   function onChangeFormParameters(event: CustomEvent<FormParameter>) {
     const { detail: formParameter } = event;
-    if (formParameter.schema.type === 'sequence') {
+    if (formParameter.schema.type === 'options-single') {
       const sequences = $userSequences.find(sequence => sequence.id === parseInt(formParameter.value));
       formParameter.value = sequences?.name ?? null;
       argumentsMap = getArguments(argumentsMap, formParameter);
-    } else if (formParameter.schema.type === 'sequenceList') {
+    } else if (formParameter.schema.type === 'options-multiple') {
       const ids: string[] = formParameter.value;
       let sequenceNames: string[] = [];
       ids.forEach(id => {
@@ -68,12 +68,10 @@
     <div class="st-typography-label pb-2">Input parameters to run <b>{actionDefinition.name}</b></div>
     <Parameters
       formParameters={getFormParameters(
-        valueSchemaRecordToParametersMap(
-          actionDefinition.parameter_schema,
-          getUserSequencesInWorkspace($userSequences, actionDefinition.workspace_id),
-        ),
+        valueSchemaRecordToParametersMap(actionDefinition.parameter_schema),
         argumentsMap,
         [],
+        getUserSequencesInWorkspace($userSequences, actionDefinition.workspace_id),
       )}
       parameterType="action"
       hideRightAdornments

--- a/src/components/parameters/ParameterBase.svelte
+++ b/src/components/parameters/ParameterBase.svelte
@@ -4,12 +4,12 @@
   import type { FormParameter, ParameterType } from '../../types/parameter';
   import type { ActionArray } from '../../utilities/useActions';
   import ParameterBaseBoolean from './ParameterBaseBoolean.svelte';
+  import ParameterBaseDropdown from './ParameterBaseDropdown.svelte';
   import ParameterBaseDuration from './ParameterBaseDuration.svelte';
   import ParameterBaseNumber from './ParameterBaseNumber.svelte';
   import ParameterBasePath from './ParameterBasePath.svelte';
   import ParameterBaseString from './ParameterBaseString.svelte';
   import ParameterBaseVariant from './ParameterBaseVariant.svelte';
-  import ParameterBaseDropdown from './ParameterBaseDropdown.svelte';
 
   export let disabled: boolean = false;
   export let formParameter: FormParameter;
@@ -112,7 +112,7 @@
     on:change
     on:reset
   />
-{:else if formParameter.schema.type === 'sequence'}
+{:else if formParameter.schema.type === 'options-single'}
   <ParameterBaseDropdown
     {disabled}
     {hideRightAdornments}
@@ -121,13 +121,11 @@
     {levelPadding}
     {formParameter}
     {parameterType}
-    placeholder="Select sequence"
-    searchPlaceholder="Filter sequences"
     {use}
     on:change
     on:reset
   />
-{:else if formParameter.schema.type === 'sequenceList'}
+{:else if formParameter.schema.type === 'options-multiple'}
   <ParameterBaseDropdown
     allowMultiple={true}
     {disabled}
@@ -137,8 +135,6 @@
     {levelPadding}
     {formParameter}
     {parameterType}
-    placeholder="Select list of sequences"
-    searchPlaceholder="Filter sequences"
     {use}
     on:change
     on:reset

--- a/src/components/parameters/ParameterBaseDropdown.svelte
+++ b/src/components/parameters/ParameterBaseDropdown.svelte
@@ -37,9 +37,9 @@
   $: if (isParameterWithOptions(formParameter.schema)) {
     dropdownOptions = formParameter.schema.options.map(option => ({ display: option.display, value: option.value }));
     placeholder = allowMultiple
-      ? `Select list of ${formParameter.schema.optionLabel}s`
-      : `Select ${formParameter.schema.optionLabel}`;
-    searchPlaceholder = `Filter ${formParameter.schema.optionLabel}s`;
+      ? `Select list of ${formParameter.schema.label}s`
+      : `Select ${formParameter.schema.label}`;
+    searchPlaceholder = `Filter ${formParameter.schema.label}s`;
   }
 
   function onChange(event: CustomEvent<SelectedDropdownOptionValue[]>) {

--- a/src/components/parameters/ParameterBaseDropdown.svelte
+++ b/src/components/parameters/ParameterBaseDropdown.svelte
@@ -1,15 +1,14 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import ParameterName from './ParameterName.svelte';
-  import type { FormParameter } from '../../types/parameter.js';
-  import type { ParameterType } from '../../types/parameter.js';
-  import type { ActionArray } from '../../utilities/useActions.js';
   import { createEventDispatcher } from 'svelte';
+  import type { DropdownOptions, SelectedDropdownOptionValue } from '../../types/dropdown';
+  import type { FormParameter, ParameterType } from '../../types/parameter.js';
+  import { isParameterWithOptions } from '../../utilities/parameters';
+  import type { ActionArray } from '../../utilities/useActions.js';
   import SearchableDropdown from '../ui/SearchableDropdown.svelte';
   import ParameterBaseRightAdornments from './ParameterBaseRightAdornments.svelte';
-  import type { DropdownOptions, SelectedDropdownOptionValue } from '../../types/dropdown';
-  import { isActionValueSchemaWithOptions } from '../../utilities/actions';
+  import ParameterName from './ParameterName.svelte';
 
   export const hideRightAdornments: boolean = false;
 
@@ -19,14 +18,14 @@
   export let labelColumnWidth: number = 200;
   export let level: number = 0;
   export let levelPadding: number = 20;
-  export let parameterType: ParameterType = 'activity';
-  export let placeholder: string = '';
-  export let searchPlaceholder: string = '';
+  export let parameterType: ParameterType = 'action';
   export let use: ActionArray = [];
 
   let columns: string = '';
   let dropdownOptions: DropdownOptions = [];
   let selectedDropdownOptions: SelectedDropdownOptionValue[] = [];
+  let placeholder: string;
+  let searchPlaceholder: string;
 
   const dispatch = createEventDispatcher<{
     change: FormParameter;
@@ -35,38 +34,12 @@
 
   $: columns = `calc(${labelColumnWidth}px - ${level * levelPadding}px) auto`;
 
-  $: if (formParameter) {
-    dropdownOptions = updateDropdownOptions();
-    selectedDropdownOptions = updateDropdownSelection();
-  }
-
-  function updateDropdownOptions(): DropdownOptions {
-    if (isActionValueSchemaWithOptions(formParameter.schema)) {
-      return formParameter.schema.options.map(option => ({ display: option.display, value: option.value }));
-    }
-    return [];
-  }
-
-  function updateDropdownSelection(): SelectedDropdownOptionValue[] {
-    formParameter.errors = null;
-    let selected: SelectedDropdownOptionValue[] = [];
-    let notFound: string[] = [];
-    if (formParameter.value !== null) {
-      const sequences: string[] = allowMultiple ? formParameter.value : [formParameter.value];
-      sequences.forEach(sequenceName => {
-        const option = dropdownOptions.find(o => o.display === sequenceName);
-        if (option === undefined) {
-          notFound.push(sequenceName);
-        } else {
-          selected.push(option.value);
-        }
-      });
-    }
-
-    if (dropdownOptions.length > 0 && notFound.length > 0) {
-      formParameter.errors = [`'${notFound.join(`', '`)}' not found`];
-    }
-    return selected;
+  $: if (isParameterWithOptions(formParameter.schema)) {
+    dropdownOptions = formParameter.schema.options.map(option => ({ display: option.display, value: option.value }));
+    placeholder = allowMultiple
+      ? `Select list of ${formParameter.schema.optionLabel}s`
+      : `Select ${formParameter.schema.optionLabel}`;
+    searchPlaceholder = `Filter ${formParameter.schema.optionLabel}s`;
   }
 
   function onChange(event: CustomEvent<SelectedDropdownOptionValue[]>) {
@@ -78,7 +51,7 @@
   }
 </script>
 
-<div class="parameter-base-sequence" style="grid-template-columns: {columns}">
+<div class="parameter-base-dropdown" style="grid-template-columns: {columns}">
   <ParameterName {formParameter} />
   <SearchableDropdown
     bind:selectedOptionValues={selectedDropdownOptions}
@@ -88,7 +61,7 @@
     placeholder={disabled ? '' : placeholder}
     {searchPlaceholder}
     on:change={onChange}
-  ></SearchableDropdown>
+  />
 </div>
 <div class="parameter-right">
   <ParameterBaseRightAdornments
@@ -102,17 +75,17 @@
 </div>
 
 <style>
-  .parameter-base-sequence {
+  .parameter-base-dropdown {
     align-items: center;
     display: grid;
   }
 
-  .parameter-base-sequence :global(.st-menu) {
+  .parameter-base-dropdown :global(.st-menu) {
     min-width: 250px;
     overflow: hidden;
   }
 
-  .parameter-base-sequence :global(.selected-display) {
+  .parameter-base-dropdown :global(.selected-display) {
     background-color: var(--st-input-background-color);
     border: var(--st-input-border);
     color: var(--st-input-color);

--- a/src/components/parameters/ParameterBaseDropdown.svelte
+++ b/src/components/parameters/ParameterBaseDropdown.svelte
@@ -57,13 +57,14 @@
     bind:selectedOptionValues={selectedDropdownOptions}
     {allowMultiple}
     {disabled}
+    showPlaceholderOption={false}
     options={dropdownOptions}
     placeholder={disabled ? '' : placeholder}
     {searchPlaceholder}
     on:change={onChange}
   />
 </div>
-<div class="parameter-right">
+<div class="parameter-right items-center">
   <ParameterBaseRightAdornments
     {disabled}
     {formParameter}
@@ -78,17 +79,6 @@
   .parameter-base-dropdown {
     align-items: center;
     display: grid;
-  }
-
-  .parameter-base-dropdown :global(.st-menu) {
-    min-width: 250px;
-    overflow: hidden;
-  }
-
-  .parameter-base-dropdown :global(.selected-display) {
-    background-color: var(--st-input-background-color);
-    border: var(--st-input-border);
-    color: var(--st-input-color);
   }
 
   .parameter-right {

--- a/src/components/sequencing/actions/ActionRun.svelte
+++ b/src/components/sequencing/actions/ActionRun.svelte
@@ -76,7 +76,10 @@
               valueSchemaRecordToParametersMap($actionRun.action_definition.settings_schema),
               $actionRun.settings,
               [],
+              undefined,
+              undefined,
               getUserSequencesInWorkspace($userSequences, workspaceId),
+              'sequence',
             )}
             parameterType="action"
             hideRightAdornments
@@ -89,7 +92,10 @@
               valueSchemaRecordToParametersMap($actionRun.action_definition.parameter_schema),
               $actionRun.parameters,
               [],
+              undefined,
+              undefined,
               getUserSequencesInWorkspace($userSequences, workspaceId),
+              'sequence',
             )}
             parameterType="action"
             hideRightAdornments

--- a/src/components/sequencing/actions/ActionRun.svelte
+++ b/src/components/sequencing/actions/ActionRun.svelte
@@ -4,6 +4,7 @@
   import { page } from '$app/stores';
   import { SearchParameters } from '../../../enums/searchParameters';
   import { actionDefinitionsByWorkspace } from '../../../stores/actions';
+  import { userSequences } from '../../../stores/sequencing';
   import { gqlSubscribable } from '../../../stores/subscribable';
   import type { ActionRun } from '../../../types/actions';
   import type { User } from '../../../types/app';
@@ -17,7 +18,6 @@
   import { getFormParameters } from '../../../utilities/parameters';
   import Parameters from '../../parameters/Parameters.svelte';
   import ActionRunCard from './ActionRunCard.svelte';
-  import { userSequences } from '../../../stores/sequencing';
 
   export let initialActionRun: ActionRun | null = null;
   export let user: User | null;
@@ -73,12 +73,10 @@
         <div class="action-run-parameters">
           <Parameters
             formParameters={getFormParameters(
-              valueSchemaRecordToParametersMap(
-                $actionRun.action_definition.settings_schema,
-                getUserSequencesInWorkspace($userSequences, workspaceId),
-              ),
+              valueSchemaRecordToParametersMap($actionRun.action_definition.settings_schema),
               $actionRun.settings,
               [],
+              getUserSequencesInWorkspace($userSequences, workspaceId),
             )}
             parameterType="action"
             hideRightAdornments
@@ -88,12 +86,10 @@
           <div class="st-typography-medium action-run-label">Action Parameters</div>
           <Parameters
             formParameters={getFormParameters(
-              valueSchemaRecordToParametersMap(
-                $actionRun.action_definition.parameter_schema,
-                getUserSequencesInWorkspace($userSequences, workspaceId),
-              ),
+              valueSchemaRecordToParametersMap($actionRun.action_definition.parameter_schema),
               $actionRun.parameters,
               [],
+              getUserSequencesInWorkspace($userSequences, workspaceId),
             )}
             parameterType="action"
             hideRightAdornments

--- a/src/components/sequencing/actions/Actions.svelte
+++ b/src/components/sequencing/actions/Actions.svelte
@@ -365,7 +365,10 @@
                       valueSchemaRecordToParametersMap(selectedActionDefinition.settings_schema),
                       argumentsMap,
                       [],
+                      undefined,
+                      undefined,
                       getUserSequencesInWorkspace($userSequences, workspaceId),
+                      'sequence',
                     )}
                     parameterType="action"
                     hideRightAdornments

--- a/src/components/sequencing/actions/Actions.svelte
+++ b/src/components/sequencing/actions/Actions.svelte
@@ -150,11 +150,11 @@
 
   function onChangeFormParameters(event: CustomEvent<FormParameter>) {
     const { detail: formParameter } = event;
-    if (formParameter.schema.type === 'sequence') {
+    if (formParameter.schema.type === 'options-single') {
       const sequences = $userSequences.find(sequence => sequence.id === parseInt(formParameter.value));
       formParameter.value = sequences?.name ?? null;
       argumentsMap = getArguments(argumentsMap, formParameter);
-    } else if (formParameter.schema.type === 'sequenceList') {
+    } else if (formParameter.schema.type === 'options-multiple') {
       const ids: string[] = formParameter.value;
       let sequenceNames: string[] = [];
       ids.forEach(id => {
@@ -362,12 +362,10 @@
                   {/if}
                   <Parameters
                     formParameters={getFormParameters(
-                      valueSchemaRecordToParametersMap(
-                        selectedActionDefinition.settings_schema,
-                        getUserSequencesInWorkspace($userSequences, workspaceId),
-                      ),
+                      valueSchemaRecordToParametersMap(selectedActionDefinition.settings_schema),
                       argumentsMap,
                       [],
+                      getUserSequencesInWorkspace($userSequences, workspaceId),
                     )}
                     parameterType="action"
                     hideRightAdornments

--- a/src/components/timeline/form/TimelineEditor/ActivityFilterBuilder.svelte
+++ b/src/components/timeline/form/TimelineEditor/ActivityFilterBuilder.svelte
@@ -242,12 +242,7 @@
         Object.entries(activityType.parameters).forEach(([parameterName, parameter]) => {
           const parameterType = parameter.schema.type;
           // TODO support series and struct?
-          if (
-            parameterType === 'series' ||
-            parameterType === 'struct' ||
-            parameterType === 'sequence' ||
-            parameterType === 'sequenceList'
-          ) {
+          if (parameterType === 'series' || parameterType === 'struct') {
             return;
           }
           const key = `${parameterName} (${parameterType})`;

--- a/src/types/actions.ts
+++ b/src/types/actions.ts
@@ -1,5 +1,8 @@
-import type { ArgumentsMap } from './parameter';
 import type { ActionValueSchema } from '@nasa-jpl/aerie-actions';
+import type { ArgumentsMap, ParameterName } from './parameter';
+
+export type ActionParameter = { order: number; schema: ActionValueSchema; unit?: string };
+export type ActionParametersMap = Record<ParameterName, ActionParameter>;
 
 export type ActionDefinition = {
   action_file_id: number;

--- a/src/types/parameter.ts
+++ b/src/types/parameter.ts
@@ -1,41 +1,4 @@
-import type { ValueSchema } from './schema';
-import type {
-  ActionValueSchemaBoolean,
-  ActionValueSchemaDuration,
-  ActionValueSchemaInt,
-  ActionValueSchemaPath,
-  ActionValueSchemaReal,
-  ActionValueSchemaSequence,
-  ActionValueSchemaSequenceList,
-  ActionValueSchemaSeries,
-  ActionValueSchemaString,
-  ActionValueSchemaStruct,
-  ActionValueSchemaVariant,
-} from '@nasa-jpl/aerie-actions/src/types/schema';
-
-export type ActionValueSchemaWithOptions = {
-  options: ActionValueSchemaOption[];
-};
-export type ActionValueSchemaOption = {
-  display: string;
-  value: string;
-};
-
-export type ActionValueSchemaSequenceWithOptions = ActionValueSchemaSequence & ActionValueSchemaWithOptions;
-export type ActionValueSchemaSequenceListWithOptions = ActionValueSchemaSequenceList & ActionValueSchemaWithOptions;
-
-export type UIActionValueSchema =
-  | ActionValueSchemaBoolean
-  | ActionValueSchemaDuration
-  | ActionValueSchemaInt
-  | ActionValueSchemaPath
-  | ActionValueSchemaReal
-  | ActionValueSchemaSequenceWithOptions
-  | ActionValueSchemaSequenceListWithOptions
-  | ActionValueSchemaSeries
-  | ActionValueSchemaString
-  | ActionValueSchemaStruct
-  | ActionValueSchemaVariant;
+import type { UIValueSchemaWithOptionsMultiple, UIValueSchemaWithOptionsSingle, ValueSchema } from './schema';
 
 export type DefaultEffectiveArguments = {
   arguments: ArgumentsMap;
@@ -50,7 +13,7 @@ export type EffectiveArguments = {
   success: boolean;
 };
 
-export type FormParameter<T = ValueSchema | UIActionValueSchema> = {
+export type FormParameter<T = ValueSchema | UIValueSchemaWithOptionsSingle | UIValueSchemaWithOptionsMultiple> = {
   errors: string[] | null;
   file?: File;
   index?: number;
@@ -68,7 +31,6 @@ export type Argument = any;
 export type ArgumentsMap = Record<ParameterName, Argument>;
 
 export type Parameter = { order: number; schema: ValueSchema; unit?: string };
-export type ActionParameter = { order: number; schema: UIActionValueSchema; unit?: string };
 export type ComputedParameter = { order: number; schema: ValueSchema; units?: Record<ParameterName, string> };
 
 export type ParameterError = { message: string; schema: ValueSchema };
@@ -79,8 +41,7 @@ export type ParameterName = string;
 
 export type RequiredParametersList = ParameterName[];
 
-export type BaseParameter = Parameter | ActionParameter;
-export type ParametersMap<T extends BaseParameter = BaseParameter> = Record<ParameterName, T>;
+export type ParametersMap = Record<ParameterName, Parameter>;
 export type ComputedParametersMap = Record<ParameterName, ComputedParameter>;
 
 export type ParameterValidationError = {

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -45,6 +45,23 @@ export type ValueSchemaVariant = {
   variants: Variant[];
 } & ValueSchemaMetadata;
 
+export type ValueSchemaOption = {
+  display: string;
+  value: string;
+};
+
+export type UIValueSchemaWithOptionsSingle = {
+  optionLabel: string;
+  options: ValueSchemaOption[];
+  type: 'options-single';
+} & ValueSchemaMetadata;
+
+export type UIValueSchemaWithOptionsMultiple = {
+  optionLabel: string;
+  options: ValueSchemaOption[];
+  type: 'options-multiple';
+} & ValueSchemaMetadata;
+
 export type ValueSchema =
   | ValueSchemaBoolean
   | ValueSchemaDuration

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -51,13 +51,13 @@ export type ValueSchemaOption = {
 };
 
 export type UIValueSchemaWithOptionsSingle = {
-  optionLabel: string;
+  label: string;
   options: ValueSchemaOption[];
   type: 'options-single';
 } & ValueSchemaMetadata;
 
 export type UIValueSchemaWithOptionsMultiple = {
-  optionLabel: string;
+  label: string;
   options: ValueSchemaOption[];
   type: 'options-multiple';
 } & ValueSchemaMetadata;

--- a/src/utilities/actions.ts
+++ b/src/utilities/actions.ts
@@ -1,22 +1,17 @@
-import type { ActionDefinition, ActionRunSlim } from '../types/actions';
 import type {
-  ActionValueSchemaOption,
-  ActionValueSchemaSequenceListWithOptions,
-  ActionValueSchemaSequenceWithOptions,
-  ParametersMap,
-  UIActionValueSchema,
-} from '../types/parameter';
+  ActionValueSchema,
+  ActionValueSchemaSequence,
+  ActionValueSchemaSequenceList,
+} from '@nasa-jpl/aerie-actions';
+import type { ActionDefinition, ActionParametersMap, ActionRunSlim } from '../types/actions';
+import type { ValueSchema, ValueSchemaOption } from '../types/schema';
 import type { UserSequence } from '../types/sequencing';
-import type { ValueSchema } from '../types/schema';
 
 // TODO explain yourself
-export function isActionValueSchemaWithOptions(
-  schema: UIActionValueSchema | ValueSchema,
-): schema is ActionValueSchemaSequenceWithOptions | ActionValueSchemaSequenceListWithOptions {
-  return (
-    (schema as ActionValueSchemaSequenceWithOptions | ActionValueSchemaSequenceListWithOptions).type === 'sequence' ||
-    (schema as ActionValueSchemaSequenceWithOptions | ActionValueSchemaSequenceListWithOptions).type === 'sequenceList'
-  );
+export function isActionValueSchemaSequence(
+  schema: ValueSchema | ActionValueSchema,
+): schema is ActionValueSchemaSequence | ActionValueSchemaSequenceList {
+  return (schema as ActionValueSchema).type === 'sequence' || (schema as ActionValueSchema).type === 'sequenceList';
 }
 
 /**
@@ -24,14 +19,9 @@ export function isActionValueSchemaWithOptions(
  */
 export function valueSchemaRecordToParametersMap(
   valueSchemaRecord: ActionDefinition['parameter_schema'],
-  options?: ActionValueSchemaOption[],
-): ParametersMap {
-  return Object.entries(valueSchemaRecord).reduce((acc: ParametersMap, [key, valueSchema], i) => {
-    const actionValueSchema: UIActionValueSchema = valueSchema as UIActionValueSchema;
-    if (isActionValueSchemaWithOptions(actionValueSchema) && options !== undefined) {
-      actionValueSchema.options = options;
-    }
-    acc[key] = { order: i, schema: actionValueSchema };
+): ActionParametersMap {
+  return Object.entries(valueSchemaRecord).reduce((acc: ActionParametersMap, [key, valueSchema], i) => {
+    acc[key] = { order: i, schema: valueSchema };
     return acc;
   }, {});
 }
@@ -39,7 +29,7 @@ export function valueSchemaRecordToParametersMap(
 export function getUserSequencesInWorkspace(
   sequences: UserSequence[],
   workspaceId: number | null,
-): ActionValueSchemaOption[] {
+): ValueSchemaOption[] {
   if (workspaceId === null) {
     return [];
   }

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -1,6 +1,7 @@
 import { goto } from '$app/navigation';
 import { base } from '$app/paths';
 import { env } from '$env/dynamic/public';
+import type { ActionValueSchema } from '@nasa-jpl/aerie-actions';
 import {
   type ChannelDictionary as AmpcsChannelDictionary,
   type CommandDictionary as AmpcsCommandDictionary,
@@ -69,7 +70,7 @@ import {
 } from '../stores/simulation';
 import { createTagError as createTagErrorStore } from '../stores/tags';
 import { applyViewUpdate, view as viewStore, viewUpdateRow, viewUpdateTimeline } from '../stores/views';
-import type { ActionDefinition, ActionDefinitionSetInput, ActionRun } from '../types/actions';
+import type { ActionDefinition, ActionDefinitionSetInput, ActionParametersMap, ActionRun } from '../types/actions';
 import type {
   ActivityDirective,
   ActivityDirectiveDB,
@@ -146,7 +147,6 @@ import type {
   ParameterValidationError,
   ParameterValidationResponse,
   ParametersMap,
-  BaseParameter,
 } from '../types/parameter';
 import type {
   PermissibleQueriesMap,
@@ -296,7 +296,6 @@ import {
   generateDefaultView,
   validateViewJSONAgainstSchema,
 } from './view';
-import type { ActionValueSchema } from '@nasa-jpl/aerie-actions';
 
 function throwPermissionError(attemptedAction: string): never {
   throw Error(`You do not have permission to: ${attemptedAction}.`);
@@ -7193,16 +7192,16 @@ const effects = {
  * @returns
  */
 export function replacePaths(
-  modelParameters: ParametersMap | null,
+  parameters: ParametersMap | ActionParametersMap | null,
   simArgs: ArgumentsMap,
   pathsToReplace: Record<string, string>,
 ): ArgumentsMap {
-  if (modelParameters === null) {
+  if (parameters === null) {
     return simArgs;
   }
   const result: ArgumentsMap = {};
-  for (const parameterName in modelParameters) {
-    const parameter: BaseParameter = modelParameters[parameterName];
+  for (const parameterName in parameters) {
+    const parameter = parameters[parameterName];
     const arg: Argument = simArgs[parameterName];
     if (arg !== undefined) {
       result[parameterName] = replacePathsHelper(parameter.schema, arg, pathsToReplace);

--- a/src/utilities/parameters.ts
+++ b/src/utilities/parameters.ts
@@ -1,4 +1,6 @@
+import type { ActionValueSchema } from '@nasa-jpl/aerie-actions';
 import { isEqual, omitBy } from 'lodash-es';
+import type { ActionParametersMap } from '../types/actions';
 import type {
   Argument,
   ArgumentsMap,
@@ -7,9 +9,23 @@ import type {
   RequiredParametersList,
   ValueSource,
 } from '../types/parameter';
-import type { ValueSchema } from '../types/schema';
+import type {
+  UIValueSchemaWithOptionsMultiple,
+  UIValueSchemaWithOptionsSingle,
+  ValueSchema,
+  ValueSchemaOption,
+} from '../types/schema';
+import { isActionValueSchemaSequence } from './actions';
 import { isEmpty } from './generic';
-import type { ActionValueSchema } from '@nasa-jpl/aerie-actions';
+
+export function isParameterWithOptions(
+  schema: ValueSchema | UIValueSchemaWithOptionsSingle | UIValueSchemaWithOptionsMultiple,
+): schema is UIValueSchemaWithOptionsSingle | UIValueSchemaWithOptionsMultiple {
+  return (
+    (schema as UIValueSchemaWithOptionsSingle).type === 'options-single' ||
+    (schema as UIValueSchemaWithOptionsMultiple).type !== 'options-multiple'
+  );
+}
 
 /**
  * Derive argument given input value, value schema, and optional default value.
@@ -59,25 +75,62 @@ export function getArguments(argumentsMap: ArgumentsMap, formParameter: FormPara
 }
 
 export function getFormParameters(
-  parametersMap: ParametersMap,
+  parametersMap: ParametersMap | ActionParametersMap,
   argumentsMap: ArgumentsMap,
   requiredParameters: RequiredParametersList,
   presetArgumentsMap: ArgumentsMap = {},
   defaultArgumentsMap: ArgumentsMap = {},
+  dropdownOptions: ValueSchemaOption[] = [],
+  optionLabel: string = 'option',
 ): FormParameter[] {
   const formParameters = Object.entries(parametersMap).map(([name, { order, schema }]) => {
+    const formParameterSchema: ValueSchema | UIValueSchemaWithOptionsSingle | UIValueSchemaWithOptionsMultiple = schema;
+
     const arg: Argument = argumentsMap[name];
     const preset: Argument = presetArgumentsMap[name];
     const defaultArg: Argument | undefined = defaultArgumentsMap[name];
     const { value, valueSource } = getArgument(arg, schema, preset, defaultArg);
     const required = requiredParameters.indexOf(name) > -1;
 
+    let errors: string[] | null = null;
+    let isMultiSelect: boolean = false;
+    if (isActionValueSchemaSequence(schema)) {
+      (formParameterSchema as UIValueSchemaWithOptionsSingle | UIValueSchemaWithOptionsMultiple).options =
+        dropdownOptions;
+      (formParameterSchema as UIValueSchemaWithOptionsSingle | UIValueSchemaWithOptionsMultiple).optionLabel =
+        optionLabel;
+      if (schema.type === 'sequence') {
+        formParameterSchema.type = 'options-single';
+      } else if (schema.type === 'sequenceList') {
+        formParameterSchema.type = 'options-multiple';
+        isMultiSelect = true;
+      }
+
+      const selected: (typeof value)[] = [];
+      const notFound: (typeof value)[] = [];
+      if (value !== null) {
+        const optionValues: string[] = isMultiSelect ? value : [value];
+        optionValues.forEach(optionValue => {
+          const option = dropdownOptions.find(dropdownOption => dropdownOption.display === optionValue);
+          if (option === undefined) {
+            notFound.push(optionValue);
+          } else {
+            selected.push(option.value);
+          }
+        });
+      }
+
+      if (dropdownOptions.length > 0 && notFound.length > 0) {
+        errors = [`'${notFound.join(`', '`)}' not found`];
+      }
+    }
+
     const formParameter: FormParameter = {
-      errors: null,
+      errors,
       name,
       order,
       required,
-      schema,
+      schema: formParameterSchema,
       value,
       valueSource,
     };

--- a/src/utilities/parameters.ts
+++ b/src/utilities/parameters.ts
@@ -23,7 +23,7 @@ export function isParameterWithOptions(
 ): schema is UIValueSchemaWithOptionsSingle | UIValueSchemaWithOptionsMultiple {
   return (
     (schema as UIValueSchemaWithOptionsSingle).type === 'options-single' ||
-    (schema as UIValueSchemaWithOptionsMultiple).type !== 'options-multiple'
+    (schema as UIValueSchemaWithOptionsMultiple).type === 'options-multiple'
   );
 }
 
@@ -105,15 +105,17 @@ export function getFormParameters(
         isMultiSelect = true;
       }
 
-      const optionValues: string[] = isMultiSelect ? value : [value];
-      // Determine if there are selected options in the value that are no longer present in the list of options
-      const missingOptions = optionValues.filter(optionValue => {
-        const option = dropdownOptions.find(dropdownOption => dropdownOption.display === optionValue);
-        return option === undefined;
-      });
+      if (value) {
+        const optionValues: string[] = isMultiSelect ? value : [value];
+        // Determine if there are selected options in the value that are no longer present in the list of options
+        const missingOptions = optionValues.filter(optionValue => {
+          const option = dropdownOptions.find(dropdownOption => dropdownOption.display === optionValue);
+          return option === undefined;
+        });
 
-      if (dropdownOptions.length > 0 && missingOptions.length > 0) {
-        errors = [`'${missingOptions.join(', ')}' not found`];
+        if (dropdownOptions.length > 0 && missingOptions.length > 0) {
+          errors = [`'${missingOptions.join(', ')}' not found`];
+        }
       }
     }
 

--- a/src/utilities/parameters.ts
+++ b/src/utilities/parameters.ts
@@ -95,13 +95,6 @@ export function getFormParameters(
     let errors: string[] | null = null;
     let isMultiSelect: boolean = false;
     if (isActionValueSchemaSequence(schema)) {
-      const optionValues: string[] = isMultiSelect ? value : [value];
-      // Determine if there are selected options in the value that are no longer present in the list of options
-      const missingOptions = optionValues.filter(optionValue => {
-        const option = dropdownOptions.find(dropdownOption => dropdownOption.display === optionValue);
-        return option === undefined;
-      });
-
       (formParameterSchema as UIValueSchemaWithOptionsSingle | UIValueSchemaWithOptionsMultiple).options =
         dropdownOptions;
       (formParameterSchema as UIValueSchemaWithOptionsSingle | UIValueSchemaWithOptionsMultiple).optionLabel =
@@ -112,6 +105,13 @@ export function getFormParameters(
         formParameterSchema.type = 'options-multiple';
         isMultiSelect = true;
       }
+
+      const optionValues: string[] = isMultiSelect ? value : [value];
+      // Determine if there are selected options in the value that are no longer present in the list of options
+      const missingOptions = optionValues.filter(optionValue => {
+        const option = dropdownOptions.find(dropdownOption => dropdownOption.display === optionValue);
+        return option === undefined;
+      });
 
       if (dropdownOptions.length > 0 && missingOptions.length > 0) {
         errors = [`'${missingOptions.join(', ')}' not found`];

--- a/src/utilities/parameters.ts
+++ b/src/utilities/parameters.ts
@@ -95,6 +95,13 @@ export function getFormParameters(
     let errors: string[] | null = null;
     let isMultiSelect: boolean = false;
     if (isActionValueSchemaSequence(schema)) {
+      const optionValues: string[] = isMultiSelect ? value : [value];
+      // Determine if there are selected options in the value that are no longer present in the list of options
+      const missingOptions = optionValues.filter(optionValue => {
+        const option = dropdownOptions.find(dropdownOption => dropdownOption.display === optionValue);
+        return option === undefined;
+      });
+
       (formParameterSchema as UIValueSchemaWithOptionsSingle | UIValueSchemaWithOptionsMultiple).options =
         dropdownOptions;
       (formParameterSchema as UIValueSchemaWithOptionsSingle | UIValueSchemaWithOptionsMultiple).optionLabel =
@@ -106,22 +113,8 @@ export function getFormParameters(
         isMultiSelect = true;
       }
 
-      const selected: (typeof value)[] = [];
-      const notFound: (typeof value)[] = [];
-      if (value !== null) {
-        const optionValues: string[] = isMultiSelect ? value : [value];
-        optionValues.forEach(optionValue => {
-          const option = dropdownOptions.find(dropdownOption => dropdownOption.display === optionValue);
-          if (option === undefined) {
-            notFound.push(optionValue);
-          } else {
-            selected.push(option.value);
-          }
-        });
-      }
-
-      if (dropdownOptions.length > 0 && notFound.length > 0) {
-        errors = [`'${notFound.join(`', '`)}' not found`];
+      if (dropdownOptions.length > 0 && missingOptions.length > 0) {
+        errors = [`'${missingOptions.join(', ')}' not found`];
       }
     }
 

--- a/src/utilities/parameters.ts
+++ b/src/utilities/parameters.ts
@@ -97,8 +97,7 @@ export function getFormParameters(
     if (isActionValueSchemaSequence(schema)) {
       (formParameterSchema as UIValueSchemaWithOptionsSingle | UIValueSchemaWithOptionsMultiple).options =
         dropdownOptions;
-      (formParameterSchema as UIValueSchemaWithOptionsSingle | UIValueSchemaWithOptionsMultiple).optionLabel =
-        optionLabel;
+      (formParameterSchema as UIValueSchemaWithOptionsSingle | UIValueSchemaWithOptionsMultiple).label = optionLabel;
       if (schema.type === 'sequence') {
         formParameterSchema.type = 'options-single';
       } else if (schema.type === 'sequenceList') {


### PR DESCRIPTION
This should be merged prior to #1672.

This further decouples `ActionParameter` from `Parameter` to prevent potentially having "action" specific code in areas that don't pertain to actions. The reason to combine the two was to take advantage of existing parameter components. However, this approach formats any "action parameters" to be usable in any parameter components rather than refactoring the parameter components to take an action parameter.