### PR TITLE
Revert to Default View

### DIFF
--- a/src/components/menus/MenuItem.svelte
+++ b/src/components/menus/MenuItem.svelte
@@ -35,13 +35,14 @@
 
 <div
   class={twMerge(
-    'flex cursor-pointer select-none items-center gap-2 rounded-sm px-3 py-3 text-[13px] font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50',
+    'flex cursor-pointer select-none items-center gap-2 rounded-sm px-3 py-3 text-[13px] font-medium hover:bg-muted aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
     className,
   )}
   class:disabled
   class:selected
   class:selectable
   role="menuitem"
+  aria-disabled={disabled}
   use:useActions={use}
   on:click|stopPropagation={() => {
     /* Prevent modal close click listener from firing */

--- a/src/components/menus/ViewMenu.svelte
+++ b/src/components/menus/ViewMenu.svelte
@@ -33,6 +33,7 @@
     createView: Pick<View, 'definition' | 'owner'>;
     editView: View;
     resetView: void;
+    resetViewToDefault: void;
     saveView: Pick<View, 'definition' | 'id' | 'name' | 'owner'>;
     toggleView: { state: boolean; type: ViewToggleType };
     uploadView: void;
@@ -69,6 +70,12 @@
   function resetView() {
     if ($view) {
       dispatch('resetView');
+    }
+  }
+
+  function resetViewToDefault() {
+    if ($view) {
+      dispatch('resetViewToDefault');
     }
   }
 
@@ -154,9 +161,10 @@
       >
         Save as
       </MenuItem>
-      <MenuItem disabled={!$viewIsModified} on:click={resetView}>
-        Reset to {$view?.name && $view.name !== defaultViewName ? 'last saved' : 'default'}
-      </MenuItem>
+      {#if $view?.name && $view.name !== defaultViewName}
+        <MenuItem disabled={!$viewIsModified} on:click={resetView}>Reset to last saved</MenuItem>
+      {/if}
+      <MenuItem on:click={resetViewToDefault}>Reset to default</MenuItem>
       <MenuItem
         on:click={uploadView}
         use={[

--- a/src/constants/view.ts
+++ b/src/constants/view.ts
@@ -70,6 +70,8 @@ export const ViewXRangeLayerSchemePresets: Record<XRangeLayerColorScheme, readon
   schemeTableau10,
 };
 
+export const ViewTimelineResourceRowsLimit = 20;
+
 export const viewSchemaVersion = 2;
 
 export const viewSchemaVersionName = `v${viewSchemaVersion}`;

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -71,6 +71,7 @@
     selectedExpansionSetId,
   } from '../../../stores/expansion';
   import { extensions } from '../../../stores/extensions';
+  import { externalEventTypes } from '../../../stores/external-event';
   import {
     initialPlan,
     maxTimeRange,
@@ -152,8 +153,10 @@
   import { getHumanReadableStatus, statusColors } from '../../../utilities/status';
   import { pluralize } from '../../../utilities/text';
   import { getUnixEpochTime } from '../../../utilities/time';
+  import { showSuccessToast } from '../../../utilities/toast';
   import { tooltip } from '../../../utilities/tooltip';
   import { getSearchParameterNumber, removeQueryParam, setQueryParam } from '../../../utilities/url';
+  import { generateDefaultView } from '../../../utilities/view';
   import type { PageData } from './$types';
 
   export let data: PageData;
@@ -599,6 +602,13 @@
     resetView();
   }
 
+  function onResetViewToDefault() {
+    const defaultView = generateDefaultView($resourceTypes, $externalEventTypes);
+    initializeView(defaultView);
+    removeQueryParam(SearchParameters.VIEW_ID);
+    showSuccessToast('View Reset to Default');
+  }
+
   async function onUploadView() {
     if (hasCreateViewPermission) {
       const success = await effects.uploadView(data.user);
@@ -866,6 +876,7 @@
           on:saveView={onSaveView}
           on:toggleView={onToggleView}
           on:resetView={onResetView}
+          on:resetViewToDefault={onResetViewToDefault}
           on:uploadView={onUploadView}
         />
       </svelte:fragment>

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -603,7 +603,7 @@
   }
 
   function onResetViewToDefault() {
-    const defaultView = generateDefaultView($resourceTypes, $externalEventTypes);
+    const defaultView = data.initialPlan.model.view || generateDefaultView($resourceTypes, $externalEventTypes);
     initializeView(defaultView);
     removeQueryParam(SearchParameters.VIEW_ID);
     showSuccessToast('View Reset to Default');

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -1,5 +1,6 @@
 import { base } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
+import { ViewTimelineResourceRowsLimit } from '../../../constants/view';
 import { SearchParameters } from '../../../enums/searchParameters';
 import { planReadOnlyMergeRequest } from '../../../stores/plan';
 import effects from '../../../utilities/effects';
@@ -50,7 +51,7 @@ export const load: PageLoad = async ({ parent, params, url }) => {
             initialActivityTypes.map(type => type.name),
             user,
           ),
-          await effects.getResourceTypes(initialPlan.model_id, user, 20),
+          await effects.getResourceTypes(initialPlan.model_id, user, ViewTimelineResourceRowsLimit),
           await effects.getExternalEventTypes(planId, user),
           await effects.getPlanTags(initialPlan.id, user),
         ]);

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -68,6 +68,7 @@ export const load: PageLoad = async ({ parent, params, url }) => {
       return {
         initialActivityArguments,
         initialActivityTypes,
+        initialExternalEventTypes,
         initialPlan,
         initialPlanSnapshotId,
         initialPlanTags,

--- a/src/utilities/view.ts
+++ b/src/utilities/view.ts
@@ -57,8 +57,8 @@ export function generateDefaultView(
     timeline.rows.push(externalEventRow);
   }
 
-  // Generate a row for every resource
-  resourceTypes.map(resourceType => {
+  // Generate a row for up to 20 resources
+  resourceTypes.slice(0, 20).map(resourceType => {
     const { layer, yAxis } = createTimelineResourceLayer(timelines, resourceType);
     const layers = layer ? [layer] : [];
     const resourceRow = createRow(timelines, {

--- a/src/utilities/view.ts
+++ b/src/utilities/view.ts
@@ -1,5 +1,10 @@
 import Ajv from 'ajv';
-import { ViewDefaultDiscreteOptions, viewSchemaVersion, viewSchemaVersionName } from '../constants/view';
+import {
+  ViewDefaultDiscreteOptions,
+  viewSchemaVersion,
+  viewSchemaVersionName,
+  ViewTimelineResourceRowsLimit,
+} from '../constants/view';
 import jsonSchema from '../schemas';
 import type { ExternalEventType } from '../types/external-event';
 import type { ResourceType } from '../types/simulation';
@@ -57,8 +62,8 @@ export function generateDefaultView(
     timeline.rows.push(externalEventRow);
   }
 
-  // Generate a row for up to 20 resources
-  resourceTypes.slice(0, 20).map(resourceType => {
+  // Generate a Resource row for up to the limit specified by ViewTimelineResourceRowsLimit
+  resourceTypes.slice(0, ViewTimelineResourceRowsLimit).map(resourceType => {
     const { layer, yAxis } = createTimelineResourceLayer(timelines, resourceType);
     const layers = layer ? [layer] : [];
     const resourceRow = createRow(timelines, {


### PR DESCRIPTION
Adds a persistent option in the view menu to reset to default view regardless of which view you currently have loaded. Additionally fixes the visual state of MenuItem when disabled by targeting the `aria-disabled` attribute that is currently used instead of the `disabled` attribute that was used prior to Tailwind.

Closes #639 

## Testing:

#### Model with no default view:
- Load a plan
- Make some view changes such as changing active panels
- Save the view
- Make some more view changes
- Click on the view menu and verify that you can see both "Reset to last saved" as well as "Reset to default"
- Click on "Reset to default"
- The default view should load and the view url parameter should clear

#### Model with default view
- Associate a default view with a model by editing the model in the models page
- Make a plan for that model
- Make view change, save the view, make some more changes
- Click on the view menu and reset to default
- The default view for the model should load and the view url parameter should clear