### PR TITLE
Fixes delete workspace context menu not doing anything on click

### DIFF
--- a/src/components/workspace/WorkspacesGrid.svelte
+++ b/src/components/workspace/WorkspacesGrid.svelte
@@ -88,7 +88,7 @@
         return actionsDiv;
       },
       cellRendererParams: {
-        deleteWorkspace,
+        deleteWorkspace: onDeleteWorkspace,
         viewWorkspace,
       } as CellRendererParams,
       field: 'actions',
@@ -107,9 +107,19 @@
     return includesName;
   });
 
-  async function deleteWorkspace(workspace: Workspace | undefined) {
+  async function deleteWorkspace(workspaceId: number) {
+    dispatch('deleteWorkspace', workspaceId);
+  }
+
+  async function deleteWorkspaceContext(event: CustomEvent<RowId[]>) {
+    const workspaceId = event.detail[0] as number;
+
+    deleteWorkspace(workspaceId);
+  }
+
+  async function onDeleteWorkspace(workspace: Workspace | undefined) {
     if (workspace !== undefined) {
-      dispatch('deleteWorkspace', workspace.id);
+      deleteWorkspace(workspace.id);
     }
   }
 
@@ -174,6 +184,7 @@
         items={filteredWorkspaces}
         selectedItemId={selectedWorkspaceId}
         {user}
+        on:deleteItem={deleteWorkspaceContext}
         on:editItem={editWorkspace}
         on:rowSelected={workspaceSelected}
         on:rowDoubleClicked={({ detail }) => viewWorkspace(detail.data)}


### PR DESCRIPTION
resolves #1799 

To test:
1. Create a workspace (doesn't matter what dictionaries are used in the parcel)
2. Navigate to the workspaces page
3. Right click on the table row for the workspace you just created
4. Click on "Delete Workspace"
5. Verify that a confirmation modal pops up and that following through with the modal results in the proper deletion of the workspace.

To test permissions:
1. Create a workspace (doesn't matter what dictionaries are used in the parcel)
2. Switch to a user that is not the same as the user that created the workspace
3. Switch your role to `user`
4. Navigate to the workspaces page
5. Verify that right clicking on the workspace that was created results in a disabled "Delete Workspace" menu item