### PR TITLE
Rename "Sequence Editor" plan menu item to "Workspaces"

### DIFF
--- a/e2e-tests/fixtures/AppNav.ts
+++ b/e2e-tests/fixtures/AppNav.ts
@@ -45,7 +45,7 @@ export class AppNav {
     this.appMenuItemPlans = this.appMenu.getByRole('menuitem', { name: 'Plans' });
     this.appMenuItemScheduling = this.appMenu.getByRole('menuitem', { name: 'Scheduling' });
     this.appMenuItemSequenceTemplates = this.appMenu.getByRole('menuitem', { name: 'Sequence Templates' });
-    this.appMenuItemSequenceWorkspace = this.appMenu.getByRole('menuitem', { name: 'Sequence Editor' });
+    this.appMenuItemSequenceWorkspace = this.appMenu.getByRole('menuitem', { name: 'Workspaces' });
     this.page = page;
     this.pageLoadingLocator = page.locator(`.loading`);
     this.pageLoadedLocatorNoData = page.locator(`.body:has-text("No Plans Found")`);

--- a/e2e-tests/tests/app-nav.test.ts
+++ b/e2e-tests/tests/app-nav.test.ts
@@ -62,7 +62,7 @@ test.describe.serial('App Nav', () => {
     await expect(page).toHaveURL(`${baseURL}/models`);
   });
 
-  test(`Clicking on the app menu 'Sequence Editor' option should route to the workspaces page`, async ({ baseURL }) => {
+  test(`Clicking on the app menu 'Workspaces' option should route to the workspaces page`, async ({ baseURL }) => {
     await appNav.appMenuButton.click();
     await appNav.appMenu.waitFor({ state: 'attached' });
     await appNav.appMenu.waitFor({ state: 'visible' });

--- a/src/components/menus/AppMenu.svelte
+++ b/src/components/menus/AppMenu.svelte
@@ -103,7 +103,7 @@
           <h3 class="px-3 pb-2 pt-2 text-sm font-medium text-muted-foreground">Sequencing</h3>
           <MenuLink on:click={closeMenu} className="text-sm py-1.5" href={getWorkspacesUrl(base)}>
             <FileCode2 size={16} />
-            Sequence Editor
+            Workspaces
           </MenuLink>
           <MenuLink on:click={closeMenu} className="text-sm py-1.5" href="{base}/dictionaries">
             <BookA size={16} />


### PR DESCRIPTION
Renames this menu item to align with current behavior.