### PR TITLE
Prevent escape and click-outside closure of workspace import file modal

### DIFF
--- a/src/components/modals/AboutModal.svelte
+++ b/src/components/modals/AboutModal.svelte
@@ -26,7 +26,7 @@
   });
 </script>
 
-<Modal height={220} width={640}>
+<Modal height={220} width={640} on:close>
   <ModalHeader on:close>About</ModalHeader>
   <ModalContent>
     <div class="text-sm leading-relaxed">

--- a/src/components/modals/ActionCreationModal.svelte
+++ b/src/components/modals/ActionCreationModal.svelte
@@ -52,7 +52,7 @@
   }
 </script>
 
-<svelte:window on:keydown={onKeydown} />
+<svelte:window on:keydown={onKeydown} on:close />
 <Modal {height} {width}>
   <ModalHeader on:close>New Action</ModalHeader>
 

--- a/src/components/modals/CancelActionRunModal.svelte
+++ b/src/components/modals/CancelActionRunModal.svelte
@@ -20,7 +20,7 @@
   }
 </script>
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Cancel Action Run</ModalHeader>
   <ModalContent>
     <div class="st-typography-body">Are you sure you want to cancel this Action run?</div>

--- a/src/components/modals/ConfirmActivityCreationModal.svelte
+++ b/src/components/modals/ConfirmActivityCreationModal.svelte
@@ -30,7 +30,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Warning</ModalHeader>
   <ModalContent>
     <span>This row is not configured to display some of the activities you are trying to create.</span>

--- a/src/components/modals/ConfirmModal.svelte
+++ b/src/components/modals/ConfirmModal.svelte
@@ -31,7 +31,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>
     {title}
   </ModalHeader>

--- a/src/components/modals/CreatePlanBranchModal.svelte
+++ b/src/components/modals/CreatePlanBranchModal.svelte
@@ -40,7 +40,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Create Branch</ModalHeader>
   <ModalContent style=" display: flex; flex-direction: column; gap: 8px; padding:8px 0 0 ;">
     <fieldset>

--- a/src/components/modals/CreatePlanSnapshotModal.svelte
+++ b/src/components/modals/CreatePlanSnapshotModal.svelte
@@ -69,7 +69,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Take Snapshot</ModalHeader>
   <ModalContent style=" display: flex; flex-direction: column; gap: 8px; padding:8px 0 16px;">
     <div class="description">Snapshot will capture activity directives and references to relevant simulations.</div>

--- a/src/components/modals/CreateViewModal.svelte
+++ b/src/components/modals/CreateViewModal.svelte
@@ -37,7 +37,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Save new view</ModalHeader>
   <ModalContent>
     <fieldset>

--- a/src/components/modals/DeleteActivitiesModal.svelte
+++ b/src/components/modals/DeleteActivitiesModal.svelte
@@ -161,7 +161,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal height="auto" {width}>
+<Modal height="auto" {width} on:close>
   <ModalHeader on:close>Delete Activity {activityIds.length > 1 ? 'Directives' : 'Directive'}</ModalHeader>
   <ModalContent>
     <div class="message">

