### PR TITLE
Remove zeros in duration strings

### DIFF
--- a/src/components/parameters/ParameterBaseDuration.svelte
+++ b/src/components/parameters/ParameterBaseDuration.svelte
@@ -27,7 +27,7 @@
 
   $: columns = `calc(${labelColumnWidth}px - ${level * levelPadding}px) auto`;
 
-  $: durationString = convertUsToDurationString(formParameter.value, true);
+  $: durationString = convertUsToDurationString(formParameter.value, false);
 
   function onChange() {
     try {

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -533,7 +533,7 @@ export function convertUsToDurationString(durationUs: number, includeZeros: bool
   const millisecondsString = milliseconds ? `${milliseconds}ms` : '';
   const microsecondsString = microseconds ? `${microseconds}us` : '';
 
-  const allParts =  [
+  const allParts = [
     yearsString,
     daysString,
     hoursString,
@@ -541,7 +541,7 @@ export function convertUsToDurationString(durationUs: number, includeZeros: bool
     secondsString,
     millisecondsString,
     microsecondsString,
-  ]
+  ];
 
   const firstIndex = allParts.findIndex(part => part !== '');
 
@@ -549,9 +549,7 @@ export function convertUsToDurationString(durationUs: number, includeZeros: bool
     return '0us';
   }
 
-  return [negativeString, ...allParts]
-    .filter(Boolean)
-    .join(' ');
+  return [negativeString, ...allParts].filter(Boolean).join(' ');
 }
 
 /**

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -533,8 +533,7 @@ export function convertUsToDurationString(durationUs: number, includeZeros: bool
   const millisecondsString = milliseconds ? `${milliseconds}ms` : '';
   const microsecondsString = microseconds ? `${microseconds}us` : '';
 
-  return [
-    negativeString,
+  const allParts =  [
     yearsString,
     daysString,
     hoursString,
@@ -543,6 +542,14 @@ export function convertUsToDurationString(durationUs: number, includeZeros: bool
     millisecondsString,
     microsecondsString,
   ]
+
+  const firstIndex = allParts.findIndex(part => part !== '');
+
+  if (firstIndex === -1) {
+    return '0us';
+  }
+
+  return [negativeString, ...allParts]
     .filter(Boolean)
     .join(' ');
 }


### PR DESCRIPTION
To test select any activity and on any parameter with duration as the type will show up without any 0s such as "0y 0d 0h 1m 0s 0ms 0us" turns into "1m"
<img width="687" height="684" alt="image" src="https://github.com/user-attachments/assets/df07b641-9f88-4116-a708-323906686ca9" />
