### PR TITLE
Fix: don't send secrets request to action server for runs which don't have secrets

### DIFF
--- a/src/components/modals/RunActionModal.svelte
+++ b/src/components/modals/RunActionModal.svelte
@@ -4,7 +4,7 @@
   import { createEventDispatcher } from 'svelte';
   import type { ActionDefinition, ActionParametersMap } from '../../types/actions';
   import type { User } from '../../types/app';
-  import type { Argument, ArgumentsMap, FormParameter, ParameterName } from '../../types/parameter';
+  import type { ArgumentsMap, FormParameter } from '../../types/parameter';
   import type { UserSequence } from '../../types/sequencing';
   import { getUserSequenceValueSchemaOptions, valueSchemaRecordToParametersMap } from '../../utilities/actions';
   import effects from '../../utilities/effects';

--- a/src/components/modals/RunActionModal.svelte
+++ b/src/components/modals/RunActionModal.svelte
@@ -24,7 +24,6 @@
   let isLoadingWorkspace: boolean = false;
   let running: boolean = false;
   let parametersMap: ActionParametersMap = {};
-  let secretParametersMap: ActionParametersMap = {};
 
   const dispatch = createEventDispatcher<{
     close: void;
@@ -41,30 +40,30 @@
 
   async function run() {
     running = true;
+    let secretParametersMap: ActionParametersMap = {};
+    let nonSecretParametersMap: ActionParametersMap = {};
+    let hasSecrets = false;
 
     // Filter out the secret params to send directly to the action server.
     for (const param of Object.keys(parametersMap)) {
       if (parametersMap[param].schema.type === 'secret') {
         secretParametersMap[param] = argumentsMap[param];
+        hasSecrets = true;
+      } else {
+        nonSecretParametersMap[param] = argumentsMap[param];
       }
     }
 
     const actionRunId = await effects.createActionRun(
       actionDefinition.id,
       // Only send non-secret arguments to the db.
-      Object.entries(argumentsMap).reduce((acc: ArgumentsMap, [paramName, argument]: [ParameterName, Argument]) => {
-        if (parametersMap[paramName].schema.type !== 'secret') {
-          acc[paramName] = argument;
-        }
-
-        return acc;
-      }, {}),
+      nonSecretParametersMap,
       actionDefinition.settings,
-      Object.keys(secretParametersMap).length > 0, // The DB only needs to know if there are secrets or not.
+      hasSecrets, // The DB only needs to know if there are secrets or not.
       user,
     );
 
-    if (actionRunId !== null) {
+    if (actionRunId !== null && hasSecrets) {
       await effects.sendActionSecretParameters(secretParametersMap, actionRunId, user);
     }
 


### PR DESCRIPTION
**Background:** Transient secrets PRs https://github.com/NASA-AMMOS/aerie-ui/pull/1711 https://github.com/NASA-AMMOS/aerie/pull/1699

I've been having a local issue when trying to test actions *without* transient secrets - the action run starts but never finishes, and action server crashes. I thought it was a race condition between the secrets request and the DB trigger, but it's a little different. What happens is:

1. The UI sends the hasura request to insert the run in the DB, succeeds, returns action run id
2. Action Server gets triggered by this to start the action run. It checks to see if secrets are needed - no, in this case - and then starts running the action (instead of queueing it to wait for secrets)
3. After getting the response from 1, UI makes an empty secrets request despite not having any secrets **(this is what this PR fixes)**
4. Action Server sees the secrets request and assumes it's for a queued action run waiting on secrets. It tries to dequeue and run it - but it's not *in* the queue, and this crashes action server.
5. Even though the action had already **started** running, the crash happens before it finishes (for me, locally), so the action never completes

This UI fix was the fastest way to get it working again, but we should also fix the backend to be more robust and not crash in this case