### PR TITLE
Rework plan grid menu

### DIFF
--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -546,8 +546,8 @@ export class Plan {
     this.constraintNewButton = page.locator(`button[name="new-constraint"]`);
     this.consoleContainer = page.getByTestId('console').filter({ hasText: 'All Errors' });
     this.externalSourceManageButton = page.getByLabel('Select derivation groups to');
-    this.gridMenuButton = page.getByLabel('Plan Menu Button', { exact: true });
-    this.gridMenu = page.getByRole('menu', { name: 'Plan Menu' });
+    this.gridMenuButton = page.getByLabel('Plan Menu', { exact: true });
+    this.gridMenu = page.getByRole('menu', { exact: true, name: 'Plan Menu' });
     this.gridMenuItem = (name: string) => this.gridMenu.getByRole('menuitem', { exact: true, name });
     this.navButtonActivityChecking = page.locator(`.nav-button:has-text("Activities")`);
     this.navButtonActivityCheckingMenu = this.navButtonActivityChecking.getByRole('menu');

--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -550,8 +550,6 @@ export class Plan {
     this.externalSourceManageButton = page.getByLabel('Select derivation groups to');
     this.gridMenuButton = page.getByLabel('Plan Menu', { exact: true });
     this.gridMenu = page.getByRole('menu', { exact: true, name: 'Plan Menu' });
-    // this.gridMenuButton = page.locator('.grid-menu');
-    // this.gridMenu = this.gridMenuButton.getByRole('menu');
     this.gridMenuItem = (name: string) => this.gridMenu.getByRole('menuitem', { exact: true, name });
     this.navButtonActivityChecking = page.locator(`.nav-button:has-text("Activities")`);
     this.navButtonActivityCheckingMenu = this.navButtonActivityChecking.getByRole('menu');

--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -546,8 +546,8 @@ export class Plan {
     this.constraintNewButton = page.locator(`button[name="new-constraint"]`);
     this.consoleContainer = page.getByTestId('console').filter({ hasText: 'All Errors' });
     this.externalSourceManageButton = page.getByLabel('Select derivation groups to');
-    this.gridMenuButton = page.locator('.grid-menu');
-    this.gridMenu = this.gridMenuButton.getByRole('menu');
+    this.gridMenuButton = page.getByLabel('Plan Menu Button', { exact: true });
+    this.gridMenu = page.getByRole('menu', { name: 'Plan Menu' });
     this.gridMenuItem = (name: string) => this.gridMenu.getByRole('menuitem', { exact: true, name });
     this.navButtonActivityChecking = page.locator(`.nav-button:has-text("Activities")`);
     this.navButtonActivityCheckingMenu = this.navButtonActivityChecking.getByRole('menu');

--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -109,6 +109,8 @@ export class Plan {
 
   async addActivity(name: string = 'GrowBanana') {
     await this.showPanel(PanelNames.TIMELINE_ITEMS);
+    // TODO try to avoid using this timeout
+    await this.page.waitForTimeout(150);
     const currentNumOfActivitiesWithName = await this.panelActivityDirectivesTable.getByRole('row', { name }).count();
     const activityListItem = this.page.locator(`.list-item :text-is("${name}")`);
     const activityRow = this.page
@@ -548,6 +550,8 @@ export class Plan {
     this.externalSourceManageButton = page.getByLabel('Select derivation groups to');
     this.gridMenuButton = page.getByLabel('Plan Menu', { exact: true });
     this.gridMenu = page.getByRole('menu', { exact: true, name: 'Plan Menu' });
+    // this.gridMenuButton = page.locator('.grid-menu');
+    // this.gridMenu = this.gridMenuButton.getByRole('menu');
     this.gridMenuItem = (name: string) => this.gridMenu.getByRole('menuitem', { exact: true, name });
     this.navButtonActivityChecking = page.locator(`.nav-button:has-text("Activities")`);
     this.navButtonActivityCheckingMenu = this.navButtonActivityChecking.getByRole('menu');

--- a/e2e-tests/tests/plan.test.ts
+++ b/e2e-tests/tests/plan.test.ts
@@ -154,7 +154,7 @@ test.describe.serial('Plan', () => {
     await page.waitForTimeout(1000);
     // TODO would ideally do this without a timeout
 
-    // Re-select the activity
+    // Add a new activity
     await plan.addActivity('GrowBanana');
 
     const branchPlanUrlRegex = new RegExp(`${baseURL}/plans/(?<planId>\\d+)`);

--- a/e2e-tests/tests/plan.test.ts
+++ b/e2e-tests/tests/plan.test.ts
@@ -143,8 +143,6 @@ test.describe.serial('Plan', () => {
   });
 
   test(`Changing to a new plan should clear the selected activity`, async ({ baseURL }) => {
-    await plan.showPanel(PanelNames.TIMELINE_ITEMS);
-
     // Create an activity which will be auto selected
     await plan.addActivity('GrowBanana');
 

--- a/src/components/menus/ActivityStatusMenu.svelte
+++ b/src/components/menus/ActivityStatusMenu.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import WaterfallIcon from '@nasa-jpl/stellar/icons/waterfall.svg?component';
+  import { ChartGantt } from 'lucide-svelte';
   import { createEventDispatcher } from 'svelte';
   import { Status } from '../../enums/status';
   import type { ActivityDirectiveValidationStatus } from '../../types/activity';
@@ -36,7 +36,7 @@
   statusBadgeText={`${invalidActivityCount}`}
   status={invalidActivityCount > 0 ? Status.Failed : Status.Complete}
 >
-  <WaterfallIcon />
+  <ChartGantt size={20} />
   <svelte:fragment slot="metadata">
     <div class="activity-status-nav-container">
       <div class="total-count">

--- a/src/components/menus/GridMenu.svelte
+++ b/src/components/menus/GridMenu.svelte
@@ -1,28 +1,26 @@
 <svelte:options accessors={true} immutable={true} />
 
 <script lang="ts">
-  import ActivityIcon from '@nasa-jpl/stellar/icons/activity.svg?component';
-  import BookIcon from '@nasa-jpl/stellar/icons/book.svg?component';
-  import CalendarIcon from '@nasa-jpl/stellar/icons/calendar.svg?component';
-  import ChecklistOnPageIcon from '@nasa-jpl/stellar/icons/checklist_on_page.svg?component';
-  import ChevronDownIcon from '@nasa-jpl/stellar/icons/chevron_down.svg?component';
-  import PlanIcon from '@nasa-jpl/stellar/icons/plan.svg?component';
-  import TableWithHeaderIcon from '@nasa-jpl/stellar/icons/table_with_header.svg?component';
-  import VerticalCollapseIcon from '@nasa-jpl/stellar/icons/vertical_collapse_with_center_line.svg?component';
-  import GearWideConnectedIcon from 'bootstrap-icons/icons/gear-wide-connected.svg?component';
-  import JournalCodeIcon from 'bootstrap-icons/icons/journal-code.svg?component';
-  import WindowFullscreenIcon from 'bootstrap-icons/icons/window-fullscreen.svg?component';
-  import ExternalEventIcon from '../../assets/external-event-box-with-arrow.svg?component';
-  import ExternalSourceIcon from '../../assets/external-source-box.svg?component';
+  import { DropdownMenu } from '@nasa-jpl/stellar-svelte';
+  import {
+    AppWindow,
+    BookOpen,
+    Boxes,
+    CalendarRange,
+    ChevronDown,
+    ChevronsLeftRight,
+    Clipboard,
+    FlipHorizontal2,
+    LucideEdit,
+    PlaySquare,
+    Table2,
+  } from 'lucide-svelte';
+  import DirectiveAndSpanIcon from '../../assets/timeline-directive-and-span.svg?component';
   import { viewUpdateGrid } from '../../stores/views';
   import type { ViewGrid, ViewGridComponent, ViewGridSection } from '../../types/view';
-  import Menu from './Menu.svelte';
-  import MenuItem from './MenuItem.svelte';
 
   export let gridSection: ViewGridSection;
   export let title: string = '';
-
-  let gridMenu: Menu;
 
   function onClickMenuItem(gridComponent: ViewGridComponent): void {
     const update: Partial<ViewGrid> = {};
@@ -40,101 +38,129 @@
     }
 
     viewUpdateGrid(update);
-    gridMenu.hide();
   }
 </script>
 
-<div class="grid-menu st-typography-medium" role="none" on:click|stopPropagation={() => gridMenu.toggle()}>
-  <div class="title">{title}</div>
-  <ChevronDownIcon />
-
-  <Menu bind:this={gridMenu}>
-    <MenuItem on:click={() => onClickMenuItem('ActivityDirectivesTablePanel')}>
-      <TableWithHeaderIcon />
+<DropdownMenu.Root>
+  <DropdownMenu.Trigger>
+    <div class="flex items-center gap-1 whitespace-nowrap rounded border px-2 py-1 text-[13px] font-medium">
+      {title}
+      <ChevronDown size={16} />
+    </div>
+  </DropdownMenu.Trigger>
+  <DropdownMenu.Content avoidCollisions fitViewport aria-label={`layer-picker`} align="start" class="overflow-auto">
+    <DropdownMenu.Label class="mb-0.5 text-[13px] font-medium text-muted-foreground">Select Panel</DropdownMenu.Label>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('ActivityDirectivesTablePanel')}
+    >
+      <Table2 size={16} />
       Activity Directives Table
-    </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('ActivitySpansTablePanel')}>
-      <TableWithHeaderIcon />
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('ActivitySpansTablePanel')}
+    >
+      <Table2 size={16} />
       Simulated Activities Table
-    </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('TimelineItemsPanel')}>
-      <BookIcon />
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('TimelineItemsPanel')}
+    >
+      <BookOpen size={16} />
       Activity, Resource, Event Types
-    </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('ConstraintsPanel')}>
-      <VerticalCollapseIcon />
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('ConstraintsPanel')}
+    >
+      <FlipHorizontal2 size={16} />
       Constraints
-    </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('ExpansionPanel')}>
-      <JournalCodeIcon />
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('ExpansionPanel')}
+    >
+      <ChevronsLeftRight size={16} />
       Expansion