--- a/src/components/modals/DeleteDerivationGroupModal.svelte
+++ b/src/components/modals/DeleteDerivationGroupModal.svelte
@@ -37,7 +37,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>
     {#if !derivationGroupsAreAllEmpty}
       Derivation Group Cannot Be Deleted

--- a/src/components/modals/DeleteExternalEventSourceTypeModal.svelte
+++ b/src/components/modals/DeleteExternalEventSourceTypeModal.svelte
@@ -29,7 +29,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>
     {#if associatedItems.size > 0}
       {itemsToDeleteTypeName} Cannot Be Deleted

--- a/src/components/modals/DeleteExternalSourceModal.svelte
+++ b/src/components/modals/DeleteExternalSourceModal.svelte
@@ -34,7 +34,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>
     {#if linked.length > 0}
       External Source Cannot Be Deleted

--- a/src/components/modals/DeleteExternalSourceModal.svelte
+++ b/src/components/modals/DeleteExternalSourceModal.svelte
@@ -34,7 +34,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width} on:close>
+<Modal {height} {width} on:close closeOnEscape={false} closeOnOutsideClick={false}>
   <ModalHeader on:close>
     {#if linked.length > 0}
       External Source Cannot Be Deleted

--- a/src/components/modals/EditViewModal.svelte
+++ b/src/components/modals/EditViewModal.svelte
@@ -42,7 +42,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Edit view</ModalHeader>
   <ModalContent>
     <fieldset>

--- a/src/components/modals/ExpansionPanelModal.svelte
+++ b/src/components/modals/ExpansionPanelModal.svelte
@@ -66,7 +66,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Send Expansion Result To Sequencing</ModalHeader>
 
   <ModalContent>

--- a/src/components/modals/ExpansionSequenceModal.svelte
+++ b/src/components/modals/ExpansionSequenceModal.svelte
@@ -53,7 +53,7 @@
   }
 </script>
 
-<Modal height={400} width={600}>
+<Modal height={400} width={600} on:close>
   <ModalHeader on:close>Sequence ID: {expansionSequence.seq_id}</ModalHeader>
   <ModalContent>
     <div style:height="300px">

--- a/src/components/modals/ImportWorkspaceFileModal.svelte
+++ b/src/components/modals/ImportWorkspaceFileModal.svelte
@@ -106,7 +106,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Upload File(s) To Workspace</ModalHeader>
 
   <ModalContent style="overflow: hidden;">

--- a/src/components/modals/LibrarySequenceModal.svelte
+++ b/src/components/modals/LibrarySequenceModal.svelte
@@ -41,7 +41,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>{modalTitle}</ModalHeader>
 
   <ModalContent>

--- a/src/components/modals/ManagePlanConstraintsModal.svelte
+++ b/src/components/modals/ManagePlanConstraintsModal.svelte
@@ -262,7 +262,7 @@
   }
 </script>
 
-<Modal height={500} width={750}>
+<Modal height={500} width={750} on:close>
   <ModalHeader on:close>Manage Constraints</ModalHeader>
   <ModalContent style="padding:0">
     <div class="constraints-modal-container">

--- a/src/components/modals/ManagePlanConstraintsModal.svelte
+++ b/src/components/modals/ManagePlanConstraintsModal.svelte
@@ -262,7 +262,7 @@
   }
 </script>
 
-<Modal height={500} width={750} on:close>
+<Modal height={500} width={750} on:close closeOnEscape={false} closeOnOutsideClick={false}>
   <ModalHeader on:close>Manage Constraints</ModalHeader>
   <ModalContent style="padding:0">
     <div class="constraints-modal-container">

--- a/src/components/modals/ManagePlanDerivationGroupsModal.svelte
+++ b/src/components/modals/ManagePlanDerivationGroupsModal.svelte
@@ -227,7 +227,7 @@
   }
 </script>
 
-<Modal height={600} width={1000}>
+<Modal height={600} width={1000} on:close>
   <ModalHeader on:close>Manage Derivation Groups</ModalHeader>
   <ModalContent style="overflow: auto; padding: 0;">
     <CssGrid columns={modalColumnSize} minHeight="100%">

--- a/src/components/modals/ManagePlanSchedulingConditionsModal.svelte
+++ b/src/components/modals/ManagePlanSchedulingConditionsModal.svelte
@@ -269,7 +269,7 @@
   }
 </script>
 
-<Modal height={500} width={750}>
+<Modal height={500} width={750} on:close>
   <ModalHeader on:close>Manage Scheduling Conditions</ModalHeader>
   <ModalContent style="padding:0">
     <div class="conditions-modal-container">

--- a/src/components/modals/ManagePlanSchedulingConditionsModal.svelte
+++ b/src/components/modals/ManagePlanSchedulingConditionsModal.svelte
@@ -269,7 +269,7 @@
   }
 </script>
 
