### PR TITLE
Allow `user` role to modify any workspace's contents

### DIFF
--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -1718,10 +1718,11 @@ const featurePermissions: FeaturePermissions = {
     canUpdate: (user, view) => queryPermissions.UPDATE_VIEW(user, view),
   },
   workspace: {
-    canCreate: (user, workspace) => isUserAdmin(user) || (!isUserViewer(user) && isUserOwner(user, workspace)),
-    canDelete: (user, workspace) => isUserAdmin(user) || (!isUserViewer(user) && isUserOwner(user, workspace)),
+    // TODO: Use workspace owners when ready to enforce
+    canCreate: (user, _workspace) => isUserAdmin(user) || !isUserViewer(user),
+    canDelete: (user, _workspace) => isUserAdmin(user) || !isUserViewer(user),
     canRead: () => true,
-    canUpdate: (user, workspace) => isUserAdmin(user) || (!isUserViewer(user) && isUserOwner(user, workspace)),
+    canUpdate: (user, _workspace) => isUserAdmin(user) || !isUserViewer(user),
   },
   workspaces: {
     canCreate: user => isUserAdmin(user) || (!isUserViewer(user) && queryPermissions.CREATE_WORKSPACE(user)),


### PR DESCRIPTION
Resolves #1790

To test:
1. Create a workspace as user A.
2. Switch to a user B
3. Switch to the "user" role as user B
4. Navigate to the workspace that user A created
5. Verify that as user B, you can do CRUD operations within the workspace