### PR TITLE
Add anchor name as a column in activities directories

### DIFF
--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -69,10 +69,11 @@
       resizable: true,
       sortable: true,
       valueGetter: (params: ValueGetterParams<ActivityDirective>) => {
-        if (params && params.data && params.data.anchor_id) {
-          return $activityDirectivesMap?.[params.data.anchor_id]?.name;
+        if (params?.data?.anchor_id && $activityDirectivesMap) {
+          return $activityDirectivesMap[params.data.anchor_id]?.name ?? ''
         }
-      },
+        return '';
+      }
     },
     anchored_to_start: {
       field: 'anchored_to_start',

--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -70,7 +70,7 @@
       sortable: true,
       valueGetter: (params: ValueGetterParams<ActivityDirective>) => {
         if (params?.data?.anchor_id && $activityDirectivesMap) {
-          return $activityDirectivesMap[params.data.anchor_id]?.name ?? ''
+          return $activityDirectivesMap[params.data.anchor_id]?.name ?? '';
         }
         return '';
       }

--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -73,7 +73,7 @@
           return $activityDirectivesMap[params.data.anchor_id]?.name ?? '';
         }
         return '';
-      }
+      },
     },
     anchored_to_start: {
       field: 'anchored_to_start',

--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -61,6 +61,19 @@
       resizable: true,
       sortable: true,
     },
+    anchor_name: {
+      field: 'anchor_name',
+      filter: 'text',
+      headerName: 'Anchor Name',
+      hide: true,
+      resizable: true,
+      sortable: true,
+      valueGetter: (params: ValueGetterParams<ActivityDirective>) => {
+        if (params && params.data && params.data.anchor_id) {
+          return $activityDirectivesMap?.[params.data.anchor_id]?.name;
+        }
+      },
+    },
     anchored_to_start: {
       field: 'anchored_to_start',
       filter: 'text',


### PR DESCRIPTION
To test:

Go to any plan and look at the activity directives table and select the anchor name as one of the displayed columns and you should be able to see the anchor names of activities
<img width="1074" height="249" alt="image" src="https://github.com/user-attachments/assets/aaf9fbbe-d99a-4148-bf3a-63c0091e647b" />