-<Modal height={500} width={750} on:close>
+<Modal height={500} width={750} on:close closeOnEscape={false} closeOnOutsideClick={false}>
   <ModalHeader on:close>Manage Scheduling Conditions</ModalHeader>
   <ModalContent style="padding:0">
     <div class="conditions-modal-container">

--- a/src/components/modals/ManagePlanSchedulingGoalsModal.svelte
+++ b/src/components/modals/ManagePlanSchedulingGoalsModal.svelte
@@ -270,7 +270,7 @@
   }
 </script>
 
-<Modal height={500} width={750}>
+<Modal height={500} width={750} on:close>
   <ModalHeader on:close>Manage Scheduling Goals</ModalHeader>
   <ModalContent style="padding:0">
     <div class="goals-modal-container">

--- a/src/components/modals/ManagePlanSchedulingGoalsModal.svelte
+++ b/src/components/modals/ManagePlanSchedulingGoalsModal.svelte
@@ -270,7 +270,7 @@
   }
 </script>
 
-<Modal height={500} width={750} on:close>
+<Modal height={500} width={750} on:close closeOnEscape={false} closeOnOutsideClick={false}>
   <ModalHeader on:close>Manage Scheduling Goals</ModalHeader>
   <ModalContent style="padding:0">
     <div class="goals-modal-container">

--- a/src/components/modals/MergeReviewEndedModal.svelte
+++ b/src/components/modals/MergeReviewEndedModal.svelte
@@ -35,7 +35,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal height={150} width={380}>
+<Modal height={150} width={380} on:close>
   <ModalHeader showClose={false}>Merge Review Ended</ModalHeader>
   <ModalContent>
     <div>This merge request has been {statusVerb}.</div>

--- a/src/components/modals/MergeReviewEndedModal.svelte
+++ b/src/components/modals/MergeReviewEndedModal.svelte
@@ -35,7 +35,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal height={150} width={380} on:close>
+<Modal height={150} width={380} on:close closeOnEscape={false} closeOnOutsideClick={false}>
   <ModalHeader showClose={false}>Merge Review Ended</ModalHeader>
   <ModalContent>
     <div>This merge request has been {statusVerb}.</div>

--- a/src/components/modals/Modal.svelte
+++ b/src/components/modals/Modal.svelte
@@ -1,8 +1,35 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { createEventDispatcher, onMount } from 'svelte';
+
+  export let closeOnOutsideClick: boolean = true;
+  export let closeOnEscape: boolean = true;
   export let height: number | string = 350;
   export let width: number | string = 400;
+
+  const dispatch = createEventDispatcher<{
+    close: void;
+  }>();
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (
+      closeOnEscape &&
+      event.key === 'Escape' &&
+      (event.target as HTMLElement)?.nodeName !== 'INPUT' &&
+      (event.target as HTMLElement)?.nodeName !== 'TEXTAREA'
+    ) {
+      dispatch('close');
+    }
+  }
+
+  onMount(() => {
+    document.addEventListener('keydown', handleKeydown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeydown);
+    };
+  });
 
   $: heightStyle = typeof height === 'number' ? `${height}px` : height;
   $: widthStyle = typeof width === 'number' ? `${width}px` : width;
@@ -12,12 +39,22 @@
   <div class="modal st-typography-body" role="none" style:height={heightStyle} style:width={widthStyle}>
     <slot />
   </div>
+  <!-- Stage to capture clicks outside of the modal body-->
+  <div
+    on:click={() => {
+      if (closeOnOutsideClick) {
+        dispatch('close');
+      }
+    }}
+    class="fixed bottom-0 left-0 top-0 h-full w-full bg-black/50"
+    data-aria-hidden="true"
+    aria-hidden="true"
+  />
 </div>
 
 <style>
   #modal-container {
     align-items: center;
