### PR TITLE
Sort scheduling/activity parameters according to optional order provided in the metadata

### DIFF
--- a/src/components/parameters/ParameterRecStruct.svelte
+++ b/src/components/parameters/ParameterRecStruct.svelte
@@ -12,6 +12,7 @@
   import ParameterName from './ParameterName.svelte';
   import ParameterRec from './ParameterRec.svelte';
   import ParameterUnits from './ParameterUnits.svelte';
+  import { compare } from '../../utilities/generic';
 
   export let disabled: boolean = false;
   export let expanded: boolean = false;
@@ -33,21 +34,29 @@
 
   function getSubFormParameters(formParameter: FormParameter<ValueSchemaStruct>): FormParameter[] {
     const { schema, value = [] } = formParameter;
-    const { items: keys } = schema;
+    const { items: keys, metadata } = schema;
+    const order = metadata?.item_order;
     const structKeys = Object.keys(keys).sort();
+
+    const structOrderMap = new Map<string, number>();
+    order?.forEach((structKey, index) => {
+      structOrderMap.set(structKey, index);
+    });
 
     const subFormParameters = structKeys.map((key, index) => {
       let subFormParameter: FormParameter = {
         errors: null,
         key,
         name: key,
-        order: index,
+        order: structOrderMap.get(key) ?? index,
         schema: schema.items[key],
         value: value !== null ? value[key] : null,
         valueSource: formParameter.valueSource,
       };
       return subFormParameter;
     });
+
+    subFormParameters.sort((a, b) => compare(a.order, b.order));
 
     return subFormParameters;
   }

--- a/src/components/scheduling/goals/SchedulingGoal.svelte
+++ b/src/components/scheduling/goals/SchedulingGoal.svelte
@@ -61,11 +61,19 @@
     const schema = version?.parameter_schema;
 
     if (schema && schema.type === 'struct') {
-      formParameters = Object.entries(schema.items).map(([name, subschema], i) => {
+      const { items, metadata } = schema;
+      const order = metadata?.item_order;
+
+      const structOrderMap = new Map<string, number>();
+      order?.forEach((structKey, index) => {
+        structOrderMap.set(structKey, index);
+      });
+
+      formParameters = Object.entries(items).map(([name, subschema], i) => {
         return {
           errors: null,
           name,
-          order: i,
+          order: structOrderMap.get(name) ?? i,
           required: true,
           schema: subschema,
           value:

--- a/src/types/schema.ts
+++ b/src/types/schema.ts
@@ -4,6 +4,7 @@ type ValueSchemaMetadata = {
     description?: {
       value: string;
     };
+    item_order?: string[];
     unit?: {
       value: string;
     };


### PR DESCRIPTION
This is the UI part of PR https://github.com/NASA-AMMOS/aerie/pull/1738. 

If an order is provided as metadata of activity/goal parameters, we use it to sort the parameters before displaying them.

As this relies on optional metadata, it will work with the current aerie version and does not depend on the merging of the above PR