### PR TITLE
Fix: Model extraction status text mismatch

### DIFF
--- a/src/components/model/ModelStatusRollup.svelte
+++ b/src/components/model/ModelStatusRollup.svelte
@@ -130,27 +130,6 @@
     </div>
     <div
       use:tooltip={{
-        content: parameterLog?.error_message ?? parameterLogTooltipMessages[parameterLogStatus],
-      }}
-    >
-      <Button
-        variant="ghost"
-        class={classNames(
-          'grid w-fit cursor-pointer grid-cols-[min-content_min-content] items-center gap-x-2 whitespace-nowrap border-none p-1 font-normal hover:bg-gray-200 ',
-          {
-            'bg-400': selectedLog !== 'parameter',
-            'bg-white hover:bg-white': selectedLog === 'parameter',
-            'cursor-default select-text border-none bg-transparent p-0 hover:bg-transparent': !selectable,
-          },
-        )}
-        on:click={selectParameterLog}
-      >
-        <ModelStatusIcon {showCompleteStatus} status={parameterLogStatus} />
-        Extract resource types
-      </Button>
-    </div>
-    <div
-      use:tooltip={{
         content: resourceLog?.error_message ?? resourceLogTooltipMessages[resourceLogStatus],
       }}
     >
@@ -167,6 +146,27 @@
         on:click={selectResourceLog}
       >
         <ModelStatusIcon {showCompleteStatus} status={resourceLogStatus} />
+        Extract resource types
+      </Button>
+    </div>
+    <div
+      use:tooltip={{
+        content: parameterLog?.error_message ?? parameterLogTooltipMessages[parameterLogStatus],
+      }}
+    >
+      <Button
+        variant="ghost"
+        class={classNames(
+          'grid w-fit cursor-pointer grid-cols-[min-content_min-content] items-center gap-x-2 whitespace-nowrap border-none p-1 font-normal hover:bg-gray-200 ',
+          {
+            'bg-400': selectedLog !== 'parameter',
+            'bg-white hover:bg-white': selectedLog === 'parameter',
+            'cursor-default select-text border-none bg-transparent p-0 hover:bg-transparent': !selectable,
+          },
+        )}
+        on:click={selectParameterLog}
+      >
+        <ModelStatusIcon {showCompleteStatus} status={parameterLogStatus} />
         Extract mission model parameters
       </Button>
     </div>


### PR DESCRIPTION
I found a minor bug where the text says "model parameters" but everything else about the code says "resource extraction" and vice versa. A good illustration of this is the tooltip, which doesn't match the text below it:

<img width="318" height="170" alt="Screenshot 2025-08-22 at 10 17 15 AM" src="https://github.com/user-attachments/assets/e20658f1-b2dd-4214-b6df-151430600537" />

The underlying error was in fact a resource extraction error:

```
aerie_merlin  | Request: POST [/refreshResourceTypes]
aerie_merlin  |     Matching endpoint-handlers: [BEFORE=*, BEFORE=*, POST=/refreshResourceTypes, AFTER=*]
aerie_merlin  |     Headers: {X-B3-SpanId=68da55e1b4ff63fb, X-B3-ParentSpanId=009cafd640caacba, User-Agent=hasura-graphql-engine/v2.12.1, Host=aerie_merlin:27183, X-B3-TraceId=2277659d17>
aerie_merlin  |     Cookies: {}
aerie_merlin  |     Body: {"created_at":"2025-08-22T17:15:42.673718Z","delivery_info":{"current_retry":0,"max_retries":0},"event":{"data":{"new":{"created_at":"2025-08-22T17:15:42.673718>
aerie_merlin  |     QueryString: null
aerie_merlin  |     QueryParams: {}
aerie_merlin  |     FormParams: {}
aerie_merlin  | Response: [500 Server Error], execution took 32.17 ms
aerie_merlin  |     Headers: {Date=Fri, 22 Aug 2025 17:15:43 GMT, Content-Type=application/json}
aerie_merlin  |     Body is 145 bytes (starts on next line):
aerie_merlin  |     {
aerie_merlin  |     "title": "Server Error",
aerie_merlin  |     "status": 500,
aerie_merlin  |     "type": "https://javalin.io/documentation#internalservererrorresponse",
aerie_merlin  |     "details": {}
aerie_merlin  | }

```

This PR leaves the visible order of the statuses the same, but changes the tooltips and icon to match the text.

Here's what it looks like after this change: 

<img width="298" height="168" alt="Screenshot 2025-08-22 at 10 26 32 AM" src="https://github.com/user-attachments/assets/547a2d19-9f7a-4e8b-a640-af1adff0a6dd" />
