### PR TITLE
Duration resource plotting

### DIFF
--- a/src/components/timeline/LayerLine.svelte
+++ b/src/components/timeline/LayerLine.svelte
@@ -548,6 +548,7 @@
       } else if (
         schema.type === 'int' ||
         schema.type === 'real' ||
+        schema.type === 'duration' ||
         (schema.type === 'struct' && schema?.items?.rate?.type === 'real' && schema?.items?.initial?.type === 'real')
       ) {
         for (valueIndex; valueIndex < values.length; ++valueIndex) {

--- a/src/components/timeline/RowHeader.svelte
+++ b/src/components/timeline/RowHeader.svelte
@@ -20,7 +20,7 @@
     LineLayer,
     MouseOver,
   } from '../../types/timeline';
-  import { filterResourcesByLayer } from '../../utilities/timeline';
+  import { getResourceForLayer } from '../../utilities/timeline';
   import { tooltip } from '../../utilities/tooltip';
   import DropTarget from './DropTarget.svelte';
   import RowHeaderDiscreteTree from './RowHeaderDiscreteTree.svelte';
@@ -80,22 +80,20 @@
       );
       // For each layer get the resources and color
       yAxisResourceLayers.forEach(layer => {
-        const layerResources = filterResourcesByLayer(layer, resources) as Resource[];
-        const newResourceLabels = layerResources
-          .map(resource => {
-            const color = (layer as LineLayer).lineColor || 'var(--st-gray-80)';
-            const unit = resource.schema.metadata?.unit?.value || '';
-            return {
-              chartType: layer.chartType,
-              color,
-              label: layer.name || resource.name,
-              resource,
-              unit,
-              yAxisId: yAxis.id,
-            };
-          })
-          .flat();
-        resourceLabels = resourceLabels.concat(newResourceLabels);
+        const layerResource = getResourceForLayer(layer, resources) as Resource;
+        if (layerResource) {
+          const color = (layer as LineLayer).lineColor || 'var(--st-gray-80)';
+          const unit = layerResource.schema.metadata?.unit?.value || '';
+          const resourceLabel = {
+            chartType: layer.chartType,
+            color,
+            label: layer.name || layerResource.name,
+            resource: layerResource,
+            unit,
+            yAxisId: yAxis.id,
+          };
+          resourceLabels = resourceLabels.concat(resourceLabel);
+        }
       });
     });
   }

--- a/src/components/timeline/RowYAxes.svelte
+++ b/src/components/timeline/RowYAxes.svelte
@@ -7,7 +7,8 @@
   import { createEventDispatcher, tick } from 'svelte';
   import type { Resource } from '../../types/simulation';
   import type { Axis, Layer, LineLayer, XRangeLayer } from '../../types/timeline';
-  import { filterResourcesByLayer, getOrdinalYScale, getYScale } from '../../utilities/timeline';
+  import { convertUsToDurationString } from '../../utilities/time';
+  import { getOrdinalYScale, getResourceForLayer, getYScale } from '../../utilities/timeline';
 
   export let drawHeight: number = 0;
   export let drawWidth: number = 0;