-    </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('ExternalSourcesPanel')}>
-      <ExternalSourceIcon />
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('ExternalSourcesPanel')}
+    >
+      <Boxes size={16} />
       External Sources
-    </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('ExternalEventsTablePanel')}>
-      <TableWithHeaderIcon />
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('ExternalEventsTablePanel')}
+    >
+      <Table2 size={16} />
       External Events Table
-    </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('IFramePanel')}>
-      <WindowFullscreenIcon />
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('IFramePanel')}
+    >
+      <AppWindow size={16} />
       External Application
-    </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('PlanMetadataPanel')}>
-      <PlanIcon />
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('PlanMetadataPanel')}
+    >
+      <Clipboard size={16} />
       Plan Metadata
-    </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('SchedulingGoalsPanel')}>
-      <CalendarIcon />
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('SchedulingGoalsPanel')}
+    >
+      <CalendarRange size={16} />
       Scheduling Goals
-    </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('SchedulingConditionsPanel')}>
-      <CalendarIcon />
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('SchedulingConditionsPanel')}
+    >
+      <CalendarRange size={16} />
       Scheduling Conditions
-    </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('ActivityFormPanel')}>
-      <ActivityIcon />
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('ActivityFormPanel')}
+    >
+      <DirectiveAndSpanIcon />
       Selected Activity
