### PR TITLE
Add activity type description on activity directive form

### DIFF
--- a/src/components/TimelineItemList.svelte
+++ b/src/components/TimelineItemList.svelte
@@ -129,6 +129,10 @@
       viewAddFilterToRow([event.detail.item], typeName, {}, event.detail.row?.id, event.detail.layer);
     }
   }
+
+  function hasDescription(item: TimelineItemType): item is TimelineItemType & { description: string } {
+    return 'description' in item;
+  }
 </script>
 
 <div class="timeline-item-list">
@@ -268,6 +272,9 @@
           style="cursor: move;"
           on:dragend={onDragEnd}
           on:dragstart={e => onDragStart(e.detail, [item])}
+          {tooltip}
+          tooltipContent={hasDescription(item) ? item.description : 'No description available.'}
+          tooltipEnabled={hasDescription(item) && !!item.description}
         >
           {item.name}
           <slot prop={item} />

--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -589,13 +589,14 @@
               <label use:tooltip={{ content: 'Activity Description', placement: 'top' }} for="activity-description">
                 Description
               </label>
-              <input
+              <textarea
                 class="st-input w-full"
                 disabled
                 name="activity-description"
                 id="activity-description"
                 value={activityType.description}
-              />
+                readonly
+              ></textarea>
             </Input>
           </Highlight>
         {/if}

--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -583,6 +583,23 @@
           </Input>
         </Highlight>
 
+        {#if activityType && activityType.description}
+          <Highlight highlight={highlightKeysMap.type}>
+            <Input layout="inline">
+              <label use:tooltip={{ content: 'Activity Description', placement: 'top' }} for="activity-description">
+                Description
+              </label>
+              <input
+                class="st-input w-full"
+                disabled
+                name="activity-description"
+                id="activity-description"
+                value={activityType.description}
+              />
+            </Input>
+          </Highlight>
+        {/if}
+
         <Highlight highlight={highlightKeysMap.start_offset}>
           <DatePickerField
             useFallback={!$plugins.time.enableDatePicker}

--- a/src/components/activity/ActivitySpanForm.svelte
+++ b/src/components/activity/ActivitySpanForm.svelte
@@ -148,6 +148,22 @@
         <input class="st-input w-full" disabled name="activityType" value={span.type} />
       </Input>
 
+      {#if activityType && activityType.description}
+        <Input layout="inline">
+          <label use:tooltip={{ content: 'Activity Description', placement: 'top' }} for="activity-description">
+            Description
+          </label>
+          <textarea
+            class="st-input w-full"
+            disabled
+            name="activity-description"
+            id="activity-description"
+            value={activityType.description}
+            readonly
+          ></textarea>
+        </Input>
+      {/if}
+      
       <Input layout="inline">
         <label use:tooltip={{ content: 'Parent ID', placement: 'top' }} for="parentId">Parent ID</label>
         <input class="st-input w-full" disabled name="parentId" value={span.parent_id ?? 'None (Root)'} />

--- a/src/components/activity/ActivitySpanForm.svelte
+++ b/src/components/activity/ActivitySpanForm.svelte
@@ -163,7 +163,7 @@
           ></textarea>
         </Input>
       {/if}
-      
+
       <Input layout="inline">
         <label use:tooltip={{ content: 'Parent ID', placement: 'top' }} for="parentId">Parent ID</label>
         <input class="st-input w-full" disabled name="parentId" value={span.parent_id ?? 'None (Root)'} />

--- a/src/components/ui/ListItem.svelte
+++ b/src/components/ui/ListItem.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import type { Action } from 'svelte/action';
 
   export { className as class };
   export { styleName as style };
   export let draggable: boolean = false;
+
+  export let tooltip: Action<HTMLElement, any> | undefined = undefined;
+  export let tooltipContent: any;
+  export let tooltipPlacement: string = 'top';
+  export let tooltipEnabled: boolean = false;
 
   const dispatch = createEventDispatcher<{
     click: MouseEvent;
@@ -14,6 +20,13 @@
   let className: string = '';
   let styleName: string = '';
   let dragging: boolean = false;
+
+  const doNothing = () => {};
+
+  $: action = tooltip && tooltipEnabled ? tooltip : doNothing;
+  $: params = tooltipEnabled
+    ? { content: tooltipContent, enabled: tooltipEnabled, placement: tooltipPlacement }
+    : undefined;
 </script>
 
 <div
@@ -31,6 +44,7 @@
     dragging = true;
     dispatch('dragstart', e);
   }}
+  use:action={params}
 >
   <div class="list-item-content">
     <slot />

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -9,6 +9,7 @@ import type { Tag } from './tags';
 
 export type ActivityType = {
   computed_attributes_value_schema: ValueSchema;
+  description: string;
   name: string;
   parameters: ParametersMap;
   required_parameters: string[];

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -2160,6 +2160,7 @@ const gql = {
           id
           name
         }
+        description
       }
     }
   `,

--- a/src/utilities/timeline.test.ts
+++ b/src/utilities/timeline.test.ts
@@ -50,7 +50,7 @@ const testActivityTypes: ActivityType[] = [
       items: {},
       type: 'struct',
     },
-    description: "",
+    description: '',
     name: 'child',
     parameters: {
       counter: {
@@ -68,7 +68,7 @@ const testActivityTypes: ActivityType[] = [
       items: {},
       type: 'struct',
     },
-    description: "",
+    description: '',
     name: 'parent',
     parameters: {
       label: {
@@ -109,7 +109,7 @@ const testActivityTypes: ActivityType[] = [
       },
       type: 'struct',
     },
-    description: "",
+    description: '',
     name: 'BiteBanana',
     parameters: {
       biteSize: {
@@ -134,7 +134,7 @@ const testActivityTypes: ActivityType[] = [
     computed_attributes_value_schema: {
       type: 'int',
     },
-    description: "",
+    description: '',
     name: 'BakeBananaBread',
     parameters: {
       glutenFree: {

--- a/src/utilities/timeline.test.ts
+++ b/src/utilities/timeline.test.ts
@@ -50,6 +50,7 @@ const testActivityTypes: ActivityType[] = [
       items: {},
       type: 'struct',
     },
+    description: "",
     name: 'child',
     parameters: {
       counter: {
@@ -67,6 +68,7 @@ const testActivityTypes: ActivityType[] = [
       items: {},
       type: 'struct',
     },
+    description: "",
     name: 'parent',
     parameters: {
       label: {
@@ -107,6 +109,7 @@ const testActivityTypes: ActivityType[] = [
       },
       type: 'struct',
     },
+    description: "",
     name: 'BiteBanana',
     parameters: {
       biteSize: {
@@ -131,6 +134,7 @@ const testActivityTypes: ActivityType[] = [
     computed_attributes_value_schema: {
       type: 'int',
     },
+    description: "",
     name: 'BakeBananaBread',
     parameters: {
       glutenFree: {


### PR DESCRIPTION
___REQUIRES_AERIE_PR___="1714"

To test:

Navigate to http://localhost:3000/models/
Upload a model with description annotations on the activity types
The banananation model has a few activities with descriptions defined, it's found under examples/banananation/build/libs in the Aerie repo
Navigate to the plans and create a plan based off of that model
Drag in the activity that you set the description on, for banananation one of the activities is BakeBananaBread
When you have the activity directive form open, you should be able to see the description under activity type and above start time
<img width="1061" height="550" alt="image" src="https://github.com/user-attachments/assets/a9d7a250-3923-41d7-96c7-b419230f0e8a" />
When the activity doesn't have the description defined, the description field doesn't display
