### PR TITLE
Fix for: Cannot copy parameter values from activity in viewer role

### DIFF
--- a/src/components/parameters/ParameterBaseNumber.svelte
+++ b/src/components/parameters/ParameterBaseNumber.svelte
@@ -52,6 +52,7 @@
     <div class="parameter-right" slot="right">
       <ParameterUnits unit={formParameter.schema?.metadata?.unit?.value} />
       <ParameterBaseRightAdornments
+        canCopy={true}
         {disabled}
         hidden={hideRightAdornments}
         {formParameter}

--- a/src/components/parameters/ParameterBaseNumber.svelte
+++ b/src/components/parameters/ParameterBaseNumber.svelte
@@ -1,9 +1,12 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import CopyIcon from 'bootstrap-icons/icons/copy.svg?component';
   import { debounce } from 'lodash-es';
   import { createEventDispatcher } from 'svelte';
   import type { FormParameter, ParameterType } from '../../types/parameter';
+  import { setClipboardContent } from '../../utilities/clipboard';
+  import { tooltip } from '../../utilities/tooltip';
   import { useActions, type ActionArray } from '../../utilities/useActions';
   import Input from '../form/Input.svelte';
   import ParameterBaseRightAdornments from './ParameterBaseRightAdornments.svelte';
@@ -51,8 +54,17 @@
     />
     <div class="parameter-right" slot="right">
       <ParameterUnits unit={formParameter.schema?.metadata?.unit?.value} />
+      <button
+        type="button"
+        class="st-icon copy-parameter-value"
+        use:tooltip={{ content: 'Copy Value' }}
+        on:click={() => {
+          setClipboardContent(formParameter.value);
+        }}
+      >
+        <CopyIcon />
+      </button>
       <ParameterBaseRightAdornments
-        canCopy={true}
         {disabled}
         hidden={hideRightAdornments}
         {formParameter}
@@ -75,5 +87,20 @@
     gap: 2px;
     min-width: min-content;
     width: 100%;
+  }
+
+  .copy-parameter-value {
+    height: 16px;
+    margin: 0 4px;
+    visibility: hidden;
+    width: 16px;
+  }
+
+  .copy-parameter-value:hover {
+    cursor: pointer;
+  }
+
+  .parameter-base-number:hover .copy-parameter-value {
+    visibility: visible;
   }
 </style>

--- a/src/components/parameters/ParameterBaseRightAdornments.svelte
+++ b/src/components/parameters/ParameterBaseRightAdornments.svelte
@@ -3,10 +3,14 @@
 <script lang="ts">
   import type { FormParameter, ParameterType } from '../../types/parameter';
   import type { ActionArray } from '../../utilities/useActions';
+  import { tooltip } from '../../utilities/tooltip';
   import InputErrorBadge from './InputErrorBadge.svelte';
   import ValueSourceBadge from './ValueSourceBadge.svelte';
+  import CopyIcon from 'bootstrap-icons/icons/copy.svg?component';
+  import { setClipboardContent } from '../../utilities/clipboard';
 
   export let disabled: boolean = false;
+  export let canCopy: boolean = false;
   export let formParameter: FormParameter;
   export let additionalErrors: string[] = [];
   export let hidden: boolean = false;
@@ -24,6 +28,18 @@
   }
 </script>
 
