### PR TITLE
Update sequence adaptation loading to inject CM dependencies

### DIFF
--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -57,6 +57,11 @@
   import { mapWorkspaceTreePaths, separateFilenameFromPath } from '../../../utilities/workspaces';
   import type { PageData } from './$types';
 
+  // codemirror dependencies to be injected into the adaptation
+  import * as cmCommands from "@codemirror/commands";
+  import * as cmLanguage from "@codemirror/language";
+  import * as cmView from "@codemirror/view";
+
   export let data: PageData;
 
   const { initialWorkspace, user } = data;
@@ -241,7 +246,22 @@
 
       if (adaptation) {
         try {
-          setSequenceLanguages(eval(String(adaptation.adaptation))); // TODO replace with a try/catch/finally using blob URLs and dynamic modules
+          // the adaptation code is expected to be a commonjs module which calls `require(...)`
+          // to load its codemirror dependencies, because the adaptation *must* use the same Codemirror
+          // instance/globals as the outer page context, rather than bundling its own, due to CM internal state.
+          // This pattern creates a function wrapping the adaptation code, which provides our own custom `require`
+          // to correctly resolve CM deps.
+          const adaptationCode = adaptation.adaptation;
+          const run = new Function("require", "exports", adaptationCode);
+          const exports: Record<string, unknown> = {};
+          const customRequire = (id: string) => {
+            return {
+              "@codemirror/commands": cmCommands,
+              "@codemirror/language": cmLanguage,
+              "@codemirror/view": cmView,
+            }[id];
+          };
+          setSequenceLanguages(run(customRequire, exports));
         } catch (e) {
           console.error(e);
           showFailureToast('Invalid sequence adaptation');

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -58,9 +58,9 @@
   import type { PageData } from './$types';
 
   // codemirror dependencies to be injected into the adaptation
-  import * as cmCommands from "@codemirror/commands";
-  import * as cmLanguage from "@codemirror/language";
-  import * as cmView from "@codemirror/view";
+  import * as cmCommands from '@codemirror/commands';
+  import * as cmLanguage from '@codemirror/language';
+  import * as cmView from '@codemirror/view';
 
   export let data: PageData;
 
@@ -252,13 +252,13 @@
           // This pattern creates a function wrapping the adaptation code, which provides our own custom `require`
           // to correctly resolve CM deps.
           const adaptationCode = adaptation.adaptation;
-          const run = new Function("require", "exports", adaptationCode);
+          const run = new Function('require', 'exports', adaptationCode);
           const exports: Record<string, unknown> = {};
           const customRequire = (id: string) => {
             return {
-              "@codemirror/commands": cmCommands,
-              "@codemirror/language": cmLanguage,
-              "@codemirror/view": cmView,
+              '@codemirror/commands': cmCommands,
+              '@codemirror/language': cmLanguage,
+              '@codemirror/view': cmView,
             }[id];
           };
           setSequenceLanguages(run(customRequire, exports));


### PR DESCRIPTION
During testing, @parkerabercrombie and I discovered that the new Aerie sequencing adaptation format (introduced in https://github.com/NASA-AMMOS/aerie-ui/pull/1804 ) was *working correctly* when running the local aerie-ui *dev server*, but NOT working when running with the *production build* of aerie-ui.

After investigation, we found that this is due to differences between the two builds regarding how the codemirror modules required by the adaptation were being loaded - in dev mode, `aerie-ui` and the adaptation were using the same codemirror instance/globals, but in the production build, the adaptation was using its own copy of Codemirror code that it had bundled into the adaptation, which caused the entire adaptation to throw errors on every keystroke when editing SeqN. This affected *both* the clipper adaptation and the one from or adaptation template:  https://github.com/NASA-AMMOS/aerie-sequence-adaptation-template

We decided that the best move is to ensure that adaptations *do not* bundle any CodeMirror code at all, which we did by marking them as external dependencies in the adaptation rollup config (see other PR), and then injecting them from the parent context when loading the adaptation (this PR). One consequence of this change is that adaptations must now be built as a CommonJS bundle, since this injection is much easier to do with `require()` than with import statements.

This will require changes to adaptations, but not to their core code, only to their rollup configs. Tested with updated versions of both the template and clipper adaptations in dev mode and production with no issues.