### PR TITLE
Update formatting for the Expansion panel

### DIFF
--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -36,7 +36,7 @@
 
   const deletePermissionSequenceError: string = 'You do not have permission to delete an expansion sequence.';
   const deletePermissionSequenceFilterError: string = 'You do not have permission to delete a sequence filter';
-  const selectExpansionSetMessage: string = 'First, select an Expansion Set!';
+  const selectExpansionSetMessage: string = 'No expansion set selected';
 
   let filterText: string;
   let sequencesAndFilters: (ExpansionSequence | SequenceFilter)[] = [];
@@ -250,8 +250,8 @@
         />
       </div>
       {#if SEQUENCE_EXPANSION_MODE === SequencingMode.TYPESCRIPT}
-        <div class="sne-expansion-set-select min-w-28">
-          <select name="expansionSetId" bind:value={selectedExpansionSetId} class="st-select w-32">
+        <div class="sne-expansion-set-select flex-1">
+          <select name="expansionSetId" bind:value={selectedExpansionSetId} class="st-select min-w-36">
             {#if !$expansionSets.length}
               <option value={null}>No Expansion Sets</option>
             {:else}
@@ -296,8 +296,8 @@
       {#each sequencesAndFilters as sequenceOrFilter}
         {#if isExpansionSequence(sequenceOrFilter)}
           <ListItem>
-            <span slot="prefix" class="sne-item">
-              <JournalCodeIcon />
+            <span slot="prefix" class="text-ellipsis overflow-hidden whitespace-nowrap align-middle">
+              <JournalCodeIcon size={16} class="inline"/>
               {sequenceOrFilter.seq_id}
             </span>
             <span slot="suffix">
@@ -380,8 +380,8 @@
           </ListItem>
         {:else}
           <ListItem>
-            <span slot="prefix" class="sne-item">
-              <FilterIcon />
+            <span slot="prefix" class="text-ellipsis overflow-hidden whitespace-nowrap align-middle">
+              <FilterIcon size={16} class="inline"/>
               {sequenceOrFilter.name}
             </span>
             <span slot="suffix">
@@ -447,16 +447,6 @@
 
   .sne-controls :global(.st-input) {
     flex: 1;
-  }
-
-  :global(.sne-item) {
-    align-items: center;
-    display: flex;
-    gap: 8px;
-  }
-
-  .sne-item :global(svg) {
-    flex-shrink: 0;
   }
 
   .expand-all-button {

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -36,6 +36,7 @@
 
   const deletePermissionSequenceError: string = 'You do not have permission to delete an expansion sequence.';
   const deletePermissionSequenceFilterError: string = 'You do not have permission to delete a sequence filter';
+  const selectExpansionSetMessage: string = 'First, select an Expansion Set!';
 
   let filterText: string;
   let sequencesAndFilters: (ExpansionSequence | SequenceFilter)[] = [];
@@ -237,11 +238,11 @@
         {/if}
       </svelte:fragment>
     </ActivityFilterBuilder>
-    <div class="sne-controls">
+    <div class="sne-controls flex flex-wrap">
       <div class="sne-filter">
         <input
           bind:value={filterText}
-          class="st-input"
+          class="st-input w-32"
           name="search"
           autocomplete="off"
           placeholder="Filter..."
@@ -249,8 +250,8 @@
         />
       </div>
       {#if SEQUENCE_EXPANSION_MODE === SequencingMode.TYPESCRIPT}
-        <div class="sne-expansion-set-select">
-          <select name="expansionSetId" bind:value={selectedExpansionSetId} class="st-select w-full">
+        <div class="sne-expansion-set-select min-w-28">
+          <select name="expansionSetId" bind:value={selectedExpansionSetId} class="st-select w-32">
             {#if !$expansionSets.length}
               <option value={null}>No Expansion Sets</option>
             {:else}
@@ -264,7 +265,7 @@
           </select>
         </div>
       {/if}
-      <div class="sne-buttons">
+      <div class="sne-buttons flex flex-wrap gap-1">
         <DropdownMenu.Root>
           <DropdownMenu.Trigger asChild let:builder>
             <Button variant="outline" builders={[builder]}>New</Button>
@@ -275,13 +276,20 @@
             <DropdownMenu.Item size="sm" on:click={onShowFilterCreate}>Sequence Filter</DropdownMenu.Item>
           </DropdownMenu.Content>
         </DropdownMenu.Root>
-        <button
-          class="st-button secondary expand-all-button"
-          disabled={isExpansionDisabled}
-          on:click|stopPropagation={onExpandAll}
+        <div
+          use:tooltip={{
+            content: isExpansionDisabled ? selectExpansionSetMessage : 'Expand All Sequences',
+            placement: 'top',
+          }}
         >
-          Expand All
-        </button>
+          <button
+            class="st-button secondary expand-all-button"
+            disabled={isExpansionDisabled}
+            on:click|stopPropagation={onExpandAll}
+          >
+            Expand All
+          </button>
+        </div>
       </div>
     </div>
     <div class="sne-items">
@@ -349,7 +357,12 @@
                   <DownloadIcon />
                 </button>
               </div>
-              <div use:tooltip={{ content: 'Expand Sequence', placement: 'top' }}>
+              <div
+                use:tooltip={{
+                  content: isExpansionDisabled ? selectExpansionSetMessage : 'Expand Sequence',
+                  placement: 'top',
+                }}
+              >
                 <button
                   aria-label={`Expand '${sequenceOrFilter.seq_id}'`}
                   class="st-button icon"
@@ -428,7 +441,6 @@
   .sne-controls {
     align-items: center;
     background: rgba(248, 248, 248, 0.6);
-    display: flex;
     gap: 8px;
     padding: 8px 8px;
   }

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -250,7 +250,7 @@
         />
       </div>
       {#if SEQUENCE_EXPANSION_MODE === SequencingMode.TYPESCRIPT}
-        <div class="sne-expansion-set-select flex-1">
+        <div class="sne-expansion-set-select">
           <select name="expansionSetId" bind:value={selectedExpansionSetId} class="st-select min-w-36">
             {#if !$expansionSets.length}
               <option value={null}>No Expansion Sets</option>
@@ -296,8 +296,8 @@
       {#each sequencesAndFilters as sequenceOrFilter}
         {#if isExpansionSequence(sequenceOrFilter)}
           <ListItem>
-            <span slot="prefix" class="text-ellipsis overflow-hidden whitespace-nowrap align-middle">
-              <JournalCodeIcon size={16} class="inline"/>
+            <span slot="prefix" class="overflow-hidden text-ellipsis whitespace-nowrap align-middle">
+              <JournalCodeIcon size={16} class="inline" />
               {sequenceOrFilter.seq_id}
             </span>
             <span slot="suffix">
@@ -380,8 +380,8 @@
           </ListItem>
         {:else}
           <ListItem>
-            <span slot="prefix" class="text-ellipsis overflow-hidden whitespace-nowrap align-middle">
-              <FilterIcon size={16} class="inline"/>
+            <span slot="prefix" class="overflow-hidden text-ellipsis whitespace-nowrap align-middle">
+              <FilterIcon size={16} class="inline" />
               {sequenceOrFilter.name}
             </span>
             <span slot="suffix">

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -239,10 +239,10 @@
       </svelte:fragment>
     </ActivityFilterBuilder>
     <div class="sne-controls flex flex-wrap">
-      <div class="sne-filter">
+      <div class="sne-filter flex-1">
         <input
           bind:value={filterText}
-          class="st-input w-32"
+          class="st-input w-full min-w-32"
           name="search"
           autocomplete="off"
           placeholder="Filter..."


### PR DESCRIPTION
This pull-request improves the formatting for the buttons, filter, and expansion set selection within the Expansion panel for the Typescript expansion mode. The display formatting changes also help improve the function of Templating expansion mode.

https://github.com/user-attachments/assets/44cd6fd8-b102-4f81-b6ce-d195e0060733

Additionally, tooltips were added to the 'Expand All' and 'Expand' buttons when an Expansion Set is not selected to tell the user that they need to first select an Expansion Set.

<img width="609" height="330" alt="Screenshot 2025-08-14 at 10 32 22 AM" src="https://github.com/user-attachments/assets/bc57ffc1-d0ae-47cd-b626-35396a4628e6" />
