### PR TITLE
Permissions for sequence filters and template expansion

### DIFF
--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -104,9 +104,9 @@
     const useTemplating = SEQUENCE_EXPANSION_MODE === SequencingMode.TEMPLATING;
     $filteredExpansionSequences.forEach(sequence => {
       if (useTemplating && $plan !== null) {
-        effects.expandTemplates([sequence.seq_id], sequence.simulation_dataset_id, $plan.model_id, user);
+        effects.expandTemplates([sequence.seq_id], sequence.simulation_dataset_id, $plan, user);
       } else if (selectedExpansionSetId !== null && $plan !== null) {
-        effects.expand(selectedExpansionSetId, sequence.simulation_dataset_id, $plan, $plan.model, user);
+        effects.expand(selectedExpansionSetId, sequence.simulation_dataset_id, $plan, user);
       }
     });
   }
@@ -151,9 +151,9 @@
   function onExpandSequence(sequence: ExpansionSequence) {
     if ($simulationDatasetLatest !== null && $plan !== null) {
       if (SEQUENCE_EXPANSION_MODE === SequencingMode.TEMPLATING) {
-        effects.expandTemplates([sequence.seq_id], $simulationDatasetLatest.id, $plan.model_id, user);
+        effects.expandTemplates([sequence.seq_id], $simulationDatasetLatest.id, $plan, user);
       } else if (selectedExpansionSetId !== null) {
-        effects.expand(selectedExpansionSetId, $simulationDatasetLatest.id, $plan, $plan.model, user);
+        effects.expand(selectedExpansionSetId, $simulationDatasetLatest.id, $plan, user);
       }
     }
   }

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -524,11 +524,11 @@
   async function onHandleExpansion() {
     if (SEQUENCE_EXPANSION_MODE === SequencingMode.TYPESCRIPT) {
       if ($selectedExpansionSetId != null && $plan) {
-        effects.expand($selectedExpansionSetId, $simulationDatasetLatest?.id || -1, $plan, $plan.model, data.user);
+        effects.expand($selectedExpansionSetId, $simulationDatasetLatest?.id || -1, $plan, data.user);
       }
     } else if (SEQUENCE_EXPANSION_MODE === SequencingMode.TEMPLATING) {
       if ($selectedSequence !== null && $plan !== null && $simulationDatasetLatest !== null) {
-        effects.expandTemplates([$selectedSequence], $simulationDatasetLatest.dataset_id, $plan.model_id, data.user);
+        effects.expandTemplates([$selectedSequence], $simulationDatasetLatest.dataset_id, $plan, data.user);
       }
     }
   }

--- a/src/utilities/effects.test.ts
+++ b/src/utilities/effects.test.ts
@@ -524,7 +524,19 @@ describe('Handle modal and requests in effects', () => {
 
       vi.spyOn(Errors, 'catchError').mockImplementationOnce(catchErrorSpy);
 
-      await effects.expandTemplates([], 0, 0, mockUser);
+      await effects.expandTemplates(
+        [],
+        0,
+        {
+          id: 3,
+          model: {
+            id: 1,
+            owner: 'test',
+          } as Model,
+          owner: 'test',
+        } as Plan,
+        mockUser,
+      );
 
       expect(catchErrorSpy).toHaveBeenCalledWith('Sequence Templating Failed', Error('Sequence Templating Failed'));
     });

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -3737,17 +3737,11 @@ const effects = {
     return null;
   },
 
-  async expand(
-    expansionSetId: number,
-    simulationDatasetId: number,
-    plan: Plan,
-    model: Model,
-    user: User | null,
-  ): Promise<void> {
+  async expand(expansionSetId: number, simulationDatasetId: number, plan: Plan, user: User | null): Promise<void> {
     try {
       planExpansionStatusStore.set(Status.Incomplete);
 
-      if (!queryPermissions.EXPAND(user, plan, model)) {
+      if (!queryPermissions.EXPAND(user, plan, plan.model)) {
         throwPermissionError('expand this plan');
       }
 
@@ -3765,22 +3759,17 @@ const effects = {
     }
   },
 
-  async expandTemplates(
-    seqIds: string[],
-    simulationDatasetId: number,
-    modelId: number,
-    user: User | null,
-  ): Promise<void> {
+  async expandTemplates(seqIds: string[], simulationDatasetId: number, plan: Plan, user: User | null): Promise<void> {
     try {
       sequenceTemplateExpansionStatus.set(Status.Incomplete);
-      if (!queryPermissions.EXPAND_TEMPLATES(user)) {
+      if (!queryPermissions.EXPAND_TEMPLATES(user, plan, plan.model)) {
         throwPermissionError('expand a sequence template');
       }
 
       const data = await reqHasura<{ success: boolean }>(
         gql.EXPAND_TEMPLATES,
         {
-          modelId,
+          modelId: plan.model.id,
           seqIds,
           simulationDatasetId,
         },

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -109,6 +109,8 @@ const functionQueryMap: Record<QueryString, FunctionString> = {
   [Queries.DENY_MERGE]: 'deny_merge',
   [Queries.DUPLICATE_PLAN]: 'branch_plan',
   [Queries.EXPAND_ALL_ACTIVITIES]: 'expand_all_activities',
+  [Queries.EXPAND_ALL_TEMPLATES]: 'expand_all_templates',
+  [Queries.APPLY_ACTIVITIES_BY_FILTER]: 'assign_activities_by_filter',
   getSequenceSeqJsonBulk: 'sequence_seq_json_bulk',
   [Queries.GET_CONFLICTING_ACTIVITIES]: 'get_conflicting_activities',
   [Queries.GET_NON_CONFLICTING_ACTIVITIES]: 'get_non_conflicting_activities',
@@ -703,9 +705,9 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
     const queries = [Queries.EXPAND_ALL_ACTIVITIES];
     return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
-  // TODO: Re-visit potential fine-grained permissions for EXPAND_TEMPLATES when implemented in back-end
-  EXPAND_TEMPLATES: (user: User | null): boolean => {
-    return isUserAdmin(user) || getPermission([Queries.EXPAND_ALL_TEMPLATES], user);
+  EXPAND_TEMPLATES: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
+    const queries = [Queries.EXPAND_ALL_TEMPLATES];
+    return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
   GET_ACTIVITY_DIRECTIVE_CHANGELOG: () => true,
   GET_ACTIVITY_TYPES_EXPANSION_RULES: () => true,


### PR DESCRIPTION
`___REQUIRES_AERIE_PR___="1687"`
https://github.com/NASA-AMMOS/aerie/pull/1687/

Run permissions checks for expanding templates and applying filters. 

Future work: disable the buttons based on permissions. But I'm just here to fix things that are broken right now.