### PR TITLE
Make Plan model nullable and display missing model message in plan

### DIFF
--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -321,7 +321,7 @@
 
   async function onDeletePreset(event: CustomEvent<ActivityPreset>) {
     const { detail: deletedActivityPreset } = event;
-    if ($plan) {
+    if ($plan && $plan.model) {
       await effects.deleteActivityPreset(deletedActivityPreset, $plan.model.name, user);
     }
   }

--- a/src/components/activity/ActivityPresetInput.svelte
+++ b/src/components/activity/ActivityPresetInput.svelte
@@ -12,6 +12,7 @@
     DropdownOptions,
     SelectedDropdownOptionValue,
   } from '../../types/dropdown';
+  import type { Model } from '../../types/model';
   import type { Plan } from '../../types/plan';
   import type { GqlSubscribable } from '../../types/subscribable';
   import gql from '../../utilities/gql';
@@ -50,13 +51,13 @@
   $: if (activityDirective != null) {
     activityPresets.setVariables({ activityTypeName: activityDirective.type, modelId });
   }
-  $: if (plan !== null) {
+  $: if (plan !== null && plan.model) {
     options = $activityPresets.map((activityPreset: ActivityPreset) => ({
       display: activityPreset.name,
       hasSelectPermission: featurePermissions.activityPresets.canAssign(
         user,
-        plan as Plan,
-        (plan as Plan).model,
+        plan,
+        plan.model as Model,
         activityPreset,
       ),
       value: activityPreset.id,

--- a/src/components/constraints/ConstraintsPanel.svelte
+++ b/src/components/constraints/ConstraintsPanel.svelte
@@ -26,7 +26,7 @@
     setConstraintVisibility,
   } from '../../stores/constraints';
   import { field } from '../../stores/form';
-  import { plan, planReadOnly, viewTimeRange } from '../../stores/plan';
+  import { plan, planModelId, planReadOnly, viewTimeRange } from '../../stores/plan';
   import { plugins } from '../../stores/plugins';
   import { simulationStatus } from '../../stores/simulation';
   import type { User } from '../../types/app';
@@ -294,9 +294,10 @@
           [
             permissionHandler,
             {
-              hasPermission: $plan
-                ? featurePermissions.constraintRuns.canCreate(user, $plan, $plan.model) && !$planReadOnly
-                : false,
+              hasPermission:
+                $plan && $plan.model
+                  ? featurePermissions.constraintRuns.canCreate(user, $plan, $plan.model) && !$planReadOnly
+                  : false,
               permissionError: $planReadOnly
                 ? PlanStatusMessages.READ_ONLY
                 : 'You do not have permission to run constraint checks',
@@ -316,9 +317,10 @@
           [
             permissionHandler,
             {
-              hasPermission: $plan
-                ? featurePermissions.constraintRuns.canCreate(user, $plan, $plan.model) && !$planReadOnly
-                : false,
+              hasPermission:
+                $plan && $plan.model
+                  ? featurePermissions.constraintRuns.canCreate(user, $plan, $plan.model) && !$planReadOnly
+                  : false,
               permissionError: $planReadOnly
                 ? PlanStatusMessages.READ_ONLY
                 : 'You do not have permission to run constraint checks',
@@ -456,7 +458,7 @@
               hasEditPermission={hasSpecEditPermission}
               hasDeletePermission={hasSpecEditPermission}
               hasReadPermission={featurePermissions.constraints.canRead(user)}
-              modelId={$plan?.model.id}
+              modelId={$planModelId}
               shouldShowUpButton={(constraintPlanSpec?.order ?? 0) > 0}
               shouldShowDownButton={specIndex < filteredConstraintPlanSpecifications.length - 1}
               totalViolationCount={$constraintResponseMap[constraintPlanSpec.constraint_id]?.[

--- a/src/components/constraints/ConstraintsPanel.svelte
+++ b/src/components/constraints/ConstraintsPanel.svelte
@@ -294,10 +294,9 @@
           [
             permissionHandler,
             {
-              hasPermission:
-                $plan && $plan.model
-                  ? featurePermissions.constraintRuns.canCreate(user, $plan, $plan.model) && !$planReadOnly
-                  : false,
+              hasPermission: $plan
+                ? featurePermissions.constraintRuns.canCreate(user, $plan, $plan.model) && !$planReadOnly
+                : false,
               permissionError: $planReadOnly
                 ? PlanStatusMessages.READ_ONLY
                 : 'You do not have permission to run constraint checks',
@@ -317,10 +316,9 @@
           [
             permissionHandler,
             {
-              hasPermission:
-                $plan && $plan.model
-                  ? featurePermissions.constraintRuns.canCreate(user, $plan, $plan.model) && !$planReadOnly
-                  : false,
+              hasPermission: $plan
+                ? featurePermissions.constraintRuns.canCreate(user, $plan, $plan.model) && !$planReadOnly
+                : false,
               permissionError: $planReadOnly
                 ? PlanStatusMessages.READ_ONLY
                 : 'You do not have permission to run constraint checks',

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -55,7 +55,7 @@
   let hasDeletePermissionSequence: boolean = false;
   let hasDeletePermissionSequenceFilter: boolean = false;
 
-  $: if (user !== null && $plan !== null) {
+  $: if (user !== null && $plan !== null && $plan.model) {
     hasDeletePermissionSequence = featurePermissions.expansionSequences.canDelete(user, $plan);
     hasDeletePermissionSequenceFilter = featurePermissions.sequenceFilter.canDelete(user, $plan.model);
   }
@@ -89,7 +89,7 @@
   }
 
   function onCreateSequenceFilter() {
-    if ($plan !== null) {
+    if ($plan !== null && $plan.model_id !== null) {
       creatingNewSequenceFilter = false;
       effects.createSequenceFilter(
         filterMenuActiveFilter as ActivityLayerFilter,
@@ -113,7 +113,7 @@
   }
 
   function onUpdateSequenceFilter() {
-    if ($plan !== null && activeSequenceFilterId !== null) {
+    if ($plan !== null && activeSequenceFilterId !== null && $plan.model) {
       creatingNewSequenceFilter = false;
       effects.updateSequenceFilter(
         filterMenuActiveFilter as ActivityLayerFilter,

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -89,12 +89,12 @@
   }
 
   function onCreateSequenceFilter() {
-    if ($plan !== null && $plan.model_id !== null) {
+    if ($plan !== null && $plan.model) {
       creatingNewSequenceFilter = false;
       effects.createSequenceFilter(
         filterMenuActiveFilter as ActivityLayerFilter,
         activeSequenceFilterName,
-        $plan.model_id,
+        $plan.model.id,
         user,
       );
       filterMenu.toggle();

--- a/src/components/menus/PlanMenu.svelte
+++ b/src/components/menus/PlanMenu.svelte
@@ -116,6 +116,7 @@
       {#if plan.parent_plan !== null}
         <MenuDivider />
         <MenuItem
+          disabled={!plan.model}
           on:click={createMergePlanBranchRequest}
           use={[
             [

--- a/src/components/menus/PlanMenu.svelte
+++ b/src/components/menus/PlanMenu.svelte
@@ -30,20 +30,22 @@
   let planExporting: boolean = false;
   let planMenu: Menu;
 
-  $: hasCreateMergeRequestPermission = plan.parent_plan
-    ? featurePermissions.planBranch.canCreateRequest(
-        user,
-        plan,
-        {
-          ...plan.parent_plan,
-          model_id: plan.model_id,
-        },
-        plan.model,
-      ) && !$planReadOnly
-    : false;
+  $: hasCreateMergeRequestPermission =
+    plan.parent_plan && plan.model
+      ? featurePermissions.planBranch.canCreateRequest(
+          user,
+          plan,
+          {
+            ...plan.parent_plan,
+            model_id: plan.model_id,
+          },
+          plan.model,
+        ) && !$planReadOnly
+      : false;
   $: hasCreatePlanBranchPermission =
-    featurePermissions.planBranch.canCreateBranch(user, plan, plan.model) && !$planReadOnly;
-  $: hasCreateSnapshotPermission = featurePermissions.planSnapshot.canCreate(user, plan, plan.model) && !$planReadOnly;
+    !!plan.model && featurePermissions.planBranch.canCreateBranch(user, plan, plan.model) && !$planReadOnly;
+  $: hasCreateSnapshotPermission =
+    !!plan.model && featurePermissions.planSnapshot.canCreate(user, plan, plan.model) && !$planReadOnly;
 
   function createMergePlanBranchRequest() {
     effects.createPlanBranchRequest(plan, 'merge', user);

--- a/src/components/menus/PlanMenu.svelte
+++ b/src/components/menus/PlanMenu.svelte
@@ -30,22 +30,20 @@
   let planExporting: boolean = false;
   let planMenu: Menu;
 
-  $: hasCreateMergeRequestPermission =
-    plan.parent_plan && plan.model
-      ? featurePermissions.planBranch.canCreateRequest(
-          user,
-          plan,
-          {
-            ...plan.parent_plan,
-            model_id: plan.model_id,
-          },
-          plan.model,
-        ) && !$planReadOnly
-      : false;
+  $: hasCreateMergeRequestPermission = plan.parent_plan
+    ? featurePermissions.planBranch.canCreateRequest(
+        user,
+        plan,
+        {
+          ...plan.parent_plan,
+          model_id: plan.model_id,
+        },
+        plan.model,
+      ) && !$planReadOnly
+    : false;
   $: hasCreatePlanBranchPermission =
-    !!plan.model && featurePermissions.planBranch.canCreateBranch(user, plan, plan.model) && !$planReadOnly;
-  $: hasCreateSnapshotPermission =
-    !!plan.model && featurePermissions.planSnapshot.canCreate(user, plan, plan.model) && !$planReadOnly;
+    featurePermissions.planBranch.canCreateBranch(user, plan, plan.model) && !$planReadOnly;
+  $: hasCreateSnapshotPermission = featurePermissions.planSnapshot.canCreate(user, plan, plan.model) && !$planReadOnly;
 
   function createMergePlanBranchRequest() {
     effects.createPlanBranchRequest(plan, 'merge', user);

--- a/src/components/modals/ManagePlanConstraintsModal.svelte
+++ b/src/components/modals/ManagePlanConstraintsModal.svelte
@@ -181,7 +181,7 @@
   function viewConstraint({ id }: Pick<ConstraintMetadata, 'id'>) {
     const constraint = ($constraints || []).find(c => c.id === id);
     window.open(
-      `${base}/constraints/edit/${constraint?.id}?${SearchParameters.REVISION}=${constraint?.versions[0].revision}&${SearchParameters.MODEL_ID}=${$plan?.model?.id}`,
+      `${base}/constraints/edit/${constraint?.id}?${SearchParameters.REVISION}=${constraint?.versions[0].revision}${typeof $plan?.model?.id === 'number' ? `&${SearchParameters.MODEL_ID}=${$plan.model.id}` : ''}`,
     );
   }
 

--- a/src/components/modals/ManagePlanConstraintsModal.svelte
+++ b/src/components/modals/ManagePlanConstraintsModal.svelte
@@ -181,7 +181,7 @@
   function viewConstraint({ id }: Pick<ConstraintMetadata, 'id'>) {
     const constraint = ($constraints || []).find(c => c.id === id);
     window.open(
-      `${base}/constraints/edit/${constraint?.id}?${SearchParameters.REVISION}=${constraint?.versions[0].revision}&${SearchParameters.MODEL_ID}=${$plan?.model.id}`,
+      `${base}/constraints/edit/${constraint?.id}?${SearchParameters.REVISION}=${constraint?.versions[0].revision}&${SearchParameters.MODEL_ID}=${$plan?.model?.id}`,
     );
   }
 

--- a/src/components/modals/ManagePlanSchedulingConditionsModal.svelte
+++ b/src/components/modals/ManagePlanSchedulingConditionsModal.svelte
@@ -195,7 +195,7 @@
   function viewCondition({ id }: Pick<SchedulingConditionMetadata, 'id'>) {
     const condition = $schedulingConditions.find(c => c.id === id);
     window.open(
-      `${base}/scheduling/conditions/edit/${condition?.id}?${SearchParameters.REVISION}=${condition?.versions[0].revision}&${SearchParameters.MODEL_ID}=${$plan?.model.id}`,
+      `${base}/scheduling/conditions/edit/${condition?.id}?${SearchParameters.REVISION}=${condition?.versions[0].revision}&${SearchParameters.MODEL_ID}=${$plan?.model?.id}`,
     );
   }
 

--- a/src/components/modals/ManagePlanSchedulingGoalsModal.svelte
+++ b/src/components/modals/ManagePlanSchedulingGoalsModal.svelte
@@ -189,7 +189,7 @@
   function viewGoal({ id }: Pick<SchedulingGoalMetadata, 'id'>) {
     const goal = $schedulingGoals.find(c => c.id === id);
     window.open(
-      `${base}/scheduling/goals/edit/${goal?.id}?${SearchParameters.REVISION}=${goal?.versions[0].revision}&${SearchParameters.MODEL_ID}=${$plan?.model.id}`,
+      `${base}/scheduling/goals/edit/${goal?.id}?${SearchParameters.REVISION}=${goal?.versions[0].revision}&${SearchParameters.MODEL_ID}=${$plan?.model?.id}`,
     );
   }
 

--- a/src/components/modals/PlanBranchRequestModal.svelte
+++ b/src/components/modals/PlanBranchRequestModal.svelte
@@ -20,12 +20,12 @@
     close: void;
     create:
       | {
-          source_plan: Plan;
+          source_plan: PlanForMerging;
           target_plan: PlanForMerging;
         }
       | {
           source_plan: PlanForMerging;
-          target_plan: Plan;
+          target_plan: PlanForMerging;
         };
   }>();
 
@@ -50,7 +50,7 @@
     actionHeader = 'Pull changes from';
     actionButtonText = 'Review Changes';
   }
-  $: if (selectedPlan && plan.parent_plan) {
+  $: if (selectedPlan && plan.parent_plan && plan.model) {
     planModelsCompatible = plan.model.id === plan.parent_plan.model.id;
   } else {
     planModelsCompatible = true;
@@ -60,9 +60,9 @@
   function create() {
     if (!createButtonDisabled && selectedPlan !== null) {
       if (action === 'merge') {
-        dispatch('create', { source_plan: plan, target_plan: selectedPlan });
+        dispatch('create', { source_plan: plan as PlanForMerging, target_plan: selectedPlan });
       } else {
-        dispatch('create', { source_plan: selectedPlan, target_plan: plan });
+        dispatch('create', { source_plan: selectedPlan, target_plan: plan as PlanForMerging });
       }
     }
   }

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import { Button } from '@nasa-jpl/stellar-svelte';
+  import { Button, cn } from '@nasa-jpl/stellar-svelte';
   import { ArrowLeftRight, FileUp } from 'lucide-svelte';
   import { PlanStatusMessages } from '../../enums/planStatusMessages';
   import { SearchParameters } from '../../enums/searchParameters';
@@ -225,7 +225,7 @@
           <label use:tooltip={{ content: 'Model Name', placement: 'top' }} for="modelName">Model Name</label>
           <div class="flex gap-1">
             <input
-              class="st-input w-full"
+              class={cn('st-input w-full', !plan.model?.name ? 'border-destructive' : '')}
               disabled
               name="modelName"
               value={plan.model?.name ?? 'Model not found'}

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -67,7 +67,7 @@
   let planEndTime: string = '';
 
   $: permissionError = $planReadOnly ? PlanStatusMessages.READ_ONLY : 'You do not have permission to edit this plan.';
-  $: if (plan) {
+  $: if (plan && plan.model) {
     hasCreateSnapshotPermission = featurePermissions.planSnapshot.canCreate(user, plan, plan.model) && !$planReadOnly;
     planStartTime = formatDate(new Date(plan.start_time), $plugins.time.primary.format);
     const endTime = convertDoyToYmd(plan.end_time_doy);
@@ -224,7 +224,13 @@
         <Input layout="inline">
           <label use:tooltip={{ content: 'Model Name', placement: 'top' }} for="modelName">Model Name</label>
           <div class="flex gap-1">
-            <input class="st-input w-full" disabled name="modelName" value={plan.model.name} id="modelName" />
+            <input
+              class="st-input w-full"
+              disabled
+              name="modelName"
+              value={plan.model?.name ?? 'Model not found'}
+              id="modelName"
+            />
             <div
               use:permissionHandler={{
                 hasPermission: hasChangePlanModelPermission && !$planReadOnly,
@@ -252,7 +258,13 @@
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Model Version', placement: 'top' }} for="modelVersion">Model Version</label>
-          <input class="st-input w-full" disabled name="modelVersion" value={plan.model.version} id="modelVersion" />
+          <input
+            class="st-input w-full"
+            disabled
+            name="modelVersion"
+            value={plan.model?.version ?? 'Model not found'}
+            id="modelVersion"
+          />
         </Input>
         <Input layout="inline">
           <label
@@ -382,7 +394,7 @@
             {#each filteredPlanSnapshots as planSnapshot (planSnapshot.snapshot_id)}
               <PlanSnapshot
                 activePlanSnapshotId={$planSnapshotId}
-                planModelId={plan.model.id}
+                planModelId={plan.model?.id}
                 {planSnapshot}
                 on:click={() => {
                   setQueryParam(SearchParameters.SNAPSHOT_ID, `${planSnapshot.snapshot_id}`, 'PUSH');

--- a/src/components/plan/PlanMergeReview.svelte
+++ b/src/components/plan/PlanMergeReview.svelte
@@ -83,7 +83,7 @@
   let sourcePlan: PlanForMerging | undefined;
   let targetPlan: PlanForMerging;
 
-  $: if (initialPlan && initialMergeRequest && initialMergeRequest.plan_receiving_changes) {
+  $: if (initialPlan && initialMergeRequest && initialMergeRequest.plan_receiving_changes && initialPlan.model) {
     sourcePlan = initialMergeRequest.plan_snapshot_supplying_changes?.plan;
     targetPlan = initialMergeRequest.plan_receiving_changes;
 
@@ -642,7 +642,7 @@
                 activityMetadataDefinitions={$activityMetadataDefinitions}
                 activityTypes={$planModelActivityTypes}
                 highlightKeys={keysWithChanges}
-                modelId={initialPlan.model_id}
+                modelId={initialPlan.model_id ?? -1}
                 planId={initialPlan.id}
                 planStartTimeYmd={initialPlan.start_time}
                 {user}
@@ -710,7 +710,7 @@
                 activityTypes={$planModelActivityTypes}
                 editable={false}
                 highlightKeys={selectedConflictingActivity !== null ? keysWithChanges : []}
-                modelId={initialPlan.model_id}
+                modelId={initialPlan.model_id ?? -1}
                 planStartTimeYmd={initialPlan.start_time}
                 showActivityName
                 showHeader={false}

--- a/src/components/plan/PlanModelErrorBar.svelte
+++ b/src/components/plan/PlanModelErrorBar.svelte
@@ -4,6 +4,7 @@
   import WarningIcon from '@nasa-jpl/stellar/icons/warning.svg?component';
   import { createEventDispatcher } from 'svelte';
 
+  export let action: string = '';
   export let modelName: string = '';
   export let hasErrors: boolean = false;
 
@@ -12,11 +13,11 @@
   $: isVisible = hasErrors;
 
   const dispatch = createEventDispatcher<{
-    viewModelErrors: void;
+    action: void;
   }>();
 
-  function onClickViewConsole() {
-    dispatch('viewModelErrors');
+  function onActionClick() {
+    dispatch('action');
   }
 
   function onDismiss() {
@@ -27,12 +28,15 @@
 {#if isVisible}
   <div class="model-error-bar">
     <div class="info">
-      Mission model <span class="model-name"><WarningIcon class="red-icon" />{modelName}</span> has extraction errors and
-      this plan may not work correctly
+      <slot />
+      {#if !$$slots.default}
+        Mission model <span class="model-name"><WarningIcon class="red-icon" />{modelName}</span> has extraction errors and
+        this plan may not work correctly
+      {/if}
     </div>
 
     <div class="buttons">
-      <button on:click={onClickViewConsole} class="st-button view-button">View errors in console</button>
+      <button on:click={onActionClick} class="st-button view-button">{action}</button>
       <button class="st-button secondary" on:click={onDismiss}>Dismiss</button>
     </div>
   </div>

--- a/src/components/scheduling/SchedulingConditionsPanel.svelte
+++ b/src/components/scheduling/SchedulingConditionsPanel.svelte
@@ -145,7 +145,7 @@
               conditionPlanSpec={specCondition}
               hasEditPermission={hasSpecEditPermission}
               hasReadPermission={featurePermissions.schedulingConditions.canRead(user)}
-              modelId={$plan?.model.id}
+              modelId={$plan?.model?.id}
               editPermissionError={$planReadOnly
                 ? PlanStatusMessages.READ_ONLY
                 : 'You do not have permission to edit scheduling conditions for this plan.'}

--- a/src/components/scheduling/SchedulingGoalsPanel.svelte
+++ b/src/components/scheduling/SchedulingGoalsPanel.svelte
@@ -69,7 +69,7 @@
       return 0;
     });
   $: numOfPrivateGoals = ($schedulingGoalSpecifications || []).length - visibleSchedulingGoalSpecs.length;
-  $: if ($plan) {
+  $: if ($plan && $plan.model) {
     hasAnalyzePermission =
       featurePermissions.schedulingGoalsPlanSpec.canAnalyze(user, $plan, $plan.model) && !$planReadOnly;
     hasSpecEditPermission = featurePermissions.schedulingGoalsPlanSpec.canUpdate(user, $plan) && !$planReadOnly;
@@ -252,7 +252,7 @@
               hasReadPermission={featurePermissions.schedulingGoals.canRead(user)}
               goal={$schedulingGoalsMap[specGoal.goal_id]}
               goalPlanSpec={specGoal}
-              modelId={$plan?.model.id}
+              modelId={$plan?.model?.id}
               shouldShowUpButton={(specGoal?.priority ?? 0) > 0}
               shouldShowDownButton={specIndex < filteredSchedulingGoalSpecs.length - 1}
               on:updateGoalPlanSpec={onUpdateGoal}

--- a/src/components/scheduling/SchedulingGoalsPanel.svelte
+++ b/src/components/scheduling/SchedulingGoalsPanel.svelte
@@ -69,7 +69,7 @@
       return 0;
     });
   $: numOfPrivateGoals = ($schedulingGoalSpecifications || []).length - visibleSchedulingGoalSpecs.length;
-  $: if ($plan && $plan.model) {
+  $: if ($plan) {
     hasAnalyzePermission =
       featurePermissions.schedulingGoalsPlanSpec.canAnalyze(user, $plan, $plan.model) && !$planReadOnly;
     hasSpecEditPermission = featurePermissions.schedulingGoalsPlanSpec.canUpdate(user, $plan) && !$planReadOnly;

--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -94,7 +94,7 @@
     return validateStartTime(startTimeDate.getTime(), endTimeDate.getTime(), 'Simulation');
   }
 
-  $: if (user !== null && $plan !== null) {
+  $: if (user !== null && $plan !== null && $plan.model) {
     hasRunPermission = featurePermissions.simulation.canRun(user, $plan, $plan.model) && !$planReadOnly;
     hasUpdatePermission = featurePermissions.simulation.canUpdate(user, $plan) && !$planReadOnly;
   }
@@ -119,7 +119,7 @@
   }, 0);
 
   $: modelParametersMap = $plan?.model?.parameters?.parameters ?? {};
-  $: if ($simulation && $plan) {
+  $: if ($simulation && $plan && $plan.model) {
     // An empty object is provided in order to get only the default argument values to better distinguish overridden arguments
     effects.getEffectiveModelArguments($plan.model.id, {}, user).then(response => {
       loadingArguments = false;
@@ -173,7 +173,7 @@
       $simulationStatus === Status.Failed);
 
   async function onChangeFormParameters(event: CustomEvent<FormParameter>) {
-    if ($simulation !== null && $plan !== null) {
+    if ($simulation !== null && $plan !== null && $plan.model) {
       const { detail: formParameter } = event;
       const newArgumentsMap = getArguments($simulation?.arguments, formParameter);
       const newFiles: File[] = formParameter.file ? [formParameter.file] : [];
@@ -187,7 +187,7 @@
   }
 
   function onResetFormParameters(event: CustomEvent<FormParameter>) {
-    if ($simulation !== null && $plan !== null) {
+    if ($simulation !== null && $plan !== null && $plan.model) {
       const { detail: formParameter } = event;
       const { arguments: argumentsMap } = $simulation;
       const newArguments = getArguments(argumentsMap, {
@@ -227,14 +227,14 @@
   }
 
   async function onDeleteSimulationTemplate(event: CustomEvent<SimulationTemplate>) {
-    if ($plan) {
+    if ($plan && $plan.model) {
       const { detail: simulationTemplate } = event;
       await effects.deleteSimulationTemplate(simulationTemplate, $plan.model.name, user);
     }
   }
 
   async function onSaveNewSimulationTemplate(event: CustomEvent<Pick<SimulationTemplateInsertInput, 'description'>>) {
-    if ($plan && $simulation !== null) {
+    if ($plan && $simulation !== null && $plan.model) {
       const {
         detail: { description: templateName },
       } = event;
@@ -495,7 +495,7 @@
                 simulationDataset={simDataset}
                 planEndTimeMs={$planEndTimeMs}
                 planStartTimeMs={$planStartTimeMs}
-                planModelId={$plan?.model.id ?? -1}
+                planModelId={$plan?.model?.id ?? -1}
                 selected={simDataset.id === $simulationDatasetId}
                 on:click={() => {
                   simulationDatasetId.set(simDataset.id);

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -4,7 +4,7 @@
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import { page } from '$app/stores';
-  import { Button, Input as InputStellar, Label, Select } from '@nasa-jpl/stellar-svelte';
+  import { Button, cn, Input as InputStellar, Label, Select } from '@nasa-jpl/stellar-svelte';
   import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
   import XIcon from 'bootstrap-icons/icons/x.svg?component';
   import { flatten } from 'lodash-es';
@@ -723,9 +723,9 @@
                       <InputStellar
                         sizeVariant="xs"
                         disabled
-                        class="w-full"
+                        class={cn('w-full', !selectedPlanModelName ? 'border-destructive' : '')}
                         name="name"
-                        value={selectedPlanModelName}
+                        value={selectedPlanModelName ?? 'Model not found'}
                       />
                     </div>
                     <div

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -6,6 +6,7 @@
   import { base } from '$app/paths';
   import { page } from '$app/stores';
   import { Button, Resizable, Select } from '@nasa-jpl/stellar-svelte';
+  import WarningIcon from '@nasa-jpl/stellar/icons/warning.svg?component';
   import { capitalize } from 'lodash-es';
   import {
     AlertTriangle,
@@ -144,6 +145,7 @@
   import effects from '../../../utilities/effects';
   import { isSaveEvent } from '../../../utilities/keyboardEvents';
   import { closeActiveModal } from '../../../utilities/modal';
+  import { getModelStatusRollup } from '../../../utilities/model';
   import { featurePermissions } from '../../../utilities/permissions';
   import {
     formatSimulationQueuePosition,
@@ -188,6 +190,7 @@
   let hasSimulatePermission: boolean = false;
   let hasCheckConstraintsPermission: boolean = false;
   let invalidActivityCount: number = 0;
+  let modelErrorCount: number = 0;
   let simulationExtent: string | null;
   let selectedSimulationStatus: Status | null;
   let windowWidth = 1600;
@@ -272,7 +275,7 @@
   ));
   $: hasCreateViewPermission = featurePermissions.view.canCreate(data.user);
   $: hasUpdateViewPermission = $view !== null ? featurePermissions.view.canUpdate(data.user, $view) : false;
-  $: if ($initialPlan) {
+  $: if ($initialPlan && $initialPlan.model) {
     hasCheckConstraintsPermission =
       featurePermissions.constraintRuns.canCreate(data.user, $initialPlan, $initialPlan.model) && !$planReadOnly;
     hasExpandPermission =
@@ -332,7 +335,7 @@
 
     planModelActivityTypes.updateValue(() => data.initialActivityTypes);
     activityArgumentDefaults.set(data.initialActivityArguments);
-    activityArgumentDefaultsModelId.set(data.initialPlan.model_id);
+    activityArgumentDefaultsModelId.set(data.initialPlan.model_id ?? -1);
     planTags.updateValue(() => data.initialPlanTags);
   }
 
@@ -488,6 +491,19 @@
     });
   }
 
+  $: if ($plan && $plan.model) {
+    const { activityLogStatus, parameterLogStatus, resourceLogStatus } = getModelStatusRollup($plan.model);
+    modelErrorCount = 0;
+    if (activityLogStatus === 'error') {
+      modelErrorCount += 1;
+    }
+    if (parameterLogStatus === 'error') {
+      modelErrorCount += 1;
+    }
+    if (resourceLogStatus === 'error') {
+      modelErrorCount += 1;
+    }
+  }
   $: lastSimulationDatasetId =
     SEQUENCE_EXPANSION_MODE === SequencingMode.TEMPLATING
       ? $lastTemplatedSimulationDatasetId
@@ -613,10 +629,12 @@
   }
 
   function onResetViewToDefault() {
-    const defaultView = data.initialPlan.model.view || generateDefaultView($resourceTypes, $externalEventTypes);
-    initializeView(defaultView);
-    removeQueryParam(SearchParameters.VIEW_ID);
-    showSuccessToast('View Reset to Default');
+    if (data.initialPlan.model) {
+      const defaultView = data.initialPlan.model.view || generateDefaultView($resourceTypes, $externalEventTypes);
+      initializeView(defaultView);
+      removeQueryParam(SearchParameters.VIEW_ID);
+      showSuccessToast('View Reset to Default');
+    }
   }
 
   async function onUploadView() {
@@ -678,6 +696,16 @@
 
   function openConsoleTab(tab: PlanConsoleTab) {
     openConsole(tab);
+  }
+
+  async function onSelectModel() {
+    if ($plan) {
+      const success = await effects.updatePlanMissionModel($plan, data.user);
+      if (success) {
+        // Clear active simulation
+        $simulationDatasetId = -1;
+      }
+    }
   }
 </script>
 
@@ -938,15 +966,24 @@
             on:restore={onRestoreSnapshot}
           />
         {/if}
-        {#if $modelErrors.length}
+        {#if modelErrorCount && $plan?.model}
           <PlanModelErrorBar
+            action="View errors in console"
             modelName={$plan?.model.name}
-            hasErrors={$modelErrors.length > 0}
             on:close={onCloseSnapshotPreview}
-            on:viewModelErrors={() => {
+            hasErrors={modelErrorCount > 0}
+            on:action={() => {
               openConsoleTab('model');
             }}
           />
+        {/if}
+        {#if $plan && !$plan.model}
+          <PlanModelErrorBar action="Select model" hasErrors on:action={onSelectModel}>
+            <div class="flex gap-1">
+              <WarningIcon class="red-icon" />Cannot find the model associated with this plan. This plan may not work
+              correctly.
+            </div>
+          </PlanModelErrorBar>
         {/if}
         <PlanGrid
           {...$view?.definition.plan.grid}

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -42,16 +42,16 @@ export const load: PageLoad = async ({ parent, params, url }) => {
           scheduling_specification: schedulingSpec ? schedulingSpec : null,
         };
       }
-
-      const initialActivityTypes = await effects.getActivityTypes(initialPlan.model_id, user);
+      const modelId = initialPlan.model_id ?? -1;
+      const initialActivityTypes = await effects.getActivityTypes(modelId, user);
       const [initialActivityArguments, initialResourceTypes, initialExternalEventTypes, initialPlanTags] =
         await Promise.all([
           await effects.getDefaultActivityArguments(
-            initialPlan.model_id,
+            modelId,
             initialActivityTypes.map(type => type.name),
             user,
           ),
-          await effects.getResourceTypes(initialPlan.model_id, user, ViewTimelineResourceRowsLimit),
+          await effects.getResourceTypes(modelId, user, ViewTimelineResourceRowsLimit),
           await effects.getExternalEventTypes(planId, user),
           await effects.getPlanTags(initialPlan.id, user),
         ]);
@@ -61,7 +61,7 @@ export const load: PageLoad = async ({ parent, params, url }) => {
         true,
         initialResourceTypes,
         initialExternalEventTypes,
-        initialPlan.model.view,
+        initialPlan.model?.view,
       );
 
       const initialPlanSnapshotId = getSearchParameterNumber(SearchParameters.SNAPSHOT_ID, url.searchParams);

--- a/src/stores/__mocks__/plan.mock.ts
+++ b/src/stores/__mocks__/plan.mock.ts
@@ -44,11 +44,9 @@ export const plan: Readable<Plan | null> = derived([initialPlan, planMetadata], 
   };
 });
 
-export const planModelId: Readable<number> = derived(initialPlan, $plan => ($plan ? ($plan.model?.id ?? -1) : -1));
+export const planModelId: Readable<number> = derived(initialPlan, $plan => $plan?.model?.id ?? -1);
 
-export const planModelRevision: Readable<number> = derived(initialPlan, $plan =>
-  $plan ? ($plan.model?.revision ?? -1) : -1,
-);
+export const planModelRevision: Readable<number> = derived(initialPlan, $plan => $plan?.model?.revision ?? -1);
 
 /* Subscriptions. */
 

--- a/src/stores/__mocks__/plan.mock.ts
+++ b/src/stores/__mocks__/plan.mock.ts
@@ -44,9 +44,11 @@ export const plan: Readable<Plan | null> = derived([initialPlan, planMetadata], 
   };
 });
 
-export const planModelId: Readable<number> = derived(initialPlan, $plan => ($plan ? $plan.model.id : -1));
+export const planModelId: Readable<number> = derived(initialPlan, $plan => ($plan ? ($plan.model?.id ?? -1) : -1));
 
-export const planModelRevision: Readable<number> = derived(initialPlan, $plan => ($plan ? $plan.model.revision : -1));
+export const planModelRevision: Readable<number> = derived(initialPlan, $plan =>
+  $plan ? ($plan.model?.revision ?? -1) : -1,
+);
 
 /* Subscriptions. */
 

--- a/src/stores/plan.ts
+++ b/src/stores/plan.ts
@@ -52,9 +52,9 @@ export const plan: Readable<Plan | null> = derived([initialPlan, planMetadata], 
   };
 });
 
-export const planModelId: Readable<number> = derived(plan, $plan => ($plan ? $plan.model.id : -1));
+export const planModelId: Readable<number> = derived(plan, $plan => ($plan ? ($plan.model?.id ?? -1) : -1));
 
-export const planModelRevision: Readable<number> = derived(plan, $plan => ($plan ? $plan.model.revision : -1));
+export const planModelRevision: Readable<number> = derived(plan, $plan => ($plan ? ($plan.model?.revision ?? -1) : -1));
 
 /* Other Subscriptions. */
 

--- a/src/stores/plan.ts
+++ b/src/stores/plan.ts
@@ -52,9 +52,9 @@ export const plan: Readable<Plan | null> = derived([initialPlan, planMetadata], 
   };
 });
 
-export const planModelId: Readable<number> = derived(plan, $plan => ($plan ? ($plan.model?.id ?? -1) : -1));
+export const planModelId: Readable<number> = derived(plan, $plan => $plan?.model?.id ?? -1);
 
-export const planModelRevision: Readable<number> = derived(plan, $plan => ($plan ? ($plan.model?.revision ?? -1) : -1));
+export const planModelRevision: Readable<number> = derived(plan, $plan => $plan?.model?.revision ?? -1);
 
 /* Other Subscriptions. */
 

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -79,8 +79,8 @@ export type PlanSchema = {
   duration: string;
   id: number;
   is_locked: boolean;
-  model: Model;
-  model_id: number;
+  model: Model | null;
+  model_id: number | null;
   name: string;
   owner: UserId;
   parent_plan:

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -1593,6 +1593,7 @@ const effects = {
       }
     } catch (e) {
       catchError('Create plan branch request failed', e as Error);
+      showFailureToast('Plan Branch Create Failed');
     }
   },
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -1567,6 +1567,9 @@ const effects = {
 
   async createPlanBranchRequest(plan: Plan, action: PlanBranchRequestAction, user: User | null): Promise<void> {
     try {
+      if (!plan.model) {
+        throw Error(`No model found for plan ${plan.id}, cannot create plan branch request`);
+      }
       const { confirm, value } = await showPlanBranchRequestModal(plan, action);
 
       if (confirm && value) {
@@ -3933,6 +3936,10 @@ const effects = {
 
   async expandTemplates(seqIds: string[], simulationDatasetId: number, plan: Plan, user: User | null): Promise<void> {
     try {
+      if (!plan.model) {
+        throw Error(`No model found for plan ${plan.id}, cannot expand templates`);
+      }
+
       sequenceTemplateExpansionStatus.set(Status.Incomplete);
       if (!queryPermissions.EXPAND_TEMPLATES(user, plan, plan.model)) {
         throwPermissionError('expand a sequence template');

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -1148,20 +1148,12 @@ export async function showPlanBranchRequestModal(
           planModal.$destroy();
         });
 
-        planModal.$on(
-          'create',
-          (
-            e: CustomEvent<{
-              source_plan: PlanForMerging;
-              target_plan: PlanForMerging;
-            }>,
-          ) => {
-            target.replaceChildren();
-            target.resolve = null;
-            resolve({ confirm: true, value: e.detail });
-            planModal.$destroy();
-          },
-        );
+        planModal.$on('create', e => {
+          target.replaceChildren();
+          target.resolve = null;
+          resolve({ confirm: true, value: e.detail });
+          planModal.$destroy();
+        });
       }
     } else {
       resolve({ confirm: false });

--- a/src/utilities/model.ts
+++ b/src/utilities/model.ts
@@ -3,7 +3,7 @@ import type { ModelLog, ModelSlim, ModelStatus, ModelStatusRollup } from '../typ
 export function getModelStatusRollup(
   model?: Partial<
     Pick<ModelSlim, 'refresh_activity_type_logs' | 'refresh_model_parameter_logs' | 'refresh_resource_type_logs'>
-  >,
+  > | null,
 ): ModelStatusRollup {
   let activityLog: ModelLog | null = null;
   let activityLogStatus: ModelStatus = 'none';

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -206,7 +206,7 @@ function getRolePlanPermission(
   queries: string[],
   user: User | null,
   plan: PlanWithOwners,
-  model: ModelWithOwner,
+  model: ModelWithOwner | null,
   assetWithOwner?: AssetWithOwner,
 ): boolean {
   if (user && user.rolePermissions) {
@@ -247,7 +247,7 @@ function getRolePlanBranchPermission(
   user: User | null,
   sourcePlan: PlanWithOwners | undefined,
   targetPlan: PlanWithOwners | undefined,
-  model: Pick<Model, 'owner'>,
+  model: Pick<Model, 'owner'> | null,
 ): boolean {
   if (user && user.rolePermissions) {
     return queries.reduce((prevValue: boolean, queryName) => {
@@ -359,7 +359,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
   APPLY_PRESET_TO_ACTIVITY: (
     user: User | null,
     plan: PlanWithOwners,
-    model: ModelWithOwner,
+    model: ModelWithOwner | null,
     preset: ActivityPreset,
   ): boolean => {
     const queries = [Queries.APPLY_PRESET_TO_ACTIVITY];
@@ -376,7 +376,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
   CANCEL_SIMULATION: (user: User | null): boolean => {
     return isUserAdmin(user) || getPermission([Queries.UPDATE_SIMULATION_DATASET], user);
   },
-  CHECK_CONSTRAINTS: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
+  CHECK_CONSTRAINTS: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner | null): boolean => {
     const queries = [Queries.CONSTRAINT_VIOLATIONS];
     return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
@@ -481,7 +481,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
     user: User | null,
     sourcePlan: PlanWithOwners | undefined,
     targetPlan: PlanWithOwners,
-    model: ModelWithOwner,
+    model: ModelWithOwner | null,
   ): boolean => {
     const queries = [Queries.CREATE_MERGE_REQUEST];
     return (
@@ -489,7 +489,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
       (getPermission(queries, user) && getRolePlanBranchPermission(queries, user, sourcePlan, targetPlan, model))
     );
   },
-  CREATE_PLAN_SNAPSHOT: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
+  CREATE_PLAN_SNAPSHOT: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner | null): boolean => {
     const queries = [Queries.CREATE_SNAPSHOT];
     return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
@@ -562,7 +562,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
   DELETE_ACTIVITY_DIRECTIVES_REANCHOR_PLAN_START: (
     user: User | null,
     plan: PlanWithOwners,
-    model: ModelWithOwner,
+    model: ModelWithOwner | null,
   ): boolean => {
     const queries = [Queries.DELETE_ACTIVITY_REANCHOR_PLAN_START_BULK];
     return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
@@ -570,12 +570,16 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
   DELETE_ACTIVITY_DIRECTIVES_REANCHOR_TO_ANCHOR: (
     user: User | null,
     plan: PlanWithOwners,
-    model: ModelWithOwner,
+    model: ModelWithOwner | null,
   ): boolean => {
     const queries = [Queries.DELETE_ACTIVITY_REANCHOR_TO_ANCHOR_BULK];
     return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
-  DELETE_ACTIVITY_DIRECTIVES_SUBTREE: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
+  DELETE_ACTIVITY_DIRECTIVES_SUBTREE: (
+    user: User | null,
+    plan: PlanWithOwners,
+    model: ModelWithOwner | null,
+  ): boolean => {
     const queries = [Queries.DELETE_ACTIVITY_DELETE_SUBTREE_BULK];
     return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
@@ -761,15 +765,15 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
         (isUserOwner(user, workspace) || isUserCollaborator(user, workspace)))
     );
   },
-  DUPLICATE_PLAN: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
+  DUPLICATE_PLAN: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner | null): boolean => {
     const queries = [Queries.DUPLICATE_PLAN];
     return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
-  EXPAND: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
+  EXPAND: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner | null): boolean => {
     const queries = [Queries.EXPAND_ALL_ACTIVITIES];
     return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
-  EXPAND_TEMPLATES: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
+  EXPAND_TEMPLATES: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner | null): boolean => {
     const queries = [Queries.EXPAND_ALL_TEMPLATES];
     return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
@@ -829,7 +833,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
   INSERT_EXPANSION_SEQUENCE_TO_ACTIVITY: (user: User | null): boolean => {
     return isUserAdmin(user) || getPermission([Queries.INSERT_SEQUENCE_TO_SIMULATED_ACTIVITY], user);
   },
-  MIGRATE_PLAN_TO_MODEL: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
+  MIGRATE_PLAN_TO_MODEL: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner | null): boolean => {
     const queries = [Queries.MIGRATE_PLAN_TO_MODEL];
     return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
@@ -837,7 +841,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
     user: User | null,
     sourcePlan: PlanWithOwners | undefined,
     targetPlan: PlanWithOwners | undefined,
-    model: ModelWithOwner,
+    model: ModelWithOwner | null,
   ): boolean => {
     const queries = [Queries.BEGIN_MERGE];
     return (
@@ -849,7 +853,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
     user: User | null,
     sourcePlan: PlanWithOwners | undefined,
     targetPlan: PlanWithOwners | undefined,
-    model: ModelWithOwner,
+    model: ModelWithOwner | null,
   ): boolean => {
     const queries = [Queries.CANCEL_MERGE];
     return (
@@ -861,7 +865,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
     user: User | null,
     sourcePlan: PlanWithOwners | undefined,
     targetPlan: PlanWithOwners | undefined,
-    model: ModelWithOwner,
+    model: ModelWithOwner | null,
   ): boolean => {
     const queries = [Queries.COMMIT_MERGE];
     return (
@@ -873,7 +877,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
     user: User | null,
     sourcePlan: PlanWithOwners | undefined,
     targetPlan: PlanWithOwners | undefined,
-    model: ModelWithOwner,
+    model: ModelWithOwner | null,
   ): boolean => {
     const queries = [Queries.DENY_MERGE];
     return (
@@ -885,7 +889,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
     user: User | null,
     sourcePlan: PlanWithOwners | undefined,
     targetPlan: PlanWithOwners | undefined,
-    model: ModelWithOwner,
+    model: ModelWithOwner | null,
   ): boolean => {
     const queries = [Queries.WITHDRAW_MERGE_REQUEST];
     return (
@@ -897,7 +901,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
     user: User | null,
     sourcePlan: PlanWithOwners,
     targetPlan: PlanWithOwners,
-    model: ModelWithOwner,
+    model: ModelWithOwner | null,
   ): boolean => {
     const queries = [Queries.SET_RESOLUTIONS];
     return (
@@ -909,7 +913,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
     user: User | null,
     sourcePlan: PlanWithOwners,
     targetPlan: PlanWithOwners,
-    model: ModelWithOwner,
+    model: ModelWithOwner | null,
   ): boolean => {
     const queries = [Queries.SET_RESOLUTION];
     return (
@@ -924,15 +928,15 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
         (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
-  RESTORE_PLAN_SNAPSHOT: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
+  RESTORE_PLAN_SNAPSHOT: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner | null): boolean => {
     const queries = [Queries.RESTORE_FROM_SNAPSHOT];
     return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
-  SCHEDULE: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
+  SCHEDULE: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner | null): boolean => {
     const queries = [Queries.SCHEDULE];
     return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
-  SIMULATE: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner): boolean => {
+  SIMULATE: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner | null): boolean => {
     const queries = [Queries.SIMULATE];
     return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
@@ -1383,13 +1387,13 @@ type PlanAssetUpdatePermissionCheck<T = AssetWithOwner> = (
   asset?: T,
 ) => boolean;
 
-type RolePlanPermissionCheck = (user: User | null, plan: PlanWithOwners, model: ModelWithOwner) => boolean;
-type RoleModelPermissionCheck = (user: User | null, plans: PlanWithOwners[], model: ModelWithOwner) => boolean;
+type RolePlanPermissionCheck = (user: User | null, plan: PlanWithOwners, model: ModelWithOwner | null) => boolean;
+type RoleModelPermissionCheck = (user: User | null, plans: PlanWithOwners[], model: ModelWithOwner | null) => boolean;
 
 type RolePlanPermissionCheckWithAsset<T = AssetWithOwner> = (
   user: User | null,
   plan: PlanWithOwners,
-  model: ModelWithOwner,
+  model: ModelWithOwner | null,
   asset: T,
 ) => boolean;
 
@@ -1397,7 +1401,7 @@ type RolePlanBranchPermissionCheck = (
   user: User | null,
   sourcePlan: PlanWithOwners | undefined,
   targetPlan: PlanWithOwners | undefined,
-  model: ModelWithOwner,
+  model: ModelWithOwner | null,
 ) => boolean;
 
 interface BaseCRUDPermission<T = null> {
@@ -1464,7 +1468,7 @@ interface RunnableCRUDPermission<T = null> extends PlanAssetCRUDPermission<T> {
   canRun: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner) => boolean;
 }
 interface RunnableSpecificationCRUDPermission<T = null> extends PlanSpecificationCRUDPermission<T> {
-  canRun: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner) => boolean;
+  canRun: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner | null) => boolean;
 }
 
 interface PlanSnapshotCRUDPermission extends Omit<PlanAssetCRUDPermission<PlanSnapshot>, 'canCreate' | 'canDelete'> {
@@ -1487,7 +1491,7 @@ interface ExpansionSequenceCRUDPermission<T = null> extends CRUDPermission<T> {
 }
 
 interface SchedulingCRUDPermission<T = null> extends RunnableSpecificationCRUDPermission<T> {
-  canAnalyze: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner) => boolean;
+  canAnalyze: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner | null) => boolean;
 }
 
 interface SequenceTemplateCRUDPermission<T = null> extends CRUDPermission<T> {

--- a/src/utilities/plan.ts
+++ b/src/utilities/plan.ts
@@ -32,7 +32,7 @@ export async function getPlanForTransfer(
   }
 
   const activityTypes = unique(activitiesToQualify.map(a => a.type));
-  const defaultActivityArguments = await effects.getDefaultActivityArguments(plan?.model_id, activityTypes, user);
+  const defaultActivityArguments = await effects.getDefaultActivityArguments(plan?.model_id ?? -1, activityTypes, user);
   const argsMap: DefaultEffectiveArgumentsMap = {};
   const defaultActivityArgumentsMap = (defaultActivityArguments || []).reduce((map, { arguments: args, typeName }) => {
     map[typeName] = args;


### PR DESCRIPTION
This PR makes `Plan.model` and `Plan.model_id` nullable to reflect the fact that the database allows for plans with no model. This situation can happen when a model associated with various plans has been deleted. Closes #1481.

Changes:
- Updated the `Plan.model` and `Plan.model_id` types to be nullable and updated various bits of code to guard against this
- Reworked `PlanModelErrorBar` to be a bit more generic and used this component to alert users when a plan's mission model is null. Additionally provides a shortcut to migrating the mission model.

Testing:
- Create a plan from a model
- Go to models page and delete model
- Go back to your plan & you should see a banner warning of "no model" & UI to switch (migrate) to new model
- Test migrating to new model & make sure plan works