### PR TITLE
Row header timeline menu fix

### DIFF
--- a/e2e-tests/tests/timeline-view-editing.test.ts
+++ b/e2e-tests/tests/timeline-view-editing.test.ts
@@ -288,4 +288,15 @@ test.describe.serial('Timeline View Editing', () => {
     await resourceLayerEditor.locator('.timeline-layer-editor').first().getByRole('button', { name: 'Delete' }).click();
     expect(await resourceLayerEditor.locator('.timeline-layer-editor').count()).toBe(1);
   });
+
+  test('Open and close the row header context menu', async () => {
+    const rowHeaderMenuButton = await page
+      .getByRole('banner')
+      .filter({ hasText: 'Activities by Type' })
+      .getByLabel('Row Settings');
+    await rowHeaderMenuButton.click();
+    expect(await page.getByRole('menu', { name: 'Context Menu' })).toBeVisible();
+    await page.getByRole('listitem').filter({ hasText: 'Activities by Type' }).click();
+    expect(await page.getByRole('menu', { name: 'Context Menu' })).not.toBeVisible();
+  });
 });

--- a/e2e-tests/tests/timeline-view-editing.test.ts
+++ b/e2e-tests/tests/timeline-view-editing.test.ts
@@ -272,6 +272,10 @@ test.describe.serial('Timeline View Editing', () => {
     await plan.runSimulation();
 
     // Expect the resource to have a y-axis label in the timline
+    await page
+      .locator('.timeline-row-wrapper', { hasText: rowName })
+      .locator('.row-header-y-axis-label')
+      .waitFor({ state: 'attached' });
     expect(
       await page.locator('.timeline-row-wrapper', { hasText: rowName }).locator('.row-header-y-axis-label').count(),
     ).toBe(1);

--- a/src/components/timeline/RowHeaderMenu.svelte
+++ b/src/components/timeline/RowHeaderMenu.svelte
@@ -14,7 +14,7 @@
 
   function onClick(e: MouseEvent) {
     const { x, y } = button.getBoundingClientRect();
-    const newEvent = new MouseEvent(e.type, { ...e, clientX: x, clientY: y });
+    const newEvent = new MouseEvent('contextmenu', { ...e, clientX: x, clientY: y });
     dispatch('contextMenu', { e: newEvent, origin: 'row-header' });
   }
 </script>

--- a/src/utilities/parameters.ts
+++ b/src/utilities/parameters.ts
@@ -116,7 +116,8 @@ export function getFormParameters(
         });
 
         if (dropdownOptions.length > 0 && missingOptions.length > 0) {
-          errors = [`'${missingOptions.join(', ')}' not found`];
+          // format missing options like: 'option 1', 'option 2' not found
+          errors = [`'${missingOptions.join("', '")}' not found`];
         }
       }
     }


### PR DESCRIPTION
Closes #1703. Test by clicking on the three dot edit button in a timeline row header and ensuring that the menu appears and is correctly positioned. 