### PR TITLE
Bug Fix for Issue #1445 (Anchor parent directive always renders at the time of the child)

### DIFF
--- a/src/components/activity/ActivityDirectiveChangelog.svelte
+++ b/src/components/activity/ActivityDirectiveChangelog.svelte
@@ -17,7 +17,7 @@
   import effects from '../../utilities/effects';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
-  import { convertUsToDurationString, formatDate, getUnixEpochTimeFromInterval } from '../../utilities/time';
+  import { convertUsToDurationString, formatDate } from '../../utilities/time';
   import { tooltip } from '../../utilities/tooltip';
 
   const dispatch = createEventDispatcher<{
@@ -29,7 +29,6 @@
   export let activityDirective: ActivityDirective;
   export let activityDirectivesMap: ActivityDirectivesMap = {};
   export let activityTypes: ActivityType[] = [];
-  export let planStartTimeYmd: string;
   export let user: User | null;
 
   let hasUpdatePermission: boolean = false;
@@ -112,15 +111,14 @@
 
     // Manually check remaining fields that could have changed and require extra formatting
 
-    if (current.start_offset !== previous.start_offset) {
-      const currentStartTime = formatDate(
-        new Date(getUnixEpochTimeFromInterval(planStartTimeYmd, current.start_offset)),
-        $plugins.time.primary.format,
-      );
-      const previousStartTime = formatDate(
-        new Date(getUnixEpochTimeFromInterval(planStartTimeYmd, previous.start_offset)),
-        $plugins.time.primary.format,
-      );
+    if (current.start_offset !== previous.start_offset || current.start_time_ms !== previous.start_time_ms) {
+      const currentStartTime =
+        current.start_time_ms !== null ? formatDate(new Date(current.start_time_ms), $plugins.time.primary.format) : '';
+
+      const previousStartTime =
+        previous.start_time_ms !== null
+          ? formatDate(new Date(previous.start_time_ms), $plugins.time.primary.format)
+          : '';
 
       differences[`Start Time (${$plugins.time.primary.label})`] = {
         currentValue: currentStartTime,

--- a/src/components/activity/ActivityDirectiveChangelog.svelte
+++ b/src/components/activity/ActivityDirectiveChangelog.svelte
@@ -120,9 +120,13 @@
           ? formatDate(new Date(previous.start_time_ms), $plugins.time.primary.format)
           : '';
 
-      differences[`Start Time (${$plugins.time.primary.label})`] = {
-        currentValue: currentStartTime,
-        previousValue: previousStartTime,
+      const cycle = current.start_time_ms === null || previous.start_time_ms === null;
+
+      const key = cycle ? 'Anchor Cycle Detected' : `Start Time (${$plugins.time.primary.label})`;
+
+      differences[key] = {
+        currentValue: cycle ? 'Cannot Calculate Absolute Start Time' : currentStartTime,
+        previousValue: cycle ? '' : previousStartTime,
       };
     }
 

--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -102,7 +102,7 @@
     (activityTypes ?? []).find(({ name: activityTypeName }) => activityDirective?.type === activityTypeName) ?? null;
   $: {
     const startTimeMs = revision ? revision.start_time_ms : activityDirective.start_time_ms;
-    startTime = startTimeMs ? formatDate(new Date(startTimeMs), $plugins.time.primary.format) : '0000-000T00:00:00:00';
+    startTime = startTimeMs ? formatDate(new Date(startTimeMs), $plugins.time.primary.format) : '';
   }
 
   $: startTimeField = field<string>(startTime, [required, $plugins.time.primary.validate]);

--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -105,7 +105,7 @@
       planStartTimeYmd,
       revision ? revision.start_offset : activityDirective.start_offset,
     );*/
-    const startTimeMs = activityDirective.start_time_ms;
+    const startTimeMs = revision ? revision.start_time_ms : activityDirective.start_time_ms;
     startTime = startTimeMs ? formatDate(new Date(startTimeMs), $plugins.time.primary.format) : '';
   }
 

--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -39,7 +39,7 @@
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
   import { pluralize } from '../../utilities/text';
-  import { formatDate, getDoyTime, getIntervalFromDoyRange, getUnixEpochTimeFromInterval } from '../../utilities/time';
+  import { formatDate, getDoyTime, getIntervalFromDoyRange } from '../../utilities/time';
   import { tooltip } from '../../utilities/tooltip';
   import { required } from '../../utilities/validators';
   import Collapse from '../Collapse.svelte';
@@ -101,11 +101,12 @@
   $: activityType =
     (activityTypes ?? []).find(({ name: activityTypeName }) => activityDirective?.type === activityTypeName) ?? null;
   $: {
-    const startTimeMs = getUnixEpochTimeFromInterval(
+    /* const startTimeMs = getUnixEpochTimeFromInterval(
       planStartTimeYmd,
       revision ? revision.start_offset : activityDirective.start_offset,
-    );
-    startTime = formatDate(new Date(startTimeMs), $plugins.time.primary.format);
+    );*/
+    const startTimeMs = activityDirective.start_time_ms;
+    startTime = startTimeMs ? formatDate(new Date(startTimeMs), $plugins.time.primary.format) : '';
   }
 
   $: startTimeField = field<string>(startTime, [required, $plugins.time.primary.validate]);

--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -101,12 +101,8 @@
   $: activityType =
     (activityTypes ?? []).find(({ name: activityTypeName }) => activityDirective?.type === activityTypeName) ?? null;
   $: {
-    /* const startTimeMs = getUnixEpochTimeFromInterval(
-      planStartTimeYmd,
-      revision ? revision.start_offset : activityDirective.start_offset,
-    );*/
     const startTimeMs = revision ? revision.start_time_ms : activityDirective.start_time_ms;
-    startTime = startTimeMs ? formatDate(new Date(startTimeMs), $plugins.time.primary.format) : '';
+    startTime = startTimeMs ? formatDate(new Date(startTimeMs), $plugins.time.primary.format) : '0000-000T00:00:00:00';
   }
 
   $: startTimeField = field<string>(startTime, [required, $plugins.time.primary.validate]);

--- a/src/components/activity/ActivityFormPanel.svelte
+++ b/src/components/activity/ActivityFormPanel.svelte
@@ -214,7 +214,6 @@
         activityDirective={$selectedActivityDirective}
         activityDirectivesMap={$activityDirectivesMap || {}}
         activityTypes={$planModelActivityTypes}
-        planStartTimeYmd={$plan.start_time}
         on:closeChangelog={onToggleViewChangelog}
         on:previewRevision={onPreviewRevision}
         {user}

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -66,7 +66,7 @@ export type ActivityDirectiveInsertInput = {
 
 export type ActivityDirectiveSetInput = Partial<ActivityDirectiveInsertInput>;
 
-export type ActivityDirectiveRevision = {
+export type ActivityDirectiveRevisionDB = {
   anchor_id: number | null;
   anchored_to_start: boolean;
   arguments: ArgumentsMap;
@@ -76,6 +76,10 @@ export type ActivityDirectiveRevision = {
   name: string;
   revision: number;
   start_offset: string;
+};
+
+export type ActivityDirectiveRevision = ActivityDirectiveRevisionDB & {
+  start_time_ms: number | null;
 };
 
 export type AppliedPreset = {

--- a/src/utilities/activities.test.ts
+++ b/src/utilities/activities.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'vitest';
 import type { ActivityDirective } from '../types/activity';
 import type { Span, SpanUtilityMaps, SpansMap } from '../types/simulation';
 import {
+  addAbsoluteTimeToRevision,
   createSpanUtilityMaps,
   getActivityMetadata,
   getAllSpanChildrenIds,
@@ -273,5 +274,121 @@ describe('getAllSpanChildrenIds', () => {
     expect(getAllSpanChildrenIds(1, testSpansUtilityMap)).to.deep.equal([2, 3]);
     expect(getAllSpanChildrenIds(2, testSpansUtilityMap)).to.deep.equal([]);
     expect(getAllSpanChildrenIds(4, testSpansUtilityMap)).to.deep.equal([]);
+  });
+});
+
+describe('addAbsoluteTimeToRevision', () => {
+  const plan = {
+    child_plans: [],
+    collaborators: [],
+    constraint_specification: [],
+    created_at: '2030-01-01T00:00:00',
+    duration: '1y',
+    end_time_doy: '2030-365T00:00:00',
+    id: 1,
+    is_locked: false,
+    model: {
+      constraint_specification: [],
+      created_at: '2030-01-01T00:00:00',
+      default_view_id: 0,
+      id: 1,
+      jar_id: 123,
+      mission: 'Test',
+      name: 'Test Model',
+      owner: 'test',
+      parameters: { parameters: {} },
+      plans: [],
+      refresh_activity_type_logs: [],
+      refresh_model_parameter_logs: [],
+      refresh_resource_type_logs: [],
+      scheduling_specification_conditions: [],
+      scheduling_specification_goals: [],
+      version: '1.0.0',
+      view: null,
+    },
+    model_id: 1,
+    name: 'Foo plan',
+    owner: 'test',
+    parent_plan: null,
+    revision: 1,
+    scheduling_specification: null,
+    simulations: [
+      {
+        id: 3,
+        simulation_datasets: [
+          {
+            id: 1,
+            plan_revision: 1,
+          },
+        ],
+      },
+    ] as [
+      {
+        id: number;
+        simulation_datasets: [
+          {
+            id: number;
+            plan_revision: number;
+          },
+        ];
+      },
+    ],
+    start_time: '2030-07-01T00:00:00+00:00',
+    start_time_doy: '2030-182T00:00:00',
+    tags: [
+      {
+        tag: {
+          color: '#fff',
+          created_at: '2024-01-01T00:00:00',
+          id: 0,
+          name: 'test tag',
+          owner: 'test',
+        },
+      },
+    ],
+    updated_at: '2030-01-01T00:00:00',
+    updated_by: 'test',
+  };
+
+  const activityDirectiveDB = {
+    anchor_id: null,
+    anchored_to_start: true,
+    applied_preset: null,
+    arguments: {},
+    created_at: '2030-01-01T00:00:00',
+    created_by: 'admin',
+    id: 1,
+    last_modified_arguments_at: '2030-01-01T00:00:00',
+    last_modified_at: '2030-01-01T00:00:00',
+    last_modified_by: 'admin',
+    metadata: {},
+    name: 'foo 1',
+    plan_id: 1,
+    source_scheduling_goal_id: null,
+    start_offset: '05:00:00',
+    tags: [],
+    type: 'foo',
+  };
+
+  const activityDirectiveRevision = {
+    anchor_id: null,
+    anchored_to_start: true,
+    arguments: {},
+    changed_at: '2030-07-03T21:53:22',
+    changed_by: 'admin',
+    metadata: {},
+    name: 'foo 1',
+    revision: 1,
+    start_offset: '10:00:00',
+    start_time_ms: null,
+  };
+
+  const activitiesDirectivesDB = [activityDirectiveDB];
+  const spansMap = {};
+  const spanUtilityMaps = createSpanUtilityMaps([]);
+
+  test('should compute and set start_time_ms on revision', () => {
+    addAbsoluteTimeToRevision(activityDirectiveRevision, 1, plan, activitiesDirectivesDB, spansMap, spanUtilityMaps);
+    expect(activityDirectiveRevision.start_time_ms).toEqual(new Date('2030-07-01T10:00:00+00:00').getTime());
   });
 });

--- a/src/utilities/activities.test.ts
+++ b/src/utilities/activities.test.ts
@@ -1,6 +1,7 @@
 import { keyBy, reverse } from 'lodash-es';
 import { describe, expect, test } from 'vitest';
 import type { ActivityDirective } from '../types/activity';
+import type { Plan } from '../types/plan';
 import type { Span, SpanUtilityMaps, SpansMap } from '../types/simulation';
 import {
   addAbsoluteTimeToRevision,
@@ -278,7 +279,7 @@ describe('getAllSpanChildrenIds', () => {
 });
 
 describe('addAbsoluteTimeToRevision', () => {
-  const plan = {
+  const plan: Plan = {
     child_plans: [],
     collaborators: [],
     constraint_specification: [],
@@ -321,16 +322,6 @@ describe('addAbsoluteTimeToRevision', () => {
             plan_revision: 1,
           },
         ],
-      },
-    ] as [
-      {
-        id: number;
-        simulation_datasets: [
-          {
-            id: number;
-            plan_revision: number;
-          },
-        ];
       },
     ],
     start_time: '2030-07-01T00:00:00+00:00',

--- a/src/utilities/activities.ts
+++ b/src/utilities/activities.ts
@@ -291,7 +291,6 @@ export function addAbsoluteTimeToRevision(
   spanUtilityMaps: SpanUtilityMaps,
 ): void {
   const activityDirectivesMap = computeActivityDirectivesMap(activitiesDirectivesDB, plan, spansMap, spanUtilityMaps);
-
   //Temporarily overlay the currentActivity with the revision
   const tempDirectivesMap: ActivityDirectivesMap = {
     ...activityDirectivesMap,
@@ -306,14 +305,19 @@ export function addAbsoluteTimeToRevision(
     },
   };
 
-  const startTimeMs = getActivityDirectiveStartTimeMs(
-    activityId,
-    plan.start_time,
-    plan.end_time_doy,
-    tempDirectivesMap,
-    spansMap,
-    spanUtilityMaps,
-  );
+  let startTimeMs;
+  try {
+    startTimeMs = getActivityDirectiveStartTimeMs(
+      activityId,
+      plan.start_time,
+      plan.end_time_doy,
+      tempDirectivesMap,
+      spansMap,
+      spanUtilityMaps,
+    );
+  } catch (e) {
+    startTimeMs = null;
+  }
 
   activityDirectiveRevision.start_time_ms = startTimeMs;
 }

--- a/src/utilities/activities.ts
+++ b/src/utilities/activities.ts
@@ -1,5 +1,10 @@
 import { keyBy, omitBy } from 'lodash-es';
-import type { ActivityDirective, ActivityDirectiveDB, ActivityDirectivesMap } from '../types/activity';
+import type {
+  ActivityDirective,
+  ActivityDirectiveDB,
+  ActivityDirectiveRevision,
+  ActivityDirectivesMap,
+} from '../types/activity';
 import type { ActivityMetadata, ActivityMetadataKey, ActivityMetadataValue } from '../types/activity-metadata';
 import type { Plan } from '../types/plan';
 import type { Span, SpanId, SpanUtilityMaps, SpansMap } from '../types/simulation';
@@ -275,4 +280,40 @@ export async function getActivityDirectivesToPaste(
     console.error(e);
   }
   return activities;
+}
+
+export function addAbsoluteTimeToRevision(
+  activityDirectiveRevision: ActivityDirectiveRevision,
+  activityId: number,
+  plan: Plan,
+  activitiesDirectivesDB: ActivityDirectiveDB[],
+  spansMap: SpansMap,
+  spanUtilityMaps: SpanUtilityMaps,
+): void {
+  const activityDirectivesMap = computeActivityDirectivesMap(activitiesDirectivesDB, plan, spansMap, spanUtilityMaps);
+
+  //Temporarily overlay the currentActivity with the revision
+  const tempDirectivesMap: ActivityDirectivesMap = {
+    ...activityDirectivesMap,
+    [activityId]: {
+      ...activityDirectivesMap[activityId],
+      anchor_id: activityDirectiveRevision.anchor_id,
+      anchored_to_start: activityDirectiveRevision.anchored_to_start,
+      arguments: activityDirectiveRevision.arguments,
+      metadata: activityDirectiveRevision.metadata,
+      name: activityDirectiveRevision.name,
+      start_offset: activityDirectiveRevision.start_offset,
+    },
+  };
+
+  const startTimeMs = getActivityDirectiveStartTimeMs(
+    activityId,
+    plan.start_time,
+    plan.end_time_doy,
+    tempDirectivesMap,
+    spansMap,
+    spanUtilityMaps,
+  );
+
+  activityDirectiveRevision.start_time_ms = startTimeMs;
 }

--- a/src/utilities/activities.ts
+++ b/src/utilities/activities.ts
@@ -3,7 +3,9 @@ import type { ActivityDirective, ActivityDirectiveDB, ActivityDirectivesMap } fr
 import type { ActivityMetadata, ActivityMetadataKey, ActivityMetadataValue } from '../types/activity-metadata';
 import type { Plan } from '../types/plan';
 import type { Span, SpanId, SpanUtilityMaps, SpansMap } from '../types/simulation';
+import { getClipboardContent, setClipboardContent } from './clipboard';
 import { compare, isEmpty } from './generic';
+import { pluralize } from './text';
 import {
   getActivityDirectiveStartTimeMs,
   getDoyTime,
@@ -11,9 +13,7 @@ import {
   getIntervalInMs,
   getUnixEpochTime,
 } from './time';
-import { getClipboardContent, setClipboardContent } from './clipboard';
 import { showFailureToast, showSuccessToast } from './toast';
-import { pluralize } from './text';
 
 /**
  * Updates activity metadata with a new key/value and removes any empty values.

--- a/src/utilities/activities.ts
+++ b/src/utilities/activities.ts
@@ -289,7 +289,7 @@ export function addAbsoluteTimeToRevision(
   activitiesDirectivesDB: ActivityDirectiveDB[],
   spansMap: SpansMap,
   spanUtilityMaps: SpanUtilityMaps,
-): void {
+): ActivityDirectiveRevision {
   const activityDirectivesMap = computeActivityDirectivesMap(activitiesDirectivesDB, plan, spansMap, spanUtilityMaps);
   //Temporarily overlay the currentActivity with the revision
   const tempDirectivesMap: ActivityDirectivesMap = {
@@ -320,4 +320,5 @@ export function addAbsoluteTimeToRevision(
   }
 
   activityDirectiveRevision.start_time_ms = startTimeMs;
+  return activityDirectiveRevision;
 }

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -3873,10 +3873,10 @@ const effects = {
 
       if (activityDirectiveRevisions != null) {
         // Fill in start_time_ms for each revision if not already calculated
-        activityDirectiveRevisions.forEach(revision => {
+        const updatedRevisions = activityDirectiveRevisions.map(revision => {
           const sourcePlan = get(plan);
           if (sourcePlan) {
-            addAbsoluteTimeToRevision(
+            return addAbsoluteTimeToRevision(
               revision,
               activityId,
               sourcePlan,
@@ -3889,9 +3889,9 @@ const effects = {
               },
             );
           }
+          return revision; // fallback if sourcePlan is undefined
         });
-
-        return activityDirectiveRevisions;
+        return updatedRevisions;
       } else {
         throw Error('Unable to retrieve activity directive changelog');
       }

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -50,6 +50,7 @@ import {
 import {
   createPlanError as createPlanErrorStore,
   creatingPlan as creatingPlanStore,
+  plan,
   planId as planIdStore,
 } from '../stores/plan';
 import {
@@ -67,6 +68,8 @@ import {
   selectedSpanId as selectedSpanIdStore,
   simulationDatasetId as simulationDatasetIdStore,
   simulationDataset as simulationDatasetStore,
+  spansMap,
+  spanUtilityMaps,
 } from '../stores/simulation';
 import { createTagError as createTagErrorStore } from '../stores/tags';
 import { applyViewUpdate, view as viewStore, viewUpdateRow, viewUpdateTimeline } from '../stores/views';
@@ -248,7 +251,7 @@ import type {
 } from '../types/tags';
 import type { ActivityLayerFilter, Layer, Row, Timeline } from '../types/timeline';
 import type { View, ViewDefinition, ViewInsertInput, ViewSlim, ViewUpdateInput } from '../types/view';
-import { ActivityDeletionAction } from './activities';
+import { ActivityDeletionAction, addAbsoluteTimeToRevision } from './activities';
 import { compare, convertToQuery, getSearchParameterNumber, setQueryParam } from './generic';
 import gql, { convertToGQLArray } from './gql';
 import {
@@ -3867,7 +3870,27 @@ const effects = {
         user,
       );
       const { activityDirectiveRevisions } = data;
+
       if (activityDirectiveRevisions != null) {
+        // Fill in start_time_ms for each revision if not already calculated
+        activityDirectiveRevisions.forEach(revision => {
+          const sourcePlan = get(plan);
+          if (sourcePlan) {
+            addAbsoluteTimeToRevision(
+              revision,
+              activityId,
+              sourcePlan,
+              get(activityDirectivesDBStore) ?? [],
+              get(spansMap) ?? {},
+              get(spanUtilityMaps) ?? {
+                directiveIdToSpanIdMap: {},
+                spanIdToChildIdsMap: {},
+                spanIdToDirectiveIdMap: {},
+              },
+            );
+          }
+        });
+
         return activityDirectiveRevisions;
       } else {
         throw Error('Unable to retrieve activity directive changelog');

--- a/src/utilities/time.test.ts
+++ b/src/utilities/time.test.ts
@@ -217,6 +217,132 @@ test('getActivityDirectiveStartTimeMs', () => {
   ).toEqual(new Date('2030-07-01T13:58:00+00:00').getTime());
 });
 
+test('getActivityDirectiveStartTimeMs - no cycles, anchor chain', () => {
+  const baseDirective: ActivityDirectiveDB = {
+    anchor_id: null,
+    anchored_to_start: true,
+    applied_preset: null,
+    arguments: {},
+    created_at: '2022-08-03T18:21:51',
+    created_by: 'admin',
+    id: 10,
+    last_modified_arguments_at: '2022-08-03T21:53:22',
+    last_modified_at: '2022-08-03T21:53:22',
+    last_modified_by: 'admin',
+    metadata: {},
+    name: 'root',
+    plan_id: 1,
+    source_scheduling_goal_id: null,
+    start_offset: '01:00:00',
+    tags: [],
+    type: 'bar',
+  };
+
+  const anchored1: ActivityDirectiveDB = {
+    ...baseDirective,
+    anchor_id: 10,
+    id: 11,
+    start_offset: '00:15:00',
+  };
+
+  const anchored2: ActivityDirectiveDB = {
+    ...baseDirective,
+    anchor_id: 11,
+    id: 12,
+    start_offset: '-00:05:00',
+  };
+
+  const anchored3: ActivityDirectiveDB = {
+    ...baseDirective,
+    anchor_id: 12,
+    id: 13,
+    start_offset: '00:30:00',
+  };
+
+  const anchored4: ActivityDirectiveDB = {
+    ...baseDirective,
+    anchor_id: 13,
+    id: 14,
+    start_offset: '-00:20:00',
+  };
+
+  const planStartTimeYmd = '2031-01-01T00:00:00+00:00';
+  const planEndTimeDoy = '2031-365T00:00:00.000';
+
+  const directiveDBMap = keyBy(
+    [baseDirective, anchored1, anchored2, anchored3, anchored4].map(d => ({
+      ...d,
+      start_time_ms: null,
+    })),
+    'id',
+  );
+
+  expect(
+    getActivityDirectiveStartTimeMs(
+      10,
+      planStartTimeYmd,
+      planEndTimeDoy,
+      directiveDBMap,
+      {},
+      createSpanUtilityMaps([]),
+      {},
+      {},
+    ),
+  ).toEqual(new Date('2031-01-01T01:00:00+00:00').getTime());
+
+  expect(
+    getActivityDirectiveStartTimeMs(
+      11,
+      planStartTimeYmd,
+      planEndTimeDoy,
+      directiveDBMap,
+      {},
+      createSpanUtilityMaps([]),
+      {},
+      {},
+    ),
+  ).toEqual(new Date('2031-01-01T01:15:00+00:00').getTime());
+
+  expect(
+    getActivityDirectiveStartTimeMs(
+      12,
+      planStartTimeYmd,
+      planEndTimeDoy,
+      directiveDBMap,
+      {},
+      createSpanUtilityMaps([]),
+      {},
+      {},
+    ),
+  ).toEqual(new Date('2031-01-01T01:10:00+00:00').getTime());
+
+  expect(
+    getActivityDirectiveStartTimeMs(
+      13,
+      planStartTimeYmd,
+      planEndTimeDoy,
+      directiveDBMap,
+      {},
+      createSpanUtilityMaps([]),
+      {},
+      {},
+    ),
+  ).toEqual(new Date('2031-01-01T01:40:00+00:00').getTime());
+
+  expect(
+    getActivityDirectiveStartTimeMs(
+      14,
+      planStartTimeYmd,
+      planEndTimeDoy,
+      directiveDBMap,
+      {},
+      createSpanUtilityMaps([]),
+      {},
+      {},
+    ),
+  ).toEqual(new Date('2031-01-01T01:20:00+00:00').getTime());
+});
+
 test('convertDoyToYmd', () => {
   expect(convertDoyToYmd('2023-001T00:10:12', false)).toEqual('2023-01-01T00:10:12Z');
   expect(convertDoyToYmd('2023-001T00:00:00', false)).toEqual('2023-01-01T00:00:00Z');


### PR DESCRIPTION
Fixes #1445 

The Anchor parent directive was always rendering same time of the child because the calculation of the `start_time_ms` attribute for `ActivityDirective` was incorrect in `getActivityDirectiveStartTimeMs.` The previous algorithm relied on nested casting and had a difficult flow to follow. The proposed change finds the anchor parent directive's `start_time_ms`, then handles if the child is anchored to the start or end. Previously, `ActivityDirectiveForm`  compared a directive's `start_offset` to the plan's start time to display Absolute Start Time. This ignores any anchor relationships leading to incorrect Absolute Start Times being displayed, instead it should be based off of `start_time_ms`.

Previously, Absolute Start Time for revisions was based only on `start_offset` and did not account for anchors. Relabeled the existing schema for `ActivityDirectiveRevision` as `ActivityDirectiveDB,` and then extended with a "new"  type called `ActivityDirective` which has an extra attribute of `start_time_ms`. Calculate the `start_time_ms` for revisions when they are retrieved from the database. Calculation for `start_time_ms` and consequently Absolute Start Time is not possible if a revision state leads to a current anchor cycle. The user is notified of this and the Absolute Start Time field is left empty. 