### PR TITLE
Fix 'Send to Workspace' to work with new Sequencing Workspaces

### DIFF
--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -169,8 +169,7 @@
     }
 
     if (expandedResult !== null) {
-      // TODO: remove this after expansion runs are made to work in new workspaces
-      // await effects.sendSequenceToWorkspace(sequence, expandedResult, user);
+      await effects.sendSequenceToWorkspace(sequence, expandedResult, user);
     }
   }
 

--- a/src/components/modals/ExpansionPanelModal.svelte
+++ b/src/components/modals/ExpansionPanelModal.svelte
@@ -4,9 +4,7 @@
   import { Label, Select } from '@nasa-jpl/stellar-svelte';
   import { createEventDispatcher } from 'svelte';
   import { field } from '../../stores/form';
-  import { parcels } from '../../stores/sequencing';
   import { workspaces } from '../../stores/workspaces';
-  import type { Parcel } from '../../types/sequencing';
   import type { Workspace } from '../../types/workspace';
   import { min } from '../../utilities/validators';
   import Field from '../form/Field.svelte';
@@ -20,24 +18,24 @@
 
   const dispatch = createEventDispatcher<{
     close: void;
-    save: { parcelId: number; workspaceId: number };
+    save: { workspaceId: number; workspaceName: string };
   }>();
 
   let workspaceIdField = field<number>(-1, [min(1, 'Field is required')]);
+  let workspaceIdFieldName: string;
   let selectedWorkspace: Workspace | undefined;
-
-  let parcelIdField = field<number>(-1, [min(1, 'Field is required')]);
-  let selectedParcel: Parcel | undefined;
 
   let saveButtonDisabled: boolean = true;
 
-  $: saveButtonDisabled = $workspaceIdField.value === -1 || $parcelIdField.value === -1;
+  $: saveButtonDisabled = $workspaceIdField.value === -1;
   $: selectedWorkspace = $workspaces.find(({ id }) => $workspaceIdField.value === id);
-  $: selectedParcel = $parcels.find(({ id }) => $parcelIdField.value === id);
+  $: if ($workspaceIdField.value) {
+    workspaceIdFieldName = $workspaces.find(workspace => workspace.id === $workspaceIdField.value)?.name ?? '';
+  }
 
   function save() {
     if (!saveButtonDisabled) {
-      dispatch('save', { parcelId: $parcelIdField.value, workspaceId: $workspaceIdField.value });
+      dispatch('save', { workspaceId: $workspaceIdField.value, workspaceName: workspaceIdFieldName });
     }
   }
 
@@ -54,13 +52,6 @@
       return '';
     }
     return `${workspace.name} (${workspace.id})`;
-  }
-
-  function getDisplayNameForParcel(parcel?: Parcel) {
-    if (!parcel) {
-      return '';
-    }
-    return `${parcel.name} (${parcel.id})`;
   }
 </script>
 
@@ -95,23 +86,6 @@
             {/each}
           </Select.Content>
           <Select.Input type="number" name="workspace-id" aria-label="Select Workspace hidden input" />
