### PR TITLE
Add metadata section to selected activity

### DIFF
--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -561,13 +561,6 @@
           </Highlight>
         {/if}
 
-        <Highlight highlight={highlightKeysMap.id}>
-          <Input layout="inline">
-            <label use:tooltip={{ content: 'Activity ID', placement: 'top' }} for="id"> ID</label>
-            <input class="st-input w-full" disabled name="id" id="id" value={activityDirective.id} />
-          </Input>
-        </Highlight>
-
         <Highlight highlight={highlightKeysMap.type}>
           <Input layout="inline">
             <label use:tooltip={{ content: 'Activity Type', placement: 'top' }} for="activity-type">
@@ -619,6 +612,56 @@
           on:updateAnchorEdge={updateAnchorEdge}
           on:updateStartOffset={updateStartOffset}
         />
+
+        <Highlight highlight={highlightKeysMap.source_scheduling_goal_id}>
+          <Input layout="inline">
+            <label
+              use:tooltip={{ content: 'Source Scheduling Goal ID', placement: 'top' }}
+              for="sourceSchedulingGoalId"
+            >
+              Source Scheduling Goal ID
+            </label>
+            <input
+              class="st-input w-full"
+              disabled
+              name="sourceSchedulingGoalId"
+              id="sourceSchedulingGoalId"
+              value={activityDirective.source_scheduling_goal_id ?? 'None'}
+            />
+          </Input>
+        </Highlight>
+
+        <Highlight highlight={highlightKeysMap.tags}>
+          <Input layout="inline">
+            <label use:tooltip={{ content: 'Tags', placement: 'top' }} for="activityDirectiveTags"> Tags </label>
+            <TagsInput
+              name="Directive tags"
+              disabled={!hasUpdatePermission}
+              options={tags}
+              selected={activityDirective.tags.map(({ tag }) => tag)}
+              use={[
+                [
+                  permissionHandler,
+                  {
+                    hasPermission: hasUpdatePermission,
+                    permissionError: updatePermissionError,
+                  },
+                ],
+              ]}
+              on:change={onTagsInputChange}
+            />
+          </Input>
+        </Highlight>
+      </Collapse>
+    </fieldset>
+    <fieldSet>
+      <Collapse title="Metadata" contentClass="px-1" defaultExpanded={false}>
+        <Highlight highlight={highlightKeysMap.id}>
+          <Input layout="inline">
+            <label use:tooltip={{ content: 'Activity ID', placement: 'top' }} for="id"> ID</label>
+            <input class="st-input w-full" disabled name="id" id="id" value={activityDirective.id} />
+          </Input>
+        </Highlight>
 
         <Highlight highlight={highlightKeysMap.created_at}>
           <Input layout="inline">
@@ -677,48 +720,8 @@
             />
           </Input>
         </Highlight>
-
-        <Highlight highlight={highlightKeysMap.source_scheduling_goal_id}>
-          <Input layout="inline">
-            <label
-              use:tooltip={{ content: 'Source Scheduling Goal ID', placement: 'top' }}
-              for="sourceSchedulingGoalId"
-            >
-              Source Scheduling Goal ID
-            </label>
-            <input
-              class="st-input w-full"
-              disabled
-              name="sourceSchedulingGoalId"
-              id="sourceSchedulingGoalId"
-              value={activityDirective.source_scheduling_goal_id ?? 'None'}
-            />
-          </Input>
-        </Highlight>
-
-        <Highlight highlight={highlightKeysMap.tags}>
-          <Input layout="inline">
-            <label use:tooltip={{ content: 'Tags', placement: 'top' }} for="activityDirectiveTags"> Tags </label>
-            <TagsInput
-              name="Directive tags"
-              disabled={!hasUpdatePermission}
-              options={tags}
-              selected={activityDirective.tags.map(({ tag }) => tag)}
-              use={[
-                [
-                  permissionHandler,
-                  {
-                    hasPermission: hasUpdatePermission,
-                    permissionError: updatePermissionError,
-                  },
-                ],
-              ]}
-              on:change={onTagsInputChange}
-            />
-          </Input>
-        </Highlight>
       </Collapse>
-    </fieldset>
+    </fieldSet>
 
     <fieldset>
       <Collapse

--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -654,7 +654,7 @@
         </Highlight>
       </Collapse>
     </fieldset>
-    <fieldSet>
+    <fieldset>
       <Collapse title="Metadata" contentClass="px-1" defaultExpanded={false}>
         <Highlight highlight={highlightKeysMap.id}>
           <Input layout="inline">
@@ -721,7 +721,7 @@
           </Input>
         </Highlight>
       </Collapse>
-    </fieldSet>
+    </fieldset>
 
     <fieldset>
       <Collapse

