### PR TITLE
Refactor activity table columns menu

### DIFF
--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -316,22 +316,15 @@
   function onColumnsChanged({
     detail: { columns },
   }: CustomEvent<{ columns: { field: any; isHidden: boolean; name: string }[] }>) {
-    viewUpdateActivityDirectivesTable({
-      columnStates: derivedColumnDefs
-        .map((columnDef: ColDef) => {
-          const activityColumnStates: ColumnState[] = activityDirectivesTable?.columnStates ?? [];
-          const existingColumnState: ColumnState | undefined = activityColumnStates.find(
-            (columnState: ColumnState) => columnDef.field === columnState.colId,
-          );
-          return existingColumnState
-            ? {
-                ...existingColumnState,
-                hide: columns.find(column => columnDef.field === column.field)?.isHidden ?? false,
-              }
-            : null;
-        })
-        .filter(filterEmpty),
+    const activityColumnStates: ColumnState[] = activityDirectivesTable?.columnStates ?? [];
+    const newActivityColumnStates = activityColumnStates.map(columnState => {
+      return { ...columnState, hide: columns.find(column => columnState.colId === column.field)?.isHidden ?? false };
     });
+
+    viewUpdateActivityDirectivesTable({
+      columnStates: newActivityColumnStates.filter(filterEmpty),
+    });
+
     requestAutoSize();
   }
 

--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -275,43 +275,6 @@
     }
   }
 
-  function onColumnToggleChange({ detail: { field, isHidden } }: CustomEvent) {
-    const activityColumnStates: ColumnState[] = activityDirectivesTable?.columnStates ?? [];
-    const existingColumnStateIndex: number = activityColumnStates.findIndex(
-      (columnState: ColumnState) => field === columnState.colId,
-    );
-    if (existingColumnStateIndex >= 0) {
-      viewUpdateActivityDirectivesTable({
-        columnStates: [
-          ...activityColumnStates.slice(0, existingColumnStateIndex),
-          {
-            ...activityColumnStates[existingColumnStateIndex],
-            hide: isHidden,
-          },
-          ...activityColumnStates.slice(existingColumnStateIndex + 1),
-        ],
-      });
-    } else {
-      viewUpdateActivityDirectivesTable({
-        columnStates: [
-          ...activityColumnStates,
-          {
-            colId: field,
-            hide: isHidden,
-          },
-        ],
-      });
-    }
-
-    setTimeout(() => {
-      if (autoSizeColumns === 'fit') {
-        autoSizeContent();
-      } else if (autoSizeColumns === 'fill') {
-        autoSizeSpace();
-      }
-    }, 0);
-  }
-
   function onColumnMoved() {
     const columnStates = dataGrid?.getColumnState();
     const updatedColumnStates = (columnStates ?? []).filter(columnState => columnState.colId !== 'actions');
@@ -350,6 +313,38 @@
     viewTogglePanel({ state: true, type: 'right', update: { rightComponentTop: 'ActivityFormPanel' } });
   }
 
+  function onColumnsChanged({
+    detail: { columns },
+  }: CustomEvent<{ columns: { field: any; isHidden: boolean; name: string }[] }>) {
+    viewUpdateActivityDirectivesTable({
+      columnStates: derivedColumnDefs
+        .map((columnDef: ColDef) => {
+          const activityColumnStates: ColumnState[] = activityDirectivesTable?.columnStates ?? [];
+          const existingColumnState: ColumnState | undefined = activityColumnStates.find(
+            (columnState: ColumnState) => columnDef.field === columnState.colId,
+          );
+          return existingColumnState
+            ? {
+                ...existingColumnState,
+                hide: columns.find(column => columnDef.field === column.field)?.isHidden ?? false,
+              }
+            : null;
+        })
+        .filter(filterEmpty),
+    });
+    requestAutoSize();
+  }
+
+  function requestAutoSize() {
+    setTimeout(() => {
+      if (autoSizeColumns === 'fit') {
+        autoSizeContent();
+      } else if (autoSizeColumns === 'fill') {
+        autoSizeSpace();
+      }
+    }, 0);
+  }
+
   function onShowHideAllColumns({ detail: { hide } }: CustomEvent<{ hide: boolean }>) {
     viewUpdateActivityDirectivesTable({
       columnStates: derivedColumnDefs
@@ -368,6 +363,7 @@
         })
         .filter(filterEmpty),
     });
