### PR TITLE
Formatting the arguments column in the activity directives table

### DIFF
--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -23,7 +23,7 @@
   import type { AutoSizeColumns, ViewGridSection, ViewTable } from '../../types/view';
   import effects from '../../utilities/effects';
   import { filterEmpty } from '../../utilities/generic';
-  import { formatDate, getUnixEpochTimeFromInterval } from '../../utilities/time';
+  import { convertUsToDurationString, formatDate, getUnixEpochTimeFromInterval } from '../../utilities/time';
   import { getTimeRangeAroundTime } from '../../utilities/timeline';
   import { tooltip } from '../../utilities/tooltip';
   import GridMenu from '../menus/GridMenu.svelte';
@@ -33,6 +33,7 @@
   import Panel from '../ui/Panel.svelte';
   import ActivityDirectivesTable from './ActivityDirectivesTable.svelte';
   import ActivityTableMenu from './ActivityTableMenu.svelte';
+  import type { ValueSchema } from '../../types/schema';
 
   export let gridSection: ViewGridSection;
   export let user: User | null;
@@ -101,6 +102,13 @@
       hide: true,
       resizable: true,
       sortable: false,
+      autoHeight: true,
+      cellRenderer: (params: ICellRendererParams<ActivityDirective>) => {
+        const div = document.createElement('div');
+        div.innerHTML = params.value || '';
+        div.style.cssText = 'white-space: pre-wrap; word-break: break-word; line-height: 1.4;';
+        return div;
+      },
       valueGetter: (params: ValueGetterParams<ActivityDirective>) => {
         const args = params?.data?.arguments;
         const activityTypeName = params?.data?.type;
@@ -122,13 +130,13 @@
             return orderA - orderB;
           })
           .map(([key, value]) => {
-            const stringValue = String(value);
-            const truncatedValue = stringValue.length > 20
-              ? stringValue.substring(0, 17) + '...'
-              : stringValue;
-            return `${key}: ${truncatedValue}`;
+            const parameterSchema = activityType?.parameters[key]?.schema;
+            const formattedValue = parameterSchema
+              ? formatParameterValue(value, parameterSchema)
+              : String(value);
+            return `<strong>${key}:</strong> ${formattedValue}`;
           })
-          .join('; ');
+          .join('\n');
       },
     },
     created_at: {
@@ -412,6 +420,46 @@
     );
     viewTimeRange.set(centeredTimeRange);
   }
+
+  function formatParameterValue(value: any, schema: ValueSchema): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  switch (schema.type) {
+    case 'duration':
+      try {
+        return convertUsToDurationString(value, true);
+      } catch (error) {
+        return String(value);
+      }
+
+    case 'series':
+      if (Array.isArray(value)) {
+        if (value.length === 0) {
+          return '[]';
+        } else {
+          return `[ \n${value.map(String).join(', ')}\n]`;
+        }
+      }
+      return String(value);
+
+    case 'struct':
+      if (typeof value === 'object' && value !== null) {
+        const keys = Object.keys(value);
+        if (keys.length === 0) {
+          return '{}';
+        } else {
+          const formattedFields = keys.map(key => `${key}: ${String(value[key])}`);
+          return `{\n${formattedFields.join(',\n')}\n}`;
+        }
+      }
+      return String(value);
+
+    default:
+      return String(value);
+  }
+}
 </script>
 
 <Panel padBody={false}>

--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -116,9 +116,7 @@
           return '';
         }
         const activityTypes = $planModelActivityTypes;
