### PR TITLE
update lint, publish and test workflows to use same NPM version as specified in the .nvmrc file

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version-file: '.nvmrc'
           cache: npm
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version-file: '.nvmrc'
           cache: npm
       - name: Install All Dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Node (UI)
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version-file: '.nvmrc'
           cache: npm
       - name: Install Dependencies (UI)
         run: npm ci


### PR DESCRIPTION
NPM 24 just became LTS, which caused our workflows to use it for CI activities (since they specified lts as their version), which caused issues due to inconsistencies in lockfiles/subdependencies. This makes it use the same version as our nvmrc