-    background-color: #00000052;
     bottom: 0;
     display: flex;
     justify-content: center;

--- a/src/components/modals/MoveItemToWorkspaceModal.svelte
+++ b/src/components/modals/MoveItemToWorkspaceModal.svelte
@@ -127,7 +127,7 @@
   }
 </script>
 
-<Modal height={450} width={380}>
+<Modal height={450} width={380} on:close>
   <ModalHeader on:close>
     <div>Move or Duplicate</div>
   </ModalHeader>

--- a/src/components/modals/MoveWorkspaceItemModal.svelte
+++ b/src/components/modals/MoveWorkspaceItemModal.svelte
@@ -66,7 +66,7 @@
   }
 </script>
 
-<Modal height={400} width={380}>
+<Modal height={400} width={380} on:close>
   <ModalHeader on:close>
     Move/Copy Workspace {typeString}
   </ModalHeader>

--- a/src/components/modals/NewSequenceModal.svelte
+++ b/src/components/modals/NewSequenceModal.svelte
@@ -22,7 +22,7 @@
   }
 </script>
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>New Sequence</ModalHeader>
   <ModalContent>
     <fieldset>

--- a/src/components/modals/NewWorkspaceFolderModal.svelte
+++ b/src/components/modals/NewWorkspaceFolderModal.svelte
@@ -51,7 +51,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>New Workspace Folder</ModalHeader>
   <ModalContent style="overflow: hidden;">
     <div class="grid h-full grid-rows-[min-content_auto_min-content_min-content] gap-1 overflow-hidden">

--- a/src/components/modals/NewWorkspaceSequenceModal.svelte
+++ b/src/components/modals/NewWorkspaceSequenceModal.svelte
@@ -51,7 +51,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>New File</ModalHeader>
   <ModalContent style="overflow: hidden;">
     <div class="grid h-full grid-rows-[min-content_auto_min-content_min-content] gap-1 overflow-hidden">

--- a/src/components/modals/PlanBranchMergeDerivationGroupMessageModal.svelte
+++ b/src/components/modals/PlanBranchMergeDerivationGroupMessageModal.svelte
@@ -28,7 +28,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Derivation Group Behavior</ModalHeader>
   <ModalContent>
     <p>

--- a/src/components/modals/PlanBranchRequestModal.svelte
+++ b/src/components/modals/PlanBranchRequestModal.svelte
@@ -78,7 +78,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>{modalHeader}</ModalHeader>
   <ModalContent>
     <div class="branch-action-container">

--- a/src/components/modals/PlanBranchesModal.svelte
+++ b/src/components/modals/PlanBranchesModal.svelte
@@ -12,7 +12,7 @@
   export let width: number = 400;
 </script>
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Branches</ModalHeader>
   <ModalContent style=" overflow: auto;padding: 0">
     <div class="plan-branched-plans">

--- a/src/components/modals/PlanMergeRequestsModal.svelte
+++ b/src/components/modals/PlanMergeRequestsModal.svelte
@@ -129,7 +129,7 @@
   }
 </script>
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Merge Requests</ModalHeader>
   <ModalContent style="overflow: auto;padding: 0">
     <div class="plan-merge-requests-container">

--- a/src/components/modals/RenameWorkspaceItemModal.svelte
+++ b/src/components/modals/RenameWorkspaceItemModal.svelte
@@ -47,7 +47,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal height={200} width={380}>
+<Modal height={200} width={380} on:close>
   <ModalHeader on:close>
     Rename Workspace {typeString}
   </ModalHeader>

--- a/src/components/modals/RestorePlanSnapshotModal.svelte
+++ b/src/components/modals/RestorePlanSnapshotModal.svelte
@@ -76,7 +76,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Restore Snapshot</ModalHeader>
   <ModalContent style=" display: flex; flex-direction: column; gap: 8px; padding:8px 0 16px;">
     <div class="message">