-        const activityType = activityTypes.find(
-          (type: ActivityType) => type.name === activityTypeName
-        );
+        const activityType = activityTypes.find((type: ActivityType) => type.name === activityTypeName);
         return Object.entries(args)
           .sort(([keyA], [keyB]) => {
             const orderA = activityType?.parameters[keyA]?.order ?? Number.MAX_SAFE_INTEGER;
@@ -131,9 +129,7 @@
           })
           .map(([key, value]) => {
             const parameterSchema = activityType?.parameters[key]?.schema;
-            const formattedValue = parameterSchema
-              ? formatParameterValue(value, parameterSchema)
-              : String(value);
+            const formattedValue = parameterSchema ? formatParameterValue(value, parameterSchema) : String(value);
             return `<strong>${key}:</strong> ${formattedValue}`;
           })
           .join('\n');
@@ -422,44 +418,44 @@
   }
 
   function formatParameterValue(value: any, schema: ValueSchema): string {
-  if (value === null || value === undefined) {
-    return '';
-  }
+    if (value === null || value === undefined) {
+      return '';
+    }
 
-  switch (schema.type) {
-    case 'duration':
-      try {
-        return convertUsToDurationString(value, true);
-      } catch (error) {
+    switch (schema.type) {
+      case 'duration':
+        try {
+          return convertUsToDurationString(value, true);
+        } catch (error) {
+          return String(value);
+        }
+
+      case 'series':
+        if (Array.isArray(value)) {
+          if (value.length === 0) {
+            return '[]';
+          } else {
+            return `${value.map(String).join(', ')}`;
+          }
+        }
         return String(value);
-      }
 
-    case 'series':
-      if (Array.isArray(value)) {
-        if (value.length === 0) {
-          return '[]';
-        } else {
-          return `${value.map(String).join(', ')}`;
+      case 'struct':
+        if (typeof value === 'object' && value !== null) {
+          const keys = Object.keys(value);
+          if (keys.length === 0) {
+            return '{}';
+          } else {
+            const formattedFields = keys.map(key => `${key}: ${String(value[key])}`);
+            return `${formattedFields.join(',\n')}`;
+          }
         }
-      }
-      return String(value);
+        return String(value);
 
-    case 'struct':
-      if (typeof value === 'object' && value !== null) {
-        const keys = Object.keys(value);
-        if (keys.length === 0) {
-          return '{}';
-        } else {
-          const formattedFields = keys.map(key => `${key}: ${String(value[key])}`);
-          return `${formattedFields.join(',\n')}`;
-        }
-      }
-      return String(value);
-
-    default:
-      return String(value);
+      default:
+        return String(value);
+    }
   }
-}
 </script>
 
 <Panel padBody={false}>

--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -439,7 +439,7 @@
         if (value.length === 0) {
           return '[]';
         } else {
-          return `[ \n${value.map(String).join(', ')}\n]`;
+          return `${value.map(String).join(', ')}`;
         }
       }
       return String(value);
@@ -451,7 +451,7 @@
           return '{}';
         } else {
           const formattedFields = keys.map(key => `${key}: ${String(value[key])}`);
-          return `{\n${formattedFields.join(',\n')}\n}`;
+          return `${formattedFields.join(',\n')}`;
         }
       }
       return String(value);

--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -15,10 +15,10 @@
   import { InvalidDate } from '../../constants/time';
   import { activityDirectivesMap, selectActivity, selectedActivityDirectiveId } from '../../stores/activities';
   import { activityErrorRollupsMap } from '../../stores/errors';
-  import { maxTimeRange, plan, planReadOnly, viewTimeRange } from '../../stores/plan';
+  import { maxTimeRange, plan, planModelActivityTypes, planReadOnly, viewTimeRange } from '../../stores/plan';
   import { plugins } from '../../stores/plugins';
   import { view, viewTogglePanel, viewUpdateActivityDirectivesTable } from '../../stores/views';
-  import type { ActivityDirective } from '../../types/activity';
+  import type { ActivityDirective, ActivityType } from '../../types/activity';
   import type { User } from '../../types/app';
   import type { AutoSizeColumns, ViewGridSection, ViewTable } from '../../types/view';
   import effects from '../../utilities/effects';
