### PR TITLE
Change plan time bounds

### DIFF
--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -190,6 +190,10 @@ export class Plan {
     await this.panelSimulation.getByRole('button', { name: bound === 'start' ? 'Plan Start' : 'Plan End' }).click();
   }
 
+  async closeSnapshotPreview() {
+    await this.page.getByRole('button', { name: 'Close Preview' }).click();
+  }
+
   async createBranch(
     baseURL?: string,
     name: string = uniqueNamesGenerator({ dictionaries: [adjectives, colors, animals] }),
@@ -352,6 +356,14 @@ export class Plan {
     return (await this.panelActivityForm.locator('input[name="start-time"]').inputValue()).trim();
   }
 
+  /** Reads the read-only Start/End time values shown in the Plan Metadata panel. */
+  async getPlanMetadataBounds(): Promise<{ end: string; start: string }> {
+    await this.showPanel(PanelNames.PLAN_METADATA, true);
+    const start = (await this.panelPlanMetadata.locator('input[name="planStartTime"]').inputValue()).trim();
+    const end = (await this.panelPlanMetadata.locator('input[name="planEndTime"]').inputValue()).trim();
+    return { end, start };
+  }
+
   async getSimulationHistoryListLength() {
     const elements = await this.simulationHistoryList.locator(`button:has-text("Simulation ID")`).all();
     return elements.length;
@@ -366,6 +378,12 @@ export class Plan {
   async goto(planId = this.plans.planId) {
     await this.page.goto(`/plans/${planId}`, { waitUntil: 'load' });
     await this.page.waitForURL(`/plans/${planId}`, { waitUntil: 'load' });
+    await this.waitForTimelineLoading();
+  }
+
+  /** Navigates to a plan in snapshot-preview mode via the `snapshotId` query parameter. */
+  async gotoSnapshotPreview(snapshotId: number, planId = this.plans.planId) {
+    await this.page.goto(`/plans/${planId}?snapshotId=${snapshotId}`, { waitUntil: 'load' });
     await this.waitForTimelineLoading();
   }
 

--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -178,6 +178,18 @@ export class Plan {
     );
   }
 
+  /**
+   * Opens the simulation start/end date picker and clicks its "Plan Start"/"Plan End" action button,
+   * which resets that bound to the plan's start/end.
+   */
+  async clickSimulationPlanBoundButton(bound: 'start' | 'end') {
+    await this.showPanel(PanelNames.SIMULATION, true);
+    const input = this.panelSimulation.locator(`input[name="${bound === 'start' ? 'start-time' : 'end-time'}"]`);
+    await input.scrollIntoViewIfNeeded();
+    await input.click(); // open the date picker dropdown that contains the action button
+    await this.panelSimulation.getByRole('button', { name: bound === 'start' ? 'Plan Start' : 'Plan End' }).click();
+  }
+
   async createBranch(
     baseURL?: string,
     name: string = uniqueNamesGenerator({ dictionaries: [adjectives, colors, animals] }),
@@ -321,6 +333,23 @@ export class Plan {
     await this.panelSimulation.getByPlaceholder('Enter template name').click();
     await this.panelSimulation.getByPlaceholder('Enter template name').fill(templateName);
     await this.panelSimulation.getByPlaceholder('Enter template name').blur();
+  }
+
+  /**
+   * Selects the activity directive with the given name in the directives table and returns the
+   * absolute start time shown in the activity form (resolved from offsets/anchors).
+   */
+  async getActivityStartTime(activityName: string): Promise<string> {
+    if (!(await this.panelActivityDirectivesTable.isVisible())) {
+      await this.showPanel(PanelNames.ACTIVITY_DIRECTIVES_TABLE);
+    }
+    await this.panelActivityDirectivesTable.getByRole('row', { name: activityName }).first().click();
+    if (!(await this.panelActivityForm.isVisible())) {
+      await this.showPanel(PanelNames.SELECTED_ACTIVITY, true);
+    }
+    // The activity name is shown as a header label (not an input) until it is edited.
+    await expect(this.panelActivityForm.locator('.activity-header-title-value')).toHaveText(activityName);
+    return (await this.panelActivityForm.locator('input[name="start-time"]').inputValue()).trim();
   }
 
   async getSimulationHistoryListLength() {
@@ -481,6 +510,60 @@ export class Plan {
       templateName,
     );
     await expect(this.panelSimulation.getByRole('combobox', { name: templateName })).toBeVisible();
+  }
+
+  /**
+   * Sets the plan's end time via the "Change Plan Time Range" modal.
+   */
+  async setPlanEndTime(value: string) {
+    await this.setPlanTimeBound('boundsEndTime', value);
+  }
+
+  /**
+   * Sets the plan's start time via the "Change Plan Time Range" modal.
+   */
+  async setPlanStartTime(value: string) {
+    await this.setPlanTimeBound('boundsStartTime', value);
+  }
+
+  /**
+   * Opens the "Change Plan Time Range" modal from the Plan Metadata panel, sets one bound
+   * (committing with Enter), and submits. If the bound did not actually change the Update button
+   * stays disabled, so the modal is dismissed instead and the caller never hangs on a no-op.
+   */
+  async setPlanTimeBound(fieldName: 'boundsStartTime' | 'boundsEndTime', value: string) {
+    await this.showPanel(PanelNames.PLAN_METADATA, true);
+    const editButton = this.panelPlanMetadata.getByRole('button', { name: 'Change plan time range' });
+    await editButton.scrollIntoViewIfNeeded();
+    await editButton.click();
+
+    const modal = this.page.locator('#modal-container');
+    await expect(modal).toContainText('Change Plan Time Range');
+
+    const input = modal.locator(`input[name="${fieldName}"]`);
+    await input.fill(value);
+    await input.press('Enter');
+
+    const updateButton = modal.getByRole('button', { name: 'Update Time Range' });
+    try {
+      await expect(updateButton).toBeEnabled({ timeout: 1000 });
+    } catch {
+      await modal.getByRole('button', { exact: true, name: 'Cancel' }).click();
+      return;
+    }
+    await updateButton.click();
+    await this.waitForToast('Plan Updated Successfully');
+  }
+
+  /**
+   * Types a value into the simulation start/end field (committing with Enter) in the Simulation panel.
+   */
+  async setSimulationBound(bound: 'start' | 'end', value: string) {
+    await this.showPanel(PanelNames.SIMULATION, true);
+    const input = this.panelSimulation.locator(`input[name="${bound === 'start' ? 'start-time' : 'end-time'}"]`);
+    await input.scrollIntoViewIfNeeded();
+    await input.fill(value);
+    await input.press('Enter');
   }
 
   async showChangeModelModal() {

--- a/e2e-tests/tests/change-plan-time.test.ts
+++ b/e2e-tests/tests/change-plan-time.test.ts
@@ -103,9 +103,9 @@ test.describe.serial('Change Plan Time Bounds', () => {
     expect(await setup.plan.getActivityStartTime(NAMES.child)).toBe(beforeChild);
   });
 
-  // KNOWN BACKEND BUG: when only the plan start moves (end fixed), a plan-end-anchored activity is
-  // shifted by the start delta instead of staying fixed in absolute time (its start_offset is
-  // wrongly adjusted). Re-enable once the backend preserves end-anchored absolute times here.
+  // Regression for the backend plan-bounds trigger: moving only the plan start (end fixed) must keep
+  // a plan-end-anchored activity fixed in absolute time — its start_offset is adjusted by the
+  // plan-end delta (zero here), not the start delta.
   test('Moving the plan start keeps plan-end-anchored activities fixed in absolute time', async () => {
     await setup.plan.setPlanStartTime('2022-001T00:00:00');
     await expect.poll(() => setup.plan.getActivityStartTime(NAMES.end)).toBe(beforeEnd);

--- a/e2e-tests/tests/change-plan-time.test.ts
+++ b/e2e-tests/tests/change-plan-time.test.ts
@@ -1,0 +1,113 @@
+import test, { expect } from '@playwright/test';
+import { setupTest, teardownTest, type FullSetupResult } from '../utilities/api.js';
+
+/**
+ * Verifies that activity directive times remain FIXED IN ABSOLUTE TIME when a plan's start/end
+ * bounds change — including activities anchored to plan start, anchored to another activity, and
+ * anchored to plan end.
+ *
+ */
+
+let setup: FullSetupResult;
+
+const NAMES = {
+  child: 'ChildAnchored', // anchored to the plan-start activity
+  end: 'PlanEndAnchored', // anchored to plan end
+  start: 'PlanStartAnchored', // anchored to plan start
+};
+
+const PLAN_START = '2022-005T00:00:00';
+const PLAN_END = '2022-020T00:00:00';
+
+test.beforeAll(async ({ browser }) => {
+  // Plan is created (not disabled), so this resolves to a FullSetupResult at runtime; the options
+  // overload widens the return type, so narrow it back here.
+  setup = (await setupTest(browser, { planEndTime: PLAN_END, planStartTime: PLAN_START })) as FullSetupResult;
+
+  // Anchored to plan start, +2 days -> 2022-007T00:00:00
+  const startAnchored = await setup.api.createActivityDirective({
+    anchor_id: null,
+    anchored_to_start: true,
+    arguments: { quantity: 1 },
+    metadata: {},
+    name: NAMES.start,
+    plan_id: setup.planId,
+    start_offset: '48:00:00',
+    type: 'GrowBanana',
+  });
+
+  // Anchored to the plan-start activity, +12 hours -> 2022-007T12:00:00
+  await setup.api.createActivityDirective({
+    anchor_id: startAnchored.id,
+    anchored_to_start: true,
+    arguments: { quantity: 1 },
+    metadata: {},
+    name: NAMES.child,
+    plan_id: setup.planId,
+    start_offset: '12:00:00',
+    type: 'GrowBanana',
+  });
+
+  // Anchored to plan end, -2 days -> 2022-018T00:00:00
+  await setup.api.createActivityDirective({
+    anchor_id: null,
+    anchored_to_start: false,
+    arguments: { quantity: 1 },
+    metadata: {},
+    name: NAMES.end,
+    plan_id: setup.planId,
+    start_offset: '-48:00:00',
+    type: 'GrowBanana',
+  });
+
+  await setup.plan.goto();
+});
+
+test.afterAll(async () => {
+  await teardownTest(setup);
+});
+
+test.describe.serial('Change Plan Time Bounds', () => {
+  let beforeStart: string;
+  let beforeChild: string;
+  let beforeEnd: string;
+
+  test('Records initial absolute activity start times', async () => {
+    beforeStart = await setup.plan.getActivityStartTime(NAMES.start);
+    beforeChild = await setup.plan.getActivityStartTime(NAMES.child);
+    beforeEnd = await setup.plan.getActivityStartTime(NAMES.end);
+
+    // Sanity check that the setup produced the expected absolute times.
+    expect(beforeStart).toContain('2022-007');
+    expect(beforeChild).toContain('2022-007');
+    expect(beforeEnd).toContain('2022-018');
+  });
+
+  // Done before any start change so the plan-end-anchored activity is checked from a clean state.
+  test('Moving the plan end later keeps activities fixed in absolute time', async () => {
+    await setup.plan.setPlanEndTime('2022-025T00:00:00');
+
+    // Plan-end-anchored activity must keep its absolute time (offset adjusted by the backend).
+    await expect.poll(() => setup.plan.getActivityStartTime(NAMES.end)).toBe(beforeEnd);
+    // Start-anchored + chained activities are unaffected since the start did not move.
+    expect(await setup.plan.getActivityStartTime(NAMES.start)).toBe(beforeStart);
+    expect(await setup.plan.getActivityStartTime(NAMES.child)).toBe(beforeChild);
+  });
+
+  test('Moving the plan start earlier keeps start-anchored and chained activities fixed', async () => {
+    await setup.plan.setPlanStartTime('2022-001T00:00:00');
+
+    // Plan-start-anchored activity must keep its absolute time (offset adjusted by the backend).
+    await expect.poll(() => setup.plan.getActivityStartTime(NAMES.start)).toBe(beforeStart);
+    // Activity anchored to another activity follows its anchor, so it is unaffected.
+    expect(await setup.plan.getActivityStartTime(NAMES.child)).toBe(beforeChild);
+  });
+
+  // KNOWN BACKEND BUG: when only the plan start moves (end fixed), a plan-end-anchored activity is
+  // shifted by the start delta instead of staying fixed in absolute time (its start_offset is
+  // wrongly adjusted). Re-enable once the backend preserves end-anchored absolute times here.
+  test('Moving the plan start keeps plan-end-anchored activities fixed in absolute time', async () => {
+    await setup.plan.setPlanStartTime('2022-001T00:00:00');
+    await expect.poll(() => setup.plan.getActivityStartTime(NAMES.end)).toBe(beforeEnd);
+  });
+});

--- a/e2e-tests/tests/plan-snapshot.test.ts
+++ b/e2e-tests/tests/plan-snapshot.test.ts
@@ -1,0 +1,60 @@
+import test, { expect } from '@playwright/test';
+import { setupTest, teardownTest, type FullSetupResult } from '../utilities/api.js';
+
+/**
+ * End-to-end tests for plan snapshots. Each behavior gets its own describe block with scoped setup
+ * so additional snapshot coverage (restore, create, etc.) can be added here rather than in new files.
+ */
+
+/**
+ * Previewing a plan snapshot taken at different bounds shows the SNAPSHOT's bounds in the Plan
+ * Metadata panel (read-only), and reverts to the live plan's bounds when the preview is closed.
+ * Activity repositioning and the timeline viewport snap are canvas behaviors covered manually / by
+ * unit tests.
+ */
+test.describe.serial('Snapshot Preview Bounds', () => {
+  let setup: FullSetupResult;
+  let snapshotId: number;
+
+  const PLAN_START = '2022-005T00:00:00';
+  const PLAN_END = '2022-020T00:00:00'; // bounds captured by the snapshot
+  const NEW_PLAN_END = '2022-025T00:00:00'; // live plan end after the change
+
+  test.beforeAll(async ({ browser }) => {
+    // Plan is created, so this resolves to a FullSetupResult at runtime.
+    setup = (await setupTest(browser, { planEndTime: PLAN_END, planStartTime: PLAN_START })) as FullSetupResult;
+    await setup.plan.goto();
+  });
+
+  test.afterAll(async () => {
+    await teardownTest(setup);
+  });
+
+  test('Snapshot captures the plan bounds; changing the plan end moves the live bounds', async () => {
+    const snapshot = await setup.api.createPlanSnapshot(setup.planId, 'Bounds Snapshot');
+    snapshotId = snapshot.snapshot_id;
+
+    await setup.plan.setPlanEndTime(NEW_PLAN_END);
+
+    const liveBounds = await setup.plan.getPlanMetadataBounds();
+    expect(liveBounds.start).toContain('2022-005');
+    expect(liveBounds.end).toContain('2022-025');
+  });
+
+  test('Previewing the snapshot shows the snapshot bounds, not the live plan bounds', async () => {
+    await setup.plan.gotoSnapshotPreview(snapshotId);
+
+    // The override is applied once the snapshot subscription resolves, so poll for it.
+    await expect.poll(async () => (await setup.plan.getPlanMetadataBounds()).end).toContain('2022-020');
+
+    const previewBounds = await setup.plan.getPlanMetadataBounds();
+    expect(previewBounds.start).toContain('2022-005');
+    expect(previewBounds.end).not.toContain('2022-025'); // not the live plan end
+  });
+
+  test('Closing the preview reverts to the live plan bounds', async () => {
+    await setup.plan.closeSnapshotPreview();
+
+    await expect.poll(async () => (await setup.plan.getPlanMetadataBounds()).end).toContain('2022-025');
+  });
+});

--- a/e2e-tests/tests/plan-snapshot.test.ts
+++ b/e2e-tests/tests/plan-snapshot.test.ts
@@ -2,27 +2,59 @@ import test, { expect } from '@playwright/test';
 import { setupTest, teardownTest, type FullSetupResult } from '../utilities/api.js';
 
 /**
- * End-to-end tests for plan snapshots. Each behavior gets its own describe block with scoped setup
- * so additional snapshot coverage (restore, create, etc.) can be added here rather than in new files.
- */
-
-/**
- * Previewing a plan snapshot taken at different bounds shows the SNAPSHOT's bounds in the Plan
- * Metadata panel (read-only), and reverts to the live plan's bounds when the preview is closed.
+ * End-to-end coverage for plan snapshots, run as a single linear flow over one plan to keep
+ * wall-clock setup cost low. It verifies two things together:
+ *  1. Previewing a snapshot taken at different bounds shows the SNAPSHOT's bounds in the Plan
+ *     Metadata panel (read-only) and reverts to the live plan's bounds when the preview is closed.
+ *  2. Activity directive times are fixed in ABSOLUTE time. Moving the plan bounds rewrites anchored
+ *     offsets to keep activities fixed, and that must not shift the absolute times shown when the
+ *     snapshot is PREVIEWED, nor after the snapshot is RESTORED.
+ *
  * Activity repositioning and the timeline viewport snap are canvas behaviors covered manually / by
  * unit tests.
  */
-test.describe.serial('Snapshot Preview Bounds', () => {
+test.describe.serial('Plan Snapshot Preview and Restore', () => {
   let setup: FullSetupResult;
   let snapshotId: number;
+
+  let beforeStart: string;
+  let beforeEnd: string;
 
   const PLAN_START = '2022-005T00:00:00';
   const PLAN_END = '2022-020T00:00:00'; // bounds captured by the snapshot
   const NEW_PLAN_END = '2022-025T00:00:00'; // live plan end after the change
 
+  const NAMES = {
+    end: 'PlanEndAnchored', // anchored to plan end, -2 days -> 2022-018T00:00:00
+    start: 'PlanStartAnchored', // anchored to plan start, +2 days -> 2022-007T00:00:00
+  };
+
   test.beforeAll(async ({ browser }) => {
     // Plan is created, so this resolves to a FullSetupResult at runtime.
     setup = (await setupTest(browser, { planEndTime: PLAN_END, planStartTime: PLAN_START })) as FullSetupResult;
+
+    await setup.api.createActivityDirective({
+      anchor_id: null,
+      anchored_to_start: true,
+      arguments: { quantity: 1 },
+      metadata: {},
+      name: NAMES.start,
+      plan_id: setup.planId,
+      start_offset: '48:00:00',
+      type: 'GrowBanana',
+    });
+
+    await setup.api.createActivityDirective({
+      anchor_id: null,
+      anchored_to_start: false,
+      arguments: { quantity: 1 },
+      metadata: {},
+      name: NAMES.end,
+      plan_id: setup.planId,
+      start_offset: '-48:00:00',
+      type: 'GrowBanana',
+    });
+
     await setup.plan.goto();
   });
 
@@ -30,18 +62,27 @@ test.describe.serial('Snapshot Preview Bounds', () => {
     await teardownTest(setup);
   });
 
-  test('Snapshot captures the plan bounds; changing the plan end moves the live bounds', async () => {
+  test('Snapshot captures the bounds and directive times; changing the plan end moves the live bounds but keeps directives fixed', async () => {
+    // Record the original absolute directive times, then snapshot them.
+    beforeStart = await setup.plan.getActivityStartTime(NAMES.start);
+    beforeEnd = await setup.plan.getActivityStartTime(NAMES.end);
+    expect(beforeStart).toContain('2022-007');
+    expect(beforeEnd).toContain('2022-018');
+
     const snapshot = await setup.api.createPlanSnapshot(setup.planId, 'Bounds Snapshot');
     snapshotId = snapshot.snapshot_id;
 
+    // Move the plan end later. The backend rewrites the plan-end-anchored offset so the live
+    // activity stays fixed in absolute time; this must not leak into the snapshot.
     await setup.plan.setPlanEndTime(NEW_PLAN_END);
 
     const liveBounds = await setup.plan.getPlanMetadataBounds();
     expect(liveBounds.start).toContain('2022-005');
     expect(liveBounds.end).toContain('2022-025');
+    await expect.poll(() => setup.plan.getActivityStartTime(NAMES.end)).toBe(beforeEnd);
   });
 
-  test('Previewing the snapshot shows the snapshot bounds, not the live plan bounds', async () => {
+  test('Previewing the snapshot shows the snapshot bounds and the original absolute directive times', async () => {
     await setup.plan.gotoSnapshotPreview(snapshotId);
 
     // The override is applied once the snapshot subscription resolves, so poll for it.
@@ -50,11 +91,25 @@ test.describe.serial('Snapshot Preview Bounds', () => {
     const previewBounds = await setup.plan.getPlanMetadataBounds();
     expect(previewBounds.start).toContain('2022-005');
     expect(previewBounds.end).not.toContain('2022-025'); // not the live plan end
+
+    expect(await setup.plan.getActivityStartTime(NAMES.start)).toBe(beforeStart);
+    expect(await setup.plan.getActivityStartTime(NAMES.end)).toBe(beforeEnd);
   });
 
   test('Closing the preview reverts to the live plan bounds', async () => {
     await setup.plan.closeSnapshotPreview();
 
     await expect.poll(async () => (await setup.plan.getPlanMetadataBounds()).end).toContain('2022-025');
+  });
+
+  test('Restoring the snapshot keeps the original absolute directive times and reverts the bounds', async () => {
+    await setup.api.restorePlanSnapshot(setup.planId, snapshotId);
+    await setup.plan.goto();
+
+    await expect.poll(() => setup.plan.getActivityStartTime(NAMES.start)).toBe(beforeStart);
+    expect(await setup.plan.getActivityStartTime(NAMES.end)).toBe(beforeEnd);
+
+    // Restoring the snapshot also restores its bounds, so the live plan end reverts.
+    await expect.poll(async () => (await setup.plan.getPlanMetadataBounds()).end).toContain('2022-020');
   });
 });

--- a/e2e-tests/tests/simulation-bounds.test.ts
+++ b/e2e-tests/tests/simulation-bounds.test.ts
@@ -1,0 +1,103 @@
+import test, { expect } from '@playwright/test';
+import { PanelNames } from '../fixtures/Plan.js';
+import { setupTest, teardownTest, type FullSetupResult } from '../utilities/api.js';
+
+/**
+ * Covers how the simulation bounds relate to the plan bounds:
+ *  - On creation the simulation bounds equal the plan bounds.
+ *  - Changing the plan bounds while the simulation bounds are untouched moves them with the plan
+ *    (the backend "follow" path — only fires when the sim bounds still equal the old plan bounds).
+ *  - Changing the plan bounds while the user has set a custom (in-range) simulation window leaves
+ *    that window alone.
+ *  - The "Plan Start" / "Plan End" buttons reset the corresponding bound to the plan's bound AND
+ *    persist it (previously they updated the field display but never saved).
+ *
+ * All persistence is asserted against the backend via the API, not the UI.
+ */
+
+let setup: FullSetupResult;
+
+const PLAN_START = '2022-005T00:00:00';
+const PLAN_END = '2022-020T00:00:00';
+
+const toMs = (time: string | null): number | null => (time ? new Date(time).getTime() : null);
+
+// Convert a `YYYY-DDDThh:mm:ss` day-of-year string (UTC) to epoch ms, avoiding a dependency on the
+// app's time utilities from within the e2e suite.
+function doyToMs(doy: string): number {
+  const match = /^(\d{4})-(\d{3})T(\d{2}):(\d{2}):(\d{2})/.exec(doy);
+  if (!match) {
+    throw new Error(`Invalid DOY string: ${doy}`);
+  }
+  const [, year, dayOfYear, hours, minutes, seconds] = match.map(Number);
+  return Date.UTC(year, 0, 1) + (dayOfYear - 1) * 86_400_000 + hours * 3_600_000 + minutes * 60_000 + seconds * 1_000;
+}
+
+const simStartMs = async (): Promise<number | null> =>
+  toMs((await setup.api.getSimulation(setup.planId)).simulation_start_time);
+const simEndMs = async (): Promise<number | null> =>
+  toMs((await setup.api.getSimulation(setup.planId)).simulation_end_time);
+
+test.beforeAll(async ({ browser }) => {
+  // Plan is created, so this resolves to a FullSetupResult at runtime.
+  setup = (await setupTest(browser, { planEndTime: PLAN_END, planStartTime: PLAN_START })) as FullSetupResult;
+  await setup.plan.goto();
+  await setup.plan.showPanel(PanelNames.SIMULATION, true);
+});
+
+test.afterAll(async () => {
+  await teardownTest(setup);
+});
+
+test.describe.serial('Simulation Bounds', () => {
+  // Track the current plan bounds as the serial tests mutate them.
+  const planStartDoy = PLAN_START; // start is never changed in these tests
+  let planEndDoy = PLAN_END;
+
+  test('Simulation bounds are initialized to the plan bounds', async () => {
+    expect(await simStartMs()).toBe(doyToMs(planStartDoy));
+    expect(await simEndMs()).toBe(doyToMs(planEndDoy));
+  });
+
+  // Must run before any sim-bound edit: the backend only "follows" when the sim bounds still equal
+  // the old plan bounds (true straight from creation).
+  test('Changing plan bounds moves untouched simulation bounds with the plan', async () => {
+    planEndDoy = '2022-025T00:00:00';
+    await setup.plan.setPlanEndTime(planEndDoy);
+
+    await expect.poll(simEndMs).toBe(doyToMs(planEndDoy));
+    expect(await simStartMs()).toBe(doyToMs(planStartDoy)); // start did not move
+  });
+
+  test('Changing plan bounds leaves a custom (in-range) simulation window alone', async () => {
+    const customStart = '2022-008T00:00:00';
+    const customEnd = '2022-012T00:00:00';
+    await setup.plan.setSimulationBound('start', customStart);
+    await setup.plan.setSimulationBound('end', customEnd);
+    await expect.poll(simStartMs).toBe(doyToMs(customStart));
+    await expect.poll(simEndMs).toBe(doyToMs(customEnd));
+
+    // Widen the plan; the custom window stays within range, so the backend must not touch it.
+    planEndDoy = '2022-030T00:00:00';
+    await setup.plan.setPlanEndTime(planEndDoy);
+
+    await expect.poll(simStartMs).toBe(doyToMs(customStart));
+    await expect.poll(simEndMs).toBe(doyToMs(customEnd));
+  });
+
+  test('"Plan Start" button resets the simulation start to the plan start and persists it', async () => {
+    await setup.plan.setSimulationBound('start', '2022-009T00:00:00');
+    await expect.poll(simStartMs).not.toBe(doyToMs(planStartDoy));
+
+    await setup.plan.clickSimulationPlanBoundButton('start');
+    await expect.poll(simStartMs).toBe(doyToMs(planStartDoy));
+  });
+
+  test('"Plan End" button resets the simulation end to the plan end and persists it', async () => {
+    await setup.plan.setSimulationBound('end', '2022-028T00:00:00');
+    await expect.poll(simEndMs).not.toBe(doyToMs(planEndDoy));
+
+    await setup.plan.clickSimulationPlanBoundButton('end');
+    await expect.poll(simEndMs).toBe(doyToMs(planEndDoy));
+  });
+});

--- a/e2e-tests/utilities/api.ts
+++ b/e2e-tests/utilities/api.ts
@@ -186,6 +186,15 @@ export class AerieApi {
     return data.plan;
   }
 
+  async getSimulation(
+    planId: number,
+  ): Promise<{ simulation_end_time: string | null; simulation_start_time: string | null }> {
+    const data = await this.gqlQuery<{
+      simulation: { simulation_end_time: string | null; simulation_start_time: string | null }[];
+    }>(convertToQuery(gql.SUB_SIMULATION), { planId });
+    return data.simulation[0];
+  }
+
   async getSimulationDataset(id: number): Promise<{ reason: string | null; status: string }> {
     const data = await this.gqlQuery<{
       simulation_dataset_by_pk: { reason: string | null; status: string };

--- a/e2e-tests/utilities/api.ts
+++ b/e2e-tests/utilities/api.ts
@@ -280,6 +280,14 @@ export class AerieApi {
     return this.user;
   }
 
+  async restorePlanSnapshot(planId: number, snapshotId: number): Promise<{ snapshot_id: number }> {
+    const data = await this.gqlQuery<{ restore_from_snapshot: { snapshot_id: number } }>(gql.RESTORE_PLAN_SNAPSHOT, {
+      plan_id: planId,
+      snapshot_id: snapshotId,
+    });
+    return data.restore_from_snapshot;
+  }
+
   /**
    * Set the user/token directly (e.g., from storage state).
    */

--- a/e2e-tests/utilities/api.ts
+++ b/e2e-tests/utilities/api.ts
@@ -94,6 +94,15 @@ export class AerieApi {
     return data.createPlan;
   }
 
+  async createPlanSnapshot(planId: number, name: string, description = ''): Promise<{ snapshot_id: number }> {
+    const data = await this.gqlQuery<{ createSnapshot: { snapshot_id: number } }>(gql.CREATE_PLAN_SNAPSHOT, {
+      description,
+      plan_id: planId,
+      snapshot_name: name,
+    });
+    return data.createSnapshot;
+  }
+
   async createSchedulingGoal(goal: SchedulingGoalInsertInput): Promise<{ id: number }> {
     const metadatadata = await this.gqlQuery<{ createSchedulingGoal: { id: number } }>(gql.CREATE_SCHEDULING_GOAL, {
       description: goal.description ?? '',

--- a/src/components/modals/ChangePlanBoundsModal.svelte
+++ b/src/components/modals/ChangePlanBoundsModal.svelte
@@ -51,6 +51,15 @@
 
   let errorMessage: string | null = null;
   let inFlight: boolean = false;
+  let startTimeMs: number | undefined;
+  let endTimeMs: number | undefined;
+  let bothValid: boolean = false;
+  let durationString: string = 'None';
+  let planStartMs: number = 0;
+  let planEndYmd: string | null = null;
+  let planEndMs: number = NaN;
+  let changed: boolean = false;
+  let updateDisabled: boolean = true;
 
   $: startTimeMs = $plugins.time.primary.parse($startTimeField.value)?.getTime();
   $: endTimeMs = $plugins.time.primary.parse($endTimeField.value)?.getTime();

--- a/src/components/modals/ChangePlanBoundsModal.svelte
+++ b/src/components/modals/ChangePlanBoundsModal.svelte
@@ -1,0 +1,168 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { createEventDispatcher, onMount } from 'svelte';
+  import { field } from '../../stores/form';
+  import { plugins } from '../../stores/plugins';
+  import type { User } from '../../types/app';
+  import type { Plan, PlanSlim } from '../../types/plan';
+  import effects from '../../utilities/effects';
+  import { computeDurationString, computePlanTimeUpdate } from '../../utilities/plan';
+  import { convertDoyToYmd, formatDate, getDoyTime } from '../../utilities/time';
+  import { required, validateStartTime } from '../../utilities/validators';
+  import DatePickerField from '../form/DatePickerField.svelte';
+  import Input from '../form/Input.svelte';
+  import AlertError from '../ui/AlertError.svelte';
+  import ProgressRadial from '../ui/ProgressRadial.svelte';
+  import Modal from './Modal.svelte';
+  import ModalContent from './ModalContent.svelte';
+  import ModalFooter from './ModalFooter.svelte';
+  import ModalHeader from './ModalHeader.svelte';
+
+  export let plan: Plan | PlanSlim;
+  export let user: User | null = null;
+
+  const dispatch = createEventDispatcher<{
+    close: void;
+    confirm: void;
+  }>();
+
+  // Cross-field validators ensure end stays after start regardless of which field changed.
+  async function validateStartTimeField(startTime: string) {
+    const startDate = $plugins.time.primary.parse(startTime);
+    const endDate = $plugins.time.primary.parse($endTimeField.value);
+    if (!startDate || !endDate) {
+      return null;
+    }
+    return validateStartTime(startDate.getTime(), endDate.getTime(), 'Plan');
+  }
+
+  async function validateEndTimeField(endTime: string) {
+    const startDate = $plugins.time.primary.parse($startTimeField.value);
+    const endDate = $plugins.time.primary.parse(endTime);
+    if (!startDate || !endDate) {
+      return null;
+    }
+    return validateStartTime(startDate.getTime(), endDate.getTime(), 'Plan');
+  }
+
+  const startTimeField = field<string>('', [required, $plugins.time.primary.validate, validateStartTimeField]);
+  const endTimeField = field<string>('', [required, $plugins.time.primary.validate, validateEndTimeField]);
+
+  let errorMessage: string | null = null;
+  let inFlight: boolean = false;
+
+  $: startTimeMs = $plugins.time.primary.parse($startTimeField.value)?.getTime();
+  $: endTimeMs = $plugins.time.primary.parse($endTimeField.value)?.getTime();
+  $: bothValid = $startTimeField.valid && $endTimeField.valid;
+  $: durationString = computeDurationString(startTimeMs, endTimeMs, bothValid);
+
+  // Compare against the plan's current bounds so we only submit a real change.
+  $: planStartMs = new Date(plan.start_time).getTime();
+  $: planEndYmd = convertDoyToYmd(plan.end_time_doy);
+  $: planEndMs = planEndYmd ? new Date(planEndYmd).getTime() : NaN;
+  $: changed = bothValid && (startTimeMs !== planStartMs || endTimeMs !== planEndMs);
+  $: updateDisabled = !bothValid || !changed || inFlight;
+
+  onMount(() => {
+    startTimeField.validateAndSet(formatDate(new Date(plan.start_time), $plugins.time.primary.format));
+    const endYmd = convertDoyToYmd(plan.end_time_doy);
+    if (endYmd) {
+      endTimeField.validateAndSet(formatDate(new Date(endYmd), $plugins.time.primary.format));
+    }
+  });
+
+  // Re-validate the opposite field so the cross-field error clears as soon as the range is valid.
+  async function onStartChange() {
+    await endTimeField.validateAndSet($endTimeField.value);
+  }
+
+  async function onEndChange() {
+    await startTimeField.validateAndSet($startTimeField.value);
+  }
+
+  function close() {
+    if (!inFlight) {
+      dispatch('close');
+    }
+  }
+
+  async function confirm() {
+    if (updateDisabled) {
+      return;
+    }
+    const startDate = $plugins.time.primary.parse($startTimeField.value);
+    const endDate = $plugins.time.primary.parse($endTimeField.value);
+    if (!startDate || !endDate) {
+      return;
+    }
+    const planTimeUpdate = computePlanTimeUpdate(getDoyTime(startDate), getDoyTime(endDate));
+    if (!planTimeUpdate) {
+      return;
+    }
+
+    inFlight = true;
+    errorMessage = null;
+    const updated = await effects.updatePlanTimeBounds(plan, planTimeUpdate, user);
+    inFlight = false;
+
+    if (updated) {
+      dispatch('confirm');
+    } else {
+      errorMessage = 'Failed to update the plan time range. Please try again.';
+    }
+  }
+</script>
+
+<Modal closeOnEscape={!inFlight} closeOnOutsideClick={!inFlight} height="auto" width={480} on:close={close}>
+  <ModalHeader showClose={!inFlight} on:close={close}>Change Plan Time Range</ModalHeader>
+  <ModalContent>
+    <p class="warning">
+      Activity directives will remain fixed in absolute time — their start offsets are adjusted automatically. Plan
+      snapshots and simulation results are also fixed and will not move.
+    </p>
+
+    {#if errorMessage}
+      <AlertError class="mb-3" error={errorMessage} />
+    {/if}
+
+    <DatePickerField
+      disabled={inFlight}
+      field={startTimeField}
+      label={`Start Time (${$plugins.time.primary.label})`}
+      layout="inline"
+      name="boundsStartTime"
+      on:change={onStartChange}
+      useFallback={!$plugins.time.enableDatePicker}
+    />
+    <DatePickerField
+      disabled={inFlight}
+      field={endTimeField}
+      label={`End Time (${$plugins.time.primary.label})`}
+      layout="inline"
+      name="boundsEndTime"
+      on:change={onEndChange}
+      useFallback={!$plugins.time.enableDatePicker}
+    />
+    <Input layout="inline">
+      <label for="boundsDuration">Plan Duration</label>
+      <input class="st-input w-full" disabled id="boundsDuration" name="boundsDuration" value={durationString} />
+    </Input>
+  </ModalContent>
+  <ModalFooter>
+    <button class="st-button secondary" disabled={inFlight} on:click={close}>Cancel</button>
+    <button class="st-button flex items-center gap-1" disabled={updateDisabled} on:click={confirm}>
+      {#if inFlight}
+        <ProgressRadial strokeWidth={1} size={14} />
+      {/if}
+      Update Time Range
+    </button>
+  </ModalFooter>
+</Modal>
+
+<style>
+  .warning {
+    color: var(--st-gray-60);
+    margin-bottom: 1rem;
+  }
+</style>

--- a/src/components/modals/ChangePlanBoundsModal.svelte
+++ b/src/components/modals/ChangePlanBoundsModal.svelte
@@ -126,7 +126,7 @@
 <Modal closeOnEscape={!inFlight} closeOnOutsideClick={!inFlight} height="auto" width={480} on:close={close}>
   <ModalHeader showClose={!inFlight} on:close={close}>Change Plan Time Range</ModalHeader>
   <ModalContent>
-    <p class="warning">
+    <p class="mb-4 text-muted-foreground">
       Activity directives will remain fixed in absolute time — their start offsets are adjusted automatically. Plan
       snapshots and simulation results are also fixed and will not move.
     </p>
@@ -168,10 +168,3 @@
     </button>
   </ModalFooter>
 </Modal>
-
-<style>
-  .warning {
-    color: var(--st-gray-60);
-    margin-bottom: 1rem;
-  }
-</style>

--- a/src/components/modals/ChangePlanBoundsModal.svelte
+++ b/src/components/modals/ChangePlanBoundsModal.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { LoaderCircle } from 'lucide-svelte';
   import { createEventDispatcher, onMount } from 'svelte';
   import { field } from '../../stores/form';
   import { plugins } from '../../stores/plugins';
@@ -13,7 +14,6 @@
   import DatePickerField from '../form/DatePickerField.svelte';
   import Input from '../form/Input.svelte';
   import AlertError from '../ui/AlertError.svelte';
-  import ProgressRadial from '../ui/ProgressRadial.svelte';
   import Modal from './Modal.svelte';
   import ModalContent from './ModalContent.svelte';
   import ModalFooter from './ModalFooter.svelte';
@@ -153,7 +153,7 @@
     <button class="st-button secondary" disabled={inFlight} on:click={close}>Cancel</button>
     <button class="st-button flex items-center gap-1" disabled={updateDisabled} on:click={confirm}>
       {#if inFlight}
-        <ProgressRadial strokeWidth={1} size={14} />
+        <LoaderCircle size={14} class="animate-spin" />
       {/if}
       Update Time Range
     </button>

--- a/src/components/modals/ChangePlanBoundsModal.svelte.test.ts
+++ b/src/components/modals/ChangePlanBoundsModal.svelte.test.ts
@@ -1,0 +1,89 @@
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Plan } from '../../types/plan';
+import effects from '../../utilities/effects';
+import ChangePlanBoundsModal from './ChangePlanBoundsModal.svelte';
+
+vi.mock('$env/dynamic/public', () => import.meta.env); // https://github.com/sveltejs/kit/issues/8180
+vi.mock('../../utilities/effects', () => ({
+  default: { updatePlanTimeBounds: vi.fn() },
+}));
+
+const plan = {
+  duration: '216:00:00',
+  end_time_doy: '2024-010T00:00:00',
+  id: 1,
+  start_time: '2024-01-01T00:00:00+00:00',
+} as Plan;
+
+// Commit a new value into a DatePicker input: set the bound value (input event) then trigger the
+// component's on:change handler.
+async function setDateInput(input: HTMLInputElement, value: string) {
+  await fireEvent.input(input, { target: { value } });
+  await fireEvent.change(input, { target: { value } });
+}
+
+describe('ChangePlanBoundsModal component', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders the warning and seeds the fields, with Update disabled until something changes', () => {
+    const { container, getByRole, getByText } = render(ChangePlanBoundsModal, { props: { plan, user: null } });
+
+    expect(getByText(/remain fixed in absolute time/i)).toBeTruthy();
+
+    const startInput = container.querySelector('input[name="boundsStartTime"]') as HTMLInputElement;
+    expect(startInput.value).toContain('2024-001');
+
+    const updateButton = getByRole('button', { name: 'Update Time Range' }) as HTMLButtonElement;
+    expect(updateButton.disabled).toBe(true);
+  });
+
+  it('dispatches close when Cancel is clicked', async () => {
+    const { component, getByRole } = render(ChangePlanBoundsModal, { props: { plan, user: null } });
+    const onClose = vi.fn();
+    component.$on('close', onClose);
+
+    await fireEvent.click(getByRole('button', { name: 'Cancel' }));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('dispatches confirm and calls the effect when the update succeeds', async () => {
+    vi.mocked(effects.updatePlanTimeBounds).mockResolvedValue(true);
+    const { component, container, getByRole } = render(ChangePlanBoundsModal, { props: { plan, user: null } });
+    const onConfirm = vi.fn();
+    component.$on('confirm', onConfirm);
+
+    const startInput = container.querySelector('input[name="boundsStartTime"]') as HTMLInputElement;
+    await setDateInput(startInput, '2023-300T00:00:00');
+
+    const updateButton = getByRole('button', { name: 'Update Time Range' }) as HTMLButtonElement;
+    await waitFor(() => expect(updateButton.disabled).toBe(false));
+    await fireEvent.click(updateButton);
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalled());
+    expect(effects.updatePlanTimeBounds).toHaveBeenCalled();
+  });
+
+  it('shows an error and stays open when the update fails', async () => {
+    vi.mocked(effects.updatePlanTimeBounds).mockResolvedValue(false);
+    const { component, container, findByText, getByRole } = render(ChangePlanBoundsModal, {
+      props: { plan, user: null },
+    });
+    const onConfirm = vi.fn();
+    component.$on('confirm', onConfirm);
+
+    const startInput = container.querySelector('input[name="boundsStartTime"]') as HTMLInputElement;
+    await setDateInput(startInput, '2023-300T00:00:00');
+
+    const updateButton = getByRole('button', { name: 'Update Time Range' }) as HTMLButtonElement;
+    await waitFor(() => expect(updateButton.disabled).toBe(false));
+    await fireEvent.click(updateButton);
+
+    expect(await findByText(/Failed to update/i)).toBeTruthy();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/modals/PlanBranchRequestModal.svelte
+++ b/src/components/modals/PlanBranchRequestModal.svelte
@@ -1,11 +1,13 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { Alert } from '@nasa-jpl/stellar-svelte';
   import BranchIcon from '@nasa-jpl/stellar/icons/branch.svg?component';
   import MergeIcon from '@nasa-jpl/stellar/icons/merge.svg?component';
+  import { TriangleAlert } from 'lucide-svelte';
   import { createEventDispatcher } from 'svelte';
   import type { Plan, PlanBranchRequestAction, PlanForMerging } from '../../types/plan';
-  import AlertError from '../ui/AlertError.svelte';
+  import { getDoyTime, getDoyTimeFromInterval, getIntervalInMs } from '../../utilities/time';
   import Modal from './Modal.svelte';
   import ModalContent from './ModalContent.svelte';
   import ModalFooter from './ModalFooter.svelte';
@@ -37,6 +39,7 @@
   let selectedPlan: PlanForMerging | null = null;
   let selectedPlanId: number | null = null;
   let planModelsCompatible: boolean = true;
+  let timeBoundsCompatible: boolean = true;
 
   $: selectedPlanId = plan?.parent_plan?.id ?? null;
   $: selectedPlan = planList.find(({ id }) => id === selectedPlanId) ?? null;
@@ -55,7 +58,21 @@
   } else {
     planModelsCompatible = true;
   }
-  $: createButtonDisabled = selectedPlanId === null || !planModelsCompatible;
+  $: if (selectedPlan && plan.parent_plan) {
+    timeBoundsCompatible =
+      new Date(plan.start_time).getTime() === new Date(plan.parent_plan.start_time).getTime() &&
+      getIntervalInMs(plan.duration) === getIntervalInMs(plan.parent_plan.duration);
+  } else {
+    timeBoundsCompatible = true;
+  }
+  $: createButtonDisabled = selectedPlanId === null || !planModelsCompatible || !timeBoundsCompatible;
+
+  $: sourceStartTime = getDoyTime(new Date(plan.start_time), false);
+  $: sourceEndTime = getDoyTimeFromInterval(plan.start_time, plan.duration, false);
+  $: targetStartTime = plan.parent_plan ? getDoyTime(new Date(plan.parent_plan.start_time), false) : '';
+  $: targetEndTime = plan.parent_plan
+    ? getDoyTimeFromInterval(plan.parent_plan.start_time, plan.parent_plan.duration, false)
+    : '';
 
   function create() {
     if (!createButtonDisabled && selectedPlan !== null) {
@@ -83,10 +100,24 @@
   <ModalContent>
     <div class="branch-action-container">
       {#if !planModelsCompatible}
-        <AlertError
-          fullError={`Current branch's model (ID: ${plan.model_id}) does not match target plan's model (ID: ${plan.parent_plan?.model_id})`}
-          error="Cannot create merge request due to mismatch in source and target plan models"
-        />
+        <Alert.Root variant="destructive" class="mb-3">
+          <TriangleAlert class="h-4 w-4" />
+          <Alert.Title>Invalid Merge Request</Alert.Title>
+          <Alert.Description>
+            Current branch's model (ID: {plan.model_id}) does not match target plan's model (ID: {plan.parent_plan
+              ?.model_id})
+          </Alert.Description>
+        </Alert.Root>
+      {/if}
+      {#if !timeBoundsCompatible}
+        <Alert.Root variant="destructive" class="mb-3">
+          <TriangleAlert class="h-4 w-4" />
+          <Alert.Title>Invalid Merge Request</Alert.Title>
+          <Alert.Description>
+            Current branch (start: {sourceStartTime}, end: {sourceEndTime}) and target plan (start: {targetStartTime},
+            end: {targetEndTime}) have different time bounds.
+          </Alert.Description>
+        </Alert.Root>
       {/if}
       <div>
         <div class="branch-header">Current branch</div>

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
   import { Button, cn } from '@nasa-jpl/stellar-svelte';
-  import { ArrowLeftRight, FileUp } from 'lucide-svelte';
+  import { FileUp, Pencil } from 'lucide-svelte';
   import { PlanStatusMessages } from '../../enums/planStatusMessages';
   import { SearchParameters } from '../../enums/searchParameters';
   import { field } from '../../stores/form';
@@ -220,7 +220,7 @@
           <div class="flex gap-1">
             <input
               class={cn('st-input w-full', !plan.model?.name ? 'border-destructive' : '')}
-              disabled
+              readonly
               name="modelName"
               value={plan.model?.name ?? 'Model not found'}
               id="modelName"
@@ -241,7 +241,7 @@
                 on:click={openChangePlanMissionModelModal}
                 aria-label="Change mission model"
               >
-                <ArrowLeftRight size={16} />
+                <Pencil size={16} />
               </Button>
             </div>
           </div>

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -14,7 +14,6 @@
     planSnapshotsWithSimulations,
   } from '../../stores/planSnapshots';
   import { plans } from '../../stores/plans';
-  import { plugins } from '../../stores/plugins';
   import { simulationDataset, simulationDatasetId } from '../../stores/simulation';
   import { viewTogglePanel } from '../../stores/views';
   import type { ActivityDirectivesMap } from '../../types/activity';
@@ -23,16 +22,14 @@
   import type { PlanSnapshot as PlanSnapshotType } from '../../types/plan-snapshot';
   import type { PlanTagsInsertInput, Tag, TagsChangeEvent } from '../../types/tags';
   import effects from '../../utilities/effects';
-  import { showConfirmModal } from '../../utilities/modal';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
-  import { computeDurationString, computePlanTimeUpdate, exportPlan } from '../../utilities/plan';
-  import { convertDoyToYmd, formatDate, getDoyTime, getShortISOForDate } from '../../utilities/time';
+  import { exportPlan } from '../../utilities/plan';
+  import { getShortISOForDate } from '../../utilities/time';
   import { tooltip } from '../../utilities/tooltip';
   import { removeQueryParam, setQueryParam } from '../../utilities/url';
   import { required, unique } from '../../utilities/validators';
   import Collapse from '../Collapse.svelte';
-  import DatePickerField from '../form/DatePickerField.svelte';
   import Field from '../form/Field.svelte';
   import Input from '../form/Input.svelte';
   import AsyncContentState from '../ui/AsyncContentState.svelte';
@@ -42,6 +39,7 @@
   import PlanCollaboratorInput from '../ui/Tags/PlanCollaboratorInput.svelte';
   import TagsInput from '../ui/Tags/TagsInput.svelte';
   import PlanSnapshot from './PlanSnapshot.svelte';
+  import PlanTimeBounds from './PlanTimeBounds.svelte';
 
   const planSnapshotsError = planSnapshots.error;
 
@@ -68,28 +66,10 @@
     ),
   ]);
   let planExporting: boolean = false;
-  let durationString: string = 'None';
-
-  $: startTimeField = field<string>('', [required, $plugins.time.primary.validate]);
-  $: endTimeField = field<string>('', [required, $plugins.time.primary.validate]);
 
   $: permissionError = $planReadOnly ? PlanStatusMessages.READ_ONLY : 'You do not have permission to edit this plan.';
   $: if (plan && plan.model) {
     hasCreateSnapshotPermission = featurePermissions.planSnapshot.canCreate(user, plan, plan.model) && !$planReadOnly;
-    // Initialize start time field from plan
-    const formattedStartTime = formatDate(new Date(plan.start_time), $plugins.time.primary.format);
-    if ($startTimeField.value !== formattedStartTime && !$startTimeField.dirty) {
-      startTimeField.validateAndSet(formattedStartTime);
-    }
-    // Initialize end time field from plan
-    const endTimeYmd = convertDoyToYmd(plan.end_time_doy);
-    if (endTimeYmd) {
-      const formattedEndTime = formatDate(new Date(endTimeYmd), $plugins.time.primary.format);
-      if ($endTimeField.value !== formattedEndTime && !$endTimeField.dirty) {
-        endTimeField.validateAndSet(formattedEndTime);
-      }
-    }
-    updateDurationString();
   }
   $: {
     if (plan && user) {
@@ -182,73 +162,6 @@
       // Optimistically update plan metadata
       planMetadata.updateValue(pm => (pm ? { ...pm, name: $planNameField.value } : null));
       effects.updatePlan(plan, { name: $planNameField.value }, user);
-    }
-  }
-
-  function updateDurationString() {
-    const startTimeMs = $plugins.time.primary.parse($startTimeField.value)?.getTime();
-    const endTimeMs = $plugins.time.primary.parse($endTimeField.value)?.getTime();
-    durationString = computeDurationString(startTimeMs, endTimeMs, $startTimeField.valid && $endTimeField.valid);
-  }
-
-  async function onStartTimeChanged() {
-    updateDurationString();
-    await updatePlanTimes();
-  }
-
-  async function onEndTimeChanged() {
-    updateDurationString();
-    await updatePlanTimes();
-  }
-
-  function revertTimeFields() {
-    if (!plan) {
-      return;
-    }
-    // Revert start time to original plan value
-    const originalStartTime = formatDate(new Date(plan.start_time), $plugins.time.primary.format);
-    startTimeField.validateAndSet(originalStartTime);
-
-    // Revert end time to original plan value
-    const endTimeYmd = convertDoyToYmd(plan.end_time_doy);
-    if (endTimeYmd) {
-      const originalEndTime = formatDate(new Date(endTimeYmd), $plugins.time.primary.format);
-      endTimeField.validateAndSet(originalEndTime);
-    }
-
-    updateDurationString();
-  }
-
-  async function updatePlanTimes() {
-    if (!plan || !$startTimeField.dirtyAndValid || !$endTimeField.dirtyAndValid) {
-      return;
-    }
-
-    const startTimeDate = $plugins.time.primary.parse($startTimeField.value);
-    const endTimeDate = $plugins.time.primary.parse($endTimeField.value);
-    if (!startTimeDate || !endTimeDate) {
-      return;
-    }
-
-    const { confirm } = await showConfirmModal(
-      'Update',
-      'Are you sure you want to change the time range of this plan? This may affect previous simulations and plan snapshots.',
-      'Confirm Plan Time Change',
-      false,
-      'Cancel',
-    );
-
-    if (!confirm) {
-      revertTimeFields();
-      return;
-    }
-
-    const startTimeDoy = getDoyTime(startTimeDate);
-    const endTimeDoy = getDoyTime(endTimeDate);
-
-    const planTimeUpdate = computePlanTimeUpdate(startTimeDoy, endTimeDoy);
-    if (planTimeUpdate) {
-      await effects.updatePlan(plan, planTimeUpdate, user);
     }
   }
 
@@ -347,46 +260,7 @@
             id="modelVersion"
           />
         </Input>
-        <DatePickerField
-          disabled={!hasPlanUpdatePermission}
-          layout="inline"
-          useFallback={!$plugins.time.enableDatePicker}
-          field={startTimeField}
-          label={`Start Time (${$plugins.time.primary.label})`}
-          name="startTime"
-          on:change={onStartTimeChanged}
-          use={[
-            [
-              permissionHandler,
-              {
-                hasPermission: hasPlanUpdatePermission,
-                permissionError,
-              },
-            ],
-          ]}
-        />
-        <DatePickerField
-          disabled={!hasPlanUpdatePermission}
-          layout="inline"
-          useFallback={!$plugins.time.enableDatePicker}
-          field={endTimeField}
-          label={`End Time (${$plugins.time.primary.label})`}
-          name="endTime"
-          on:change={onEndTimeChanged}
-          use={[
-            [
-              permissionHandler,
-              {
-                hasPermission: hasPlanUpdatePermission,
-                permissionError,
-              },
-            ],
-          ]}
-        />
-        <Input layout="inline">
-          <label use:tooltip={{ content: 'Plan Duration', placement: 'top' }} for="planDuration">Plan Duration</label>
-          <input class="st-input w-full" disabled name="planDuration" value={durationString} id="planDuration" />
-        </Input>
+        <PlanTimeBounds {plan} {user} hasUpdatePermission={hasPlanUpdatePermission} {permissionError} />
         <Input layout="inline">
           <label use:tooltip={{ content: 'Owner', placement: 'top' }} for="owner">Owner</label>
           <input class="st-input w-full" disabled name="owner" value={plan.owner} id="owner" />

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -23,17 +23,19 @@
   import type { PlanSnapshot as PlanSnapshotType } from '../../types/plan-snapshot';
   import type { PlanTagsInsertInput, Tag, TagsChangeEvent } from '../../types/tags';
   import effects from '../../utilities/effects';
+  import { showConfirmModal } from '../../utilities/modal';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
-  import { exportPlan } from '../../utilities/plan';
-  import { convertDoyToYmd, formatDate, getShortISOForDate } from '../../utilities/time';
+  import { computeDurationString, computePlanTimeUpdate, exportPlan } from '../../utilities/plan';
+  import { convertDoyToYmd, formatDate, getDoyTime, getShortISOForDate } from '../../utilities/time';
   import { tooltip } from '../../utilities/tooltip';
   import { removeQueryParam, setQueryParam } from '../../utilities/url';
   import { required, unique } from '../../utilities/validators';
   import Collapse from '../Collapse.svelte';
-  import AsyncContentState from '../ui/AsyncContentState.svelte';
+  import DatePickerField from '../form/DatePickerField.svelte';
   import Field from '../form/Field.svelte';
   import Input from '../form/Input.svelte';
+  import AsyncContentState from '../ui/AsyncContentState.svelte';
   import CardList from '../ui/CardList.svelte';
   import FilterToggleButton from '../ui/FilterToggleButton.svelte';
   import ProgressRadial from '../ui/ProgressRadial.svelte';
@@ -66,19 +68,28 @@
     ),
   ]);
   let planExporting: boolean = false;
-  let planStartTime: string = '';
-  let planEndTime: string = '';
+  let durationString: string = 'None';
+
+  $: startTimeField = field<string>('', [required, $plugins.time.primary.validate]);
+  $: endTimeField = field<string>('', [required, $plugins.time.primary.validate]);
 
   $: permissionError = $planReadOnly ? PlanStatusMessages.READ_ONLY : 'You do not have permission to edit this plan.';
   $: if (plan && plan.model) {
     hasCreateSnapshotPermission = featurePermissions.planSnapshot.canCreate(user, plan, plan.model) && !$planReadOnly;
-    planStartTime = formatDate(new Date(plan.start_time), $plugins.time.primary.format);
-    const endTime = convertDoyToYmd(plan.end_time_doy);
-    if (endTime) {
-      planEndTime = formatDate(new Date(endTime), $plugins.time.primary.format);
-    } else {
-      planEndTime = '';
+    // Initialize start time field from plan
+    const formattedStartTime = formatDate(new Date(plan.start_time), $plugins.time.primary.format);
+    if ($startTimeField.value !== formattedStartTime && !$startTimeField.dirty) {
+      startTimeField.validateAndSet(formattedStartTime);
     }
+    // Initialize end time field from plan
+    const endTimeYmd = convertDoyToYmd(plan.end_time_doy);
+    if (endTimeYmd) {
+      const formattedEndTime = formatDate(new Date(endTimeYmd), $plugins.time.primary.format);
+      if ($endTimeField.value !== formattedEndTime && !$endTimeField.dirty) {
+        endTimeField.validateAndSet(formattedEndTime);
+      }
+    }
+    updateDurationString();
   }
   $: {
     if (plan && user) {
@@ -171,6 +182,73 @@
       // Optimistically update plan metadata
       planMetadata.updateValue(pm => (pm ? { ...pm, name: $planNameField.value } : null));
       effects.updatePlan(plan, { name: $planNameField.value }, user);
+    }
+  }
+
+  function updateDurationString() {
+    const startTimeMs = $plugins.time.primary.parse($startTimeField.value)?.getTime();
+    const endTimeMs = $plugins.time.primary.parse($endTimeField.value)?.getTime();
+    durationString = computeDurationString(startTimeMs, endTimeMs, $startTimeField.valid && $endTimeField.valid);
+  }
+
+  async function onStartTimeChanged() {
+    updateDurationString();
+    await updatePlanTimes();
+  }
+
+  async function onEndTimeChanged() {
+    updateDurationString();
+    await updatePlanTimes();
+  }
+
+  function revertTimeFields() {
+    if (!plan) {
+      return;
+    }
+    // Revert start time to original plan value
+    const originalStartTime = formatDate(new Date(plan.start_time), $plugins.time.primary.format);
+    startTimeField.validateAndSet(originalStartTime);
+
+    // Revert end time to original plan value
+    const endTimeYmd = convertDoyToYmd(plan.end_time_doy);
+    if (endTimeYmd) {
+      const originalEndTime = formatDate(new Date(endTimeYmd), $plugins.time.primary.format);
+      endTimeField.validateAndSet(originalEndTime);
+    }
+
+    updateDurationString();
+  }
+
+  async function updatePlanTimes() {
+    if (!plan || !$startTimeField.dirtyAndValid || !$endTimeField.dirtyAndValid) {
+      return;
+    }
+
+    const startTimeDate = $plugins.time.primary.parse($startTimeField.value);
+    const endTimeDate = $plugins.time.primary.parse($endTimeField.value);
+    if (!startTimeDate || !endTimeDate) {
+      return;
+    }
+
+    const { confirm } = await showConfirmModal(
+      'Update',
+      'Are you sure you want to change the time range of this plan? This may affect previous simulations and plan snapshots.',
+      'Confirm Plan Time Change',
+      false,
+      'Cancel',
+    );
+
+    if (!confirm) {
+      revertTimeFields();
+      return;
+    }
+
+    const startTimeDoy = getDoyTime(startTimeDate);
+    const endTimeDoy = getDoyTime(endTimeDate);
+
+    const planTimeUpdate = computePlanTimeUpdate(startTimeDoy, endTimeDoy);
+    if (planTimeUpdate) {
+      await effects.updatePlan(plan, planTimeUpdate, user);
     }
   }
 
@@ -269,20 +347,45 @@
             id="modelVersion"
           />
         </Input>
+        <DatePickerField
+          disabled={!hasPlanUpdatePermission}
+          layout="inline"
+          useFallback={!$plugins.time.enableDatePicker}
+          field={startTimeField}
+          label={`Start Time (${$plugins.time.primary.label})`}
+          name="startTime"
+          on:change={onStartTimeChanged}
+          use={[
+            [
+              permissionHandler,
+              {
+                hasPermission: hasPlanUpdatePermission,
+                permissionError,
+              },
+            ],
+          ]}
+        />
+        <DatePickerField
+          disabled={!hasPlanUpdatePermission}
+          layout="inline"
+          useFallback={!$plugins.time.enableDatePicker}
+          field={endTimeField}
+          label={`End Time (${$plugins.time.primary.label})`}
+          name="endTime"
+          on:change={onEndTimeChanged}
+          use={[
+            [
+              permissionHandler,
+              {
+                hasPermission: hasPlanUpdatePermission,
+                permissionError,
+              },
+            ],
+          ]}
+        />
         <Input layout="inline">
-          <label
-            use:tooltip={{ content: `Start Time (${$plugins.time.primary.label})`, placement: 'top' }}
-            for="startTime"
-          >
-            Start Time ({$plugins.time.primary.label})
-          </label>
-          <input class="st-input w-full" disabled name="startTime" value={planStartTime} id="startTime" />
-        </Input>
-        <Input layout="inline">
-          <label use:tooltip={{ content: `End Time (${$plugins.time.primary.label})`, placement: 'top' }} for="endTime">
-            End Time ({$plugins.time.primary.label})
-          </label>
-          <input class="st-input w-full" disabled name="endTime" value={planEndTime} id="endTime" />
+          <label use:tooltip={{ content: 'Plan Duration', placement: 'top' }} for="planDuration">Plan Duration</label>
+          <input class="st-input w-full" disabled name="planDuration" value={durationString} id="planDuration" />
         </Input>
         <Input layout="inline">
           <label use:tooltip={{ content: 'Owner', placement: 'top' }} for="owner">Owner</label>

--- a/src/components/plan/PlanMergeReview.test.ts
+++ b/src/components/plan/PlanMergeReview.test.ts
@@ -67,6 +67,7 @@ const mockMergeRequest: PlanMergeRequestSchema = {
   id: 1,
   plan_receiving_changes: {
     collaborators: [],
+    duration: '168:00:00',
     id: 1,
     model: {
       owner: 'unknown',
@@ -79,6 +80,7 @@ const mockMergeRequest: PlanMergeRequestSchema = {
   plan_snapshot_supplying_changes: {
     plan: {
       collaborators: [],
+      duration: '168:00:00',
       id: 2,
       model: {
         owner: 'unknown',

--- a/src/components/plan/PlanTimeBounds.svelte
+++ b/src/components/plan/PlanTimeBounds.svelte
@@ -17,6 +17,11 @@
   export let hasUpdatePermission: boolean = false;
   export let permissionError: string = '';
 
+  let startTimeString: string = '';
+  let endTimeYmd: string | null = null;
+  let endTimeString: string = '';
+  let durationString: string = 'None';
+
   // Display values are read-only but selectable (the inputs are `readonly`, not `disabled`) so the
   // text remains copyable. Editing goes through ChangePlanBoundsModal, which edits both at once.
   $: startTimeString = formatDate(new Date(plan.start_time), $plugins.time.primary.format);

--- a/src/components/plan/PlanTimeBounds.svelte
+++ b/src/components/plan/PlanTimeBounds.svelte
@@ -1,0 +1,63 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { Button } from '@nasa-jpl/stellar-svelte';
+  import { Pencil } from 'lucide-svelte';
+  import { plugins } from '../../stores/plugins';
+  import type { User } from '../../types/app';
+  import type { Plan, PlanSlim } from '../../types/plan';
+  import { showChangePlanBoundsModal } from '../../utilities/modal';
+  import { permissionHandler } from '../../utilities/permissionHandler';
+  import { convertDoyToYmd, convertUsToDurationString, formatDate, getIntervalInMs } from '../../utilities/time';
+  import { tooltip } from '../../utilities/tooltip';
+  import Input from '../form/Input.svelte';
+
+  export let plan: Plan | PlanSlim;
+  export let user: User | null = null;
+  export let hasUpdatePermission: boolean = false;
+  export let permissionError: string = '';
+
+  // Display values are read-only but selectable (the inputs are `readonly`, not `disabled`) so the
+  // text remains copyable. Editing goes through ChangePlanBoundsModal, which edits both at once.
+  $: startTimeString = formatDate(new Date(plan.start_time), $plugins.time.primary.format);
+  $: endTimeYmd = convertDoyToYmd(plan.end_time_doy);
+  $: endTimeString = endTimeYmd ? formatDate(new Date(endTimeYmd), $plugins.time.primary.format) : plan.end_time_doy;
+  $: durationString = convertUsToDurationString(getIntervalInMs(plan.duration) * 1000) || 'None';
+
+  function openChangePlanBoundsModal() {
+    showChangePlanBoundsModal(plan, user);
+  }
+</script>
+
+<Input layout="inline">
+  <label use:tooltip={{ content: `Start Time (${$plugins.time.primary.label})`, placement: 'top' }} for="planStartTime">
+    Start Time ({$plugins.time.primary.label})
+  </label>
+  <div class="flex gap-1">
+    <input class="st-input w-full" id="planStartTime" name="planStartTime" readonly value={startTimeString} />
+    <div
+      use:permissionHandler={{ hasPermission: hasUpdatePermission, permissionError }}
+      use:tooltip={{ content: 'Change Plan Time Range', placement: 'top' }}
+    >
+      <Button
+        aria-label="Change plan time range"
+        class="shrink-0"
+        on:click={openChangePlanBoundsModal}
+        size="icon"
+        variant="outline"
+      >
+        <Pencil size={16} />
+      </Button>
+    </div>
+  </div>
+</Input>
+<Input layout="inline">
+  <label use:tooltip={{ content: `End Time (${$plugins.time.primary.label})`, placement: 'top' }} for="planEndTime">
+    End Time ({$plugins.time.primary.label})
+  </label>
+  <input class="st-input w-full" id="planEndTime" name="planEndTime" readonly value={endTimeString} />
+</Input>
+<Input layout="inline">
+  <label use:tooltip={{ content: 'Plan Duration', placement: 'top' }} for="planDuration">Plan Duration</label>
+  <input class="st-input w-full" id="planDuration" name="planDuration" readonly value={durationString} />
+</Input>

--- a/src/components/plan/PlanTimeBounds.svelte.test.ts
+++ b/src/components/plan/PlanTimeBounds.svelte.test.ts
@@ -1,0 +1,48 @@
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Plan } from '../../types/plan';
+import { showChangePlanBoundsModal } from '../../utilities/modal';
+import PlanTimeBounds from './PlanTimeBounds.svelte';
+
+vi.mock('../../utilities/modal', () => ({
+  showChangePlanBoundsModal: vi.fn(),
+}));
+
+const plan = {
+  duration: '216:00:00',
+  end_time_doy: '2024-010T00:00:00',
+  id: 1,
+  start_time: '2024-01-01T00:00:00+00:00',
+} as Plan;
+
+describe('PlanTimeBounds component', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders the start and end times as read-only (copyable) inputs', () => {
+    const { container } = render(PlanTimeBounds, { props: { hasUpdatePermission: true, plan, user: null } });
+
+    const startInput = container.querySelector('input[name="planStartTime"]') as HTMLInputElement;
+    const endInput = container.querySelector('input[name="planEndTime"]') as HTMLInputElement;
+    const durationInput = container.querySelector('input[name="planDuration"]') as HTMLInputElement;
+
+    // Read-only (so text stays selectable/copyable) rather than disabled.
+    expect(startInput.hasAttribute('readonly')).toBe(true);
+    expect(startInput.hasAttribute('disabled')).toBe(false);
+    expect(endInput.hasAttribute('readonly')).toBe(true);
+
+    expect(startInput.value).toContain('2024-001');
+    expect(endInput.value).toContain('2024-010');
+    expect(durationInput.value).not.toBe('');
+  });
+
+  it('opens the change-plan-bounds modal when the edit button is clicked', async () => {
+    const { getByRole } = render(PlanTimeBounds, { props: { hasUpdatePermission: true, plan, user: null } });
+
+    await fireEvent.click(getByRole('button', { name: 'Change plan time range' }));
+
+    expect(showChangePlanBoundsModal).toHaveBeenCalledWith(plan, null);
+  });
+});

--- a/src/components/simulation/SimulationHistoryDataset.svelte
+++ b/src/components/simulation/SimulationHistoryDataset.svelte
@@ -54,8 +54,20 @@
   let startTimeText: string = '';
   let status: Status | null = null;
   let simulationLoadable: boolean = true;
+  let simulationOutOfBounds: boolean = false;
 
   $: simulationLoadable = planModelId === simulationDataset.model_id;
+  // True when the simulation's time range falls entirely outside the plan's current bounds.
+  $: {
+    const simStartMs = simulationDataset.simulation_start_time
+      ? new Date(simulationDataset.simulation_start_time).getTime()
+      : null;
+    const simEndMs = simulationDataset.simulation_end_time
+      ? new Date(simulationDataset.simulation_end_time).getTime()
+      : null;
+    simulationOutOfBounds =
+      simStartMs !== null && simEndMs !== null && (simEndMs < planStartTimeMs || simStartMs > planEndTimeMs);
+  }
   $: simulationBoundsVizRangeWidthStyle =
     simulationBoundsVizRangeWidth < 1 ? '4px' : `${simulationBoundsVizRangeWidth}%`;
   $: simulationExtentVizRangeWidthStyle =
@@ -221,6 +233,16 @@
         }}
       >
         <WarningIcon class="red-icon" />Model Differs
+      </div>
+    {/if}
+    {#if simulationOutOfBounds}
+      <div
+        class="st-typography-label message"
+        use:tooltip={{
+          content: 'This simulation falls entirely outside the current plan bounds and may not be relevant.',
+        }}
+      >
+        <WarningIcon class="red-icon" />Out of Bounds
       </div>
     {/if}
   </div>

--- a/src/components/simulation/SimulationPanel.svelte
+++ b/src/components/simulation/SimulationPanel.svelte
@@ -317,14 +317,26 @@
   async function onPlanStartTimeClick() {
     if ($plan) {
       await startTimeField.validateAndSet(formatDate(new Date($planStartTimeMs), $plugins.time.primary.format));
-      updateStartEndTimes({ startString: $startTimeField.value });
+      // Re-validate the end field and send both bounds — updateStartEndTimes only persists when it
+      // receives a complete start/end pair.
+      await endTimeField.validateAndSet($endTimeField.value);
+      updateStartEndTimes({
+        ...($endTimeField.valid ? { endString: $endTimeField.value } : {}),
+        startString: $startTimeField.value,
+      });
     }
   }
 
   async function onPlanEndTimeClick() {
     if ($plan) {
       await endTimeField.validateAndSet(formatDate(new Date($planEndTimeMs), $plugins.time.primary.format));
-      updateStartEndTimes({ endString: $endTimeField.value });
+      // Re-validate the start field and send both bounds — updateStartEndTimes only persists when it
+      // receives a complete start/end pair.
+      await startTimeField.validateAndSet($startTimeField.value);
+      updateStartEndTimes({
+        endString: $endTimeField.value,
+        ...($startTimeField.valid ? { startString: $startTimeField.value } : {}),
+      });
     }
   }
 

--- a/src/components/timeline/LayerDiscrete.svelte
+++ b/src/components/timeline/LayerDiscrete.svelte
@@ -33,9 +33,7 @@
   import { isDeleteEvent } from '../../utilities/keyboardEvents';
   import {
     getActivityDirectiveStartTimeMs,
-    getDoyTime,
     getIntervalUnixEpochTime,
-    getUnixEpochTime,
     getUnixEpochTimeFromInterval,
   } from '../../utilities/time';
   import {
@@ -118,7 +116,6 @@
   let dragActivityDirectiveActive: ActivityDirective | null = null;
   let dragStartX: number | null = null;
   let minRectSize: number = 4;
-  let planStartTimeMs: number;
   let quadtreeActivityDirectives: Quadtree<QuadtreeRect>;
   let quadtreeSpans: Quadtree<QuadtreeRect>;
   let quadtreeExternalEvents: Quadtree<QuadtreeRect>;
@@ -145,8 +142,8 @@
   $: canvasHeightDpr = drawHeight * dpr;
   $: canvasWidthDpr = drawWidth * dpr;
   $: rowHeight = discreteOptions.height;
+  $: planStartTimeMs = planStartTimeYmd ? new Date(planStartTimeYmd).getTime() : 0;
   $: timelineLocked = timelineLockStatus === TimelineLockStatus.Locked;
-  $: planStartTimeMs = getUnixEpochTime(getDoyTime(new Date(planStartTimeYmd)));
 
   // the following are NOT mutually exclusive.
   $: canDrawActivities =

--- a/src/components/timeline/LayerDiscrete.svelte
+++ b/src/components/timeline/LayerDiscrete.svelte
@@ -31,11 +31,7 @@
   import { getExternalEventRowId } from '../../utilities/externalEvents';
   import { isRightClick } from '../../utilities/generic';
   import { isDeleteEvent } from '../../utilities/keyboardEvents';
-  import {
-    getActivityDirectiveStartTimeMs,
-    getIntervalUnixEpochTime,
-    getUnixEpochTimeFromInterval,
-  } from '../../utilities/time';
+  import { getActivityDirectiveStartTimeMs, getIntervalInMs, getIntervalUnixEpochTime } from '../../utilities/time';
   import {
     directiveInView,
     externalEventInView,
@@ -115,6 +111,9 @@
   let dragPreviousX: number | null = null;
   let dragActivityDirectiveActive: ActivityDirective | null = null;
   let dragStartX: number | null = null;
+  // Absolute time the dragged directive's start_offset is measured from (plan start, plan end, or its
+  // anchor) — captured at drag start so the dragged position converts back to an offset in the right frame.
+  let dragBaseMs: number | null = null;
   let minRectSize: number = 4;
   let quadtreeActivityDirectives: Quadtree<QuadtreeRect>;
   let quadtreeSpans: Quadtree<QuadtreeRect>;
@@ -211,7 +210,11 @@
     if (activityDirectives.length) {
       const [activityDirective] = activityDirectives; // Select just the first one for now.
 
-      const x = getUnixEpochTimeFromInterval(planStartTimeYmd, activityDirective.start_offset);
+      // Drag in absolute time using the directive's already-resolved start time (which respects
+      // plan-end and activity anchoring), and remember the base its offset is measured from so the
+      // dragged position can be converted back to an offset in the correct frame.
+      const x = activityDirective.start_time_ms;
+      dragBaseMs = activityDirective.start_time_ms - getIntervalInMs(activityDirective.start_offset);
       if (xScaleView !== null) {
         dragOffsetX = offsetX - xScaleView(x);
       }
@@ -228,7 +231,7 @@
       const xMs = xScaleView.invert(x).getTime();
       dragCurrentX = typeof dragActivityDirectiveActive.anchor_id === 'number' ? xMs : Math.max(xMs, planStartTimeMs);
       if (dragCurrentX !== dragPreviousX) {
-        const start_offset = getIntervalUnixEpochTime(planStartTimeMs, dragCurrentX);
+        const start_offset = getIntervalUnixEpochTime(dragBaseMs ?? planStartTimeMs, dragCurrentX);
         dragActivityDirectiveActive.start_offset = start_offset; // Update activity in memory.
         dragActivityDirectiveActive.start_time_ms = getActivityDirectiveStartTimeMs(
           dragActivityDirectiveActive.id,
@@ -248,11 +251,12 @@
   function dragActivityEnd(): void {
     if (dragActivityDirectiveActive !== null && dragStartX !== null && dragCurrentX !== null) {
       if (dragStartX !== dragCurrentX && plan) {
-        const start_offset = getIntervalUnixEpochTime(planStartTimeMs, dragCurrentX);
+        const start_offset = getIntervalUnixEpochTime(dragBaseMs ?? planStartTimeMs, dragCurrentX);
         effects.updateActivityDirective(plan, dragActivityDirectiveActive.id, { start_offset }, null, user);
       }
 
       dragActivityDirectiveActive = null;
+      dragBaseMs = null;
       dragCurrentX = null;
       dragOffsetX = null;
       dragStartX = null;

--- a/src/components/timeline/TimelineContextMenu.svelte
+++ b/src/components/timeline/TimelineContextMenu.svelte
@@ -116,9 +116,9 @@
   }
 
   $: startYmd = simulationDataset?.simulation_start_time ?? planStartTimeYmd;
-  $: activityDirectiveStartDate = activityDirective
-    ? new Date(getUnixEpochTimeFromInterval(planStartTimeYmd, activityDirective.start_offset))
-    : null;
+  // Use the directive's already-computed absolute start time so that directives anchored to the plan
+  // end (or to other directives) resolve correctly instead of being recomputed from the plan start.
+  $: activityDirectiveStartDate = activityDirective ? new Date(activityDirective.start_time_ms) : null;
   // Explicitly keep track of offsetX because Firefox ends up zeroing it out on the original `contextmenu` MouseEvent
   $: offsetX = contextMenu?.e.offsetX;
 

--- a/src/components/ui/DatePicker/DatePicker.svelte
+++ b/src/components/ui/DatePicker/DatePicker.svelte
@@ -221,6 +221,10 @@
 
     if (key === 'Enter') {
       event.preventDefault();
+      // Stop the Enter from bubbling to window-level listeners. Committing a value here can open a
+      // confirmation modal (which confirms on Enter); without this, that same Enter keystroke would
+      // immediately auto-confirm the modal before the user can read it.
+      event.stopPropagation();
 
       attemptAutoCompleteDate(event);
       closeDatePicker();

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -190,6 +190,7 @@
 
   let canCreate: boolean = false;
   let canChangePlanModel: boolean = false;
+  let canUpdatePlan: boolean = false;
   let columnDefs: DataGridColumnDef[] = baseColumnDefs;
   let createPlanButtonText: string = 'Create';
   let durationString: string = 'None';

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -16,6 +16,7 @@
   import Field from '../../components/form/Field.svelte';
   import Input from '../../components/form/Input.svelte';
   import ModelStatusRollup from '../../components/model/ModelStatusRollup.svelte';
+  import PlanTimeBounds from '../../components/plan/PlanTimeBounds.svelte';
   import AlertError from '../../components/ui/AlertError.svelte';
   import CssGrid from '../../components/ui/CssGrid.svelte';
   import DataGridActions from '../../components/ui/DataGrid/DataGridActions.svelte';
@@ -47,11 +48,9 @@
   import { computeDurationString, exportPlan, isDeprecatedPlanTransfer } from '../../utilities/plan';
   import {
     convertDoyToYmd,
-    convertUsToDurationString,
     formatDate,
     getDoyTime,
     getDoyTimeFromInterval,
-    getIntervalInMs,
     getShortISOForDate,
   } from '../../utilities/time';
   import { tooltip } from '../../utilities/tooltip';
@@ -204,8 +203,6 @@
   let selectedPlan: PlanSlim | undefined;
   let selectedPlanId: number | null = null;
   let selectedPlanModelName: string | null = null;
-  let selectedPlanStartTime: string | null = null;
-  let selectedPlanEndTime: string | null = null;
   let modelIdField = field<number>(-1, [min(1, 'Field is required')]);
   let nameField = field<string>('', [
     required,
@@ -222,6 +219,8 @@
   $: startTimeField = field<string>('', [required, $plugins.time.primary.validate]);
   $: endTimeField = field<string>('', [required, $plugins.time.primary.validate]);
   $: canChangePlanModel = selectedPlan !== undefined && featurePermissions.plan.canUpdateModel($user, selectedPlan);
+  $: canUpdatePlan =
+    selectedPlan !== undefined && $user ? featurePermissions.plan.canUpdate($user, selectedPlan) : false;
 
   $: if ($plans) {
     nameField.updateValidators([
@@ -234,18 +233,6 @@
 
     selectedPlan = $plans.find(({ id }) => id === selectedPlanId);
     if (selectedPlan) {
-      try {
-        const parsedPlanStartTime = $plugins.time.primary.parse(selectedPlan?.start_time_doy);
-        const parsedPlanEndTime = $plugins.time.primary.parse(selectedPlan?.end_time_doy);
-        if (parsedPlanStartTime) {
-          selectedPlanStartTime = formatDate(parsedPlanStartTime, $plugins.time.primary.format);
-        }
-        if (parsedPlanEndTime) {
-          selectedPlanEndTime = formatDate(parsedPlanEndTime, $plugins.time.primary.format);
-        }
-      } catch (e) {
-        console.log(e);
-      }
       selectedPlanModelName = $models.find(model => model.id === selectedPlan?.model_id)?.name ?? null;
     }
   }
@@ -739,36 +726,12 @@
                 <Label size="sm" class="overflow-hidden text-ellipsis whitespace-nowrap" for="id">Name</Label>
                 <InputStellar sizeVariant="xs" disabled class="w-full" name="id" value={selectedPlan.name} />
               </Input>
-              <Input layout="inline">
-                <Label size="sm" class="overflow-hidden text-ellipsis whitespace-nowrap" for="start-time">
-                  Start Time - {$plugins.time.primary.label}
-                </Label>
-                <InputStellar
-                  sizeVariant="xs"
-                  disabled
-                  class="w-full"
-                  name="start-time"
-                  value={selectedPlanStartTime}
-                />
-              </Input>
-              <Input layout="inline">
-                <Label size="sm" class="overflow-hidden text-ellipsis whitespace-nowrap" for="end-time">
-                  End Time - {$plugins.time.primary.label}
-                </Label>
-                <InputStellar sizeVariant="xs" disabled class="w-full" name="end-time" value={selectedPlanEndTime} />
-              </Input>
-              <Input layout="inline">
-                <Label size="sm" class="overflow-hidden text-ellipsis whitespace-nowrap" for="duration">
-                  Plan Duration
-                </Label>
-                <InputStellar
-                  sizeVariant="xs"
-                  disabled
-                  class="w-full"
-                  name="duration"
-                  value={convertUsToDurationString(getIntervalInMs(selectedPlan.duration) * 1000)}
-                />
-              </Input>
+              <PlanTimeBounds
+                plan={selectedPlan}
+                user={$user}
+                hasUpdatePermission={canUpdatePlan}
+                permissionError="You do not have permission to edit this plan."
+              />
               <Input layout="inline">
                 <Label size="sm" class="overflow-hidden text-ellipsis whitespace-nowrap" for="tags">Tags</Label>
                 <TagsInput

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -7,7 +7,7 @@
   import { Button, cn, Input as InputStellar, Label, Select } from '@nasa-jpl/stellar-svelte';
   import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
   import { flatten } from 'lodash-es';
-  import { ArrowLeftRight, FileUp, Import, X } from 'lucide-svelte';
+  import { FileUp, Import, Pencil, X } from 'lucide-svelte';
   import { onDestroy, onMount } from 'svelte';
   import Nav from '../../components/app/Nav.svelte';
   import PageTitle from '../../components/app/PageTitle.svelte';
@@ -696,7 +696,7 @@
                     <div use:tooltip={{ content: selectedPlanModelName, placement: 'top' }}>
                       <InputStellar
                         sizeVariant="xs"
-                        disabled
+                        readonly
                         class={cn('w-full', !selectedPlanModelName ? 'border-destructive' : '')}
                         name="name"
                         value={selectedPlanModelName ?? 'Model not found'}
@@ -716,7 +716,7 @@
                         on:click={openChangePlanMissionModelModal}
                         aria-label="Change mission model"
                       >
-                        <ArrowLeftRight size={16} />
+                        <Pencil size={16} />
                       </Button>
                     </div>
                   </div>

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -44,7 +44,7 @@
   import { parseJSONStream } from '../../utilities/generic';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
-  import { exportPlan, isDeprecatedPlanTransfer } from '../../utilities/plan';
+  import { computeDurationString, exportPlan, isDeprecatedPlanTransfer } from '../../utilities/plan';
   import {
     convertDoyToYmd,
     convertUsToDurationString,
@@ -537,21 +537,9 @@
   }
 
   function updateDurationString() {
-    if ($startTimeField.valid && $endTimeField.valid) {
-      let startTimeMs = $plugins.time.primary.parse($startTimeField.value)?.getTime();
-      let endTimeMs = $plugins.time.primary.parse($endTimeField.value)?.getTime();
-      if (typeof startTimeMs === 'number' && typeof endTimeMs === 'number') {
-        durationString = convertUsToDurationString((endTimeMs - startTimeMs) * 1000);
-
-        if (!durationString) {
-          durationString = 'None';
-        }
-      } else {
-        durationString = 'Invalid';
-      }
-    } else {
-      durationString = 'None';
-    }
+    const startTimeMs = $plugins.time.primary.parse($startTimeField.value)?.getTime();
+    const endTimeMs = $plugins.time.primary.parse($endTimeField.value)?.getTime();
+    durationString = computeDurationString(startTimeMs, endTimeMs, $startTimeField.valid && $endTimeField.valid);
   }
 
   async function parsePlanFileStream(stream: ReadableStream) {

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -85,6 +85,7 @@
     initialPlan,
     maxTimeRange,
     plan,
+    planBoundsPreviewOverride,
     planDatasets,
     planId,
     planModelActivityTypes,
@@ -361,6 +362,9 @@
     $planSnapshotId = data.initialPlanSnapshotId;
     $planReadOnlySnapshot = true;
   }
+  // While previewing a snapshot, render against the snapshot's own plan bounds and snap the timeline
+  // viewport to them; revert to the live plan and the pre-preview viewport on exit.
+  $: applySnapshotPreviewBounds($planSnapshot);
   $: if ($planSnapshot !== null) {
     effects.getPlanSnapshotActivityDirectives($planSnapshot, $user).then(directives => {
       if (directives !== null) {
@@ -535,6 +539,40 @@
     $planSnapshotId = null;
     $planReadOnlySnapshot = false;
     $simulationDatasetId = $simulationDatasetLatest?.id ?? -1;
+  }
+
+  // Tracks snapshot-preview transitions (enter/exit/switch) so we only snap the viewport on a real
+  // change — not on every snapshot subscription emission or while the user pans during preview.
+  let previewedSnapshotId: number | null = null;
+  let preSnapshotViewTimeRange: { end: number; start: number } | null = null;
+
+  function applySnapshotPreviewBounds(snapshot: PlanSnapshot | null) {
+    const newSnapshotId = snapshot?.snapshot_id ?? null;
+    if (newSnapshotId === previewedSnapshotId) {
+      return;
+    }
+
+    const snapshotBounds =
+      snapshot?.plan_start_time && snapshot?.plan_duration
+        ? { duration: snapshot.plan_duration, start_time: snapshot.plan_start_time }
+        : null;
+
+    // Remember the live viewport when first entering preview so it can be restored on exit.
+    if (previewedSnapshotId === null) {
+      preSnapshotViewTimeRange = get(viewTimeRange);
+    }
+    previewedSnapshotId = newSnapshotId;
+
+    // Setting the override updates the derived plan bounds synchronously, so maxTimeRange below
+    // already reflects the snapshot's bounds.
+    planBoundsPreviewOverride.set(snapshotBounds);
+
+    if (snapshotBounds) {
+      viewTimeRange.set(get(maxTimeRange));
+    } else if (newSnapshotId === null && preSnapshotViewTimeRange) {
+      viewTimeRange.set(preSnapshotViewTimeRange);
+      preSnapshotViewTimeRange = null;
+    }
   }
 
   function onClearConsole() {

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -86,14 +86,13 @@
     maxTimeRange,
     plan,
     planDatasets,
-    planEndTimeMs,
     planId,
     planModelActivityTypes,
     planModelId,
     planReadOnly,
     planReadOnlyMergeRequest,
     planReadOnlySnapshot,
-    planStartTimeMs,
+    planStartTimeYmd,
     planTags,
     resetPlanStores,
     viewTimeRange,
@@ -162,7 +161,6 @@
   } from '../../../utilities/simulation';
   import { getHumanReadableStatus, statusColors } from '../../../utilities/status';
   import { pluralize } from '../../../utilities/text';
-  import { getUnixEpochTime } from '../../../utilities/time';
   import { showSuccessToast } from '../../../utilities/toast';
   import { tooltip } from '../../../utilities/tooltip';
   import { getSearchParameterNumber, removeQueryParam, setQueryParam } from '../../../utilities/url';
@@ -292,9 +290,6 @@
   }
   $: if (data.initialPlan) {
     $initialPlan = data.initialPlan;
-    $planEndTimeMs = getUnixEpochTime(data.initialPlan.end_time_doy);
-    $planStartTimeMs = getUnixEpochTime(data.initialPlan.start_time_doy);
-    $maxTimeRange = { end: $planEndTimeMs, start: $planStartTimeMs };
     $simulationDatasetId = -1;
 
     const querySimulationDatasetId = $page.url.searchParams.get(SearchParameters.SIMULATION_DATASET_ID);
@@ -395,7 +390,7 @@
   // before the view loads would read `$view === null` and stay false until the next view change.
   $: hasUpdateViewPermission = $view !== null ? featurePermissions.view.canUpdate($user, $view) : false;
 
-  $: if ($initialPlan && $planDatasets) {
+  $: if ($planId > -1 && $planStartTimeYmd && $planDatasets) {
     const datasetNames = [];
 
     for (const dataset of $planDatasets) {
@@ -412,9 +407,9 @@
     $externalResources = [];
     effects
       .getResourcesExternal(
-        $initialPlan.id,
+        $planId,
         $simulationDatasetId > -1 ? $simulationDatasetId : null,
-        $initialPlan.start_time,
+        $planStartTimeYmd,
         get(user),
         resourcesExternalAbortController.signal,
       )
@@ -431,7 +426,11 @@
     selectActivity(null, null);
   }
 
-  $: if ($initialPlan && $simulationDataset !== null && getSimulationStatus($simulationDataset) === Status.Complete) {
+  $: if (
+    $planStartTimeYmd &&
+    $simulationDataset !== null &&
+    getSimulationStatus($simulationDataset) === Status.Complete
+  ) {
     const datasetId = $simulationDataset.dataset_id;
     simulationDataAbortController?.abort();
     simulationDataAbortController = new AbortController();
@@ -439,7 +438,7 @@
     effects
       .getSpans(
         datasetId,
-        $simulationDataset.simulation_start_time ?? $initialPlan.start_time,
+        $simulationDataset.simulation_start_time ?? $planStartTimeYmd,
         get(user),
         simulationDataAbortController.signal,
       )

--- a/src/stores/__mocks__/plan.mock.ts
+++ b/src/stores/__mocks__/plan.mock.ts
@@ -25,6 +25,8 @@ export const maxTimeRange: Writable<TimeRange> = writable({ end: 0, start: 0 });
 
 export const viewTimeRange: Writable<TimeRange> = writable({ end: 0, start: 0 });
 
+export const planBoundsPreviewOverride: Writable<{ duration: string; start_time: string } | null> = writable(null);
+
 /* "plan" store dependencies */
 export const initialPlan: Writable<Plan | null> = writable(null);
 

--- a/src/stores/__mocks__/plan.mock.ts
+++ b/src/stores/__mocks__/plan.mock.ts
@@ -48,6 +48,10 @@ export const planModelId: Readable<number> = derived(initialPlan, $plan => $plan
 
 export const planModelRevision: Readable<number> = derived(initialPlan, $plan => $plan?.model?.revision ?? -1);
 
+export const planStartTimeYmd: Readable<string> = derived(plan, $plan => $plan?.start_time ?? '');
+
+export const planEndTimeDoy: Readable<string> = derived(plan, $plan => $plan?.end_time_doy ?? '');
+
 /* Subscriptions. */
 
 export const activityTypes = writable<ActivityType[]>([]);

--- a/src/stores/__mocks__/plan.mock.ts
+++ b/src/stores/__mocks__/plan.mock.ts
@@ -73,9 +73,6 @@ export function resetPlanStores() {
   createPlanError.set(null);
   creatingPlan.set(false);
   initialPlan.set(null);
-  planEndTimeMs.set(0);
-  planStartTimeMs.set(0);
-  maxTimeRange.set({ end: 0, start: 0 });
   viewTimeRange.set({ end: 0, start: 0 });
 }
 

--- a/src/stores/activities.ts
+++ b/src/stores/activities.ts
@@ -10,7 +10,7 @@ import type { DefaultEffectiveArguments, DefaultEffectiveArgumentsMap } from '..
 import type { SpanId } from '../types/simulation';
 import { computeActivityDirectivesMap } from '../utilities/activities';
 import gql from '../utilities/gql';
-import { initialPlan, planId } from './plan';
+import { planEndTimeDoy, planId, planStartTimeYmd } from './plan';
 import { planSnapshotActivityDirectives, planSnapshotId } from './planSnapshots';
 import { selectedSpanId, spansMap, spanUtilityMaps } from './simulation';
 import { gqlSubscribable } from './subscribable';
@@ -59,24 +59,34 @@ export const activityArgumentDefaultsMap: Readable<DefaultEffectiveArgumentsMap>
 );
 
 export const activityDirectivesMap = derived(
-  [activityDirectivesDB, planSnapshotId, planSnapshotActivityDirectives, initialPlan, spansMap, spanUtilityMaps],
+  [
+    activityDirectivesDB,
+    planSnapshotId,
+    planSnapshotActivityDirectives,
+    planStartTimeYmd,
+    planEndTimeDoy,
+    spansMap,
+    spanUtilityMaps,
+  ],
   ([
     $activityDirectivesDB,
     $planSnapshotId,
     $planSnapshotActivityDirectives,
-    $initialPlan,
+    $planStartTimeYmd,
+    $planEndTimeDoy,
     $spansMap,
     $spanUtilityMaps,
   ]) => {
     if (!$spansMap) {
       return null;
     }
-    if ($initialPlan === null) {
+    if (!$planStartTimeYmd) {
       return {};
     }
     return computeActivityDirectivesMap(
       $planSnapshotId !== null ? $planSnapshotActivityDirectives : $activityDirectivesDB,
-      $initialPlan,
+      $planStartTimeYmd,
+      $planEndTimeDoy,
       $spansMap,
       $spanUtilityMaps,
     );

--- a/src/stores/plan.ts
+++ b/src/stores/plan.ts
@@ -5,6 +5,7 @@ import type { PlanDataset } from '../types/simulation';
 import type { Tag } from '../types/tags';
 import type { TimeRange } from '../types/timeline';
 import gql from '../utilities/gql';
+import { getDoyTime, getDoyTimeFromInterval, getUnixEpochTime } from '../utilities/time';
 import { gqlSubscribable } from './subscribable';
 
 /* Writeable. */
@@ -25,12 +26,6 @@ export const createPlanError: Writable<string | null> = writable(null);
 
 export const creatingPlan: Writable<boolean> = writable(false);
 
-export const planEndTimeMs: Writable<number> = writable(0);
-
-export const planStartTimeMs: Writable<number> = writable(0);
-
-export const maxTimeRange: Writable<TimeRange> = writable({ end: 0, start: 0 });
-
 export const viewTimeRange: Writable<TimeRange> = writable({ end: 0, start: 0 });
 
 /* "plan" store dependencies */
@@ -46,15 +41,42 @@ export const plan: Readable<Plan | null> = derived([initialPlan, planMetadata], 
   if (!$initialPlan) {
     return null;
   }
-  return {
+
+  const newPlan: Plan = {
     ...$initialPlan,
     ...($planMetadata || {}),
   };
+
+  // Recompute start_time and start_time_doy since these may have changed in planMetadata update
+  newPlan.start_time_doy = getDoyTime(new Date(newPlan.start_time));
+  newPlan.end_time_doy = getDoyTimeFromInterval(newPlan.start_time, newPlan.duration);
+
+  return newPlan;
 });
 
 export const planModelId: Readable<number> = derived(plan, $plan => $plan?.model?.id ?? -1);
 
 export const planModelRevision: Readable<number> = derived(plan, $plan => $plan?.model?.revision ?? -1);
+
+export const planStartTimeYmd: Readable<string> = derived(plan, $plan => $plan?.start_time ?? '');
+
+export const planEndTimeDoy: Readable<string> = derived(plan, $plan => $plan?.end_time_doy ?? '');
+
+export const planStartTimeMs: Readable<number> = derived(plan, $plan =>
+  $plan?.start_time_doy ? getUnixEpochTime($plan?.start_time_doy) : 0,
+);
+
+export const planEndTimeMs: Readable<number> = derived(plan, $plan =>
+  $plan?.end_time_doy ? getUnixEpochTime($plan?.end_time_doy) : 0,
+);
+
+export const maxTimeRange: Readable<TimeRange> = derived(
+  [planStartTimeMs, planEndTimeMs],
+  ([$planStartTimeMs, $planEndTimeMs]) => ({
+    end: $planEndTimeMs,
+    start: $planStartTimeMs,
+  }),
+);
 
 /* Other Subscriptions. */
 
@@ -118,9 +140,6 @@ export function resetPlanStores() {
   createPlanError.set(null);
   creatingPlan.set(false);
   initialPlan.set(null);
-  planEndTimeMs.set(0);
-  planStartTimeMs.set(0);
-  maxTimeRange.set({ end: 0, start: 0 });
   viewTimeRange.set({ end: 0, start: 0 });
 }
 

--- a/src/stores/plan.ts
+++ b/src/stores/plan.ts
@@ -28,6 +28,11 @@ export const creatingPlan: Writable<boolean> = writable(false);
 
 export const viewTimeRange: Writable<TimeRange> = writable({ end: 0, start: 0 });
 
+// Display-only override of the plan's effective time bounds, used while previewing a plan snapshot
+// taken at different bounds so activities (esp. plan-end-anchored) and the timeline render correctly.
+// Null when not previewing (or for snapshots that predate stored bounds).
+export const planBoundsPreviewOverride: Writable<{ duration: string; start_time: string } | null> = writable(null);
+
 /* "plan" store dependencies */
 export const initialPlan: Writable<Plan | null> = writable(null);
 
@@ -37,22 +42,31 @@ export const planMetadata = gqlSubscribable<PlanMetadata | null>(gql.SUB_PLAN_ME
 
 /* Derived. */
 
-export const plan: Readable<Plan | null> = derived([initialPlan, planMetadata], ([$initialPlan, $planMetadata]) => {
-  if (!$initialPlan) {
-    return null;
-  }
+export const plan: Readable<Plan | null> = derived(
+  [initialPlan, planMetadata, planBoundsPreviewOverride],
+  ([$initialPlan, $planMetadata, $planBoundsPreviewOverride]) => {
+    if (!$initialPlan) {
+      return null;
+    }
 
-  const newPlan: Plan = {
-    ...$initialPlan,
-    ...($planMetadata || {}),
-  };
+    const newPlan: Plan = {
+      ...$initialPlan,
+      ...($planMetadata || {}),
+    };
 
-  // Recompute start_time and start_time_doy since these may have changed in planMetadata update
-  newPlan.start_time_doy = getDoyTime(new Date(newPlan.start_time));
-  newPlan.end_time_doy = getDoyTimeFromInterval(newPlan.start_time, newPlan.duration);
+    // While previewing a snapshot taken at different bounds, render against the snapshot's bounds.
+    if ($planBoundsPreviewOverride) {
+      newPlan.start_time = $planBoundsPreviewOverride.start_time;
+      newPlan.duration = $planBoundsPreviewOverride.duration;
+    }
 
-  return newPlan;
-});
+    // Recompute start_time and start_time_doy since these may have changed in planMetadata update
+    newPlan.start_time_doy = getDoyTime(new Date(newPlan.start_time));
+    newPlan.end_time_doy = getDoyTimeFromInterval(newPlan.start_time, newPlan.duration);
+
+    return newPlan;
+  },
+);
 
 export const planModelId: Readable<number> = derived(plan, $plan => $plan?.model?.id ?? -1);
 
@@ -140,6 +154,7 @@ export function resetPlanStores() {
   createPlanError.set(null);
   creatingPlan.set(false);
   initialPlan.set(null);
+  planBoundsPreviewOverride.set(null);
   viewTimeRange.set({ end: 0, start: 0 });
 }
 

--- a/src/stores/subscribable.ts
+++ b/src/stores/subscribable.ts
@@ -170,14 +170,6 @@ export function gqlSubscribable<T>(
     debouncedClientSubscribe();
   }
 
-  // Re-pull fresh data for the active subscription. Guarded by subscriptionActive so we never spin
-  // up an orphan subscription when nothing is currently listening (those re-fetch on next mount).
-  function refetch() {
-    if (subscriptionActive) {
-      resubscribe();
-    }
-  }
-
   function restartSocket() {
     setLoading(true);
     setError(''); // Clear previous error on restart
@@ -287,7 +279,6 @@ export function gqlSubscribable<T>(
     error: errorStore,
     filterValueById,
     loading: loadingStore,
-    refetch,
     restartSocket,
     setVariables,
     subscribe,

--- a/src/stores/subscribable.ts
+++ b/src/stores/subscribable.ts
@@ -170,6 +170,14 @@ export function gqlSubscribable<T>(
     debouncedClientSubscribe();
   }
 
+  // Re-pull fresh data for the active subscription. Guarded by subscriptionActive so we never spin
+  // up an orphan subscription when nothing is currently listening (those re-fetch on next mount).
+  function refetch() {
+    if (subscriptionActive) {
+      resubscribe();
+    }
+  }
+
   function restartSocket() {
     setLoading(true);
     setError(''); // Clear previous error on restart
@@ -279,6 +287,7 @@ export function gqlSubscribable<T>(
     error: errorStore,
     filterValueById,
     loading: loadingStore,
+    refetch,
     restartSocket,
     setVariables,
     subscribe,

--- a/src/types/plan-snapshot.ts
+++ b/src/types/plan-snapshot.ts
@@ -5,7 +5,9 @@ import type { Tag } from './tags';
 export type PlanSnapshot = {
   description: string;
   model_id: number;
+  plan_duration: string;
   plan_id: number;
+  plan_start_time: string;
   revision: number;
   simulation: SimulationDataset | null;
   snapshot_id: number;

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -152,7 +152,16 @@ export type DeprecatedPlanTransfer = Omit<PlanTransfer, 'duration' | 'simulation
 
 export type PlanMetadata = Pick<
   PlanSchema,
-  'id' | 'updated_at' | 'updated_by' | 'name' | 'owner' | 'created_at' | 'collaborators' | 'model' | 'start_time' | 'duration'
+  | 'id'
+  | 'updated_at'
+  | 'updated_by'
+  | 'name'
+  | 'owner'
+  | 'created_at'
+  | 'collaborators'
+  | 'model'
+  | 'start_time'
+  | 'duration'
 >;
 
 export type PlanSlim = Pick<

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -146,7 +146,7 @@ export type DeprecatedPlanTransfer = Omit<PlanTransfer, 'duration' | 'simulation
 
 export type PlanMetadata = Pick<
   PlanSchema,
-  'id' | 'updated_at' | 'updated_by' | 'name' | 'owner' | 'created_at' | 'collaborators' | 'model'
+  'id' | 'updated_at' | 'updated_by' | 'name' | 'owner' | 'created_at' | 'collaborators' | 'model' | 'start_time' | 'duration'
 >;
 
 export type PlanSlim = Pick<

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -78,7 +78,10 @@ export type PlanMergeRequest = PlanMergeRequestSchema & { pending: boolean; type
 
 export type PlanMergeRequestStatus = 'accepted' | 'in-progress' | 'pending' | 'rejected' | 'withdrawn';
 
-export type PlanForMerging = Pick<PlanSchema, 'id' | 'name' | 'owner' | 'collaborators' | 'model_id' | 'start_time'> & {
+export type PlanForMerging = Pick<
+  PlanSchema,
+  'id' | 'name' | 'owner' | 'collaborators' | 'model_id' | 'start_time' | 'duration'
+> & {
   model: Pick<Model, 'id' | 'name' | 'owner' | 'version'>;
 };
 
@@ -109,7 +112,10 @@ export type PlanSchema = {
   name: string;
   owner: UserId;
   parent_plan:
-    | (Pick<PlanSchema, 'id' | 'name' | 'owner' | 'collaborators' | 'is_locked' | 'model_id' | 'start_time'> & {
+    | (Pick<
+        PlanSchema,
+        'id' | 'name' | 'owner' | 'collaborators' | 'is_locked' | 'model_id' | 'start_time' | 'duration'
+      > & {
         model: Pick<Model, 'id' | 'name' | 'owner' | 'version'>;
       })
     | null;

--- a/src/types/subscribable.ts
+++ b/src/types/subscribable.ts
@@ -7,6 +7,12 @@ export type GqlSubscribable<T> = {
   setVariables: (newVariables: QueryVariables) => void;
   subscribe: (next: Subscriber<T>) => Unsubscriber;
   filterValueById(id: number): void;
+  /**
+   * Force the active subscription to re-pull fresh data from the server (no-op if nothing is
+   * currently subscribed). Useful after a mutation whose effects are applied server-side (e.g. a
+   * Postgres trigger) and may not always be surfaced by the live subscription immediately.
+   */
+  refetch(): void;
   /** Readable store for the subscription's loading state */
   restartSocket(): void;
   updateValue(fn: Updater<T>): void;

--- a/src/types/subscribable.ts
+++ b/src/types/subscribable.ts
@@ -7,12 +7,6 @@ export type GqlSubscribable<T> = {
   setVariables: (newVariables: QueryVariables) => void;
   subscribe: (next: Subscriber<T>) => Unsubscriber;
   filterValueById(id: number): void;
-  /**
-   * Force the active subscription to re-pull fresh data from the server (no-op if nothing is
-   * currently subscribed). Useful after a mutation whose effects are applied server-side (e.g. a
-   * Postgres trigger) and may not always be surfaced by the live subscription immediately.
-   */
-  refetch(): void;
   /** Readable store for the subscription's loading state */
   restartSocket(): void;
   updateValue(fn: Updater<T>): void;

--- a/src/utilities/activities.test.ts
+++ b/src/utilities/activities.test.ts
@@ -540,9 +540,11 @@ describe('updateAnchorStartOffset', () => {
     spanIdToDirectiveIdMap,
   };
 
+  const testPlan = getTestPlan();
   const activityDirectivesMap = computeActivityDirectivesMap(
     getTestActivityDirectivesDB(),
-    getTestPlan(),
+    testPlan.start_time,
+    testPlan.end_time_doy,
     spans,
     spanUtilityMaps,
   );

--- a/src/utilities/activities.ts
+++ b/src/utilities/activities.ts
@@ -142,7 +142,8 @@ export enum ActivityDeletionAction {
 
 export function computeActivityDirectivesMap(
   activityDirectiveDBs: ActivityDirectiveDB[],
-  plan: Plan,
+  planStartTimeYmd: string,
+  planEndTimeDoy: string,
   spansMap: SpansMap,
   spanUtilityMaps: SpanUtilityMaps,
 ) {
@@ -156,7 +157,8 @@ export function computeActivityDirectivesMap(
     preprocessActivityDirectiveDB(
       activityDirectiveDB,
       directiveDBMap,
-      plan,
+      planStartTimeYmd,
+      planEndTimeDoy,
       spansMap,
       spanUtilityMaps,
       cachedStartTimes,
@@ -168,17 +170,18 @@ export function computeActivityDirectivesMap(
 export function preprocessActivityDirectiveDB(
   activityDirectiveDB: ActivityDirectiveDB,
   activityDirectivesMap: ActivityDirectivesMap,
-  plan: Plan,
+  planStartTimeYmd: string,
+  planEndTimeDoy: string,
   spansMap: SpansMap,
   spanUtilityMaps: SpanUtilityMaps,
   cachedStartTimes = {},
 ): ActivityDirective {
   let start_time_ms = -1;
-  if (plan && typeof plan.start_time === 'string') {
+  if (planStartTimeYmd) {
     start_time_ms = getActivityDirectiveStartTimeMs(
       activityDirectiveDB.id,
-      plan.start_time,
-      plan.end_time_doy,
+      planStartTimeYmd,
+      planEndTimeDoy,
       activityDirectivesMap,
       spansMap,
       spanUtilityMaps,
@@ -380,7 +383,13 @@ export function addAbsoluteTimeToRevision(
   spansMap: SpansMap,
   spanUtilityMaps: SpanUtilityMaps,
 ): ActivityDirectiveRevision {
-  const activityDirectivesMap = computeActivityDirectivesMap(activitiesDirectivesDB, plan, spansMap, spanUtilityMaps);
+  const activityDirectivesMap = computeActivityDirectivesMap(
+    activitiesDirectivesDB,
+    plan.start_time,
+    plan.end_time_doy,
+    spansMap,
+    spanUtilityMaps,
+  );
   //Temporarily overlay the currentActivity with the revision
   const tempDirectivesMap: ActivityDirectivesMap = {
     ...activityDirectivesMap,
@@ -454,7 +463,8 @@ export function packActivityDirectivesInPlan(
 
   const activityDirectivesMap = computeActivityDirectivesMap(
     activitiesDirectivesDB,
-    sourcePlan,
+    sourcePlan.start_time,
+    sourcePlan.end_time_doy,
     spansMap,
     spanUtilityMaps,
   );

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -73,6 +73,7 @@ import {
 } from '../stores/sequencing';
 import {
   selectedSpanId as selectedSpanIdStore,
+  simulation as simulationStore,
   simulationDatasetId as simulationDatasetIdStore,
   simulationDataset as simulationDatasetStore,
   spansMap,
@@ -7984,7 +7985,7 @@ const effects = {
     }
   },
 
-  async updatePlan(plan: Plan, planMetadata: Partial<PlanMetadata>, user: User | null): Promise<void> {
+  async updatePlan(plan: Plan, planMetadata: Partial<PlanMetadata>, user: User | null): Promise<boolean> {
     try {
       if (!queryPermissions.UPDATE_PLAN(user, plan)) {
         throwPermissionError('update plan');
@@ -7996,14 +7997,14 @@ const effects = {
       if (updatePlan.id != null) {
         showSuccessToast('Plan Updated Successfully');
         logMessage(`Updated plan "${plan.name}" (ID=${plan.id}).`);
-        return;
+        return true;
       } else {
         throw Error(`Unable to update plan with ID: "${plan.id}"`);
       }
     } catch (e) {
       catchError('Plan Update Failed', e as Error);
       showFailureToast('Plan Update Failed');
-      return;
+      return false;
     }
   },
 
@@ -8055,6 +8056,27 @@ const effects = {
       showFailureToast('Plan Snapshot Update Failed');
       return;
     }
+  },
+
+  /**
+   * Applies a plan time-bounds update (new `start_time` + `duration`) and returns whether it
+   * succeeded. The confirmation/warning UX and the start/end editing now live in
+   * ChangePlanBoundsModal, which calls this; callers compute `planTimeUpdate` with
+   * `computePlanTimeUpdate` (kept pure in utilities/plan.ts to avoid an effects <-> plan cycle).
+   */
+  async updatePlanTimeBounds(
+    plan: Plan | PlanSlim,
+    planTimeUpdate: { duration: string; start_time: string },
+    user: User | null,
+  ): Promise<boolean> {
+    const updated = await effects.updatePlan(plan as Plan, planTimeUpdate, user);
+    if (updated) {
+      // The backend trigger recomputes the simulation start/end times when the plan bounds change.
+      // Force the simulation subscription to re-pull so the UI reflects those values without a
+      // page refresh (the backend result is the source of truth).
+      simulationStore.refetch();
+    }
+    return updated;
   },
 
   async updateSchedulingConditionDefinitionTags(

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -73,7 +73,6 @@ import {
 } from '../stores/sequencing';
 import {
   selectedSpanId as selectedSpanIdStore,
-  simulation as simulationStore,
   simulationDatasetId as simulationDatasetIdStore,
   simulationDataset as simulationDatasetStore,
   spansMap,
@@ -8069,14 +8068,7 @@ const effects = {
     planTimeUpdate: { duration: string; start_time: string },
     user: User | null,
   ): Promise<boolean> {
-    const updated = await effects.updatePlan(plan as Plan, planTimeUpdate, user);
-    if (updated) {
-      // The backend trigger recomputes the simulation start/end times when the plan bounds change.
-      // Force the simulation subscription to re-pull so the UI reflects those values without a
-      // page refresh (the backend result is the source of truth).
-      simulationStore.refetch();
-    }
-    return updated;
+    return effects.updatePlan(plan as Plan, planTimeUpdate, user);
   },
 
   async updateSchedulingConditionDefinitionTags(

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1557,6 +1557,7 @@ const gql = {
           }
           is_locked
           start_time
+          duration
         }
         revision
         scheduling_specification {

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -3205,6 +3205,8 @@ const gql = {
     subscription SubPlanMetadata($planId: Int!) {
       plan_metadata: ${Queries.PLAN}(id: $planId) {
         id
+        start_time
+        duration
         model: mission_model {
           id
           jar_id

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -3272,6 +3272,8 @@ const gql = {
         snapshot_id
         model_id
         plan_id
+        plan_start_time
+        plan_duration
         revision
         snapshot_name
         description

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -3,6 +3,7 @@ import AboutModal from '../components/modals/AboutModal.svelte';
 import ActionCreationModal from '../components/modals/ActionCreationModal.svelte';
 import ApplySequenceFilterModal from '../components/modals/ApplySequenceFilterModal.svelte';
 import CancelActionRunModal from '../components/modals/CancelActionRunModal.svelte';
+import ChangePlanBoundsModal from '../components/modals/ChangePlanBoundsModal.svelte';
 import ConfirmActivityCreationModal from '../components/modals/ConfirmActivityCreationModal.svelte';
 import ConfirmModal from '../components/modals/ConfirmModal.svelte';
 import CreatePlanBranchModal from '../components/modals/CreatePlanBranchModal.svelte';
@@ -1603,6 +1604,42 @@ export async function showNewSequenceModal(): Promise<ModalElementValue<{ newSeq
           target.resolve = null;
           resolve({ confirm: true, value: e.detail });
           newSequenceModal.$destroy();
+        });
+      }
+    } else {
+      resolve({ confirm: false });
+    }
+  });
+}
+
+/**
+ * Shows a ChangePlanBoundsModal for editing a plan's start/end. The modal owns the warning,
+ * the mutation, and the in-flight/retry UX, so it resolves { confirm: true } only once the
+ * update has succeeded (or { confirm: false } if the user cancels).
+ */
+export async function showChangePlanBoundsModal(plan: Plan | PlanSlim, user: User | null): Promise<ModalElementValue> {
+  return new Promise(resolve => {
+    if (browser) {
+      const target: ModalElement | null = document.querySelector('#svelte-modal');
+      if (target) {
+        const modal = new ChangePlanBoundsModal({
+          props: { plan, user },
+          target,
+        });
+        target.resolve = resolve;
+
+        modal.$on('close', () => {
+          target.replaceChildren();
+          target.resolve = null;
+          resolve({ confirm: false });
+          modal.$destroy();
+        });
+
+        modal.$on('confirm', () => {
+          target.replaceChildren();
+          target.resolve = null;
+          resolve({ confirm: true });
+          modal.$destroy();
         });
       }
     } else {

--- a/src/utilities/plan.ts
+++ b/src/utilities/plan.ts
@@ -12,7 +12,12 @@ import type {
 import type { Simulation } from '../types/simulation';
 import effects from './effects';
 import { downloadJSON, unique } from './generic';
-import { convertDoyToYmd, convertUsToDurationString, getIntervalFromDoyRange, switchISOTimezoneRepresentation } from './time';
+import {
+  convertDoyToYmd,
+  convertUsToDurationString,
+  getIntervalFromDoyRange,
+  switchISOTimezoneRepresentation,
+} from './time';
 
 /**
  * Computes a human-readable duration string from start and end times.

--- a/src/utilities/plan.ts
+++ b/src/utilities/plan.ts
@@ -12,7 +12,45 @@ import type {
 import type { Simulation } from '../types/simulation';
 import effects from './effects';
 import { downloadJSON, unique } from './generic';
-import { convertDoyToYmd, switchISOTimezoneRepresentation } from './time';
+import { convertDoyToYmd, convertUsToDurationString, getIntervalFromDoyRange, switchISOTimezoneRepresentation } from './time';
+
+/**
+ * Computes a human-readable duration string from start and end times.
+ * Returns 'None' if fields are invalid or times can't be parsed, 'Invalid' if parsing fails.
+ */
+export function computeDurationString(
+  startTimeMs: number | null | undefined,
+  endTimeMs: number | null | undefined,
+  areFieldsValid: boolean,
+): string {
+  if (!areFieldsValid) {
+    return 'None';
+  }
+  if (typeof startTimeMs === 'number' && typeof endTimeMs === 'number') {
+    const duration = convertUsToDurationString((endTimeMs - startTimeMs) * 1000);
+    return duration || 'None';
+  }
+  return 'Invalid';
+}
+
+/**
+ * Computes the plan update payload for a time change.
+ * Returns the start_time (as ISO string) and duration (as Postgres interval).
+ */
+export function computePlanTimeUpdate(
+  startTimeDoy: string,
+  endTimeDoy: string,
+): { duration: string; start_time: string } | null {
+  const startTimeYmd = convertDoyToYmd(startTimeDoy);
+  if (!startTimeYmd) {
+    return null;
+  }
+  const duration = getIntervalFromDoyRange(startTimeDoy, endTimeDoy);
+  return {
+    duration,
+    start_time: startTimeYmd,
+  };
+}
 
 export async function getPlanForTransfer(
   plan: Plan | PlanSlim,

--- a/src/utilities/time.test.ts
+++ b/src/utilities/time.test.ts
@@ -15,6 +15,7 @@ import {
   getDoyTime,
   getDoyTimeComponents,
   getDurationTimeComponents,
+  getIntervalUnixEpochTime,
   getShortISOForDate,
   getTimeAgo,
   getUnixEpochTime,
@@ -758,4 +759,16 @@ test('usToOffset', () => {
   expect(usToOffset(2.84)).toBe('00:00:00.000003');
   expect(usToOffset(1 / 0)).toBe('INVALID');
   expect(usToOffset(NaN)).toBe('INVALID');
+});
+
+test('getIntervalUnixEpochTime', () => {
+  // Whole-millisecond differences format as HH:MM:SS.mmm.
+  expect(getIntervalUnixEpochTime(0, 41209216)).toBe('11:26:49.216');
+  expect(getIntervalUnixEpochTime(1000, 0)).toBe('-00:00:01.000');
+  expect(getIntervalUnixEpochTime(0, 0)).toBe('00:00:00.000');
+
+  // A fractional-millisecond difference (e.g. a base derived from a sub-ms offset) must still
+  // produce a valid single-decimal interval, not "11:26:49.216.0100..." with a second decimal point.
+  expect(getIntervalUnixEpochTime(0, 41209216.010009765625)).toBe('11:26:49.216');
+  expect(getIntervalUnixEpochTime(0.49, 41209216.51)).toBe('11:26:49.216');
 });

--- a/src/utilities/time.ts
+++ b/src/utilities/time.ts
@@ -746,7 +746,10 @@ export function getIntervalUnixEpochTime(startTimeMs: number, endTimeMs: number)
   const differenceMs = endTimeMs - startTimeMs;
 
   const isNegative = differenceMs < 0;
-  const absoluteDifferenceMs = Math.abs(differenceMs);
+  // Round to whole milliseconds — this interval string only carries ms precision, and a fractional
+  // input (e.g. an offset with sub-ms precision) would otherwise stringify a non-integer ms with its
+  // own decimal point, producing an invalid Postgres interval like "11:26:49.216.0100".
+  const absoluteDifferenceMs = Math.round(Math.abs(differenceMs));
 
   const seconds = Math.floor(absoluteDifferenceMs / 1000);
   const hours = Math.floor(seconds / 3600);


### PR DESCRIPTION
`___REQUIRES_AERIE_PR___="1833"`

## Summary
Allows users to change plan start and end dates from within the plans page and from within the Plan Metadata panel in a plan. Corresponding backend PR: https://github.com/NASA-AMMOS/plandev/pull/1833. As described in the backend PR, activities remained **absolutely positioned** in time during plan bounds changes. Corresponding issue: https://github.com/NASA-AMMOS/plandev/issues/1616.

## Details
- **Change plan time bounds**: The time bounds of a plan can now be changed in two places, both with the same blocking modal UX:
  - Plans page when user selects a plan
  - Plan page from within the Plan Metadata tab
- **Simulation bounds stay in sync**: When changing plan bounds causes the backend to adjust the simulation bounds, the UI now reflects that without a page refresh. The backend only adjusts them in specific cases (e.g. when the user hasn't customized them, or when they fall entirely outside the new plan bounds).
- **Reset simulation bounds to the plan**: In the Simulation tab, the "Plan Start" / "Plan End" buttons now actually save when used to reset a simulation bound back to the plan's bound (previously they updated the field but didn't persist).
- **Out of bounds simulations**: Simulation datasets that fall entirely outside of the current plan bounds now display a warning in their cards in the Simulation tab but can still be loaded
- **Plan merge protections**: The backend disallows merging plans with different time bounds. For clearer UX we also surface this in the create merge request modal and the manage merge requests modal in the receiving plan (attempting the merge shows a failure toast explaining the time-bound mismatch).
- **Bug fixes**: Fixed two anchor-related timeline bugs that became more visible while testing plan-bounds changes. Both came from not using the pre-computed `activityDirective.start_time_ms`, which accounts for anchored relationships:
  - Manual dragging of anchored activities (they no longer snap to the wrong spot or fail to save)
  - Placement of timeline guides at an anchored activity's start via the timeline context menu
  - Additional fix for `getIntervalUnixEpochTime` util that was failing to produce correct postgres intervals for sub-ms offsets.

## Visible UX Changes
- Start / End / Duration in the Plan Metadata panel and on the plans page are now read-only (still selectable to copy), with an edit button that opens a "Change Plan Time Range" modal for editing both bounds together.
- The modal shows a warning about how directives, snapshots, and simulation results are affected, blocks dismissal while the update runs, and surfaces failures so the user can retry.
- Warning indicator on simulation cards whose results fall entirely outside the current plan bounds.
- Failure toast when attempting to merge plans with mismatched time bounds.

## Verification
- Automated:
  - Unit tests:
     - New: `ChangePlanBoundsModal.svelte.test.ts`
     - New: `PlanTimeBounds.svelte.test.ts`
     - Modified: `time.test.ts`
  - e2e:
    - New: `simulation-bounds.test.ts`
    - New `change-plan-time.test.ts`

- Manual:
  - Change plan bounds from both the plans page and the Plan Metadata panel and confirm the modal blocks during the update and that directives stay fixed in absolute time. Modal blocking will be more obvious when operating on a plan with thousands of directives.
  - Confirm simulation bounds update without a refresh after a plan-bounds change.
  - Confirm user specified simulation bounds do not update after a plan-bounds change.
  - Drag an activity anchored to plan end and confirm it lands where dropped and saves.
  - Attempt to merge two plans with different time bounds and confirm the warning / failure toast.
  - Restore a snapshot from a plan with different time bounds and confirm the plan time bounds update. 


## TODOs
- [x] Resolve UX issues around model switch vs plan bounds change vs plan name inputs all looking/behaving somewhat differently
- [x] Replace spinner in button in change plan bounds modal with something more appropriate
- [x] Should previewing a plan snapshot change the time bounds locally in the UI?