-        </Select.Root>
-      </Field>
-      <Field field={parcelIdField}>
-        <Label size="sm" for="parcel-id" class="pb-0.5">Parcel Id</Label>
-        <Select.Root selected={{ label: getDisplayNameForParcel(selectedParcel), value: selectedParcel?.id ?? '' }}>
-          <Select.Trigger class="min-w-[124px]" value={selectedParcel?.id} size="xs" aria-labelledby={null}>
-            <Select.Value aria-label="Select a parcel" placeholder="Select a parcel" />
-          </Select.Trigger>
-          <Select.Content class="z-[10000]">
-            {#each $parcels as parcel}
-              <Select.Item size="xs" value={parcel.id} label={getDisplayNameForParcel(parcel)} class="flex gap-1">
-                {parcel.name}
-                <div class="whitespace-nowrap text-muted-foreground">(Id: {parcel.id})</div>
-              </Select.Item>
-            {/each}
-          </Select.Content>
-          <Select.Input type="number" name="parcel-id" aria-label="Select Parcel hidden input" />
         </Select.Root>
       </Field>
     </fieldset>

--- a/src/components/modals/ExpansionPanelModal.svelte
+++ b/src/components/modals/ExpansionPanelModal.svelte
@@ -5,7 +5,9 @@
   import { createEventDispatcher } from 'svelte';
   import { field } from '../../stores/form';
   import { workspaces } from '../../stores/workspaces';
+  import type { User } from '../../types/app';
   import type { Workspace } from '../../types/workspace';
+  import { featurePermissions } from '../../utilities/permissions';
   import { min } from '../../utilities/validators';
   import Field from '../form/Field.svelte';
   import Modal from './Modal.svelte';
@@ -13,6 +15,7 @@
   import ModalFooter from './ModalFooter.svelte';
   import ModalHeader from './ModalHeader.svelte';
 
+  export let user: User | null;
   export let height: number = 200;
   export let width: number = 380;
 
@@ -24,10 +27,14 @@
   let workspaceIdField = field<number>(-1, [min(1, 'Field is required')]);
   let workspaceIdFieldName: string;
   let selectedWorkspace: Workspace | undefined;
+  let hasUpdatePermission: boolean = false;
 
   let saveButtonDisabled: boolean = true;
 
-  $: saveButtonDisabled = $workspaceIdField.value === -1;
+  $: if (selectedWorkspace !== undefined) {
+    hasUpdatePermission = featurePermissions.workspace.canUpdate(user, selectedWorkspace)
+  };
+  $: saveButtonDisabled = $workspaceIdField.value === -1 || !hasUpdatePermission;
   $: selectedWorkspace = $workspaces.find(({ id }) => $workspaceIdField.value === id);
   $: if ($workspaceIdField.value) {
     workspaceIdFieldName = $workspaces.find(workspace => workspace.id === $workspaceIdField.value)?.name ?? '';

--- a/src/components/modals/ExpansionPanelModal.svelte
+++ b/src/components/modals/ExpansionPanelModal.svelte
@@ -32,8 +32,8 @@
   let saveButtonDisabled: boolean = true;
 
   $: if (selectedWorkspace !== undefined) {
-    hasUpdatePermission = featurePermissions.workspace.canUpdate(user, selectedWorkspace)
-  };
+    hasUpdatePermission = featurePermissions.workspace.canUpdate(user, selectedWorkspace);
+  }
   $: saveButtonDisabled = $workspaceIdField.value === -1 || !hasUpdatePermission;
   $: selectedWorkspace = $workspaces.find(({ id }) => $workspaceIdField.value === id);
   $: if ($workspaceIdField.value) {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -270,6 +270,7 @@ import {
   showDeleteExternalEventSourceTypeModal,
   showDeleteExternalSourceModal,
   showEditViewModal,
+  showExpansionPanelModal,
   showImportWorkspaceFileModal,
   showLibrarySequenceModel,
   showManagePlanConstraintsModal,
@@ -7120,6 +7121,61 @@ const effects = {
       catchError('Sending Action Secret Parameters Failed', e as Error);
       showFailureToast('Sending Action Secret Parameters Failed');
     }
+  },
+
+  async sendSequenceToWorkspace(
+    sequence: ExpansionSequence | null,
+    expandedSequence: string | null,
+    user: User | null,
+  ): Promise<string | null> {
+    try {
+      if (sequence === null) {
+        throw new Error("Sequence Doesn't Exist");
+      }
+      if (expandedSequence === null) {
+        throw new Error("Expanded Sequence Doesn't Exist");
+      }
+
+      const { confirm: confirmWorkspace, value: valueWorkspace } = await showExpansionPanelModal();
+
+      if (!confirmWorkspace || !valueWorkspace) {
+        throw new Error('Unable To Find The Specified Workspace');
+      }
+
+      const { workspaceId, workspaceName } = valueWorkspace;
+
+      const workspaceContents = await effects.getWorkspaceContents(workspaceId, user);
+      if (!workspaceContents) {
+        throw new Error('Unable To Find The Specified Workspace');
+      }
+
+      const workspaceTree: WorkspaceTreeNode = {
+        contents: workspaceContents,
+        name: workspaceName,
+        type: WorkspaceContentType.Workspace,
+      };
+      workspaceTree;
+
+      const { confirm: confirmNewFile, value: confirmNewFileValue } = await showNewWorkspaceSequenceModal(
+        workspaceId,
+        workspaceTree,
+        '',
+        user,
+      );
+
+      if (confirmNewFile && confirmNewFileValue) {
+        const { filePath: newFilePath } = confirmNewFileValue;
+        const body = createWorkspaceSequenceFileFormData(newFilePath, expandedSequence);
+        await reqWorkspace<Workspace>(`${workspaceId}/${newFilePath}?type=file`, 'PUT', body, user, undefined, false);
+        showSuccessToast('Workspace File Created Successfully');
+      } else {
+        throw new Error('Workspace File Creation Failed');
+      }
+    } catch (e) {
+      catchError('Workspace file was unable to be created', e as Error);
+      showFailureToast('Workspace File Creation Failed');
+    }
+    return null;
   },
 
   async session(user: BaseUser | null): Promise<ReqSessionResponse> {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -7136,13 +7136,17 @@ const effects = {
         throw new Error("Expanded Sequence Doesn't Exist");
       }
 
-      const { confirm: confirmWorkspace, value: valueWorkspace } = await showExpansionPanelModal();
+      const { confirm: confirmWorkspace, value: valueWorkspace } = await showExpansionPanelModal(user);
 
       if (!confirmWorkspace || !valueWorkspace) {
         throw new Error('Unable To Find The Specified Workspace');
       }
 
       const { workspaceId, workspaceName } = valueWorkspace;
+
+      if (!featurePermissions.workspace.canUpdate(user, workspaceId)) {
+        throwPermissionError('upload to the selected workspace');
+      }
 
       const workspaceContents = await effects.getWorkspaceContents(workspaceId, user);
       if (!workspaceContents) {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -7176,7 +7176,6 @@ const effects = {
           newFilePathContents.shift();
           newFilePath = newFilePathContents.join(PATH_DELIMITER);
         }
-        console.log(newFilePath);
         await WorkspaceApi.saveFile(workspaceId, newFilePath, expandedSequence, false, user);
 
         showSuccessToast('Workspace File Created Successfully');

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -17,6 +17,7 @@ import {
 import type { SeqJson } from '@nasa-jpl/seq-json-schema/types';
 import { chunk } from 'lodash-es';
 import { get } from 'svelte/store';
+import { PATH_DELIMITER } from '../constants/workspaces';
 import { ConstraintDefinitionType } from '../enums/constraint';
 import { DictionaryTypes } from '../enums/dictionaryTypes';
 import { SchedulingDefinitionType } from '../enums/scheduling';
@@ -7163,12 +7164,19 @@ const effects = {
       const { confirm: confirmNewFile, value: confirmNewFileValue } = await showNewWorkspaceSequenceModal(
         workspaceId,
         workspaceTree,
-        '',
+        workspaceName,
         user,
       );
 
       if (confirmNewFile && confirmNewFileValue) {
-        const { filePath: newFilePath } = confirmNewFileValue;
+        let { filePath: newFilePath } = confirmNewFileValue;
+        // Trim workspace from path to avoid making extra directory
+        if (newFilePath.includes(PATH_DELIMITER)) {
+          const newFilePathContents: Array<string> = newFilePath.split(PATH_DELIMITER);
+          newFilePathContents.shift();
+          newFilePath = newFilePathContents.join(PATH_DELIMITER);
+        }
+        console.log(newFilePath);
         await WorkspaceApi.saveFile(workspaceId, newFilePath, expandedSequence, false, user);
 
         showSuccessToast('Workspace File Created Successfully');

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -7149,7 +7149,7 @@ const effects = {
         throwPermissionError('upload to the selected workspace');
       }
 
-      const workspaceContents = await effects.getWorkspaceContents(workspaceId, user);
+      const workspaceContents = await effects.getWorkspaceContents(workspaceId, '', user);
       if (!workspaceContents) {
         throw new Error('Unable To Find The Specified Workspace');
       }

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -7169,8 +7169,8 @@ const effects = {
 
       if (confirmNewFile && confirmNewFileValue) {
         const { filePath: newFilePath } = confirmNewFileValue;
-        const body = createWorkspaceSequenceFileFormData(newFilePath, expandedSequence);
-        await reqWorkspace<Workspace>(`${workspaceId}/${newFilePath}?type=file`, 'PUT', body, user, undefined, false);
+        await WorkspaceApi.saveFile(workspaceId, newFilePath, expandedSequence, false, user);
+
         showSuccessToast('Workspace File Created Successfully');
       } else {
         throw new Error('Workspace File Creation Failed');

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -1604,13 +1604,13 @@ export async function showUpdatePlanMissionModelModal(plan: PlanSlim, user: User
 /**
  * Shows an ExpansionPanelModal.
  */
-export async function showExpansionPanelModal(): Promise<ModalElementValue> {
+export async function showExpansionPanelModal(user: User | null): Promise<ModalElementValue> {
   return new Promise(resolve => {
     if (browser) {
       const target: ModalElement | null = document.querySelector('#svelte-modal');
 
       if (target) {
-        const expansionPanelModal = new ExpansionPanelModal({ props: {}, target });
+        const expansionPanelModal = new ExpansionPanelModal({ props: { user }, target });
         target.resolve = resolve;
 
         expansionPanelModal.$on('close', () => {

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -1620,7 +1620,7 @@ export async function showExpansionPanelModal(user: User | null): Promise<ModalE
           expansionPanelModal.$destroy();
         });
 
-        expansionPanelModal.$on('save', (e: CustomEvent<{ workspaceId: number }>) => {
+        expansionPanelModal.$on('save', (e: CustomEvent<{ workspaceId: number; workspaceName: string }>) => {
           target.replaceChildren();
           target.resolve = null;
           resolve({ confirm: true, value: e.detail });

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -1620,7 +1620,7 @@ export async function showExpansionPanelModal(): Promise<ModalElementValue> {
           expansionPanelModal.$destroy();
         });
 
-        expansionPanelModal.$on('save', (e: CustomEvent<{ parcelId: number; workspaceId: number }>) => {
+        expansionPanelModal.$on('save', (e: CustomEvent<{ workspaceId: number }>) => {
           target.replaceChildren();
           target.resolve = null;
           resolve({ confirm: true, value: e.detail });


### PR DESCRIPTION
This pull-request updates the 'Send to Workspace' feature in plan expansion to let the user create a new file in a sequencing workspace loaded with the expansion result of an expanded sequence.

https://github.com/user-attachments/assets/0ba50c37-40b7-4b04-9f4c-c412d7af5578

# Testing
1. Set `PUBLIC_COMMAND_EXPANSION_MODE=templating` in `.env` to enable Sequence Templating expansion
2. Upload [bananation.jar](https://github.com/NASA-AMMOS/aerie-ui/blob/develop/e2e-tests/data/banananation-develop.jar)
3. Upload [command_dictionary.xml](https://github.com/NASA-AMMOS/aerie-ui/blob/develop/e2e-tests/data/command-dictionary.xml), and create a new parcel called `Test` with it
4. Create a Workspace using the `Test` parcel
5. From the `Sequence Templates` menu option, create a new Sequence Template with the following criteria:

> Template Name: `Test`
> Template Language: `Text`
> Parcel: `Test`
> Model: `Bananation`
> Activity Type: `BakeBananaBread`

6. Modify the content of the Sequence Template to say `Test data`
7. Create a new plan with the `Bananation` model, any time range
8. Insert a `BakeBananaBread` activity, set arguments to any values, simulate
9. Under `Expansion`, create a new sequence called `Test`
10. Add the `BakeBananaBread` activity to the `Test` sequence
11. Within the `Expansion` panel, hover over the `Test` sequence and click the play/`Expand Sequence` button
12. Within the `Expansion` panel, hover over the `Test` sequence and click the `Send Expanded Sequence to Workspace` button
13. Select the previously created workspace and click `Save`
14. Enter `Test.txt` for the filename and click `Confirm`
15. Navigate to the workspace and confirm the file is created with the `Test data` content inside