@@ -103,18 +103,31 @@
       sortable: false,
       valueGetter: (params: ValueGetterParams<ActivityDirective>) => {
         const args = params?.data?.arguments;
-        params.data?.arguments
-        if (!args || typeof args !== 'object') {return '';}
-
+        const activityTypeName = params?.data?.type;
+        if (!args || typeof args !== 'object') {
+          return '';
+        }
+        const activityTypes = $planModelActivityTypes;
+        const activityType = activityTypes.find(
+          (type: ActivityType) => type.name === activityTypeName
+        );
         return Object.entries(args)
-        .sort(([a], [b]) => a.localeCompare(b))
-        .map(([key, value]) => {
-          const stringValue = String(value);
-          const truncatedValue = stringValue.length > 20
-            ? stringValue.substring(0, 17) + '...'
-            : stringValue;
-          return `${key}: ${truncatedValue}`;
-        })
+          .sort(([keyA], [keyB]) => {
+            const orderA = activityType?.parameters[keyA]?.order ?? Number.MAX_SAFE_INTEGER;
+            const orderB = activityType?.parameters[keyB]?.order ?? Number.MAX_SAFE_INTEGER;
+            // If orders are the same, fall back to alphabetical
+            if (orderA === orderB) {
+              return keyA.localeCompare(keyB);
+            }
+            return orderA - orderB;
+          })
+          .map(([key, value]) => {
+            const stringValue = String(value);
+            const truncatedValue = stringValue.length > 20
+              ? stringValue.substring(0, 17) + '...'
+              : stringValue;
+            return `${key}: ${truncatedValue}`;
+          })
           .join('; ');
       },
     },

--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -18,12 +18,12 @@
   import { maxTimeRange, plan, planModelActivityTypes, planReadOnly, viewTimeRange } from '../../stores/plan';
   import { plugins } from '../../stores/plugins';
   import { view, viewTogglePanel, viewUpdateActivityDirectivesTable } from '../../stores/views';
-  import type { ActivityDirective, ActivityType } from '../../types/activity';
+  import type { ActivityDirective } from '../../types/activity';
   import type { User } from '../../types/app';
   import type { AutoSizeColumns, ViewGridSection, ViewTable } from '../../types/view';
   import effects from '../../utilities/effects';
   import { filterEmpty } from '../../utilities/generic';
-  import { convertUsToDurationString, formatDate, getUnixEpochTimeFromInterval } from '../../utilities/time';
+  import { formatDate, getUnixEpochTimeFromInterval } from '../../utilities/time';
   import { getTimeRangeAroundTime } from '../../utilities/timeline';
   import { tooltip } from '../../utilities/tooltip';
   import GridMenu from '../menus/GridMenu.svelte';
@@ -33,7 +33,7 @@
   import Panel from '../ui/Panel.svelte';
   import ActivityDirectivesTable from './ActivityDirectivesTable.svelte';
   import ActivityTableMenu from './ActivityTableMenu.svelte';
-  import type { ValueSchema } from '../../types/schema';
+  import ArgumentsCellRenderer from './ArgumentsCellRenderer.svelte';
 
   export let gridSection: ViewGridSection;
   export let user: User | null;