+    requestAutoSize();
   }
 
   function toggleAutoSizeContent() {
@@ -429,7 +425,7 @@
         </button>
       </div>
       <ActivityTableMenu
-        on:toggle-column={onColumnToggleChange}
+        on:columns-changed={onColumnsChanged}
         on:show-hide-all-columns={onShowHideAllColumns}
         columnDefs={derivedColumnDefs}
         columnStates={activityDirectivesTable?.columnStates}

--- a/src/components/activity/ActivitySpansTablePanel.svelte
+++ b/src/components/activity/ActivitySpansTablePanel.svelte
@@ -185,22 +185,15 @@
   function onColumnsChanged({
     detail: { columns },
   }: CustomEvent<{ columns: { field: any; isHidden: boolean; name: string }[] }>) {
-    viewUpdateActivitySpansTable({
-      columnStates: derivedColumnDefs
-        .map((columnDef: ColDef) => {
-          const activityColumnStates: ColumnState[] = activitySpansTable?.columnStates ?? [];
-          const existingColumnState: ColumnState | undefined = activityColumnStates.find(
-            (columnState: ColumnState) => columnDef.field === columnState.colId,
-          );
-          return existingColumnState
-            ? {
-                ...existingColumnState,
-                hide: columns.find(column => columnDef.field === column.field)?.isHidden ?? false,
-              }
-            : null;
-        })
-        .filter(filterEmpty),
+    const activityColumnStates: ColumnState[] = activitySpansTable?.columnStates ?? [];
+    const newActivityColumnStates = activityColumnStates.map(columnState => {
+      return { ...columnState, hide: columns.find(column => columnState.colId === column.field)?.isHidden ?? false };
     });
+
+    viewUpdateActivitySpansTable({
+      columnStates: newActivityColumnStates.filter(filterEmpty),
+    });
+
     requestAutoSize();
   }
 

--- a/src/components/activity/ActivitySpansTablePanel.svelte
+++ b/src/components/activity/ActivitySpansTablePanel.svelte
@@ -182,34 +182,29 @@
     dataGrid?.sizeColumnsToFit();
   }
 
-  function onColumnToggleChange({ detail: { field, isHidden } }: CustomEvent) {
-    const activityColumnStates: ColumnState[] = activitySpansTable?.columnStates ?? [];
-    const existingColumnStateIndex: number = activityColumnStates.findIndex(
-      (columnState: ColumnState) => field === columnState.colId,
-    );
-    if (existingColumnStateIndex >= 0) {
-      viewUpdateActivitySpansTable({
-        columnStates: [
-          ...activityColumnStates.slice(0, existingColumnStateIndex),
-          {
-            ...activityColumnStates[existingColumnStateIndex],
-            hide: isHidden,
-          },
-          ...activityColumnStates.slice(existingColumnStateIndex + 1),
-        ],
-      });
-    } else {
-      viewUpdateActivitySpansTable({
-        columnStates: [
-          ...activityColumnStates,
-          {
-            colId: field,
-            hide: isHidden,
-          },
-        ],
-      });
-    }
+  function onColumnsChanged({
+    detail: { columns },
+  }: CustomEvent<{ columns: { field: any; isHidden: boolean; name: string }[] }>) {
+    viewUpdateActivitySpansTable({
+      columnStates: derivedColumnDefs
+        .map((columnDef: ColDef) => {
+          const activityColumnStates: ColumnState[] = activitySpansTable?.columnStates ?? [];
+          const existingColumnState: ColumnState | undefined = activityColumnStates.find(
+            (columnState: ColumnState) => columnDef.field === columnState.colId,
+          );
+          return existingColumnState
+            ? {
+                ...existingColumnState,
+                hide: columns.find(column => columnDef.field === column.field)?.isHidden ?? false,
+              }
+            : null;
+        })
+        .filter(filterEmpty),
+    });
+    requestAutoSize();
+  }
 
+  function requestAutoSize() {
     setTimeout(() => {
       if (autoSizeColumns === 'fit') {
         autoSizeContent();
@@ -283,6 +278,7 @@
         })
         .filter(filterEmpty),
     });
+    requestAutoSize();
   }
 
   function toggleAutoSizeContent() {
@@ -328,7 +324,7 @@
         </button>
       </div>
       <ActivityTableMenu
-        on:toggle-column={onColumnToggleChange}
+        on:columns-changed={onColumnsChanged}
         on:show-hide-all-columns={onShowHideAllColumns}
         columnDefs={derivedColumnDefs}
         columnStates={activitySpansTable?.columnStates}

--- a/src/components/activity/ActivityTableMenu.svelte
+++ b/src/components/activity/ActivityTableMenu.svelte
@@ -1,16 +1,18 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { tooltip } from '../../utilities/tooltip';
+
+  import { uniqueId } from 'lodash-es';
+
+  import { Button, Select } from '@nasa-jpl/stellar-svelte';
+
   type T = $$Generic<TRowData>;
 
-  import SearchIcon from '@nasa-jpl/stellar/icons/search.svg?component';
   import type { ColDef, ColumnState } from 'ag-grid-community';
+  import { MoreHorizontal } from 'lucide-svelte';
   import { createEventDispatcher } from 'svelte';
   import type { TRowData } from '../../types/data-grid';
-  import Input from '../form/Input.svelte';
-  import Menu from '../menus/Menu.svelte';
-  import MenuHeader from '../menus/MenuHeader.svelte';
-  import MenuItem from '../menus/MenuItem.svelte';
 
   export let columnDefs: ColDef[] | undefined = [];
   export let columnStates: ColumnState[] | undefined = [];
@@ -22,14 +24,15 @@
   };
 
   const dispatch = createEventDispatcher<{
+    'columns-changed': { columns: ColumnMenuItem[] };
     'show-hide-all-columns': { hide: boolean };
-    'toggle-column': { field: keyof T; isHidden: boolean };
   }>();
 
   let columnMenuItems: ColumnMenuItem[] = [];
-  let displayedColumnMenuItems: ColumnMenuItem[] = [];
-  let searchFilter: string = '';
-  let tableMenu: Menu;
+
+  // Generate a unique ID for this component so we can work around inability to
+  // get an element ref for a Button in this version of shadcn-svelte.
+  let id = uniqueId();
 
   $: columnMenuItems = (columnDefs ?? []).map((derivedColumnDef: ColDef) => {
     const columnState = columnStates?.find((columnState: ColumnState) => columnState.colId === derivedColumnDef.field);
@@ -49,15 +52,11 @@
     };
   });
 
-  $: displayedColumnMenuItems = columnMenuItems.filter((columnMenuItem: ColumnMenuItem) => {
-    return new RegExp(searchFilter, 'i').test(columnMenuItem.field as string);
-  });
-
-  function onColumnToggleChange(column: ColumnMenuItem) {
-    dispatch('toggle-column', {
-      field: column.field,
-      isHidden: !column.isHidden,
+  function onColumnsChanged(columns: { value: string | number | symbol }[]) {
+    const newColumns = columnMenuItems.map(item => {
+      return { ...item, isHidden: !columns.find(i => i.value === item.field) };
     });
+    dispatch('columns-changed', { columns: newColumns });
   }
 
   function onHideAllColumns() {
@@ -67,96 +66,51 @@
   function onShowAllColumns() {
     dispatch('show-hide-all-columns', { hide: false });
   }
-
-  function onSearchFilterChange(event: Event) {
-    const input = event.target as HTMLInputElement;
-    searchFilter = input.value;
-  }
 </script>
 
-<div class="activity-table-menu st-typography-medium" role="none" on:click|stopPropagation={() => tableMenu.toggle()}>
-  <div class="button"><div class="button-title">...</div></div>
-  <Menu bind:this={tableMenu} hideAfterClick={false}>
-    <MenuHeader title="Columns" showBorder={false} />
-    <div class="search-field">
-      <Input>
-        <input class="st-input w-full" value={searchFilter} on:input={onSearchFilterChange} />
-        <div class="search-icon" slot="left"><SearchIcon /></div>
-      </Input>
-    </div>
-    {#each displayedColumnMenuItems as columnMenuItem (columnMenuItem)}
-      <MenuItem className="py-1.5 text-xs" on:click={() => onColumnToggleChange(columnMenuItem)}>
-        <input type="checkbox" checked={!columnMenuItem.isHidden} />
-        <div class="column-name">{columnMenuItem.name}</div>
-      </MenuItem>
-    {/each}
-    <div class="bulk-actions">
-      <button class="st-button secondary" on:click={onShowAllColumns}>Show All</button>
-      <button class="st-button secondary" on:click={onHideAllColumns}>Hide All</button>
-    </div>
-  </Menu>
+<div use:tooltip={{ content: 'Configure table columns' }}>
+  <Select.Root
+    multiple
+    typeahead={false}
+    selected={columnMenuItems.filter(i => !i.isHidden).map(i => ({ label: i.name, value: i.field }))}
+    onSelectedChange={values => {
+      if (values) {
+        onColumnsChanged(values);
+        document.getElementById(id)?.focus();
+      }
+    }}
+  >
+    <Select.Trigger asChild let:builder {id}>
+      <Button
+        builders={[builder]}
+        aria-label="Configure table columns"
+        size="icon"
+        variant="outline"
+        class="flex-shrink-0 [&+div]:hidden"
+      >
+        <MoreHorizontal size={16} />
+      </Button>
+    </Select.Trigger>
+    <Select.Content
+      class="flex flex-col overflow-hidden [&>div]:flex [&>div]:flex-col [&>div]:overflow-hidden"
+      sameWidth={false}
+      fitViewport
+      sideOffset={4}
+      side="top"
+      align="end"
+    >
+      <Select.Label size="xs" class="pb-2">Columns</Select.Label>
+      <div class="overflow-auto">
+        {#each columnMenuItems as columnMenuItem (columnMenuItem)}
+          <Select.Item value={columnMenuItem.field} label={columnMenuItem.name} size="xs">
+            {columnMenuItem.name}</Select.Item
+          >
+        {/each}
+      </div>
+      <div class="mb-0.5 mt-2 flex gap-1">
+        <Button class="flex-1" variant="outline" on:click={onShowAllColumns}>Show All</Button>
+        <Button class="flex-1" variant="outline" on:click={onHideAllColumns}>Hide All</Button>
+      </div>
+    </Select.Content>
+  </Select.Root>
 </div>
-
-<style>
-  .activity-table-menu {
-    --aerie-menu-item-template-columns: min-content auto;
-    --aerie-menu-item-line-height: 1rem;
-    --aerie-menu-item-font-size: 12px;
-    --aerie-menu-item-padding: 4px;
-    align-items: center;
-    border: 1px solid var(--st-gray-20);
-    border-radius: 4px;
-    cursor: pointer;
-    display: flex;
-    font-size: 13px;
-    gap: 5px;
-    height: 24px;
-    justify-content: center;
-    padding: 4px 8px;
-    position: relative;
-    user-select: none;
-  }
-
-  .activity-table-menu:hover {
-    background-color: var(--st-button-secondary-hover-background-color);
-  }
-
-  .button {
-    position: relative;
-    z-index: 1;
-  }
-
-  .button-title {
-    align-items: baseline;
-    display: flex;
-    font-size: 1.5rem;
-    font-weight: bold;
-    letter-spacing: -1px;
-    line-height: 0px;
-    margin-top: -6.5px;
-  }
-
-  .search-field {
-    display: flex;
-    margin: 0 4px;
-    position: relative;
-  }
-
-  .search-icon {
-    align-items: center;
-    color: var(--st-gray-50);
-    display: flex;
-  }
-
-  .column-name {
-    color: var(--st-gray-60);
-    letter-spacing: 0.04em;
-  }
-
-  .bulk-actions {
-    column-gap: 0.5rem;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    margin: 0.5rem;
-  }
-</style>

--- a/src/components/activity/ActivityTableMenu.svelte
+++ b/src/components/activity/ActivityTableMenu.svelte
@@ -54,7 +54,7 @@
 
   function onColumnsChanged(columns: { value: string | number | symbol }[]) {
     const newColumns = columnMenuItems.map(item => {
-      return { ...item, isHidden: !columns.find(i => i.value === item.field) };
+      return { ...item, isHidden: !columns.find(column => column.value === item.field) };
     });
     dispatch('columns-changed', { columns: newColumns });
   }

--- a/src/components/simulation/SimulationEventsPanel.svelte
+++ b/src/components/simulation/SimulationEventsPanel.svelte
@@ -144,22 +144,15 @@
   function onColumnsChanged({
     detail: { columns },
   }: CustomEvent<{ columns: { field: any; isHidden: boolean; name: string }[] }>) {
-    viewUpdateSimulationEventsTable({
-      columnStates: derivedColumnDefs
-        .map((columnDef: ColDef) => {
-          const activityColumnStates: ColumnState[] = simulationEventsTable?.columnStates ?? [];
-          const existingColumnState: ColumnState | undefined = activityColumnStates.find(
-            (columnState: ColumnState) => columnDef.field === columnState.colId,
-          );
-          return existingColumnState
-            ? {
-                ...existingColumnState,
-                hide: columns.find(column => columnDef.field === column.field)?.isHidden ?? false,
-              }
-            : null;
-        })
-        .filter(filterEmpty),
+    const activityColumnStates: ColumnState[] = simulationEventsTable?.columnStates ?? [];
+    const newActivityColumnStates = activityColumnStates.map(columnState => {
+      return { ...columnState, hide: columns.find(column => columnState.colId === column.field)?.isHidden ?? false };
     });
+
+    viewUpdateSimulationEventsTable({
+      columnStates: newActivityColumnStates.filter(filterEmpty),
+    });
+
     requestAutoSize();
   }
 

--- a/src/components/simulation/SimulationEventsPanel.svelte
+++ b/src/components/simulation/SimulationEventsPanel.svelte
@@ -141,34 +141,29 @@
     dataGrid?.sizeColumnsToFit();
   }
 
-  function onColumnToggleChange({ detail: { field, isHidden } }: CustomEvent) {
-    const columnStates: ColumnState[] = simulationEventsTable?.columnStates ?? [];
-    const existingColumnStateIndex: number = columnStates.findIndex(
-      (columnState: ColumnState) => field === columnState.colId,
-    );
-    if (existingColumnStateIndex >= 0) {
-      viewUpdateSimulationEventsTable({
-        columnStates: [
-          ...columnStates.slice(0, existingColumnStateIndex),
-          {
-            ...columnStates[existingColumnStateIndex],
-            hide: isHidden,
-          },
-          ...columnStates.slice(existingColumnStateIndex + 1),
-        ],
-      });
-    } else {
-      viewUpdateSimulationEventsTable({
-        columnStates: [
-          ...columnStates,
-          {
-            colId: field,
-            hide: isHidden,
-          },
-        ],
-      });
-    }
+  function onColumnsChanged({
+    detail: { columns },
+  }: CustomEvent<{ columns: { field: any; isHidden: boolean; name: string }[] }>) {
+    viewUpdateSimulationEventsTable({
+      columnStates: derivedColumnDefs
+        .map((columnDef: ColDef) => {
+          const activityColumnStates: ColumnState[] = simulationEventsTable?.columnStates ?? [];
+          const existingColumnState: ColumnState | undefined = activityColumnStates.find(
+            (columnState: ColumnState) => columnDef.field === columnState.colId,
+          );
+          return existingColumnState
+            ? {
+                ...existingColumnState,
+                hide: columns.find(column => columnDef.field === column.field)?.isHidden ?? false,
+              }
+            : null;
+        })
+        .filter(filterEmpty),
+    });
+    requestAutoSize();
+  }
 
+  function requestAutoSize() {
     setTimeout(() => {
       if (autoSizeColumns === 'fit') {
         autoSizeContent();
@@ -242,6 +237,7 @@
         })
         .filter(filterEmpty),
     });
+    requestAutoSize();
   }
 
   function toggleAutoSizeContent() {
@@ -287,7 +283,7 @@
         </button>
       </div>
       <ActivityTableMenu
-        on:toggle-column={onColumnToggleChange}
+        on:columns-changed={onColumnsChanged}
         on:show-hide-all-columns={onShowHideAllColumns}
         columnDefs={derivedColumnDefs}
         columnStates={simulationEventsTable?.columnStates}


### PR DESCRIPTION
Refactors activity table columns menu to use the Stellar Select component. Required additional refactoring of the tables where this was being used in order to account for the different behavior of Stellar multiselect which, on change, emits all selected values as opposed to the newly selected value. This should generally improve the usability of the component in terms of keyboard navigation and aria labeling. This PR also removes the quick filter on the list given that the list is not quite long enough to merit a filter though if anyone objects it can be worked back in.

Closes #1728