--- a/src/components/modals/RunActionModal.svelte
+++ b/src/components/modals/RunActionModal.svelte
@@ -94,7 +94,7 @@
   }
 </script>
 
-<Modal height="max-content" width={500} on:close>
+<Modal height="max-content" width={500} on:close closeOnEscape={false} closeOnOutsideClick={false}>
   <ModalHeader on:close>Run Action</ModalHeader>
 
   <ModalContent style="max-height: 50vh;overflow: auto">

--- a/src/components/modals/RunActionModal.svelte
+++ b/src/components/modals/RunActionModal.svelte
@@ -94,7 +94,7 @@
   }
 </script>
 
-<Modal height="max-content" width={500}>
+<Modal height="max-content" width={500} on:close>
   <ModalHeader on:close>Run Action</ModalHeader>
 
   <ModalContent style="max-height: 50vh;overflow: auto">

--- a/src/components/modals/RunActionResultsModal.svelte
+++ b/src/components/modals/RunActionResultsModal.svelte
@@ -1,11 +1,11 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { createEventDispatcher } from 'svelte';
   import Modal from './Modal.svelte';
-  import ModalHeader from './ModalHeader.svelte';
   import ModalContent from './ModalContent.svelte';
   import ModalFooter from './ModalFooter.svelte';
-  import { createEventDispatcher } from 'svelte';
+  import ModalHeader from './ModalHeader.svelte';
 
   export let actionRunId: number;
 
@@ -23,7 +23,7 @@
   }
 </script>
 
-<Modal height="max-content" width={300}>
+<Modal height="max-content" width={300} on:close>
   <ModalHeader on:close>Action Run Started</ModalHeader>
   <ModalContent style="max-height: 50vh;overflow: auto">
     <div class="st-typography-label pb-2">

--- a/src/components/modals/SavedViewsModal.svelte
+++ b/src/components/modals/SavedViewsModal.svelte
@@ -88,7 +88,7 @@
   }
 </script>
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Saved Views</ModalHeader>
   <ModalContent style="padding:0">
     <Tabs class="view-tabs" tabListClassName="view-tabs-list">

--- a/src/components/modals/TimeRangeModal.svelte
+++ b/src/components/modals/TimeRangeModal.svelte
@@ -39,7 +39,7 @@
   }
 </script>
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Create Sequence from Filter</ModalHeader>
   <ModalContent>
     <div class="st-typography-body">Select the time range to apply the sequence filter to.</div>

--- a/src/components/modals/TransformActivitiesModal.svelte
+++ b/src/components/modals/TransformActivitiesModal.svelte
@@ -48,7 +48,7 @@
   }
 </script>
 
-<Modal height="min-content" width="min-content">
+<Modal height="min-content" width="min-content" on:close>
   <ModalHeader on:close>{title}</ModalHeader>
 
   <ModalContent>

--- a/src/components/modals/UpdatePlanMissionModelModal.svelte
+++ b/src/components/modals/UpdatePlanMissionModelModal.svelte
@@ -150,7 +150,7 @@
   }
 </script>
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Change Mission Model</ModalHeader>
   <div class="flex h-full flex-1 flex-col overflow-hidden p-4">
     {#if $planMergeRequestsIncoming !== null && $planMergeRequestsIncoming.length}

--- a/src/components/modals/UploadViewModal.svelte
+++ b/src/components/modals/UploadViewModal.svelte
@@ -61,7 +61,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Upload View JSON</ModalHeader>
   <ModalContent style="overflow: auto; padding: 0">
     <fieldset>

--- a/src/components/sequence-templates/NewSequenceTemplateModal.svelte
+++ b/src/components/sequence-templates/NewSequenceTemplateModal.svelte
@@ -14,8 +14,8 @@
   import type { Parcel } from '../../types/sequencing';
   import effects from '../../utilities/effects';
   import { compare } from '../../utilities/generic';
-  import { featurePermissions } from '../../utilities/permissions';
   import { permissionHandler } from '../../utilities/permissionHandler';
+  import { featurePermissions } from '../../utilities/permissions';
   import { min, required } from '../../utilities/validators';
   import Modal from '../modals/Modal.svelte';
   import ModalContent from '../modals/ModalContent.svelte';
@@ -153,7 +153,7 @@
 
 <svelte:window on:keydown={onKeydown} />
 
-<Modal {height} {width}>
+<Modal {height} {width} on:close>
   <ModalHeader on:close>Create Sequence Template</ModalHeader>
 
   <ModalContent>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,7 +9,6 @@
   import Nav from '../components/app/Nav.svelte';
   import Loading from '../components/Loading.svelte';
   import { plugins, pluginsError, pluginsLoaded } from '../stores/plugins';
-  import { modalBodyClickListener, modalBodyKeyListener } from '../utilities/modal';
   import { loadPluginCode } from '../utilities/plugins';
 
   let pluginsEnabled = env.PUBLIC_TIME_PLUGIN_ENABLED === 'true';
@@ -34,8 +33,6 @@
     }
   }
 </script>