@@ -105,34 +105,17 @@
       autoHeight: true,
       cellRenderer: (params: ICellRendererParams<ActivityDirective>) => {
         const div = document.createElement('div');
-        div.innerHTML = params.value || '';
-        div.style.cssText = 'white-space: pre-wrap; word-break: break-word; line-height: 1.4;';
-        return div;
-      },
-      valueGetter: (params: ValueGetterParams<ActivityDirective>) => {
-        const args = params?.data?.arguments;
-        const activityTypeName = params?.data?.type;
-        if (!args || typeof args !== 'object') {
-          return '';
+        if (!params.data) {
+          return div;
         }
-        const activityTypes = $planModelActivityTypes;
-        const activityType = activityTypes.find((type: ActivityType) => type.name === activityTypeName);
-        return Object.entries(args)
-          .sort(([keyA], [keyB]) => {
-            const orderA = activityType?.parameters[keyA]?.order ?? Number.MAX_SAFE_INTEGER;
-            const orderB = activityType?.parameters[keyB]?.order ?? Number.MAX_SAFE_INTEGER;
-            // If orders are the same, fall back to alphabetical
-            if (orderA === orderB) {
-              return keyA.localeCompare(keyB);
-            }
-            return orderA - orderB;
-          })
-          .map(([key, value]) => {
-            const parameterSchema = activityType?.parameters[key]?.schema;
-            const formattedValue = parameterSchema ? formatParameterValue(value, parameterSchema) : String(value);
-            return `<strong>${key}:</strong> ${formattedValue}`;
-          })
-          .join('\n');
+        new ArgumentsCellRenderer({
+          target: div,
+          props: {
+            data: params.data,
+            activityTypes: $planModelActivityTypes,
+          },
+        });
+        return div;
       },
     },
     created_at: {
@@ -415,46 +398,6 @@
       get(maxTimeRange),
     );
     viewTimeRange.set(centeredTimeRange);
-  }
-
-  function formatParameterValue(value: any, schema: ValueSchema): string {
-    if (value === null || value === undefined) {
-      return '';
-    }
-
-    switch (schema.type) {
-      case 'duration':
-        try {
-          return convertUsToDurationString(value, true);
-        } catch (error) {
-          return String(value);
-        }
-
-      case 'series':
-        if (Array.isArray(value)) {
-          if (value.length === 0) {
-            return '[]';
-          } else {
-            return `${value.map(String).join(', ')}`;
-          }
-        }
-        return String(value);
-
-      case 'struct':
-        if (typeof value === 'object' && value !== null) {
-          const keys = Object.keys(value);
-          if (keys.length === 0) {
-            return '{}';
-          } else {
-            const formattedFields = keys.map(key => `${key}: ${value[key]}`);
-            return `${formattedFields.join(',\n')}`;
-          }
-        }
-        return String(value);
-
-      default:
-        return String(value);
-    }
   }
 </script>
 

--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -102,7 +102,20 @@
       resizable: true,
       sortable: false,
       valueGetter: (params: ValueGetterParams<ActivityDirective>) => {
-        return JSON.stringify(params?.data?.arguments);
+        const args = params?.data?.arguments;
+        params.data?.arguments
+        if (!args || typeof args !== 'object') {return '';}
+
+        return Object.entries(args)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, value]) => {
+          const stringValue = String(value);
+          const truncatedValue = stringValue.length > 20
+            ? stringValue.substring(0, 17) + '...'
+            : stringValue;
+          return `${key}: ${truncatedValue}`;
+        })
+          .join('; ');
       },
     },
     created_at: {

--- a/src/components/activity/ActivityDirectivesTablePanel.svelte
+++ b/src/components/activity/ActivityDirectivesTablePanel.svelte
@@ -446,7 +446,7 @@
           if (keys.length === 0) {
             return '{}';
           } else {
-            const formattedFields = keys.map(key => `${key}: ${String(value[key])}`);
+            const formattedFields = keys.map(key => `${key}: ${value[key]}`);
             return `${formattedFields.join(',\n')}`;
           }
         }

--- a/src/components/activity/ArgumentsCellRenderer.svelte
+++ b/src/components/activity/ArgumentsCellRenderer.svelte
@@ -1,50 +1,9 @@
 <script lang="ts">
   import type { ActivityDirective, ActivityType } from '../../types/activity';
-  import type { ValueSchema } from '../../types/schema';
-  import { convertUsToDurationString } from '../../utilities/time';
+  import { formatParameterValue } from '../../utilities/parameters';
 
   export let data: ActivityDirective;
   export let activityTypes: ActivityType[];