@@ -44,15 +45,15 @@
       let i = 0;
 
       for (const layer of xRangeLayers) {
-        const layerResources = filterResourcesByLayer(layer, resources) as Resource[];
+        const layerResource = getResourceForLayer(layer, resources) as Resource;
         const xRangeAxisG = gSelection.append('g').attr('class', axisClass);
         xRangeAxisG.selectAll('*').remove();
 
-        if ((layer as XRangeLayer).showAsLinePlot && layerResources && layerResources.length > 0) {
+        if ((layer as XRangeLayer).showAsLinePlot && layerResource) {
           let domain: string[] = [];
 
           // Get all the unique ordinal values of the chart.
-          for (const value of layerResources[0].values) {
+          for (const value of layerResource.values) {
             if (domain.indexOf(value.y as string) === -1) {
               domain.push(value.y as string);
             }
@@ -100,6 +101,14 @@
           color = (yAxisLayers[0] as LineLayer).lineColor;
         }
 
+        // Detect if this axis contains only duration resources
+        const allResourcesAreDuration = !yAxisLayers.find(layer => {
+          const resource = getResourceForLayer(layer, resources);
+          if (!resource || resource.schema.type !== 'duration') {
+            return true;
+          }
+        });
+
         // TODO deprecate these view properties?
         // const labelColor = axis.label?.color || 'black';
         // const labelFontFace = axis.label?.fontFace || 'sans-serif';
@@ -118,6 +127,11 @@
             .tickSizeOuter(0)
             .ticks(tickCount)
             .tickFormat(n => {
+              if (allResourcesAreDuration) {
+                // Take the largest component of the duration string
+                const durationString = convertUsToDurationString(n.valueOf());
+                return durationString.split(' ')[0];
+              }
               // Format -1 to 1 as normal numbers instead of <number>m (milli) which d3
               // does out of the box to align with various standards but which can be
               // commonly confused for M (million).

--- a/src/components/timeline/Tooltip.svelte
+++ b/src/components/timeline/Tooltip.svelte
@@ -13,8 +13,8 @@
   import type { ResourceType, Span } from '../../types/simulation';
   import type { LineLayer, LinePoint, MouseOver, Point, Row, XRangePoint } from '../../types/timeline';
   import { addPageFocusListener } from '../../utilities/generic';
-  import { formatDate, getDoyTime } from '../../utilities/time';
-  import { filterResourcesByLayer } from '../../utilities/timeline';
+  import { convertUsToDurationString, formatDate, getDoyTime } from '../../utilities/time';
+  import { getResourceForLayer } from '../../utilities/timeline';
 
   export let interpolateHoverValue: boolean = false;
   export let hidden: boolean = false;
@@ -432,13 +432,19 @@
     let color = '#FFFFFF';
     let unit = '';
     let name = point.name;
+    let formattedYValue = y;
     if (layer && layer.chartType === 'line') {
       name = layer.name ? layer.name : point.name;
-      const layerResources = filterResourcesByLayer(layer, resourceTypes);
-      if (layerResources.length > 0) {
+      const layerResource = getResourceForLayer(layer, resourceTypes);
+      if (layerResource) {
         // Only consider a single resource since multiple resources on a single layer is
         // supported in config but not valid
-        unit = layerResources[0].schema.metadata?.unit?.value || '';
+        unit = layerResource.schema.metadata?.unit?.value || '';
+
+        // Format if type equals duration
+        if (layerResource?.schema.type === 'duration' && typeof y === 'number' && y > 0) {
+          formattedYValue = convertUsToDurationString(y); // convert from microseconds to milliseconds
+        }
       }
       color = (layer as LineLayer).lineColor;
     }
@@ -478,7 +484,7 @@
         <div class='tooltip-row'>
           <span>${interpolateHoverValue ? 'Interpolated' : 'Nearest'} Value:</span>
           <span class='tooltip-value-highlight st-typography-medium'>
-            ${y}${unit ? ` (${unit})` : ''}
+            ${formattedYValue}${unit ? ` (${unit})` : ''}
           </span>
         </div>
       </div>

--- a/src/utilities/timeline.test.ts
+++ b/src/utilities/timeline.test.ts
@@ -27,9 +27,9 @@ import {
   directiveInView,
   duplicateRow,
   externalEventInView,
-  filterResourcesByLayer,
   generateDiscreteTreeUtil,
   getMatchingTypesForActivityLayerFilter,
+  getResourceForLayer,
   getTimeRangeAroundTime,
   getUniqueColorForActivityLayer,
   getUniqueColorForLineLayer,
@@ -512,7 +512,7 @@ test('duplicateRow', () => {
   }
 });
 
-test('filterResourcesByLayer', () => {
+test('getResourceForLayer', () => {
   const resourceA: ResourceType = {
     name: 'resourceA',
     schema: {
@@ -534,14 +534,14 @@ test('filterResourcesByLayer', () => {
     },
   };
   const layer = createTimelineLineLayer([], []);
-  expect(filterResourcesByLayer(layer, [resourceA, resourceB])).to.deep.equal([]);
+  expect(getResourceForLayer(layer, [resourceA, resourceB])).to.deep.equal(undefined);
 
   const layer2 = createTimelineLineLayer([], []);
-  expect(filterResourcesByLayer(layer2, [])).to.deep.equal([]);
+  expect(getResourceForLayer(layer2, [])).to.deep.equal(undefined);
 
   const layer3 = createTimelineLineLayer([], []);
   layer3.filter.resource = 'resourceA';
-  expect(filterResourcesByLayer(layer3, [resourceA, resourceB])).to.deep.equal([resourceA]);
+  expect(getResourceForLayer(layer3, [resourceA, resourceB])).to.deep.equal(resourceA);
 });
 
 // TODO - should we make a test case for filtering the sources in an ExternalEventsLayer?

--- a/src/utilities/timeline.ts
+++ b/src/utilities/timeline.ts
@@ -633,6 +633,7 @@ export function createTimelineResourceLayer(timelines: Timeline[], resourceType:
   const isNumericSchema =
     schemaType === 'int' ||
     schemaType === 'real' ||
+    schemaType === 'duration' ||
     (schemaType === 'struct' && schema?.items?.rate?.type === 'real' && schema?.items?.initial?.type === 'real');
 
   const yAxis = createYAxis(timelines, {
@@ -713,72 +714,70 @@ export function getYAxisBounds(
   let minY: number | undefined = undefined;
   let maxY: number | undefined = undefined;
   yAxisLayers.forEach(layer => {
-    const layerResources = filterResourcesByLayer(layer, resources) as Resource[];
-    if (layerResources) {
-      layerResources.forEach(resource => {
-        let leftValue: ResourceValue | undefined;
-        let rightValue: ResourceValue | undefined;
-        resource.values.forEach(value => {
-          const isNumber = typeof value.y === 'number';
-          // Identify the first value to the left of the viewTimeRange
-          if (viewTimeRange && value.x < viewTimeRange.start) {
-            // TODO shouldn't we continue on to next value if this is a gap?
-            if (value.is_gap) {
-              leftValue = undefined;
-            } else {
-              if (isNumber) {
-                if (!leftValue) {
-                  leftValue = value;
-                } else if (value.x >= leftValue.x) {
-                  leftValue = value;
-                }
+    const layerResource = getResourceForLayer(layer, resources) as Resource;
+    if (layerResource) {
+      let leftValue: ResourceValue | undefined;
+      let rightValue: ResourceValue | undefined;
+      layerResource.values.forEach(value => {
+        const isNumber = typeof value.y === 'number';
+        // Identify the first value to the left of the viewTimeRange
+        if (viewTimeRange && value.x < viewTimeRange.start) {
+          // TODO shouldn't we continue on to next value if this is a gap?
+          if (value.is_gap) {
+            leftValue = undefined;
+          } else {
+            if (isNumber) {
+              if (!leftValue) {
+                leftValue = value;
+              } else if (value.x >= leftValue.x) {
+                leftValue = value;
               }
             }
           }
-          // Identify the first value to the right of the viewTimeRange
-          if (viewTimeRange && value.x > viewTimeRange.end) {
-            if (value.is_gap) {
-              rightValue = undefined;
-            } else {
-              if (isNumber) {
-                if (!rightValue) {
-                  rightValue = value;
-                } else if (value.x < rightValue.x) {
-                  rightValue = value;
-                }
+        }
+        // Identify the first value to the right of the viewTimeRange
+        if (viewTimeRange && value.x > viewTimeRange.end) {
+          if (value.is_gap) {
+            rightValue = undefined;
+          } else {
+            if (isNumber) {
+              if (!rightValue) {
+                rightValue = value;
+              } else if (value.x < rightValue.x) {
+                rightValue = value;
               }
             }
           }
-          // Consider a value for min and max if it is a number and it falls within the time range or
-          // no time range is supplied or the domain fit mode is not fitTimeWindow
-          if (
-            typeof value.y === 'number' &&
-            (!viewTimeRange ||
-              yAxis.domainFitMode !== 'fitTimeWindow' ||
-              (value.x >= viewTimeRange.start && value.x <= viewTimeRange.end))
-          ) {
-            if (minY === undefined || value.y < minY) {
-              minY = value.y;
-            }
-            if (maxY === undefined || value.y > maxY) {
-              maxY = value.y;
-            }
+        }
+        // Consider a value for min and max if it is a number and it falls within the time range or
+        // no time range is supplied or the domain fit mode is not fitTimeWindow
+        if (
+          typeof value.y === 'number' &&
+          (!viewTimeRange ||
+            yAxis.domainFitMode !== 'fitTimeWindow' ||
+            (value.x >= viewTimeRange.start && value.x <= viewTimeRange.end))
+        ) {
+          if (minY === undefined || value.y < minY) {
+            minY = value.y;
           }
-        });
-        // Account for the neighboring left and right values as these values are connected to in line drawing
-        if (viewTimeRange) {
-          minY = Math.min(
-            minY ?? Number.MAX_SAFE_INTEGER,
-            leftValue !== undefined && leftValue.y ? (leftValue.y as number) : Number.MAX_SAFE_INTEGER,
-            rightValue !== undefined && rightValue.y ? (rightValue.y as number) : Number.MAX_SAFE_INTEGER,
-          );
-          maxY = Math.max(
-            maxY ?? Number.MIN_SAFE_INTEGER,
-            leftValue !== undefined && leftValue.y ? (leftValue.y as number) : Number.MIN_SAFE_INTEGER,
-            rightValue !== undefined && rightValue.y ? (rightValue.y as number) : Number.MIN_SAFE_INTEGER,
-          );
+          if (maxY === undefined || value.y > maxY) {
+            maxY = value.y;
+          }
         }
       });
+      // Account for the neighboring left and right values as these values are connected to in line drawing
+      if (viewTimeRange) {
+        minY = Math.min(
+          minY ?? Number.MAX_SAFE_INTEGER,
+          leftValue !== undefined && leftValue.y ? (leftValue.y as number) : Number.MAX_SAFE_INTEGER,
+          rightValue !== undefined && rightValue.y ? (rightValue.y as number) : Number.MAX_SAFE_INTEGER,
+        );
+        maxY = Math.max(
+          maxY ?? Number.MIN_SAFE_INTEGER,
+          leftValue !== undefined && leftValue.y ? (leftValue.y as number) : Number.MIN_SAFE_INTEGER,
+          rightValue !== undefined && rightValue.y ? (rightValue.y as number) : Number.MIN_SAFE_INTEGER,
+        );
+      }
     }
   });
 
@@ -949,8 +948,8 @@ export function minMaxDecimation<T>(
 /**
  * Filters list of resources by the layer's resource filter
  */
-export function filterResourcesByLayer(layer: Layer, resources: Resource[] | ResourceType[]) {
-  return resources.filter(resource => layer.filter.resource === resource.name);
+export function getResourceForLayer(layer: Layer, resources: Resource[] | ResourceType[]) {
+  return resources.find(resource => layer.filter.resource === resource.name);
 }
 
 /**


### PR DESCRIPTION
Plot and format duration resource types in the timeline. Closes #1119. The issue also mentions formatting date-time resources but these are not currently a supported type in the backend so the UI can't do much about this. Perhaps an aerie issue is needed to support this sort of time type.