-    </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('ExternalEventFormPanel')}>
-      <ExternalEventIcon />
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('ExternalEventFormPanel')}
+    >
+      <Table2 size={16} />
       Selected External Event
-    </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('SimulationPanel')}>
-      <GearWideConnectedIcon />
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('SimulationPanel')}
+    >
+      <PlaySquare size={16} />
       Simulation
-    </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('SimulationEventsPanel')}>
-      <TableWithHeaderIcon />
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('SimulationEventsPanel')}
+    >
+      <Table2 size={16} />
       Simulation Events Table
-    </MenuItem>
-    <MenuItem on:click={() => onClickMenuItem('TimelineEditorPanel')}>
-      <ChecklistOnPageIcon />
+    </DropdownMenu.Item>
+    <DropdownMenu.Item
+      class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
+      on:click={() => onClickMenuItem('TimelineEditorPanel')}
+    >
+      <LucideEdit size={16} />
       Timeline Editor
-    </MenuItem>
-  </Menu>
-</div>
-
-<style>
-  .grid-menu {
-    align-items: center;
-    border: 1px solid var(--st-gray-30);
-    border-radius: 4px;
-    cursor: pointer;
-    display: flex;
-    font-size: 13px;
-    gap: 5px;
-    height: 24px;
-    justify-content: center;
-    padding: 4px 8px;
-    position: relative;
-    user-select: none;
-  }
-
-  .title {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-</style>
+    </DropdownMenu.Item>
+  </DropdownMenu.Content>
+</DropdownMenu.Root>

--- a/src/components/menus/GridMenu.svelte
+++ b/src/components/menus/GridMenu.svelte
@@ -42,13 +42,13 @@
 </script>
 
 <DropdownMenu.Root>
-  <DropdownMenu.Trigger>
+  <DropdownMenu.Trigger aria-label="Plan Menu Button">
     <div class="flex items-center gap-1 whitespace-nowrap rounded border px-2 py-1 text-[13px] font-medium">
       {title}
       <ChevronDown size={16} />
     </div>
   </DropdownMenu.Trigger>
-  <DropdownMenu.Content avoidCollisions fitViewport aria-label={`layer-picker`} align="start" class="overflow-auto">
+  <DropdownMenu.Content avoidCollisions fitViewport aria-label="Plan Menu" align="start" class="overflow-auto">
     <DropdownMenu.Label class="mb-0.5 text-[13px] font-medium text-muted-foreground">Select Panel</DropdownMenu.Label>
     <DropdownMenu.Item
       class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"

--- a/src/components/menus/GridMenu.svelte
+++ b/src/components/menus/GridMenu.svelte
@@ -5,6 +5,7 @@
   import {
     AppWindow,
     BookOpen,
+    Box,
     Boxes,
     CalendarRange,
     ChevronDown,
@@ -138,7 +139,7 @@
       class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"
       on:click={() => onClickMenuItem('ExternalEventFormPanel')}
     >
-      <Table2 size={16} />
+      <Box size={16} />
       Selected External Event
     </DropdownMenu.Item>
     <DropdownMenu.Item

--- a/src/components/menus/GridMenu.svelte
+++ b/src/components/menus/GridMenu.svelte
@@ -42,13 +42,13 @@
 </script>
 
 <DropdownMenu.Root>
-  <DropdownMenu.Trigger aria-label="Plan Menu Button">
+  <DropdownMenu.Trigger aria-label="Plan Menu">
     <div class="flex items-center gap-1 whitespace-nowrap rounded border px-2 py-1 text-[13px] font-medium">
       {title}
       <ChevronDown size={16} />
     </div>
   </DropdownMenu.Trigger>
-  <DropdownMenu.Content avoidCollisions fitViewport aria-label="Plan Menu" align="start" class="overflow-auto">
+  <DropdownMenu.Content avoidCollisions fitViewport align="start" class="overflow-auto">
     <DropdownMenu.Label class="mb-0.5 text-[13px] font-medium text-muted-foreground">Select Panel</DropdownMenu.Label>
     <DropdownMenu.Item
       class="flex cursor-pointer select-none items-center gap-2 rounded-sm py-2.5 text-[13px] font-medium"

--- a/src/components/menus/PlanMenu.svelte
+++ b/src/components/menus/PlanMenu.svelte
@@ -4,7 +4,7 @@
   import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import BranchIcon from '@nasa-jpl/stellar/icons/branch.svg?component';
-  import ChevronDownIcon from '@nasa-jpl/stellar/icons/chevron_down.svg?component';
+  import { ChevronDown } from 'lucide-svelte';
   import { PlanStatusMessages } from '../../enums/planStatusMessages';
   import { activityDirectivesMap } from '../../stores/activities';
   import { planReadOnly } from '../../stores/plan';
@@ -92,7 +92,7 @@
   {/if}
 
   <div class="plan-menu st-typography-medium" role="none" on:click|stopPropagation={() => planMenu.toggle()}>
-    <div class="plan-title">{plan.name}<ChevronDownIcon /></div>
+    <div class="plan-title">{plan.name}<ChevronDown size={16} /></div>
     <Menu hideAfterClick={false} bind:this={planMenu}>
       <MenuItem
         use={[

--- a/src/components/menus/ViewMenu.svelte
+++ b/src/components/menus/ViewMenu.svelte
@@ -3,7 +3,6 @@
 <script lang="ts">
   import ViewGridBottomPanelEmpty from '@nasa-jpl/stellar/icons/view_grid_bottom_panel_empty.svg?component';
   import ViewGridBottomPanelFilled from '@nasa-jpl/stellar/icons/view_grid_bottom_panel_filled.svg?component';
-  import ViewGridIcon from '@nasa-jpl/stellar/icons/view_grid_filled.svg?component';
   import ViewGridLeftPanelEmpty from '@nasa-jpl/stellar/icons/view_grid_left_panel_empty.svg?component';
   import ViewGridLeftPanelFilled from '@nasa-jpl/stellar/icons/view_grid_left_panel_filled.svg?component';
   import ViewGridLeftPanelSplitEmpty from '@nasa-jpl/stellar/icons/view_grid_left_panel_split_empty.svg?component';
@@ -12,6 +11,7 @@
   import ViewGridRightPanelFilled from '@nasa-jpl/stellar/icons/view_grid_right_panel_filled.svg?component';
   import ViewGridRightPanelSplitEmpty from '@nasa-jpl/stellar/icons/view_grid_right_panel_split_empty.svg?component';
   import ViewGridRightPanelSplitFilled from '@nasa-jpl/stellar/icons/view_grid_right_panel_split_filled.svg?component';
+  import { LayoutPanelLeftIcon } from 'lucide-svelte';
   import { createEventDispatcher } from 'svelte';
   import { Status } from '../../enums/status';
   import { view, viewIsModified } from '../../stores/views';
@@ -96,7 +96,7 @@
 
 <div class="view-menu-button st-typography-medium">
   <PlanNavButton status={$viewIsModified ? Status.Modified : null} title={$view?.name ?? defaultViewName} menuTitle="">
-    <ViewGridIcon />
+    <LayoutPanelLeftIcon class="fill-current" size={20} />
     <div class="view-menu st-typography-medium" slot="menu">
       <div class="toggles">
         <MenuItem className="p-0" on:click={() => toggleView('left', !leftPanelIsOn)}>

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -6,11 +6,7 @@
   import { base } from '$app/paths';
   import { page } from '$app/stores';
   import { Button, Resizable } from '@nasa-jpl/stellar-svelte';
-  import CalendarIcon from '@nasa-jpl/stellar/icons/calendar.svg?component';
-  import PlanIcon from '@nasa-jpl/stellar/icons/plan.svg?component';
-  import PlayIcon from '@nasa-jpl/stellar/icons/play.svg?component';
-  import VerticalCollapseIcon from '@nasa-jpl/stellar/icons/vertical_collapse_with_center_line.svg?component';
-  import { ListX } from 'lucide-svelte';
+  import { CalendarRange, ChevronsLeftRight, FlipHorizontal2, ListX, PlaySquareIcon } from 'lucide-svelte';
   import type { PaneAPI } from 'paneforge';
   import { onDestroy } from 'svelte';
   import Nav from '../../../components/app/Nav.svelte';
@@ -716,7 +712,7 @@
               status={$planExpansionStatus}
               on:click={() => onHandleExpansion()}
             >
-              <PlanIcon />
+              <ChevronsLeftRight size={20} />
               <svelte:fragment slot="metadata">
                 {#if SEQUENCE_EXPANSION_MODE === SequencingMode.TYPESCRIPT}
                   <div>Expansion Set ID: {$selectedExpansionSetId || 'None'}</div>
@@ -746,7 +742,7 @@
               showStatusInMenu={false}
               on:click={() => effects.simulate($plan, false, data.user)}
             >
-              <PlayIcon />
+              <PlaySquareIcon size={20} />
               <svelte:fragment slot="metadata">
                 <div class="st-typography-body">
                   <div class="simulation-header">
@@ -810,7 +806,7 @@
               on:click={() => $plan && effects.checkConstraints($plan, data.user, false)}
               indeterminate
             >
-              <VerticalCollapseIcon />
+              <FlipHorizontal2 size={20} />
               <svelte:fragment slot="metadata">
                 <div class="st-typography-body constraints-status">
                   {#if $constraintsStatus}
@@ -872,7 +868,7 @@
               on:click={() => effects.schedule(true, $plan, data.user)}
               indeterminate
             >
-              <CalendarIcon />
+              <CalendarRange size={20} />
               <svelte:fragment slot="metadata">
                 <div class="st-typography-body">
                   {#if !$schedulingAnalysisStatus}


### PR DESCRIPTION
Reworks the plan grid menu to use new Stellar components and icons. Menu now properly supports overflowing content. Also tweaks a few icons in the plan navigation menu to be more consistent with the grid menu. Closes [#1486 ](https://github.com/NASA-AMMOS/aerie-ui/issues/979)