### PR TITLE
Improve expansion run page performance

### DIFF
--- a/src/components/expansion/ExpansionRuns.svelte
+++ b/src/components/expansion/ExpansionRuns.svelte
@@ -21,13 +21,14 @@
   } from '../../stores/sequencing';
   import type { User } from '../../types/app';
   import type { DataGridColumnDef, DataGridRowSelection } from '../../types/data-grid';
-  import type { ActivityInstanceJoin, ExpandedSequence, ExpansionRun } from '../../types/expansion';
+  import type { ActivityInstanceJoin, ExpandedSequence, ExpansionRun, ExpansionRunSlim } from '../../types/expansion';
   import type {
     ChannelDictionaryMetadata,
     CommandDictionaryMetadata,
     ParameterDictionaryMetadata,
     Parcel,
   } from '../../types/sequencing';
+  import effects from '../../utilities/effects';
   import { filterEmpty } from '../../utilities/generic';
   import SequenceEditor from '../sequencing/SequenceEditor.svelte';
   import CssGrid from '../ui/CssGrid.svelte';
@@ -37,16 +38,19 @@
   import SectionTitle from '../ui/SectionTitle.svelte';
   import ExpandedSequencesDownloadButton from './ExpandedSequencesDownloadButton.svelte';
 
-  export let expansionRuns: ExpansionRun[] = [];
+  export let expansionRuns: ExpansionRunSlim[] = [];
   export let user: User | null;
 
   let channelDictionary: ChannelDictionary | null = null;
   let commandDictionary: CommandDictionary | null = null;
+  let fetchAbortController: AbortController | null = null;
+  let loadingExpansionRunDetails: boolean = false;
   let parameterDictionaries: ParameterDictionary[] = [];
   let parcel: Parcel | null;
+  let selectedExpansionRun: ExpansionRun | null = null;
+  let selectedExpansionRunId: number | null = null;
   let selectedSequence: ExpandedSequence | null = null;
   let selectedSequenceIds: number[] = [];
-  let selectedExpansionRun: ExpansionRun | null = null;
   let sequenceDefinition: string;
   let phoenixContext: PhoenixContext;
 
@@ -194,17 +198,34 @@
   $: parcel = $parcels.find(p => p.id === selectedExpansionRun?.expansion_set.parcel_id) ?? null;
   $: selectedSequenceIds = selectedSequence ? [selectedSequence.id] : [];
 
