### PR TITLE
Display plan import error in plan form

### DIFF
--- a/src/components/Collapse.svelte
+++ b/src/components/Collapse.svelte
@@ -36,6 +36,7 @@
 
 <div class={collapseClasses} class:error role="group" aria-label="{ariaTitle || title}-collapse">
   <button
+    type="button"
     on:contextmenu|preventDefault={contextMenu?.show}
     tabindex={!collapsible ? -1 : 0}
     class="collapse-header st-button st-typography-medium tertiary"

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -346,6 +346,7 @@
     $modelIdField.dirtyAndValid &&
     $nameField.dirtyAndValid &&
     $startTimeField.dirtyAndValid &&
+    !planUploadFilesError &&
     !$creatingPlan;
   $: if ($creatingPlan) {
     createPlanButtonText = planUploadFiles ? 'Creating from .json...' : 'Creating...';
@@ -830,7 +831,6 @@
               />
               {#if planUploadFilesError}
                 <Collapse
-                  title=""
                   ariaTitle="Plan import error"
                   defaultExpanded={false}
                   className="text-destructive [&_*]:!text-destructive "

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -12,6 +12,7 @@
   import { onDestroy, onMount } from 'svelte';
   import Nav from '../../components/app/Nav.svelte';
   import PageTitle from '../../components/app/PageTitle.svelte';
+  import Collapse from '../../components/Collapse.svelte';
   import DatePickerField from '../../components/form/DatePickerField.svelte';
   import Field from '../../components/form/Field.svelte';
   import Input from '../../components/form/Input.svelte';
@@ -397,7 +398,7 @@
     let startTime = getDoyTime(startTimeDate);
     let endTime = getDoyTime(endTimeDate);
     if (planUploadFiles && planUploadFiles.length) {
-      await effects.importPlan(
+      const { error } = await effects.importPlan(
         $nameField.value,
         $modelIdField.value,
         startTime,
@@ -407,11 +408,15 @@
         planUploadFiles,
         user,
       );
-      planUploadFileInput.value = '';
-      planUploadFiles = undefined;
-      startTimeField.reset('');
-      endTimeField.reset('');
-      nameField.reset('');
+      if (error) {
+        planUploadFilesError = error.message;
+      } else {
+        planUploadFileInput.value = '';
+        planUploadFiles = undefined;
+        startTimeField.reset('');
+        endTimeField.reset('');
+        nameField.reset('');
+      }
     } else {
       const newPlan: PlanSlim | null = await effects.createPlan(
         endTime,
@@ -824,7 +829,15 @@
                 on:change={onPlanFileChange}
               />
               {#if planUploadFilesError}
-                <div class="overflow-hidden text-ellipsis whitespace-nowrap text-red-500">{planUploadFilesError}</div>
+                <Collapse
+                  title=""
+                  ariaTitle="Plan import error"
+                  defaultExpanded={false}
+                  className="text-destructive [&_*]:!text-destructive "
+                >
+                  <div slot="title">Plan import failed</div>
+                  {planUploadFilesError}
+                </Collapse>
               {/if}
             </fieldset>
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -5300,7 +5300,7 @@ const effects = {
     tagIds: number[],
     files: FileList,
     user: User | null,
-  ): Promise<PlanSlim | null> {
+  ): Promise<{ error?: Error; plan?: PlanSlim }> {
     try {
       if (!gatewayPermissions.IMPORT_PLAN(user)) {
         throwPermissionError('import a plan');
@@ -5327,14 +5327,14 @@ const effects = {
 
       creatingPlanStore.set(false);
       if (createdPlan != null) {
-        return createdPlan;
+        return { plan: createdPlan };
+      } else {
+        throw new Error('Plan import failed');
       }
-
-      return null;
     } catch (e) {
       catchError(e as Error);
       creatingPlanStore.set(false);
-      return null;
+      return { error: e as Error };
     }
   },
 


### PR DESCRIPTION
Displays a plan import error in a Collapse in the plan form if the import failed. Closes #1588.

Testing:
1. Go to the plans page and click import
2. Select a json file unrelated to plans
3. Verify that the plan import displays an error message in a collapse below
4. Repeat steps 2-3 with variations on bad plan json files such as one that will fail at the gateway stage (i.e. has `start_time` but no `activities` array)
5. Verify that a valid plan json imports successfully
6. Verify that a plan made without import creates successfully