-
-  function formatParameterValue(value: any, schema: ValueSchema): string {
-    if (value === null || value === undefined) {
-      return '';
-    }
-
-    switch (schema.type) {
-      case 'duration':
-        try {
-          return convertUsToDurationString(value, true);
-        } catch (error) {
-          return String(value);
-        }
-
-      case 'series':
-        if (Array.isArray(value)) {
-          if (value.length === 0) {
-            return '[]';
-          } else {
-            return `${value.map(String).join(', ')}`;
-          }
-        }
-        return String(value);
-
-      case 'struct':
-        if (typeof value === 'object' && value !== null) {
-          const keys = Object.keys(value);
-          if (keys.length === 0) {
-            return '{}';
-          } else {
-            const formattedFields = keys.map(key => `${key}: ${value[key]}`);
-            return `${formattedFields.join(',\n')}`;
-          }
-        }
-        return String(value);
-
-      default:
-        return String(value);
-    }
-  }
 
   let formattedArguments: { key: string; value: string }[] = [];
 

--- a/src/components/activity/ArgumentsCellRenderer.svelte
+++ b/src/components/activity/ArgumentsCellRenderer.svelte
@@ -46,32 +46,34 @@
     }
   }
 
-  $: formattedArguments = (() => {
+  let formattedArguments: { key: string; value: string }[] = [];
+
+  $: {
     const args = data?.arguments;
     const activityTypeName = data?.type;
 
     if (!args || typeof args !== 'object') {
-      return [];
+      formattedArguments = [];
+    } else {
+      const activityType = activityTypes.find((type: ActivityType) => type.name === activityTypeName);
+
+      formattedArguments = Object.entries(args)
+        .sort(([keyA], [keyB]) => {
+          const orderA = activityType?.parameters[keyA]?.order ?? Number.MAX_SAFE_INTEGER;
+          const orderB = activityType?.parameters[keyB]?.order ?? Number.MAX_SAFE_INTEGER;
+          // If orders are the same, fall back to alphabetical
+          if (orderA === orderB) {
+            return keyA.localeCompare(keyB);
+          }
+          return orderA - orderB;
+        })
+        .map(([key, value]) => {
+          const parameterSchema = activityType?.parameters[key]?.schema;
+          const formattedValue = parameterSchema ? formatParameterValue(value, parameterSchema) : String(value);
+          return { key, value: formattedValue };
+        });
     }
-
-    const activityType = activityTypes.find((type: ActivityType) => type.name === activityTypeName);
-
-    return Object.entries(args)
-      .sort(([keyA], [keyB]) => {
-        const orderA = activityType?.parameters[keyA]?.order ?? Number.MAX_SAFE_INTEGER;
-        const orderB = activityType?.parameters[keyB]?.order ?? Number.MAX_SAFE_INTEGER;
-        // If orders are the same, fall back to alphabetical
-        if (orderA === orderB) {
-          return keyA.localeCompare(keyB);
-        }
-        return orderA - orderB;
-      })
-      .map(([key, value]) => {
-        const parameterSchema = activityType?.parameters[key]?.schema;
-        const formattedValue = parameterSchema ? formatParameterValue(value, parameterSchema) : String(value);
-        return { key, value: formattedValue };
-      });
-  })();
+  }
 </script>
 
 <div class="arguments-container">