--- a/src/components/activity/ActivitySpanForm.svelte
+++ b/src/components/activity/ActivitySpanForm.svelte
@@ -139,35 +139,13 @@
   <fieldset>
     <Collapse title="Definition">
       <Input layout="inline">
-        <label use:tooltip={{ content: 'ID', placement: 'top' }} for="id"> ID </label>
-        <input class="st-input w-full" disabled name="id" value={span.span_id} />
-      </Input>
-
-      <Input layout="inline">
         <label use:tooltip={{ content: 'Activity Type', placement: 'top' }} for="activityType"> Activity Type </label>
         <input class="st-input w-full" disabled name="activityType" value={span.type} />
       </Input>
 
       <Input layout="inline">
-        <label use:tooltip={{ content: 'Parent ID', placement: 'top' }} for="parentId">Parent ID</label>
-        <input class="st-input w-full" disabled name="parentId" value={span.parent_id ?? 'None (Root)'} />
-      </Input>
-
-      <Input layout="inline">
         <label use:tooltip={{ content: 'Duration', placement: 'top' }} for="duration">Duration</label>
         <input class="st-input w-full" disabled name="duration" value={span.duration ?? 'None'} />
-      </Input>
-
-      <Input layout="inline">
-        <label use:tooltip={{ content: 'Simulation Status', placement: 'top' }} for="simulationStatus">
-          Simulation Status
-        </label>
-        <input
-          class="st-input w-full"
-          disabled
-          name="simulationStatus"
-          value={span.duration === null ? 'Unfinished' : span.duration ? 'Finished' : 'None'}
-        />
       </Input>
 
       <Input layout="inline">
@@ -182,6 +160,32 @@
           End Time ({$plugins.time.primary.label})
         </label>
         <input class="st-input w-full" disabled name="endTime" value={endTime ?? 'None'} />
+      </Input>
+    </Collapse>
+  </fieldset>
+
+  <fieldset>
+    <Collapse title="Metadata" defaultExpanded={false}>
+      <Input layout="inline">
+        <label use:tooltip={{ content: 'ID', placement: 'top' }} for="id"> ID </label>
+        <input class="st-input w-full" disabled name="id" value={span.span_id} />
+      </Input>
+
+      <Input layout="inline">
+        <label use:tooltip={{ content: 'Parent ID', placement: 'top' }} for="parentId">Parent ID</label>
+        <input class="st-input w-full" disabled name="parentId" value={span.parent_id ?? 'None (Root)'} />
+      </Input>
+
+      <Input layout="inline">
+        <label use:tooltip={{ content: 'Simulation Status', placement: 'top' }} for="simulationStatus">
+          Simulation Status
+        </label>
+        <input
+          class="st-input w-full"
+          disabled
+          name="simulationStatus"
+          value={span.duration === null ? 'Unfinished' : span.duration ? 'Finished' : 'None'}
+        />
       </Input>
     </Collapse>
   </fieldset>

--- a/src/components/activity/ActivitySpanForm.svelte
+++ b/src/components/activity/ActivitySpanForm.svelte
@@ -149,6 +149,18 @@
       </Input>
 
       <Input layout="inline">
+        <label use:tooltip={{ content: 'Simulation Status', placement: 'top' }} for="simulationStatus">
+          Simulation Status
+        </label>
+        <input
+          class="st-input w-full"
+          disabled
+          name="simulationStatus"
+          value={span.duration === null ? 'Unfinished' : span.duration ? 'Finished' : 'None'}
+        />
+      </Input>
+
+      <Input layout="inline">
         <label use:tooltip={{ content: 'Start Time', placement: 'top' }} for="startTime">
           Start Time ({$plugins.time.primary.label})
         </label>
@@ -174,18 +186,6 @@
       <Input layout="inline">
         <label use:tooltip={{ content: 'Parent ID', placement: 'top' }} for="parentId">Parent ID</label>
         <input class="st-input w-full" disabled name="parentId" value={span.parent_id ?? 'None (Root)'} />
-      </Input>
-
-      <Input layout="inline">
-        <label use:tooltip={{ content: 'Simulation Status', placement: 'top' }} for="simulationStatus">
-          Simulation Status
-        </label>
-        <input
-          class="st-input w-full"
-          disabled
-          name="simulationStatus"
-          value={span.duration === null ? 'Unfinished' : span.duration ? 'Finished' : 'None'}
-        />
       </Input>
     </Collapse>
   </fieldset>


### PR DESCRIPTION
To test select any activity and open up the metadata section to see the fields that were moved into the metadata section.

<img width="688" height="496" alt="image" src="https://github.com/user-attachments/assets/90e49eef-37d1-4f48-ad39-2b544d6888f3" />
<img width="696" height="736" alt="image" src="https://github.com/user-attachments/assets/30fa81cf-8db5-46e1-a776-6f2ec7141ecb" />
