### PR TITLE
Preserve reverse-chronological order of action runs on Actions page

### DIFF
--- a/src/components/sequencing/actions/Actions.svelte
+++ b/src/components/sequencing/actions/Actions.svelte
@@ -62,7 +62,7 @@
 
   $: if (typeof workspaceId === 'number') {
     workspaceActionDefinitions = Object.values($actionDefinitionsByWorkspace[workspaceId] || {});
-    workspaceActionRuns = Object.values($actionRunsByWorkspace[workspaceId] || {});
+    workspaceActionRuns = $actionRunsByWorkspace[workspaceId] || [];
     getWorkspaceSequences(workspaceId);
   }
 

--- a/src/stores/actions.ts
+++ b/src/stores/actions.ts
@@ -32,17 +32,17 @@ export const actionDefinitionsByWorkspace: Readable<Record<number, Record<number
   },
 );
 
-export const actionRunsByWorkspace: Readable<Record<number, Record<number, ActionRunSlim>>> = derived(
+export const actionRunsByWorkspace: Readable<Record<number, ActionRunSlim[]>> = derived(
   actionRuns,
   $actionRuns => {
     if (!$actionRuns) {
       return {};
     }
-    return $actionRuns.reduce((acc: Record<number, Record<number, ActionRunSlim>>, actionRun) => {
+    return $actionRuns.reduce((acc: Record<number, ActionRunSlim[]>, actionRun) => {
       if (!acc[actionRun.action_definition.workspace_id]) {
-        acc[actionRun.action_definition.workspace_id] = {};
+        acc[actionRun.action_definition.workspace_id] = [];
       }
-      acc[actionRun.action_definition.workspace_id][actionRun.id] = actionRun;
+      acc[actionRun.action_definition.workspace_id].push(actionRun);
       return acc;
     }, {});
   },

--- a/src/stores/actions.ts
+++ b/src/stores/actions.ts
@@ -32,18 +32,15 @@ export const actionDefinitionsByWorkspace: Readable<Record<number, Record<number
   },
 );
 
-export const actionRunsByWorkspace: Readable<Record<number, ActionRunSlim[]>> = derived(
-  actionRuns,
-  $actionRuns => {
-    if (!$actionRuns) {
-      return {};
+export const actionRunsByWorkspace: Readable<Record<number, ActionRunSlim[]>> = derived(actionRuns, $actionRuns => {
+  if (!$actionRuns) {
+    return {};
+  }
+  return $actionRuns.reduce((acc: Record<number, ActionRunSlim[]>, actionRun) => {
+    if (!acc[actionRun.action_definition.workspace_id]) {
+      acc[actionRun.action_definition.workspace_id] = [];
     }
-    return $actionRuns.reduce((acc: Record<number, ActionRunSlim[]>, actionRun) => {
-      if (!acc[actionRun.action_definition.workspace_id]) {
-        acc[actionRun.action_definition.workspace_id] = [];
-      }
-      acc[actionRun.action_definition.workspace_id].push(actionRun);
-      return acc;
-    }, {});
-  },
-);
+    acc[actionRun.action_definition.workspace_id].push(actionRun);
+    return acc;
+  }, {});
+});


### PR DESCRIPTION
Fixes https://github.com/NASA-AMMOS/aerie-ui/issues/1793

The query for getting the list of action runs on the Actions page already retrieves them in the desired reverse-chronological order (...actually by `{ id: desc }`, but they're created with incremental ids at action-run-time) - this updates the derived `actionRunsByWorkspace` store to keep them in lists to preserve the order rather than a map by ID.