### PR TITLE
Remove zeros in duration strings

### DIFF
--- a/src/components/parameters/ParameterBaseDuration.svelte
+++ b/src/components/parameters/ParameterBaseDuration.svelte
@@ -27,7 +27,7 @@
 
   $: columns = `calc(${labelColumnWidth}px - ${level * levelPadding}px) auto`;
 
-  $: durationString = convertUsToDurationString(formParameter.value, true);
+  $: durationString = convertUsToDurationString(formParameter.value, false);
 
   function onChange() {
     try {

--- a/src/components/parameters/ParameterBaseDuration.svelte
+++ b/src/components/parameters/ParameterBaseDuration.svelte
@@ -27,7 +27,7 @@
 
   $: columns = `calc(${labelColumnWidth}px - ${level * levelPadding}px) auto`;
 
-  $: durationString = convertUsToDurationString(formParameter.value, false);
+  $: durationString = convertUsToDurationString(formParameter.value, !disabled);
 
   function onChange() {
     try {

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -525,30 +525,26 @@ export function convertUsToDurationString(durationUs: number, includeZeros: bool
   }
 
   const negativeString = isNegative ? '-' : '';
-  const components: [number, string][] = [
-    [years, 'y'],
-    [days, 'd'],
-    [hours, 'h'],
-    [minutes, 'm'],
-    [seconds, 's'],
-    [milliseconds, 'ms'],
-    [microseconds, 'us'],
-  ];
+  const yearsString = years ? `${years}y` : '';
+  const daysString = days ? `${days}d` : '';
+  const hoursString = hours ? `${hours}h` : '';
+  const minutesString = minutes ? `${minutes}m` : '';
+  const secondsString = seconds ? `${seconds}s` : '';
+  const millisecondsString = milliseconds ? `${milliseconds}ms` : '';
+  const microsecondsString = microseconds ? `${microseconds}us` : '';
 
-  const firstNonZeroIndex = components.findIndex(([value]) => value > 0);
-  const lastNonZeroIndex = components.findLastIndex(([value]) => value > 0);
-
-  if (firstNonZeroIndex === -1) {
-    return '0us';
-  }
-
-  const parts = [];
-  for (let i = firstNonZeroIndex; i <= lastNonZeroIndex; i++) {
-    const [value, unit] = components[i];
-    parts.push(`${value}${unit}`);
-  }
-
-  return [negativeString, ...parts].filter(Boolean).join(' ');
+  return [
+    negativeString,
+    yearsString,
+    daysString,
+    hoursString,
+    minutesString,
+    secondsString,
+    millisecondsString,
+    microsecondsString,
+  ]
+    .filter(Boolean)
+    .join(' ');
 }
 
 /**

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -248,7 +248,7 @@ export function parseDurationString(
     const number = parseInt(int);
     const decimalNum = decimal ? parseFloat(decimal) : 0;
 
-    //shift everthing based on units
+    //shift everything based on units
     switch (units) {
       case 'microseconds':
         microsecond = number;
@@ -295,7 +295,7 @@ export function parseDurationString(
     day += Math.floor(hour / 24);
     hour = hour % 24;
 
-    // Normlize days and years
+    // Normalize days and years
     year += Math.floor(day / 365);
     day = day % 365;
 
@@ -525,31 +525,30 @@ export function convertUsToDurationString(durationUs: number, includeZeros: bool
   }
 
   const negativeString = isNegative ? '-' : '';
-  const yearsString = years ? `${years}y` : '';
-  const daysString = days ? `${days}d` : '';
-  const hoursString = hours ? `${hours}h` : '';
-  const minutesString = minutes ? `${minutes}m` : '';
-  const secondsString = seconds ? `${seconds}s` : '';
-  const millisecondsString = milliseconds ? `${milliseconds}ms` : '';
-  const microsecondsString = microseconds ? `${microseconds}us` : '';
-
-  const allParts = [
-    yearsString,
-    daysString,
-    hoursString,
-    minutesString,
-    secondsString,
-    millisecondsString,
-    microsecondsString,
+  const components: [number, string][] = [
+    [years, 'y'],
+    [days, 'd'],
+    [hours, 'h'],
+    [minutes, 'm'],
+    [seconds, 's'],
+    [milliseconds, 'ms'],
+    [microseconds, 'us']
   ];
 
-  const firstIndex = allParts.findIndex(part => part !== '');
+  const firstNonZeroIndex = components.findIndex(([value]) => value > 0);
+  const lastNonZeroIndex = components.findLastIndex(([value]) => value > 0);
 
-  if (firstIndex === -1) {
+  if (firstNonZeroIndex === -1) {
     return '0us';
   }
 
-  return [negativeString, ...allParts].filter(Boolean).join(' ');
+  const parts = [];
+  for (let i = firstNonZeroIndex; i <= lastNonZeroIndex; i++) {
+    const [value, unit] = components[i];
+    parts.push(`${value}${unit}`);
+  }
+
+  return [negativeString, ...parts].filter(Boolean).join(' ');
 }
 
 /**

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -533,7 +533,7 @@ export function convertUsToDurationString(durationUs: number, includeZeros: bool
   const millisecondsString = milliseconds ? `${milliseconds}ms` : '';
   const microsecondsString = microseconds ? `${microseconds}us` : '';
 
-  const allParts =  [
+  const allParts = [
     yearsString,
     daysString,
     hoursString,
@@ -541,7 +541,7 @@ export function convertUsToDurationString(durationUs: number, includeZeros: bool
     secondsString,
     millisecondsString,
     microsecondsString,
-  ]
+  ];
 
   const firstIndex = allParts.findIndex(part => part !== '');
 
@@ -549,9 +549,7 @@ export function convertUsToDurationString(durationUs: number, includeZeros: bool
     return '0us';
   }
 
-  return [negativeString, ...allParts]
-    .filter(Boolean)
-    .join(' ');
+  return [negativeString, ...allParts].filter(Boolean).join(' ');
 }
 
 /**

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -532,7 +532,7 @@ export function convertUsToDurationString(durationUs: number, includeZeros: bool
     [minutes, 'm'],
     [seconds, 's'],
     [milliseconds, 'ms'],
-    [microseconds, 'us']
+    [microseconds, 'us'],
   ];
 
   const firstNonZeroIndex = components.findIndex(([value]) => value > 0);

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -533,8 +533,7 @@ export function convertUsToDurationString(durationUs: number, includeZeros: bool
   const millisecondsString = milliseconds ? `${milliseconds}ms` : '';
   const microsecondsString = microseconds ? `${microseconds}us` : '';
 
-  return [
-    negativeString,
+  const allParts =  [
     yearsString,
     daysString,
     hoursString,
@@ -543,6 +542,14 @@ export function convertUsToDurationString(durationUs: number, includeZeros: bool
     millisecondsString,
     microsecondsString,
   ]
+
+  const firstIndex = allParts.findIndex(part => part !== '');
+
+  if (firstIndex === -1) {
+    return '0us';
+  }
+
+  return [negativeString, ...allParts]
     .filter(Boolean)
     .join(' ');
 }


### PR DESCRIPTION
To test select any activity and on any parameter with duration as the type will show up without any 0s such as "0y 0d 0h 1m 0s 0ms 0us" turns into "1m"
<img width="687" height="684" alt="image" src="https://github.com/user-attachments/assets/79289263-419a-45a6-bbb4-5054e3b68e01" />
