### PR TITLE
Fix bug with Menus inside Modals by allowing click events to propagate

### DIFF
--- a/src/components/menus/Menu.svelte
+++ b/src/components/menus/Menu.svelte
@@ -126,9 +126,9 @@
 
 {#if shown}
   <!-- svelte-ignore a11y-click-events-have-key-events a11y-interactive-supports-focus -->
-  <div class="menu" role="menu" use:popperRef on:click|stopPropagation={onClick}>
+  <div class="menu pointer-events-none" role="menu" use:popperRef on:click|stopPropagation={onClick}>
     <div
-      class="st-menu st-typography-medium"
+      class="st-menu st-typography-medium pointer-events-auto"
       style:width={typeof width === 'number' ? `${width}px` : null}
       use:popperContent={extraOpts}
     >

--- a/src/components/modals/Modal.svelte
+++ b/src/components/modals/Modal.svelte
@@ -9,13 +9,7 @@
 </script>
 
 <div id="modal-container">
-  <div
-    bind:this={modal}
-    class="modal st-typography-body"
-    role="none"
-    style:height={heightStyle}
-    style:width={widthStyle}
-  >
+  <div class="modal st-typography-body" role="none" style:height={heightStyle} style:width={widthStyle}>
     <slot />
   </div>
 </div>

--- a/src/components/modals/Modal.svelte
+++ b/src/components/modals/Modal.svelte
@@ -4,18 +4,8 @@
   export let height: number | string = 350;
   export let width: number | string = 400;
 
-  let modal: HTMLDivElement | null = null;
-
   $: heightStyle = typeof height === 'number' ? `${height}px` : height;
   $: widthStyle = typeof width === 'number' ? `${width}px` : width;
-
-  function onClickOutside(event: MouseEvent | TouchEvent) {
-    // Stop propagation of events that originate from within the modal
-    // to prevent the modal from closing.
-    if (modal && modal.contains(event.target as Node)) {
-      event.stopPropagation();
-    }
-  }
 </script>
 
 <div id="modal-container">
@@ -25,7 +15,6 @@
     role="none"
     style:height={heightStyle}
     style:width={widthStyle}
-    on:click={onClickOutside}
   >
     <slot />
   </div>

--- a/src/components/ui/SearchableDropdown.svelte
+++ b/src/components/ui/SearchableDropdown.svelte
@@ -55,8 +55,19 @@
   }
   export function openMenu() {
     if (!disabled && hasUpdatePermission && menuRef) {
-      dispatch('openMenu');
-      menuRef.show();
+      if (menuOpen) {
+        hideMenu();
+      } else {
+        dispatch('openMenu');
+        menuRef.show();
+      }
+    }
+  }
+  export function toggleMenu() {
+    if (menuOpen) {
+      hideMenu();
+    } else {
+      openMenu();
     }
   }
 
@@ -169,7 +180,7 @@
     class:error
     class:disabled
     {name}
-    on:click|stopPropagation={openMenu}
+    on:click|stopPropagation={toggleMenu}
     role="combobox"
     aria-controls="menu"
     aria-expanded={menuOpen}
@@ -181,7 +192,7 @@
     use:tooltip={{ content: error || selectTooltip, placement: selectTooltipPlacement }}
   >
     <span class="selected-display-value" class:error>{label}</span>
-    <button class="icon st-button icon-right" aria-label={name} on:click|stopPropagation={openMenu}>
+    <button class="icon st-button icon-right" aria-label={name} on:click|stopPropagation={toggleMenu}>
       {#if $$slots.icon}
         <slot name="icon" />
       {:else}


### PR DESCRIPTION
While testing #1691 and #1672 we discovered a usability issue when dropdown `Menu` components are used inside of a `Modal` component.

### Symptoms

* If you use a `<Menu>` component inside of a `<Modal>` (eg. the `SearchableDropdown` component used inside of `RunActionModal`), then when you open the dropdown menu, it doesn't close/hide when you click outside the menu, which dropdowns usually do.
* When used with a single-item-select dropdown, this is not terrible because the menu closes anyway when you select an item. But when it's a multi-select, there is no way to close the menu other than closing the modal

### Cause

* In `Menu.svelte`, menus attach a click handler to the `body` which normally closes them: `<svelte:body on:click={hide} />`
* However, when used in a Modal, the click event is stopped from propagating by the function `onClickOutside` in `Modal.svelte` (which should really be named `onClickInside`).
* This function exists because Modal has *its own* closing click handler on the `body` (`modalBodyClickListener`), and `onClickOutside` stops propagation of clicks *inside* the modal from propagating to that handler and closing it.
* However, AFAICT, `onClickOutside` **is not actually needed**, because the `modalBodyClickListener` already checks to see if the click event's `target` (the thing you actually clicked on) is the `"modal-container"`, (the shaded region *around* the modal, **not** the modal itself)

## Fix

The fix is to just to remove the `onClickOutside` handler from `Modal.svelte` & let the event propagate normally to both the `Menu` and `Modal` body handlers

## Testing

The only realistic way I know of to test this right now is to use the changes in #1672, set up a sequencing workpace, and upload an Action that has a parameter of type "sequence" or "sequenceList". Then when you click "Run", the Run Action modal will have a sequence dropdown menu that has this bug. Reviewer can decide whether it's fastest to reproduce this themselves, contact me so I can walk you through it, or find/setup a more minimal test case.
