### PR TITLE
Fix e2e tests by using node 22.17.1 instead of LTS (22.18)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Node (UI)
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: '22.17.1'
           cache: npm
       - name: Extract Aerie backend docker tag from PR body
         # look in the PR body for eg. the string ___REQUIRES_AERIE_PR___=9999, extract the number & save to env var

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:22.17.1-alpine3.22
 COPY build /app
 COPY package.json /app
 COPY node_modules /app/node_modules


### PR DESCRIPTION
UI e2e tests were running with `lts` version of node, which recently got updated (22.17.1 -> 22.18.0). Apparently [this release changed how node handles Typescript ](https://nodejs.org/en/blog/release/v22.18.0)and enables “type stripping” by default, which broke our playwright config. We pinned it back to 22.17.1 for now, but should assess (later) what to do to support future versions.