--- a/src/components/activity/ArgumentsCellRenderer.svelte
+++ b/src/components/activity/ArgumentsCellRenderer.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+  import type { ActivityDirective, ActivityType } from '../../types/activity';
+  import type { ValueSchema } from '../../types/schema';
+  import { convertUsToDurationString } from '../../utilities/time';
+
+  export let data: ActivityDirective;
+  export let activityTypes: ActivityType[];
+
+  function formatParameterValue(value: any, schema: ValueSchema): string {
+    if (value === null || value === undefined) {
+      return '';
+    }
+
+    switch (schema.type) {
+      case 'duration':
+        try {
+          return convertUsToDurationString(value, true);
+        } catch (error) {
+          return String(value);
+        }
+
+      case 'series':
+        if (Array.isArray(value)) {
+          if (value.length === 0) {
+            return '[]';
+          } else {
+            return `${value.map(String).join(', ')}`;
+          }
+        }
+        return String(value);
+
+      case 'struct':
+        if (typeof value === 'object' && value !== null) {
+          const keys = Object.keys(value);
+          if (keys.length === 0) {
+            return '{}';
+          } else {
+            const formattedFields = keys.map(key => `${key}: ${value[key]}`);
+            return `${formattedFields.join(',\n')}`;
+          }
+        }
+        return String(value);
+
+      default:
+        return String(value);
+    }
+  }
+
+  $: formattedArguments = (() => {
+    const args = data?.arguments;
+    const activityTypeName = data?.type;
+
+    if (!args || typeof args !== 'object') {
+      return [];
+    }
+
+    const activityType = activityTypes.find((type: ActivityType) => type.name === activityTypeName);
+
+    return Object.entries(args)
+      .sort(([keyA], [keyB]) => {
+        const orderA = activityType?.parameters[keyA]?.order ?? Number.MAX_SAFE_INTEGER;
+        const orderB = activityType?.parameters[keyB]?.order ?? Number.MAX_SAFE_INTEGER;
+        // If orders are the same, fall back to alphabetical
+        if (orderA === orderB) {
+          return keyA.localeCompare(keyB);
+        }
+        return orderA - orderB;
+      })
+      .map(([key, value]) => {
+        const parameterSchema = activityType?.parameters[key]?.schema;
+        const formattedValue = parameterSchema ? formatParameterValue(value, parameterSchema) : String(value);
+        return { key, value: formattedValue };
+      });
+  })();
+</script>
+
+<div class="arguments-container">
+  {#each formattedArguments as { key, value }}
+    <div class="argument-line">
+      <strong>{key}:</strong>
+      {value}
+    </div>
+  {/each}
+</div>
+
+<style>
+  .arguments-container {
+    line-height: 1.4;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  .argument-line {
+    margin-bottom: 0;
+  }
+</style>

--- a/src/utilities/parameters.test.ts
+++ b/src/utilities/parameters.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'vitest';
-import { getArgument, getCleansedStructArguments, getValueSchemaDefaultValue, isRecParameter } from './parameters';
+import {
+  formatParameterValue,
+  getArgument,
+  getCleansedStructArguments,
+  getValueSchemaDefaultValue,
+  isRecParameter,
+} from './parameters';
 
 describe('getArgument', () => {
   test('Should return the preset value', () => {
@@ -217,6 +223,40 @@ describe('isRecParameter', () => {
         valueSource: 'mission',
       }),
     ).toEqual(false);
+  });
+});
+
+describe('formatParameterValue', () => {
+  test('Should return empty string for null and undefined values', () => {
+    expect(formatParameterValue(null, { type: 'string' })).toBe('');
+    expect(formatParameterValue(undefined, { type: 'string' })).toBe('');
+  });
+
+  test('Should format duration values using convertUsToDurationString', () => {
+    expect(formatParameterValue(3600000000, { type: 'duration' })).toBe('0y 0d 1h 0m 0s 0ms 0us');
+    expect(formatParameterValue(0, { type: 'duration' })).toBe('0y 0d 0h 0m 0s 0ms 0us');
+  });
+
+  test('Should handle duration formatting errors', () => {
+    expect(formatParameterValue('invalid', { type: 'duration' })).toBe('NaNy NaNd NaNh NaNm NaNs NaNms NaNus');
+  });
+
+  test('Should format series values as lists', () => {
+    expect(formatParameterValue([], { items: { type: 'string' }, type: 'series' })).toBe('[]');
+    expect(formatParameterValue(['a', 'b', 'c'], { items: { type: 'string' }, type: 'series' })).toBe('a, b, c');
+  });
+
+  test('Should format struct values with keys and values', () => {
+    expect(formatParameterValue({}, { items: {}, type: 'struct' })).toBe('{}');
+    expect(formatParameterValue({ a: 1, b: 2 }, { items: {}, type: 'struct' })).toBe('a: 1,\nb: 2');
+  });
+
+  test('Should convert values to string for other types', () => {
+    expect(formatParameterValue('hello', { type: 'string' })).toBe('hello');
+    expect(formatParameterValue(42, { type: 'int' })).toBe('42');
+    expect(formatParameterValue(true, { type: 'boolean' })).toBe('true');
+    expect(formatParameterValue(3.14, { type: 'real' })).toBe('3.14');
+    expect(formatParameterValue('/path/to/file', { type: 'path' })).toBe('/path/to/file');
   });
 });
 

--- a/src/utilities/parameters.test.ts
+++ b/src/utilities/parameters.test.ts
@@ -246,6 +246,26 @@ describe('formatParameterValue', () => {
     expect(formatParameterValue(['a', 'b', 'c'], { items: { type: 'string' }, type: 'series' })).toBe('a, b, c');
   });
 
+  test('Should format map structures (arrays of key-value objects) properly', () => {
+    const intMapValue = [
+      { key: 551, value: 56111 },
+      { key: 5311, value: 541 },
+    ];
+    expect(formatParameterValue(intMapValue, { items: { type: 'string' }, type: 'series' })).toBe(
+      '551: 56111, 5311: 541 ',
+    );
+
+    const stringMapValue = [
+      { key: '699', value: '70' },
+      { key: '711', value: '721' },
+    ];
+    expect(formatParameterValue(stringMapValue, { items: { type: 'string' }, type: 'series' })).toBe(
+      '699: 70, 711: 721 ',
+    );
+
+    expect(formatParameterValue([], { items: { type: 'string' }, type: 'series' })).toBe('[]');
+  });
+
   test('Should format struct values with keys and values', () => {
     expect(formatParameterValue({}, { items: {}, type: 'struct' })).toBe('{}');
     expect(formatParameterValue({ a: 1, b: 2 }, { items: {}, type: 'struct' })).toBe('a: 1,\nb: 2');

--- a/src/utilities/parameters.test.ts
+++ b/src/utilities/parameters.test.ts
@@ -252,7 +252,7 @@ describe('formatParameterValue', () => {
       { key: 5311, value: 541 },
     ];
     expect(formatParameterValue(intMapValue, { items: { type: 'string' }, type: 'series' })).toBe(
-      '551: 56111, 5311: 541 ',
+      '551: 56111, 5311: 541',
     );
 
     const stringMapValue = [
@@ -260,7 +260,7 @@ describe('formatParameterValue', () => {
       { key: '711', value: '721' },
     ];
     expect(formatParameterValue(stringMapValue, { items: { type: 'string' }, type: 'series' })).toBe(
-      '699: 70, 711: 721 ',
+      '699: 70, 711: 721',
     );
 
     expect(formatParameterValue([], { items: { type: 'string' }, type: 'series' })).toBe('[]');

--- a/src/utilities/parameters.ts
+++ b/src/utilities/parameters.ts
@@ -47,6 +47,24 @@ export function formatParameterValue(value: any, schema: ValueSchema): string {
         if (value.length === 0) {
           return '[]';
         } else {
+          const isMapStructure = value.every(
+            item =>
+              typeof item === 'object' &&
+              item !== null &&
+              'key' in item &&
+              'value' in item &&
+              Object.keys(item).length === 2,
+          );
+
+          if (isMapStructure) {
+            const mapEntries = value.map(item => `${item.key}: ${item.value}`);
+            return `${mapEntries.join(', ')} `;
+          }
+          const itemSchema = (schema as ValueSchemaSeries).items;
+          if (itemSchema) {
+            const formattedItems = value.map(item => formatParameterValue(item, itemSchema));
+            return `${formattedItems.join(', ')}`;
+          }
           return `${value.map(String).join(', ')}`;
         }
       }
@@ -58,7 +76,17 @@ export function formatParameterValue(value: any, schema: ValueSchema): string {
         if (keys.length === 0) {
           return '{}';
         } else {
-          const formattedFields = keys.map(key => `${key}: ${value[key]}`);
+          const formattedFields = keys.map(key => {
+            const fieldValue = value[key];
+            const fieldSchema = (schema as ValueSchemaStruct).items?.[key];
+
+            if (fieldSchema) {
+              const formattedValue = formatParameterValue(fieldValue, fieldSchema);
+              return `${key}: ${formattedValue}`;
+            }
+
+            return `${key}: ${String(fieldValue)}`;
+          });
           return `${formattedFields.join(',\n')}`;
         }
       }

--- a/src/utilities/parameters.ts
+++ b/src/utilities/parameters.ts
@@ -21,6 +21,53 @@ import type {
 } from '../types/schema';
 import { isActionValueSchemaSequence } from './actions';
 import { isEmpty } from './generic';
+import { convertUsToDurationString } from './time';
+
+/**
+ * Formats a parameter value according to its schema type for display purposes.
+ * @param value - The parameter value to format
+ * @param schema - The schema defining the parameter type
+ * @returns A formatted string representation of the value
+ */
+export function formatParameterValue(value: any, schema: ValueSchema): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  switch (schema.type) {
+    case 'duration':
+      try {
+        return convertUsToDurationString(value, true);
+      } catch (error) {
+        return String(value);
+      }
+
+    case 'series':
+      if (Array.isArray(value)) {
+        if (value.length === 0) {
+          return '[]';
+        } else {
+          return `${value.map(String).join(', ')}`;
+        }
+      }
+      return String(value);
+
+    case 'struct':
+      if (typeof value === 'object' && value !== null) {
+        const keys = Object.keys(value);
+        if (keys.length === 0) {
+          return '{}';
+        } else {
+          const formattedFields = keys.map(key => `${key}: ${value[key]}`);
+          return `${formattedFields.join(',\n')}`;
+        }
+      }
+      return String(value);
+
+    default:
+      return String(value);
+  }
+}
 
 export function isParameterWithOptions(
   schema: ValueSchema | UIValueSchemaWithOptionsSingle | UIValueSchemaWithOptionsMultiple,

--- a/src/utilities/parameters.ts
+++ b/src/utilities/parameters.ts
@@ -57,8 +57,24 @@ export function formatParameterValue(value: any, schema: ValueSchema): string {
           );
 
           if (isMapStructure) {
-            const mapEntries = value.map(item => `${item.key}: ${item.value}`);
-            return `${mapEntries.join(', ')} `;
+            const itemSchema = (schema as ValueSchemaSeries).items;
+            const mapEntries = value.map(item => {
+              let keySchema: ValueSchema | undefined;
+              let valueSchema: ValueSchema | undefined;
+
+              if (itemSchema && itemSchema.type === 'struct' && itemSchema.items) {
+                keySchema = itemSchema.items['key'];
+                valueSchema = itemSchema.items['value'];
+              } else {
+                keySchema = itemSchema;
+                valueSchema = itemSchema;
+              }
+
+              const formattedKey = keySchema ? formatParameterValue(item.key, keySchema) : String(item.key);
+              const formattedValue = valueSchema ? formatParameterValue(item.value, valueSchema) : String(item.value);
+              return `${formattedKey}: ${formattedValue}`;
+            });
+            return `${mapEntries.join(', ')}`;
           }
           const itemSchema = (schema as ValueSchemaSeries).items;
           if (itemSchema) {


### PR DESCRIPTION


To test open up the activity directives table and select the arguments column in any plan and it will display arguments as formatted instead of being a stringified json

<img width="268" height="236" alt="image" src="https://github.com/user-attachments/assets/6fb28511-e72e-4d02-8467-4390aebe6bc9" />
