### PR TITLE
Show specific error message in toast when plan merge fails to begin

### DIFF
--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -5815,7 +5815,7 @@ const effects = {
         throw Error('Unable to begin plan merge');
       }
     } catch (error) {
-      showFailureToast('Begin Merge Failed');
+      showFailureToast((error as Error)?.message ?? error);
       catchError('Begin Merge Failed', error as Error);
       return false;
     }


### PR DESCRIPTION
Closes #851 by presenting the specific error message that results from beginning the merge. We don't have a feasible method at the moment for checking plan merge validity (e.g. one plan is deleted, plans are identical, etc) so surfacing the error message is the best we can do for now.

#### Testing:
1. Create a plan
2. Create a branch off the plan
3. Create a merge request
4. Go back to the parent plan and open the merge request modal
5. Click "begin review"
6. Verify that the toast error message alerts the user about the plans being identical