### PR TITLE
Add ability to convert imported files into target language

### DIFF
--- a/src/components/modals/ImportWorkspaceFileModal.svelte
+++ b/src/components/modals/ImportWorkspaceFileModal.svelte
@@ -51,10 +51,10 @@
     saveButtonDisabled = files?.length === 0;
     selectedFileGroupings = Array.from(files ?? []).reduce(
       (previousFileGroupings: { convertableFiles: File[]; uploadableFiles: File[] }, file) => {
-        const extension = file.name.replace(/^(?:[^.]+)(\..+)?$/, '$1');
         if (
-          extension &&
-          outputLanguageExtensions.findIndex(fileExtension => extension === `.${fileExtension.replace(/^\./, '')}`) > -1
+          outputLanguageExtensions.findIndex(fileExtension =>
+            file.name.endsWith(`.${fileExtension.replace(/^\./, '')}`),
+          ) > -1
         ) {
           return {
             ...previousFileGroupings,

--- a/src/components/modals/ImportWorkspaceFileModal.svelte
+++ b/src/components/modals/ImportWorkspaceFileModal.svelte
@@ -1,12 +1,14 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { Input } from '@nasa-jpl/stellar-svelte';
   import { createEventDispatcher } from 'svelte';
   import * as Sidebar from '../../components/ui/Sidebar/index.js';
   import type { User } from '../../types/app';
   import type { Workspace, WorkspaceNodeEvent } from '../../types/workspace';
   import type { WorkspaceTreeNode } from '../../types/workspace-tree-view';
-  import { cleanPath, joinPath, separateFilenameFromPath } from '../../utilities/workspaces.js';
+  import { cleanPath, joinPath } from '../../utilities/workspaces.js';
+  import InputInternal from '../form/Input.svelte';
   import WorkspaceTreeView from '../workspace/WorkspaceTreeView/WorkspaceTreeView.svelte';
   import Modal from './Modal.svelte';
   import ModalContent from './ModalContent.svelte';
@@ -15,6 +17,8 @@
 
   export let currentWorkspace: Workspace;
   export let currentWorkspaceContents: WorkspaceTreeNode | null;
+  export let inputLanguageName: string = 'SeqN';
+  export let outputLanguageExtensions: string[] = ['.seq.json'];
   export let height: number = 400;
   export let width: number = 380;
   export let startingPath: string = '';
@@ -23,21 +27,37 @@
 
   const dispatch = createEventDispatcher<{
     close: void;
-    confirm: { files: FileList; targetDirectory: string };
+    confirm: {
+      convertedFileExtension: string;
+      files: FileList;
+      keepOriginalFiles: boolean;
+      shouldConvert: boolean;
+      targetDirectory: string;
+    };
   }>();
 
-  let targetPath: string = joinPath([currentWorkspace.name, startingPath]);
-  let targetDirectory: string = startingPath;
-  let targetFilename: string = '';
+  let targetDirectory: string = joinPath([currentWorkspace?.name ?? '', startingPath]);
   let saveButtonDisabled: boolean = false;
   let filesToUpload: FileList;
+  let keepOriginalFiles: boolean = false;
+  let shouldConvert: boolean = false;
+  let convertedFileExtension: string = '.seqN.txt';
+  let numberOfConvertableFiles: number = 0;
 
   $: {
-    const { filename, path } = separateFilenameFromPath(targetPath);
-    targetDirectory = path;
-    targetFilename = filename;
+    saveButtonDisabled = filesToUpload?.length === 0;
+    numberOfConvertableFiles = 0;
+    for (let i = 0; i < (filesToUpload?.length ?? 0); i++) {
+      const file = filesToUpload[i];
+      const extension = file.name.replace(/^(?:[^.]+)(\..+)?$/, '$1');
+      if (
+        extension &&
+        outputLanguageExtensions.findIndex(fileExtension => extension === `.${fileExtension.replace(/^\./, '')}`) > -1
+      ) {
+        numberOfConvertableFiles++;
+      }
+    }
   }
-  $: saveButtonDisabled = filesToUpload?.length === 0;
 
   function onFolderClicked(event: CustomEvent<WorkspaceNodeEvent>) {
     targetDirectory = event.detail.treeNodePath;
@@ -46,10 +66,11 @@
   function save() {
     if (!saveButtonDisabled) {
       dispatch('confirm', {
+        convertedFileExtension,
         files: filesToUpload,
-        targetDirectory: cleanPath(
-          joinPath([targetDirectory.replace(new RegExp(`^${currentWorkspace.name}`), ''), targetFilename]),
-        ),
+        keepOriginalFiles,
+        shouldConvert,
+        targetDirectory: cleanPath(joinPath([targetDirectory.replace(new RegExp(`^${currentWorkspace.name}`), '')])),
       });
     }
   }
@@ -69,7 +90,7 @@
   <ModalHeader on:close>Upload File(s) To Workspace</ModalHeader>
 
   <ModalContent style="overflow: hidden;">
-    <div class="grid h-full grid-rows-[auto_min-content] gap-1 overflow-hidden">
+    <div class="grid h-full grid-rows-[auto_min-content] gap-1">
       <Sidebar.Provider
         style="--sidebar-width: auto"
         className="min-h-full overflow-y-auto rounded-md border-(--st-gray-20) border-2"
@@ -89,9 +110,45 @@
           </Sidebar.Menu>
         </Sidebar.Content>
       </Sidebar.Provider>
-      <div class="py-1">
-        <label class="block pb-0.5" for="file">File(s)</label>
-        <input bind:files={filesToUpload} multiple class="w-100" name="file" type="file" aria-label="File(s)" />
+      <div class="flex flex-col gap-2 py-1">
+        <InputInternal layout="stacked">
+          <label class="block pb-0.5" for="file">File(s)</label>
+          <input bind:files={filesToUpload} multiple class="w-100" name="file" type="file" aria-label="File(s)" />
+        </InputInternal>
+        {#if numberOfConvertableFiles > 0}
+          <div class="flex gap-8">
+            <div class="flex items-center gap-1">
+              <input bind:checked={shouldConvert} aria-label="Should translate" id="should-convert" type="checkbox" />
+              <label class="select-none" for="should-convert">
+                Translate{numberOfConvertableFiles > 1 ? ` ${numberOfConvertableFiles} files ` : ' '}to {inputLanguageName}
+              </label>
+            </div>
+            {#if shouldConvert}
+              <div class="flex items-center gap-1">
+                <input
+                  bind:checked={keepOriginalFiles}
+                  aria-label="Keep original files"
+                  id="keep-files"
+                  type="checkbox"
+                />
+                <label class="select-none" for="keep-files">Keep original files</label>
+              </div>
+            {/if}
+          </div>
+          {#if shouldConvert}
+            <InputInternal layout="stacked">
+              <label class="block pb-0.5" for="file-extension">Translated file extension</label>
+              <Input
+                class="mx-1"
+                sizeVariant="xs"
+                bind:value={convertedFileExtension}
+                aria-label="Translated file extension"
+                id="file-extension"
+                type="text"
+              />
+            </InputInternal>
+          {/if}
+        {/if}
       </div>
     </div>
   </ModalContent>

--- a/src/components/modals/ImportWorkspaceFileModal.svelte
+++ b/src/components/modals/ImportWorkspaceFileModal.svelte
@@ -37,8 +37,8 @@
   }>();
 
   let targetDirectory: string = joinPath([currentWorkspace?.name ?? '', startingPath]);
-  let saveButtonDisabled: boolean = false;
-  let files: FileList;
+  let uploadButtonDisabled: boolean = true;
+  let files: FileList | undefined;
   let selectedFileGroupings: { convertableFiles: File[]; uploadableFiles: File[] } = {
     convertableFiles: [],
     uploadableFiles: [],
@@ -48,7 +48,7 @@
   let convertedFileExtension: string = '.seqN.txt';
 
   $: {
-    saveButtonDisabled = files?.length === 0;
+    uploadButtonDisabled = files === undefined || files.length === 0;
     selectedFileGroupings = Array.from(files ?? []).reduce(
       (previousFileGroupings: { convertableFiles: File[]; uploadableFiles: File[] }, file) => {
         if (
@@ -74,8 +74,8 @@
     targetDirectory = event.detail.treeNodePath;
   }
 
-  function save() {
-    if (!saveButtonDisabled) {
+  function upload() {
+    if (!uploadButtonDisabled) {
       let filesToConvert: File[] = [];
       let filesToUpload: File[] = [];
       if (shouldConvert) {
@@ -99,7 +99,7 @@
     const { key } = event;
     if (key === 'Enter') {
       event.preventDefault();
-      save();
+      upload();
     }
   }
 </script>
@@ -177,6 +177,6 @@
 
   <ModalFooter>
     <button class="st-button secondary" on:click={() => dispatch('close')}> Cancel </button>
-    <button class="st-button" disabled={saveButtonDisabled} on:click={save}> Upload </button>
+    <button class="st-button" disabled={uploadButtonDisabled} on:click={upload}> Upload </button>
   </ModalFooter>
 </Modal>

--- a/src/components/modals/ImportWorkspaceFileModal.svelte
+++ b/src/components/modals/ImportWorkspaceFileModal.svelte
@@ -29,34 +29,45 @@
     close: void;
     confirm: {
       convertedFileExtension: string;
-      files: FileList;
-      keepOriginalFiles: boolean;
-      shouldConvert: boolean;
+      filesToConvert: File[];
+      filesToUpload: File[];
+      shouldKeepOriginalFiles: boolean;
       targetDirectory: string;
     };
   }>();
 
   let targetDirectory: string = joinPath([currentWorkspace?.name ?? '', startingPath]);
   let saveButtonDisabled: boolean = false;
-  let filesToUpload: FileList;
-  let keepOriginalFiles: boolean = false;
+  let files: FileList;
+  let selectedFileGroupings: { convertableFiles: File[]; uploadableFiles: File[] } = {
+    convertableFiles: [],
+    uploadableFiles: [],
+  };
   let shouldConvert: boolean = false;
+  let shouldKeepOriginalFiles: boolean = false;
   let convertedFileExtension: string = '.seqN.txt';
-  let numberOfConvertableFiles: number = 0;
 
   $: {
-    saveButtonDisabled = filesToUpload?.length === 0;
-    numberOfConvertableFiles = 0;
-    for (let i = 0; i < (filesToUpload?.length ?? 0); i++) {
-      const file = filesToUpload[i];
-      const extension = file.name.replace(/^(?:[^.]+)(\..+)?$/, '$1');
-      if (
-        extension &&
-        outputLanguageExtensions.findIndex(fileExtension => extension === `.${fileExtension.replace(/^\./, '')}`) > -1
-      ) {
-        numberOfConvertableFiles++;
-      }
-    }
+    saveButtonDisabled = files?.length === 0;
+    selectedFileGroupings = Array.from(files ?? []).reduce(
+      (previousFileGroupings: { convertableFiles: File[]; uploadableFiles: File[] }, file) => {
+        const extension = file.name.replace(/^(?:[^.]+)(\..+)?$/, '$1');
+        if (
+          extension &&
+          outputLanguageExtensions.findIndex(fileExtension => extension === `.${fileExtension.replace(/^\./, '')}`) > -1
+        ) {
+          return {
+            ...previousFileGroupings,
+            convertableFiles: [...previousFileGroupings.convertableFiles, file],
+          };
+        }
+        return {
+          ...previousFileGroupings,
+          uploadableFiles: [...previousFileGroupings.uploadableFiles, file],
+        };
+      },
+      { convertableFiles: [], uploadableFiles: [] },
+    );
   }
 
   function onFolderClicked(event: CustomEvent<WorkspaceNodeEvent>) {
@@ -65,11 +76,20 @@
 
   function save() {
     if (!saveButtonDisabled) {
+      let filesToConvert: File[] = [];
+      let filesToUpload: File[] = [];
+      if (shouldConvert) {
+        filesToConvert = selectedFileGroupings.convertableFiles;
+        filesToUpload = selectedFileGroupings.uploadableFiles;
+      } else {
+        filesToUpload = [...selectedFileGroupings.convertableFiles, ...selectedFileGroupings.uploadableFiles];
+      }
+
       dispatch('confirm', {
         convertedFileExtension,
-        files: filesToUpload,
-        keepOriginalFiles,
-        shouldConvert,
+        filesToConvert,
+        filesToUpload,
+        shouldKeepOriginalFiles,
         targetDirectory: cleanPath(joinPath([targetDirectory.replace(new RegExp(`^${currentWorkspace.name}`), '')])),
       });
     }
@@ -113,20 +133,22 @@
       <div class="flex flex-col gap-2 py-1">
         <InputInternal layout="stacked">
           <label class="block pb-0.5" for="file">File(s)</label>
-          <input bind:files={filesToUpload} multiple class="w-100" name="file" type="file" aria-label="File(s)" />
+          <input bind:files multiple class="w-100" name="file" type="file" aria-label="File(s)" />
         </InputInternal>
-        {#if numberOfConvertableFiles > 0}
+        {#if selectedFileGroupings.convertableFiles.length > 0}
           <div class="flex gap-8">
             <div class="flex items-center gap-1">
               <input bind:checked={shouldConvert} aria-label="Should translate" id="should-convert" type="checkbox" />
               <label class="select-none" for="should-convert">
-                Translate{numberOfConvertableFiles > 1 ? ` ${numberOfConvertableFiles} files ` : ' '}to {inputLanguageName}
+                Translate{selectedFileGroupings.convertableFiles.length > 1
+                  ? ` ${selectedFileGroupings.convertableFiles.length} files `
+                  : ' '}to {inputLanguageName}
               </label>
             </div>
             {#if shouldConvert}
               <div class="flex items-center gap-1">
                 <input
-                  bind:checked={keepOriginalFiles}
+                  bind:checked={shouldKeepOriginalFiles}
                   aria-label="Keep original files"
                   id="keep-files"
                   type="checkbox"

--- a/src/components/modals/NewWorkspaceFolderModal.svelte
+++ b/src/components/modals/NewWorkspaceFolderModal.svelte
@@ -88,6 +88,6 @@
   </ModalContent>
   <ModalFooter>
     <button class="st-button secondary" on:click={() => dispatch('close')}> Cancel </button>
-    <button class="st-button" on:click={onConfirm}> Confirm </button>
+    <button class="st-button" disabled={!folderName} on:click={onConfirm}> Confirm </button>
   </ModalFooter>
 </Modal>

--- a/src/components/modals/NewWorkspaceSequenceModal.svelte
+++ b/src/components/modals/NewWorkspaceSequenceModal.svelte
@@ -96,6 +96,6 @@
   </ModalContent>
   <ModalFooter>
     <button class="st-button secondary" on:click={() => dispatch('close')}> Cancel </button>
-    <button class="st-button" on:click={onConfirm}> Confirm </button>
+    <button class="st-button" disabled={!fileName} on:click={onConfirm}> Confirm </button>
   </ModalFooter>
 </Modal>

--- a/src/components/workspace/WorkspacesGrid.svelte
+++ b/src/components/workspace/WorkspacesGrid.svelte
@@ -5,7 +5,7 @@
   import { createEventDispatcher } from 'svelte';
   import { workspaces } from '../../stores/workspaces';
   import type { User } from '../../types/app';
-  import type { DataGridColumnDef, DataGridRowSelection } from '../../types/data-grid';
+  import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { Workspace } from '../../types/workspace';
   import { featurePermissions } from '../../utilities/permissions';
   import Input from '../form/Input.svelte';
@@ -113,8 +113,16 @@
     }
   }
 
+  function hasEditPermission(user: User | null, workspace: Workspace) {
+    return featurePermissions.workspaces.canUpdate(user, workspace);
+  }
+
   function hasDeletePermission(user: User | null, workspace: Workspace) {
     return featurePermissions.workspaces.canDelete(user, workspace);
+  }
+
+  function editWorkspace(event: CustomEvent<RowId[]>) {
+    dispatch('viewWorkspace', event.detail[0] as number);
   }
 
   async function viewWorkspace(workspace: Workspace | undefined) {
@@ -160,11 +168,13 @@
         loading={$workspaces === null}
         columnDefs={baseColumnDefs}
         hasEdit={true}
-        itemDisplayText="Workspaces"
+        {hasDeletePermission}
+        {hasEditPermission}
+        itemDisplayText="Workspace"
         items={filteredWorkspaces}
         selectedItemId={selectedWorkspaceId}
-        hasDeletePermission={false}
         {user}
+        on:editItem={editWorkspace}
         on:rowSelected={workspaceSelected}
         on:rowDoubleClicked={({ detail }) => viewWorkspace(detail.data)}
       />

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -487,6 +487,10 @@
 
   onDestroy(() => {
     resetSequenceAdaptation();
+
+    if (refreshInterval !== null) {
+      clearInterval(refreshInterval);
+    }
   });
 </script>
 

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -7,6 +7,7 @@
   import { page } from '$app/stores';
   import { env } from '$env/dynamic/public';
   import type { ChannelDictionary, CommandDictionary, ParameterDictionary } from '@nasa-jpl/aerie-ampcs';
+  import { seqJsonToSeqn } from '@nasa-jpl/aerie-sequence-languages';
   import type { IRowNode } from 'ag-grid-community';
   import { onDestroy, onMount } from 'svelte';
   import PageTitle from '../../../components/app/PageTitle.svelte';
@@ -333,7 +334,15 @@
   async function onImportFile(event: CustomEvent<string>) {
     if ($workspace != null && workspaceTree && user) {
       const { detail: startingPath } = event;
-      const targetPath = await effects.importWorkspaceFile($workspace, workspaceTree, startingPath, user);
+      const targetPath = await effects.importWorkspaceFile(
+        $workspace,
+        workspaceTree,
+        startingPath,
+        $sequenceAdaptation.inputFormat.name,
+        $sequenceAdaptation.outputFormat.map(outputFormat => outputFormat.fileExtension),
+        user,
+        $sequenceAdaptation.inputFormat.toInputFormat ?? (async (input: string) => seqJsonToSeqn(JSON.parse(input))),
+      );
       refreshWorkspaceContents();
 
       if (targetPath) {

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -7,7 +7,6 @@
   import { page } from '$app/stores';
   import { env } from '$env/dynamic/public';
   import type { ChannelDictionary, CommandDictionary, ParameterDictionary } from '@nasa-jpl/aerie-ampcs';
-  import { seqJsonToSeqn } from '@nasa-jpl/aerie-sequence-languages';
   import type { IRowNode } from 'ag-grid-community';
   import { onDestroy, onMount } from 'svelte';
   import PageTitle from '../../../components/app/PageTitle.svelte';
@@ -61,6 +60,7 @@
   import { showConfirmModal } from '../../../utilities/modal';
   import { featurePermissions } from '../../../utilities/permissions';
   import { getActionsUrl, getWorkspacesUrl } from '../../../utilities/routes';
+  import { toInputFormat } from '../../../utilities/sequence-editor/extension-points';
   import { userSequenceToLibrarySequence } from '../../../utilities/sequence-editor/languages/seq-n/seq-n-tree-utils';
   import { parseFunctionSignatures } from '../../../utilities/sequence-editor/languages/vml/vml-adaptation';
   import { isVmlSequence } from '../../../utilities/sequence-editor/sequence-utils';
@@ -341,7 +341,7 @@
         $sequenceAdaptation.inputFormat.name,
         $sequenceAdaptation.outputFormat.map(outputFormat => outputFormat.fileExtension),
         user,
-        $sequenceAdaptation.inputFormat.toInputFormat ?? (async (input: string) => seqJsonToSeqn(JSON.parse(input))),
+        async (input: string) => toInputFormat(input, parameterDictionaries, channelDictionary, $sequenceAdaptation),
       );
       refreshWorkspaceContents();
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -5506,7 +5506,7 @@ const effects = {
           );
         }
 
-        if (successfullyUploadedFileNames) {
+        if (successfullyUploadedFileNames.length > 0) {
           showSuccessToast(
             `Workspace File${successfullyUploadedFileNames.length > 1 ? 's' : ''} Uploaded Successfully`,
           );

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -5403,60 +5403,33 @@ const effects = {
         user,
       );
       if (confirm) {
-        const { convertedFileExtension, files, keepOriginalFiles, shouldConvert, targetDirectory } = value as {
-          convertedFileExtension: string;
-          files: FileList;
-          keepOriginalFiles: boolean;
-          shouldConvert: boolean;
-          targetDirectory: string;
-        };
+        const { convertedFileExtension, filesToConvert, filesToUpload, shouldKeepOriginalFiles, targetDirectory } =
+          value as {
+            convertedFileExtension: string;
+            filesToConvert: File[];
+            filesToUpload: File[];
+            shouldKeepOriginalFiles: boolean;
+            targetDirectory: string;
+          };
 
         let fileArray: File[] = [];
-        if (shouldConvert) {
-          const { convertableFiles, leftoverFiles } = Array.from(files).reduce(
-            (previousFileGroupings: { convertableFiles: File[]; leftoverFiles: File[] }, file) => {
-              const extension = file.name.replace(/^(?:[^.]+)(\..+)?$/, '$1');
-              if (
-                extension &&
-                outputLanguageExtensions.findIndex(
-                  fileExtension => extension === `.${fileExtension.replace(/^\./, '')}`,
-                ) > -1
-              ) {
-                return {
-                  ...previousFileGroupings,
-                  convertableFiles: [...previousFileGroupings.convertableFiles, file],
-                };
-              }
-              return {
-                ...previousFileGroupings,
-                leftoverFiles: [...previousFileGroupings.leftoverFiles, file],
-              };
-            },
-            { convertableFiles: [], leftoverFiles: [] },
-          );
 
-          const convertedFiles: File[] = await Promise.all(
-            convertableFiles.map(async file => {
-              const fileName = file.name.replace(
-                /^([^.]+)(?:\..+)?$/,
-                `$1.${convertedFileExtension.replace(/^\./, '')}`,
-              );
-              const lastModified = Date.now();
-              const content = await file.text();
-              const convertedContent = await toInputFormat(content);
-              const fileBlob = new Blob([convertedContent], { type: 'text/plain' });
+        const convertedFiles: File[] = await Promise.all(
+          filesToConvert.map(async file => {
+            const fileName = file.name.replace(/^([^.]+)(?:\..+)?$/, `$1.${convertedFileExtension.replace(/^\./, '')}`);
+            const lastModified = Date.now();
+            const content = await file.text();
+            const convertedContent = await toInputFormat(content);
+            const fileBlob = new Blob([convertedContent], { type: 'text/plain' });
 
-              return new File([fileBlob], fileName, { lastModified, type: 'text/plain' });
-            }),
-          );
+            return new File([fileBlob], fileName, { lastModified, type: 'text/plain' });
+          }),
+        );
 
-          if (keepOriginalFiles) {
-            fileArray = [...convertedFiles, ...convertableFiles, ...leftoverFiles];
-          } else {
-            fileArray = [...convertedFiles, ...leftoverFiles];
-          }
+        if (shouldKeepOriginalFiles) {
+          fileArray = [...convertedFiles, ...filesToConvert, ...filesToUpload];
         } else {
-          fileArray = Array.from<File>(files);
+          fileArray = [...convertedFiles, ...filesToUpload];
         }
 
         const cleanedTargetPath = cleanPath(targetDirectory);

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -5412,7 +5412,7 @@ const effects = {
             targetDirectory: string;
           };
 
-        let fileArray: File[] = [];
+        const convertedFileMap: Record<string, string> = {};
 
         const convertedFiles: File[] = await Promise.all(
           filesToConvert.map(async file => {
@@ -5429,6 +5429,7 @@ const effects = {
               const content = await file.text();
               const convertedContent = await toInputFormat(content);
 
+              convertedFileMap[file.name] = fileName;
               return new File([convertedContent], fileName, { lastModified, type: 'text/plain' });
             }
 
@@ -5436,13 +5437,51 @@ const effects = {
           }),
         );
 
-        if (shouldKeepOriginalFiles) {
-          fileArray = [...convertedFiles, ...filesToConvert, ...filesToUpload];
-        } else {
-          fileArray = [...convertedFiles, ...filesToUpload];
+        const cleanedTargetPath = cleanPath(targetDirectory);
+        const convertedChunkedFiles = chunk(convertedFiles, 10);
+
+        const failedConvertedFileUploads: Record<string, boolean> = {};
+
+        for (let i = 0; i < convertedChunkedFiles.length; i++) {
+          const fileChunk: File[] = convertedChunkedFiles[i];
+
+          await Promise.all(
+            fileChunk.map(async file => {
+              const body = new FormData();
+              body.append('file', file, file.name);
+              try {
+                await reqWorkspace<Workspace>(
+                  `${joinPath([workspace.id, cleanedTargetPath, file.name])}?type=file`,
+                  'PUT',
+                  body,
+                  user,
+                  undefined,
+                  false,
+                );
+              } catch (error) {
+                failedConvertedFileUploads[file.name] = true;
+                catchError(`${file.name} was unable to be uploaded`, error as Error);
+                showFailureToast(`${file.name} was unable to be uploaded`);
+              }
+            }),
+          );
         }
 
-        const cleanedTargetPath = cleanPath(targetDirectory);
+        let fileArray: File[] = [];
+        if (shouldKeepOriginalFiles) {
+          fileArray = [
+            ...filesToConvert.reduce((previousFilesToConvert: File[], currentFile: File) => {
+              if (failedConvertedFileUploads[convertedFileMap[currentFile.name]]) {
+                return previousFilesToConvert;
+              }
+              return [...previousFilesToConvert, currentFile];
+            }, []),
+            ...filesToUpload,
+          ];
+        } else {
+          fileArray = [...filesToUpload];
+        }
+
         const chunkedFiles = chunk(fileArray, 10);
 
         for (let i = 0; i < chunkedFiles.length; i++) {
@@ -5462,11 +5501,17 @@ const effects = {
             }),
           );
         }
-        showSuccessToast(`Workspace File${fileArray.length > 1 ? 's' : ''} Uploaded Successfully`);
+
+        if (fileArray.length) {
+          showSuccessToast(`Workspace File${fileArray.length > 1 ? 's' : ''} Uploaded Successfully`);
+        } else {
+          throw new Error('No files were uploaded');
+        }
         return joinPath([cleanedTargetPath, fileArray[0].name]);
       }
     } catch (e) {
       catchError(`Workspace file was unable to be uploaded`, e as Error);
+      showFailureToast(`Workspace file was unable to be uploaded`);
     }
 
     return null;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -5428,9 +5428,8 @@ const effects = {
               const lastModified = Date.now();
               const content = await file.text();
               const convertedContent = await toInputFormat(content);
-              const fileBlob = new Blob([convertedContent], { type: 'text/plain' });
 
-              return new File([fileBlob], fileName, { lastModified, type: 'text/plain' });
+              return new File([convertedContent], fileName, { lastModified, type: 'text/plain' });
             }
 
             return file;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -5384,7 +5384,10 @@ const effects = {
     workspace: Workspace,
     workspaceContents: WorkspaceTreeNode,
     startingPath: string,
+    inputLanguageName: string,
+    outputLanguageExtensions: string[],
     user: User | null,
+    toInputFormat: (input: string) => Promise<string>,
   ): Promise<string | null> {
     try {
       if (!featurePermissions.workspace.canUpdate(user, workspace)) {
@@ -5393,14 +5396,71 @@ const effects = {
       const { confirm, value } = await showImportWorkspaceFileModal(
         workspace,
         workspaceContents,
+        inputLanguageName,
+        outputLanguageExtensions,
         startingPath,
         workspace,
         user,
       );
       if (confirm) {
-        const { files, targetDirectory } = value;
+        const { convertedFileExtension, files, keepOriginalFiles, shouldConvert, targetDirectory } = value as {
+          convertedFileExtension: string;
+          files: FileList;
+          keepOriginalFiles: boolean;
+          shouldConvert: boolean;
+          targetDirectory: string;
+        };
+
+        let fileArray: File[] = [];
+        if (shouldConvert) {
+          const { convertableFiles, leftoverFiles } = Array.from(files).reduce(
+            (previousFileGroupings: { convertableFiles: File[]; leftoverFiles: File[] }, file) => {
+              const extension = file.name.replace(/^(?:[^.]+)(\..+)?$/, '$1');
+              if (
+                extension &&
+                outputLanguageExtensions.findIndex(
+                  fileExtension => extension === `.${fileExtension.replace(/^\./, '')}`,
+                ) > -1
+              ) {
+                return {
+                  ...previousFileGroupings,
+                  convertableFiles: [...previousFileGroupings.convertableFiles, file],
+                };
+              }
+              return {
+                ...previousFileGroupings,
+                leftoverFiles: [...previousFileGroupings.leftoverFiles, file],
+              };
+            },
+            { convertableFiles: [], leftoverFiles: [] },
+          );
+
+          const convertedFiles: File[] = await Promise.all(
+            convertableFiles.map(async file => {
+              const fileName = file.name.replace(
+                /^([^.]+)(?:\..+)?$/,
+                `$1.${convertedFileExtension.replace(/^\./, '')}`,
+              );
+              const lastModified = Date.now();
+              const content = await file.text();
+              const convertedContent = await toInputFormat(content);
+              const fileBlob = new Blob([convertedContent], { type: 'text/plain' });
+
+              return new File([fileBlob], fileName, { lastModified, type: 'text/plain' });
+            }),
+          );
+
+          if (keepOriginalFiles) {
+            fileArray = [...convertedFiles, ...convertableFiles, ...leftoverFiles];
+          } else {
+            fileArray = [...convertedFiles, ...leftoverFiles];
+          }
+        } else {
+          fileArray = Array.from<File>(files);
+        }
+
         const cleanedTargetPath = cleanPath(targetDirectory);
-        const chunkedFiles = chunk(Array.from<File>(files), 10);
+        const chunkedFiles = chunk(fileArray, 10);
 
         for (let i = 0; i < chunkedFiles.length; i++) {
           const fileChunk: File[] = chunkedFiles[i];
@@ -5419,13 +5479,11 @@ const effects = {
             }),
           );
         }
-
-        showSuccessToast(`Workspace File${files.length > 1 ? 's' : ''} Uploaded Successfully`);
-        return joinPath([cleanedTargetPath, files[0].name]);
+        showSuccessToast(`Workspace File${fileArray.length > 1 ? 's' : ''} Uploaded Successfully`);
+        return joinPath([cleanedTargetPath, fileArray[0].name]);
       }
     } catch (e) {
       catchError(`Workspace file was unable to be uploaded`, e as Error);
-      showFailureToast(`Workspace File Upload Failed`);
     }
 
     return null;

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -5442,6 +5442,8 @@ const effects = {
 
         const failedConvertedFileUploads: Record<string, boolean> = {};
 
+        const successfullyUploadedFileNames: string[] = [];
+
         for (let i = 0; i < convertedChunkedFiles.length; i++) {
           const fileChunk: File[] = convertedChunkedFiles[i];
 
@@ -5458,6 +5460,7 @@ const effects = {
                   undefined,
                   false,
                 );
+                successfullyUploadedFileNames.push(file.name);
               } catch (error) {
                 failedConvertedFileUploads[file.name] = true;
                 catchError(`${file.name} was unable to be uploaded`, error as Error);
@@ -5498,16 +5501,19 @@ const effects = {
                 undefined,
                 false,
               );
+              successfullyUploadedFileNames.push(file.name);
             }),
           );
         }
 
-        if (fileArray.length) {
-          showSuccessToast(`Workspace File${fileArray.length > 1 ? 's' : ''} Uploaded Successfully`);
+        if (successfullyUploadedFileNames) {
+          showSuccessToast(
+            `Workspace File${successfullyUploadedFileNames.length > 1 ? 's' : ''} Uploaded Successfully`,
+          );
         } else {
           throw new Error('No files were uploaded');
         }
-        return joinPath([cleanedTargetPath, fileArray[0].name]);
+        return joinPath([cleanedTargetPath, successfullyUploadedFileNames[0]]);
       }
     } catch (e) {
       catchError(`Workspace file was unable to be uploaded`, e as Error);

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -5416,13 +5416,24 @@ const effects = {
 
         const convertedFiles: File[] = await Promise.all(
           filesToConvert.map(async file => {
-            const fileName = file.name.replace(/^([^.]+)(?:\..+)?$/, `$1.${convertedFileExtension.replace(/^\./, '')}`);
-            const lastModified = Date.now();
-            const content = await file.text();
-            const convertedContent = await toInputFormat(content);
-            const fileBlob = new Blob([convertedContent], { type: 'text/plain' });
+            const matchingOutputLanguageExtension = outputLanguageExtensions.find(fileExtension =>
+              file.name.endsWith(`.${fileExtension.replace(/^\./, '')}`),
+            );
 
-            return new File([fileBlob], fileName, { lastModified, type: 'text/plain' });
+            if (matchingOutputLanguageExtension) {
+              const fileName = file.name.replace(
+                matchingOutputLanguageExtension.replace(/^\./, ''),
+                convertedFileExtension.replace(/^\./, ''),
+              );
+              const lastModified = Date.now();
+              const content = await file.text();
+              const convertedContent = await toInputFormat(content);
+              const fileBlob = new Blob([convertedContent], { type: 'text/plain' });
+
+              return new File([fileBlob], fileName, { lastModified, type: 'text/plain' });
+            }
+
+            return file;
           }),
         );
 

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -339,12 +339,23 @@ export async function showImportWorkspaceFileModal(
         });
         target.resolve = resolve;
 
-        importWorkspaceFileModal.$on('confirm', (e: CustomEvent<{ files: FileList; targetDirectory: string }>) => {
-          target.replaceChildren();
-          target.resolve = null;
-          resolve({ confirm: true, value: e.detail });
-          importWorkspaceFileModal.$destroy();
-        });
+        importWorkspaceFileModal.$on(
+          'confirm',
+          (
+            e: CustomEvent<{
+              convertedFileExtension: string;
+              filesToConvert: File[];
+              filesToUpload: File[];
+              shouldKeepOriginalFiles: boolean;
+              targetDirectory: string;
+            }>,
+          ) => {
+            target.replaceChildren();
+            target.resolve = null;
+            resolve({ confirm: true, value: e.detail });
+            importWorkspaceFileModal.$destroy();
+          },
+        );
 
         importWorkspaceFileModal.$on('close', () => {
           target.replaceChildren();

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -314,6 +314,8 @@ export async function showDeleteExternalEventSourceTypeModal(
 export async function showImportWorkspaceFileModal(
   currentWorkspace: Workspace,
   currentWorkspaceContents: WorkspaceTreeNode,
+  inputLanguageName: string,
+  outputLanguageExtensions: string[],
   startingPath: string,
   workspace: Workspace | null | undefined,
   user: User | null,
@@ -327,6 +329,8 @@ export async function showImportWorkspaceFileModal(
           props: {
             currentWorkspace,
             currentWorkspaceContents,
+            inputLanguageName,
+            outputLanguageExtensions,
             startingPath,
             user,
             workspace,


### PR DESCRIPTION
Resolves #1762 

To test:
1. Create a workspace with a parcel that has a sequence adaptation ([this one will suffice](https://github.com/NASA-AMMOS/aerie-ui/blob/develop/e2e-tests/data/sequence-adaptation.js))
2. Create/acquire a SeqJson file. The following can be used as a test:
```
{
  "id": "foo",
  "metadata": {},
  "steps": [
    {
      "args": [
        {
          "type": "string",
          "value": "ON",
          "name": "enum_arg_0"
        },
        {
          "type": "boolean",
          "value": false,
          "name": "boolean_arg_0"
        },
        {
          "type": "number",
          "value": 1,
          "name": "float_arg_0"
        }
      ],
      "stem": "FSW_CMD_0",
      "time": {
        "type": "COMMAND_COMPLETE"
      },
      "type": "command"
    }
  ]
}
```
3. Click the `+` button on the desired workspace page
4. Click "Upload File" 
5. Select the target workspace directory
6. Click the "Choose Files" button
7. Select the newly created SeqJson file in step 2
8. Check on the "Translate to SeqN" checkbox
9. Click "Confirm" button
10. Verify that the desired sequence file is now present in the workspace and not the original SeqJson file.