+{#if canCopy}
+  <button
+    type="button"
+    class="copy-parameter-value"
+    use:tooltip={{ content: 'Copy Value' }}
+    on:click={() => {
+      setClipboardContent(formParameter.value);
+    }}
+  >
+    <CopyIcon />
+  </button>
+{/if}
 <div class="parameter-base-right-adornment" {hidden}>
   {#if errors.length > 0 && !hideError}
     <InputErrorBadge {errors} />
@@ -34,8 +50,15 @@
 </div>
 
 <style>
+  .copy-parameter-value {
+    height: 16px;
+    margin: 0 4px;
+    visibility: hidden;
+    width: 16px;
+  }
+
   .parameter-base-right-adornment:not([hidden]) {
     column-gap: 1px;
-    display: flex;
+    display: contents;
   }
 </style>

--- a/src/components/parameters/ParameterBaseRightAdornments.svelte
+++ b/src/components/parameters/ParameterBaseRightAdornments.svelte
@@ -3,14 +3,10 @@
 <script lang="ts">
   import type { FormParameter, ParameterType } from '../../types/parameter';
   import type { ActionArray } from '../../utilities/useActions';
-  import { tooltip } from '../../utilities/tooltip';
   import InputErrorBadge from './InputErrorBadge.svelte';
   import ValueSourceBadge from './ValueSourceBadge.svelte';
-  import CopyIcon from 'bootstrap-icons/icons/copy.svg?component';
-  import { setClipboardContent } from '../../utilities/clipboard';
 
   export let disabled: boolean = false;
-  export let canCopy: boolean = false;
   export let formParameter: FormParameter;
   export let additionalErrors: string[] = [];
   export let hidden: boolean = false;
@@ -28,18 +24,6 @@
   }
 </script>
 
-{#if canCopy}
-  <button
-    type="button"
-    class="copy-parameter-value"
-    use:tooltip={{ content: 'Copy Value' }}
-    on:click={() => {
-      setClipboardContent(formParameter.value);
-    }}
-  >
-    <CopyIcon />
-  </button>
-{/if}
 <div class="parameter-base-right-adornment" {hidden}>
   {#if errors.length > 0 && !hideError}
     <InputErrorBadge {errors} />
@@ -50,15 +34,8 @@
 </div>
 
 <style>
-  .copy-parameter-value {
-    height: 16px;
-    margin: 0 4px;
-    visibility: hidden;
-    width: 16px;
-  }
-
   .parameter-base-right-adornment:not([hidden]) {
     column-gap: 1px;
-    display: contents;
+    display: flex;
   }
 </style>

--- a/src/components/parameters/ParameterBaseString.svelte
+++ b/src/components/parameters/ParameterBaseString.svelte
@@ -48,6 +48,7 @@
     <div class="parameter-right" slot="right">
       <ParameterUnits unit={formParameter.schema?.metadata?.unit?.value} />
       <ParameterBaseRightAdornments
+        canCopy={true}
         {disabled}
         hidden={hideRightAdornments}
         {formParameter}

--- a/src/components/parameters/ParameterBaseString.svelte
+++ b/src/components/parameters/ParameterBaseString.svelte
@@ -1,8 +1,11 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import CopyIcon from 'bootstrap-icons/icons/copy.svg?component';
   import { createEventDispatcher } from 'svelte';
   import type { FormParameter, ParameterType } from '../../types/parameter';
+  import { setClipboardContent } from '../../utilities/clipboard';
+  import { tooltip } from '../../utilities/tooltip';
   import { useActions, type ActionArray } from '../../utilities/useActions';
   import Input from '../form/Input.svelte';
   import ParameterBaseRightAdornments from './ParameterBaseRightAdornments.svelte';
@@ -47,8 +50,17 @@
     />
     <div class="parameter-right" slot="right">
       <ParameterUnits unit={formParameter.schema?.metadata?.unit?.value} />
+      <button
+        type="button"
+        class="st-icon copy-parameter-value"
+        use:tooltip={{ content: 'Copy Value' }}
+        on:click={() => {
+          setClipboardContent(formParameter.value);
+        }}
+      >
+        <CopyIcon />
+      </button>
       <ParameterBaseRightAdornments
-        canCopy={true}
         {disabled}
         hidden={hideRightAdornments}
         {formParameter}
@@ -71,5 +83,20 @@
     gap: 2px;
     min-width: min-content;
     width: 100%;
+  }
+
+  .copy-parameter-value {
+    height: 16px;
+    margin: 0 4px;
+    visibility: hidden;
+    width: 16px;
+  }
+
+  .copy-parameter-value:hover {
+    cursor: pointer;
+  }
+
+  .parameter-base-string:hover .copy-parameter-value {
+    visibility: visible;
   }
 </style>

--- a/src/components/parameters/Parameters.svelte
+++ b/src/components/parameters/Parameters.svelte
@@ -106,10 +106,16 @@
   .right-actions {
     display: flex;
     gap: 2px;
+    margin: auto;
     transition: visibility 0.1s;
     visibility: hidden;
   }
+
   .parameters-container :global(> div.highlight:hover .right-actions) {
+    visibility: visible;
+  }
+
+  .parameters-container :global(> div.highlight:hover .copy-parameter-value) {
     visibility: visible;
   }
 </style>

--- a/src/components/parameters/Parameters.svelte
+++ b/src/components/parameters/Parameters.svelte
@@ -106,16 +106,12 @@
   .right-actions {
     display: flex;
     gap: 2px;
-    margin: auto;
+    margin-top: 0.25rem;
     transition: visibility 0.1s;
     visibility: hidden;
   }
 
   .parameters-container :global(> div.highlight:hover .right-actions) {
-    visibility: visible;
-  }
-
-  .parameters-container :global(> div.highlight:hover .copy-parameter-value) {
     visibility: visible;
   }
 </style>


### PR DESCRIPTION
Fix for #1726 

For activity parameters, even if the role doesn't allow you to edit, allow copying the value. Needs the native `disabled` attribute that allows this kind of input to work like other inputs which allow copying the value 