### PR TITLE
update aerie-actions dependency to 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@lezer/generator": "^1.7.3",
         "@lezer/highlight": "^1.2.1",
         "@lezer/lr": "^1.4.2",
-        "@nasa-jpl/aerie-actions": "1.0.0",
+        "@nasa-jpl/aerie-actions": "1.0.2",
         "@nasa-jpl/aerie-ampcs": "^1.0.5",
         "@nasa-jpl/aerie-sequence-languages": "0.0.8",
         "@nasa-jpl/seq-json-schema": "^1.3.1",
@@ -1299,9 +1299,9 @@
       }
     },
     "node_modules/@nasa-jpl/aerie-actions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-actions/-/aerie-actions-1.0.0.tgz",
-      "integrity": "sha512-jVfr9RT3FhnQkNDZ6UlbxOr2/nuMWQzUqcsF13ju7SjPbfX4rxkNZPjSXl8QyfwjzdfNZo552QLtvn/LQVvEYQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-actions/-/aerie-actions-1.0.2.tgz",
+      "integrity": "sha512-z+PJh5NFrYyNaLvOU2poawZeDkrX/HDXwKYdjy3wMnZPt7ZbtLskr1/+yXxCS6wHE237qwoK0xtvjxG1udkD6Q==",
       "dependencies": {
         "@types/node": "^22.13.4",
         "@types/pg": "^8.11.11"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@lezer/generator": "^1.7.3",
     "@lezer/highlight": "^1.2.1",
     "@lezer/lr": "^1.4.2",
-    "@nasa-jpl/aerie-actions": "1.0.0",
+    "@nasa-jpl/aerie-actions": "1.0.2",
     "@nasa-jpl/aerie-ampcs": "^1.0.5",
     "@nasa-jpl/aerie-sequence-languages": "0.0.8",
     "@nasa-jpl/seq-json-schema": "^1.3.1",


### PR DESCRIPTION
Update based on this hotfix from yesterday https://github.com/NASA-AMMOS/aerie-actions/pull/10