-  function toggleRun(event: CustomEvent<DataGridRowSelection<ExpansionRun>>) {
+  async function fetchExpansionRunDetails(id: number): Promise<void> {
+    // Abort any in-flight request
+    if (fetchAbortController) {
+      fetchAbortController.abort();
+    }
+
+    fetchAbortController = new AbortController();
+    loadingExpansionRunDetails = true;
+    selectedExpansionRun = null;
+
+    const { aborted, expansionRun } = await effects.getExpansionRun(id, user, fetchAbortController.signal);
+
+    if (!aborted) {
+      selectedExpansionRun = expansionRun;
+      loadingExpansionRunDetails = false;
+      fetchAbortController = null;
+    }
+  }
+
+  function selectRun(event: CustomEvent<DataGridRowSelection<ExpansionRunSlim>>) {
     const {
       detail: { data: clickedRun, isSelected },
     } = event;
 
-    selectedSequence = null;
-
-    if (isSelected) {
-      selectedExpansionRun = clickedRun;
-    } else if (selectedExpansionRun?.id === clickedRun.id) {
-      selectedExpansionRun = null;
+    if (isSelected && selectedExpansionRunId !== clickedRun.id) {
+      selectedSequence = null;
+      selectedExpansionRunId = clickedRun.id;
+      fetchExpansionRunDetails(clickedRun.id);
     }
   }
 
@@ -215,8 +236,6 @@
 
     if (isSelected) {
       selectedSequence = clickedSequence;
-    } else if (selectedSequence?.id === clickedSequence.id) {
-      selectedSequence = null;
     }
   }
 </script>
@@ -229,11 +248,7 @@
       </svelte:fragment>
 
       <svelte:fragment slot="body">
-        {#if expansionRuns.length}
-          <DataGrid {columnDefs} rowSelection="single" rowData={expansionRuns} on:rowSelected={toggleRun} />
-        {:else}
-          No Expansion Runs Found
-        {/if}
+        <DataGrid {columnDefs} rowSelection="single" rowData={expansionRuns} on:rowSelected={selectRun} />
       </svelte:fragment>
     </Panel>
 
@@ -242,27 +257,28 @@
     <Panel>
       <svelte:fragment slot="header">
         <SectionTitle>Expanded Sequences</SectionTitle>
-        {#if selectedExpansionRun}
+        {#if selectedExpansionRun && !loadingExpansionRunDetails}
           <div class="right">
             <ExpandedSequencesDownloadButton
-              expandedSequences={selectedExpansionRun?.expanded_sequences}
-              filename={`expanded_sequences_${selectedExpansionRun?.created_at.split('.')[0]}`}
+              expandedSequences={selectedExpansionRun.expanded_sequences}
+              filename={`expanded_sequences_${selectedExpansionRun.created_at.split('.')[0]}`}
             />
           </div>
         {/if}
       </svelte:fragment>
 
       <svelte:fragment slot="body">
-        {#if selectedExpansionRun}
+        {#if selectedExpansionRunId !== null}
           <DataGrid
             columnDefs={sequenceColumnDefs}
-            rowData={selectedExpansionRun?.expanded_sequences}
+            loading={loadingExpansionRunDetails}
+            rowData={selectedExpansionRun?.expanded_sequences ?? []}
             rowSelection="single"
             selectedRowIds={selectedSequenceIds}
             on:rowSelected={toggleSequence}
           />
         {:else}
-          No Expansion Run Selected
+          <div class="text-muted-foreground">No Expansion Run Selected</div>
         {/if}
       </svelte:fragment>
     </Panel>

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -96,12 +96,7 @@ export type ExpandedSequence = {
 
 export type ExpansionRunSlim = {
   created_at: string;
-  expansion_set: {
-    created_at: string;
-    id: number;
-    name: string;
-    parcel_id: number;
-  };
+  expansion_set: Pick<ExpansionSet, 'created_at' | 'id' | 'name' | 'parcel_id'>;
   id: number;
   simulation_dataset: {
     dataset_id: number;

--- a/src/types/expansion.ts
+++ b/src/types/expansion.ts
@@ -94,10 +94,14 @@ export type ExpandedSequence = {
   };
 };
 
-export type ExpansionRun = {
+export type ExpansionRunSlim = {
   created_at: string;
-  expanded_sequences: ExpandedSequence[];
-  expansion_set: ExpansionSet;
+  expansion_set: {
+    created_at: string;
+    id: number;
+    name: string;
+    parcel_id: number;
+  };
   id: number;
   simulation_dataset: {
     dataset_id: number;
@@ -108,4 +112,8 @@ export type ExpansionRun = {
       };
     };
   };
+};
+
+export type ExpansionRun = ExpansionRunSlim & {
+  expanded_sequences: ExpandedSequence[];
 };

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -118,6 +118,7 @@ import type {
   ExpansionRuleInsertInput,
   ExpansionRuleSetInput,
   ExpansionRun,
+  ExpansionRunSlim,
   ExpansionSequence,
   ExpansionSequenceInsertInput,
   ExpansionSequenceToActivityInsertInput,
@@ -4451,9 +4452,33 @@ const effects = {
     }
   },
 
-  async getExpansionRuns(user: User | null): Promise<ExpansionRun[]> {
+  async getExpansionRun(
+    id: number,
+    user: User | null,
+    signal?: AbortSignal,
+  ): Promise<{ aborted: boolean; expansionRun: ExpansionRun | null }> {
     try {
-      const data = await reqHasura<ExpansionRun[]>(gql.GET_EXPANSION_RUNS, {}, user);
+      const data = await reqHasura<ExpansionRun>(gql.GET_EXPANSION_RUN, { id }, user, signal);
+      const { expansionRun } = data;
+      if (expansionRun) {
+        logMessage(`Retrieved expansion run (ID=${id}).`);
+        return { aborted: false, expansionRun };
+      } else {
+        return { aborted: false, expansionRun: null };
+      }
+    } catch (e) {
+      if ((e as Error).name === 'AbortError') {
+        return { aborted: true, expansionRun: null };
+      }
+      catchError('Failed to get expansion run', e as Error);
+      showFailureToast('Expansion Run Details Retrieval Failed');
+      return { aborted: false, expansionRun: null };
+    }
+  },
+
+  async getExpansionRuns(user: User | null): Promise<ExpansionRunSlim[]> {
+    try {
+      const data = await reqHasura<ExpansionRunSlim[]>(gql.GET_EXPANSION_RUNS, {}, user);
       const { expansionRuns } = data;
       if (expansionRuns) {
         logMessage(`Retrieved ${expansionRuns.length} expansion run${pluralize(expansionRuns.length)}.`);
@@ -4463,6 +4488,7 @@ const effects = {
       }
     } catch (e) {
       catchError('Failed to get expansion runs', e as Error);
+      showFailureToast('Expansion Runs Retrieval Failed');
       return [];
     }
   },

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1245,9 +1245,9 @@ const gql = {
     }
   `,
 
-  GET_EXPANSION_RUNS: `#graphql
-    query GetExpansionRuns {
-      expansionRuns: ${Queries.EXPANSION_RUNS}(order_by: { id: desc }) {
+  GET_EXPANSION_RUN: `#graphql
+    query GetExpansionRun($id: Int!) {
+      expansionRun: ${Queries.EXPANSION_RUNS}_by_pk(id: $id) {
         created_at
         expansion_set {
           created_at
@@ -1267,6 +1267,30 @@ const gql = {
               }
             }
           }
+        }
+        simulation_dataset {
+          dataset_id
+          simulation {
+            plan {
+              id
+              name
+            }
+          }
+        }
+        id
+      }
+    }
+  `,
+
+  GET_EXPANSION_RUNS: `#graphql
+    query GetExpansionRuns {
+      expansionRuns: ${Queries.EXPANSION_RUNS}(order_by: { id: desc }) {
+        created_at
+        expansion_set {
+          created_at
+          id
+          name
+          parcel_id
         }
         simulation_dataset {
           dataset_id

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -783,6 +783,9 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
   GET_EFFECTIVE_MODEL_ARGUMENTS: () => true,
   GET_EVENTS: () => true,
   GET_EXPANSION_RULE: () => true,
+  GET_EXPANSION_RUN: (user: User | null): boolean => {
+    return isUserAdmin(user) || getPermission([Queries.EXPANSION_RUNS], user);
+  },
   GET_EXPANSION_RUNS: (user: User | null): boolean => {
     return isUserAdmin(user) || getPermission([Queries.EXPANSION_RUNS], user);
   },


### PR DESCRIPTION
Dynamically fetch expansion run details on run row click in the top table instead of fetching all of the nested data for all expansion runs up front. This should significantly improve page load times in scenarios like #1811. Closes #1811.

<a id="verification"></a>
## Verification
1. Use the [DB seed scripts](https://github.com/NASA-AMMOS/plandev-ui/pull/1837) to insert expansion rules in the DB.
2. Run PlanDev and create a test model with some activities
3. Run expansion rules on your plan multiple times to generate some expansion runs
4. Go to the Expansion page in the menu
5. Go to the Runs tab in the top right
6. Open your network tab and refresh
7. Look at network requests for the expansion run and verify that only one run is being loaded at a time

**OR** run this branch on deployment with a large number of expansion runs already in the database, and verify that the Expansion Runs page no longer loads slowly.
