### PR TITLE
Rework Workspace File Download

### DIFF
--- a/src/components/workspace/WorkspaceContextMenuContents.svelte
+++ b/src/components/workspace/WorkspaceContextMenuContents.svelte
@@ -45,7 +45,9 @@
       : '';
   }
 
-  $: canDownload = selectedWorkspaceNodes.map(node => node.type !== WorkspaceContentType.Directory).every(nodeType => nodeType === true);
+  $: canDownload = selectedWorkspaceNodes
+    .map(node => node.type !== WorkspaceContentType.Directory)
+    .every(nodeType => nodeType === true);
 </script>
 
 <ContextMenu.Group>
@@ -97,7 +99,8 @@
 {#if selectedWorkspaceNodes.length === 1}
   {#if canDownload}
     <div>
-      <ContextMenu.Item size="sm" on:click={() => dispatch('download')} aria-label="Download">Download</ContextMenu.Item>
+      <ContextMenu.Item size="sm" on:click={() => dispatch('download')} aria-label="Download">Download</ContextMenu.Item
+      >
     </div>
     <ContextMenu.Separator />
   {/if}

--- a/src/components/workspace/WorkspaceContextMenuContents.svelte
+++ b/src/components/workspace/WorkspaceContextMenuContents.svelte
@@ -3,6 +3,7 @@
 <script lang="ts">
   import { ContextMenu } from '@nasa-jpl/stellar-svelte';
   import { createEventDispatcher } from 'svelte';
+  import { WorkspaceContentType } from '../../enums/workspace';
   import type { ActionParameterPair } from '../../types/workspace';
   import type { WorkspaceTreeNode, WorkspaceTreeNodeWithFullPath } from '../../types/workspace-tree-view';
   import { permissionHandler } from '../../utilities/permissionHandler';
@@ -43,6 +44,8 @@
       ? `${selectedWorkspaceNodes.length} File${pluralize(selectedWorkspaceNodes.length)}`
       : '';
   }
+
+  $: canDownload = selectedWorkspaceNodes.map(node => node.type !== WorkspaceContentType.Directory).every(nodeType => nodeType === true);
 </script>
 
 <ContextMenu.Group>
@@ -92,10 +95,12 @@
 </ContextMenu.Group>
 <ContextMenu.Separator />
 {#if selectedWorkspaceNodes.length === 1}
-  <div>
-    <ContextMenu.Item size="sm" on:click={() => dispatch('download')} aria-label="Download">Download</ContextMenu.Item>
-  </div>
-  <ContextMenu.Separator />
+  {#if canDownload}
+    <div>
+      <ContextMenu.Item size="sm" on:click={() => dispatch('download')} aria-label="Download">Download</ContextMenu.Item>
+    </div>
+    <ContextMenu.Separator />
+  {/if}
 {/if}
 <div
   use:permissionHandler={{

--- a/src/components/workspace/WorkspaceContextMenuContents.svelte
+++ b/src/components/workspace/WorkspaceContextMenuContents.svelte
@@ -3,7 +3,6 @@
 <script lang="ts">
   import { ContextMenu } from '@nasa-jpl/stellar-svelte';
   import { createEventDispatcher } from 'svelte';
-  import { WorkspaceContentType } from '../../enums/workspace';
   import type { ActionParameterPair } from '../../types/workspace';
   import type { WorkspaceTreeNode, WorkspaceTreeNodeWithFullPath } from '../../types/workspace-tree-view';
   import { permissionHandler } from '../../utilities/permissionHandler';
@@ -18,6 +17,7 @@
   const dispatch = createEventDispatcher<{
     copyFileLocation: void;
     delete: void;
+    download: void;
     hide: void;
     importFile: void;
     move: void;
@@ -93,11 +93,7 @@
 <ContextMenu.Separator />
 {#if selectedWorkspaceNodes.length === 1}
   <div>
-    <ContextMenu.Item size="sm" on:click={() => dispatch('copyFileLocation')} aria-label="Copy Link to">
-      Copy {selectedWorkspaceNodes[0].type === WorkspaceContentType.Directory
-        ? 'Link to Directory'
-        : 'Download Link to File'}
-    </ContextMenu.Item>
+    <ContextMenu.Item size="sm" on:click={() => dispatch('download')} aria-label="Download">Download</ContextMenu.Item>
   </div>
   <ContextMenu.Separator />
 {/if}

--- a/src/components/workspace/WorkspaceGridView/WorkspaceGridView.svelte
+++ b/src/components/workspace/WorkspaceGridView/WorkspaceGridView.svelte
@@ -70,6 +70,7 @@
     newFolder: string;
     newSequence: string;
     nodeDelete: WorkspaceNodeEvent;
+    nodeDownload: WorkspaceNodeEvent;
     nodeMove: WorkspaceNodeEvent;
     nodeRename: WorkspaceNodeEvent;
     runAction: WorkspaceNodeRunActionEvent;
@@ -285,6 +286,15 @@
     closeBreadcrumbMenu();
   }
 
+  function onDownloadNode(node: WorkspaceTreeNodeWithFullPath) {
+    dispatch('nodeDownload', {
+      toggleState: true,
+      treeNode: node,
+      treeNodePath: node.fullPath,
+    });
+    closeBreadcrumbMenu();
+  }
+
   function onMoveNode(node: WorkspaceTreeNodeWithFullPath) {
     dispatch('nodeMove', {
       toggleState: true,
@@ -387,6 +397,12 @@
   function onTableDeleteNode() {
     if (contextMenuNode) {
       onDeleteNode(contextMenuNode);
+    }
+  }
+
+  function onTableDownloadNode() {
+    if (contextMenuNode) {
+      onDownloadNode(contextMenuNode);
     }
   }
 
@@ -622,6 +638,7 @@
         on:rename={onTableMenuRenameNode}
         on:move={onTableMenuMoveNode}
         on:delete={onTableDeleteNode}
+        on:download={onTableDownloadNode}
         on:copyFileLocation={onTableCopyFileLocation}
         on:moveToWorkspace={onTableMoveToWorkspace}
         on:runAction={event => onTableRunAction(event, selectedItemIds)}

--- a/src/components/workspace/WorkspaceSidebar.svelte
+++ b/src/components/workspace/WorkspaceSidebar.svelte
@@ -214,6 +214,7 @@
                         {user}
                         on:nodeClicked
                         on:nodeDelete
+                        on:nodeDownload
                         on:nodeMove
                         on:nodeRename
                         on:newFolder
@@ -261,6 +262,7 @@
                         {user}
                         {isRowSelectable}
                         on:nodeDelete
+                        on:nodeDownload
                         on:nodeMove
                         on:nodeRename
                         on:newSequence

--- a/src/components/workspace/WorkspaceTreeView/WorkspaceTreeView.svelte
+++ b/src/components/workspace/WorkspaceTreeView/WorkspaceTreeView.svelte
@@ -36,6 +36,7 @@
     newSequence: string;
     nodeClicked: WorkspaceNodeEvent;
     nodeDelete: WorkspaceNodeEvent;
+    nodeDownload: WorkspaceNodeEvent;
     nodeMove: WorkspaceNodeEvent;
     nodeRename: WorkspaceNodeEvent;
     runAction: WorkspaceNodeRunActionEvent;
@@ -81,6 +82,16 @@
   function onDeleteNode() {
     if (contextMenuNode) {
       dispatch('nodeDelete', {
+        toggleState: true,
+        treeNode: contextMenuNode,
+        treeNodePath: contextMenuNode.fullPath,
+      });
+    }
+  }
+
+  function onDownloadNode() {
+    if (contextMenuNode) {
+      dispatch('nodeDownload', {
         toggleState: true,
         treeNode: contextMenuNode,
         treeNodePath: contextMenuNode.fullPath,
@@ -162,6 +173,7 @@
         on:rename={onRenameNode}
         on:move={onMoveNode}
         on:delete={onDeleteNode}
+        on:download={onDownloadNode}
         on:copyFileLocation={onCopyFileLocation}
         on:moveToWorkspace={onMoveToWorkspace}
         on:runAction={onRunAction}

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -57,7 +57,7 @@
   import { openActionRun } from '../../../utilities/actions';
   import { setClipboardContent } from '../../../utilities/clipboard';
   import effects from '../../../utilities/effects';
-  import { filterEmpty } from '../../../utilities/generic';
+  import { downloadBlob, filterEmpty } from '../../../utilities/generic';
   import { showConfirmModal } from '../../../utilities/modal';
   import { featurePermissions } from '../../../utilities/permissions';
   import { getActionsUrl, getWorkspacesUrl } from '../../../utilities/routes';
@@ -442,6 +442,18 @@
     }
   }
 
+  async function onNodeDownload({ detail: { treeNode, treeNodePath } }: CustomEvent<WorkspaceNodeEvent>) {
+    if ($workspaceId) {
+      const filename = treeNode.name;
+      if (filename) {
+        const fileContent = await effects.getWorkspaceFileContent($workspaceId, treeNodePath, user);
+        if (fileContent) {
+          downloadBlob(new Blob([fileContent]), filename);
+        }
+      }
+    }
+  }
+
   async function onNodeMove({ detail: { treeNode, treeNodePath } }: CustomEvent<WorkspaceNodeEvent>) {
     if ($workspace && workspaceTree) {
       let shouldUpdateSelectedSequencePath = treeNodePath === activeFilePath;
@@ -616,6 +628,7 @@
       on:deleteCollaborator={onDeleteCollaborator}
       on:nodeClicked={onNodeClicked}
       on:nodeDelete={onNodeDelete}
+      on:nodeDownload={onNodeDownload}
       on:nodeMove={onNodeMove}
       on:nodeRename={onNodeRename}
       on:newFolder={onNewFolder}


### PR DESCRIPTION
This PR reworks the file download within workspaces, removing the 'Copy Download Link to File' button and adding a 'Download' button which requests the content from the workspace server and downloads it as a `Blob`.

<img width="3024" height="1100" alt="image" src="https://github.com/user-attachments/assets/14276a59-022a-45d1-bd5f-2b2f36900766" />

Related to: https://github.com/NASA-AMMOS/aerie-ui/issues/1810