### PR TITLE
Improve error toast when user attempts to create anchor cycle

### DIFF
--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -6478,7 +6478,7 @@ const effects = {
       }
     } catch (e) {
       catchError('Activity Directive Update Failed', e as Error);
-      showFailureToast('Activity Directive Update Failed');
+      showFailureToast(`Activity Directive Update Failed: \n${(e as Error).message}`);
     }
   },
 

--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -150,7 +150,7 @@ export async function reqHasura<T = any>(
     const [error] = json.errors;
     const code = error?.extensions?.code;
 
-    if (code === 'unexpected') {
+    if (code === 'unexpected' || code === 'postgres-error') {
       // This is often thrown when a Postgres exception is raised for a Hasura query.
       // @see https://github.com/hasura/graphql-engine/issues/3658
       throw new Error(error?.extensions?.internal?.error?.message ?? error?.message ?? defaultError);


### PR DESCRIPTION
Closes #1713. Shows the extracted message in the toast when an activity directive update fails. Adds message extraction handling for the `postgres-error` code in `reqHasura` to cover the anchor cycle message case.

Testing:
1. Create a plan
2. Create two activities
3. Anchor activity 1 to activity 2 by clicking on activity 1 and opening the anchor collapse and selecting activity 2 as the anchor
4. Anchor activity 2 to activity 1
5. Verify that the toast failure message contains language related to a cycle being detected