### PR TITLE
Fix: don't append .txt extension to sequence files when downloading from editor

### DIFF
--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -360,7 +360,7 @@
   }
 
   function downloadInputFormat(): void {
-    downloadBlob(new Blob([editorSequenceView.state.doc.toString()], { type: 'text/plain' }), `${sequenceName}.txt`);
+    downloadBlob(new Blob([editorSequenceView.state.doc.toString()], { type: 'text/plain' }), sequenceName);
   }
 
   async function copyOutputFormatToClipboard(): Promise<void> {


### PR DESCRIPTION
Closes #1788. In the `SequenceEditor` we were appending `.txt` when downloading, which is no longer correct in a file-based-workspace world.

Related but different behavior: in testing, I noticed that files with **no extension**, which are treated as text files by default in the sequence editor, also end up getting downloaded with `.txt` extension. This is using a different component (`TextEditor.svelte`) which does *not* append `.txt` in code, so I think the browser is doing this - it gets downloaded with the MIME type `text/plain` so I suspect the browser adds an extension in this case when none is present. Anyway, I think we can safely ignore this, it seems like an OK default & the bug report is mainly concerned with `.seqn.txt` files not getting downloaded as `.seqn.txt.txt`.

### Testing
1. Create a workspace
2. Create a file named `foo.seqn.txt`
3. open the file, add some text, Save it
4. Click "Download" and confirm it is downloaded as `foo.seqn.txt`