-
-<svelte:body on:click={modalBodyClickListener} on:keydown={modalBodyKeyListener} />
 
 {#if !pluginsEnabled || ($pluginsLoaded && !$pluginsError)}
   <slot />

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -115,6 +115,7 @@ export async function showAboutModal(): Promise<ModalElementValue> {
       const target: ModalElement | null = document.querySelector('#svelte-modal');
 
       if (target) {
+        target.setAttribute('data-dismissible', 'false');
         const aboutModal = new AboutModal({ target });
         target.resolve = resolve;
 
@@ -341,6 +342,9 @@ export async function showImportWorkspaceFileModal(
         });
         target.resolve = resolve;
 
+        // Do not allow users to dismiss this modal
+        target.setAttribute('data-dismissible', 'false');
+
         importWorkspaceFileModal.$on(
           'confirm',
           (
@@ -362,6 +366,7 @@ export async function showImportWorkspaceFileModal(
         importWorkspaceFileModal.$on('close', () => {
           target.replaceChildren();
           target.resolve = null;
+          target.removeAttribute('data-dismissible');
           importWorkspaceFileModal.$destroy();
         });
       }

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -63,36 +63,6 @@ import type { Workspace } from '../types/workspace';
 import type { WorkspaceTreeNode } from '../types/workspace-tree-view';
 
 /**
- * Listens for clicks on the document body and removes the modal children.
- */
-export function modalBodyClickListener(e: MouseEvent): void {
-  // Check that we have browser access and that the click is originating from outside
-  // of the modal element (i.e. the modal's overlay container)
-  if (browser && (e.target as HTMLElement).id === 'modal-container') {
-    const target: ModalElement | null = document.querySelector('#svelte-modal');
-    if (target && target.resolve && target.getAttribute('data-dismissible') !== 'false') {
-      target.replaceChildren();
-      target.resolve({ confirm: false });
-      target.resolve = null;
-    }
-  }
-}
-
-/**
- * Listens for escape key presses on the document body and removes the modal children.
- */
-export function modalBodyKeyListener(event: KeyboardEvent): void {
-  if (browser) {
-    const target: ModalElement | null = document.querySelector('#svelte-modal');
-    if (target && target.resolve && event.key === 'Escape' && target.getAttribute('data-dismissible') !== 'false') {
-      target.replaceChildren();
-      target.resolve({ confirm: false });
-      target.resolve = null;
-    }
-  }
-}
-
-/**
  * Closes the active modal if found and resolve nothing
  */
 export function closeActiveModal(): void {
@@ -115,7 +85,6 @@ export async function showAboutModal(): Promise<ModalElementValue> {
       const target: ModalElement | null = document.querySelector('#svelte-modal');
 
       if (target) {
-        target.setAttribute('data-dismissible', 'false');
         const aboutModal = new AboutModal({ target });
         target.resolve = resolve;
 
@@ -342,9 +311,6 @@ export async function showImportWorkspaceFileModal(
         });
         target.resolve = resolve;
 
-        // Do not allow users to dismiss this modal
-        target.setAttribute('data-dismissible', 'false');
-
         importWorkspaceFileModal.$on(
           'confirm',
           (
@@ -366,7 +332,6 @@ export async function showImportWorkspaceFileModal(
         importWorkspaceFileModal.$on('close', () => {
           target.replaceChildren();
           target.resolve = null;
-          target.removeAttribute('data-dismissible');
           importWorkspaceFileModal.$destroy();
         });
       }

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -69,7 +69,6 @@ export function closeActiveModal(): void {
   if (browser) {
     const target: ModalElement | null = document.querySelector('#svelte-modal');
     if (target && target.resolve) {
-      target.removeAttribute('data-dismissible');
       target.replaceChildren();
       target.resolve = null;
     }
@@ -182,10 +181,6 @@ export async function showDeleteExternalSourceModal(
       const target: ModalElement | null = document.querySelector('#svelte-modal');
 
       if (target) {
-        // if we don't do this, on clicking "Delete Unassociated Sources", modalBodyClickListener fires and the modal closes, which in this case is undesired
-        //    NOTE: in any case, ideally speaking, that method *should* only fire if anything _outside_ the target is clicked, right?
-        target.setAttribute('data-dismissible', 'false');
-
         const deleteExternalSourceModal = new DeleteExternalSourceModal({
           props: { linked, sources, unassociatedSources },
           target,
@@ -359,7 +354,6 @@ export async function showManagePlanConstraintsModal(user: User | null): Promise
         managePlanConstraintsModal.$on('close', () => {
           target.replaceChildren();
           target.resolve = null;
-          target.removeAttribute('data-dismissible');
           managePlanConstraintsModal.$destroy();
         });
 
@@ -397,7 +391,6 @@ export async function showManagePlanDerivationGroups(user: User | null): Promise
         managePlanDerivationGroupsModal.$on('close', () => {
           target.replaceChildren();
           target.resolve = null;
-          target.removeAttribute('data-dismissible');
           managePlanDerivationGroupsModal.$destroy();
         });
         managePlanDerivationGroupsModal.$on('add', (e: CustomEvent<{ derivationGroupName: string }[]>) => {
@@ -430,7 +423,6 @@ export async function showManagePlanSchedulingConditionsModal(user: User | null)
         managePlanConditionsModal.$on('close', () => {
           target.replaceChildren();
           target.resolve = null;
-          target.removeAttribute('data-dismissible');
           managePlanConditionsModal.$destroy();
         });
 
@@ -465,7 +457,6 @@ export async function showManagePlanSchedulingGoalsModal(user: User | null): Pro
         managePlanGoalsModal.$on('close', () => {
           target.replaceChildren();
           target.resolve = null;
-          target.removeAttribute('data-dismissible');
           managePlanGoalsModal.$destroy();
         });
 
@@ -500,13 +491,9 @@ export async function showMergeReviewEndedModal(
         });
         target.resolve = resolve;
 
-        // Do not allow users to dismiss this modal
-        target.setAttribute('data-dismissible', 'false');
-
         mergeReviewEndedModal.$on('close', () => {
           target.replaceChildren();
           target.resolve = null;
-          target.removeAttribute('data-dismissible');
           mergeReviewEndedModal.$destroy();
         });
       }


### PR DESCRIPTION
Reworks the `Modal` component to use internal click-outside and escape key handling. Previously these behaviors were handled by event listeners on the body. This PR also moves click-outside handling to a "stage" that is behind the modal instead of the parent component. This fixes issues like text highlighting ending outside of the modal causing modal closure. Additionally, modal props have been added to indicate whether the modal should close on escape and/or click-outside. By default, these behaviors are enabled and this PR disables those behaviors for the actions modal. Closes #1794.