### PR TITLE
Improved parcel viewing permissions

### DIFF
--- a/e2e-tests/fixtures/Parcels.ts
+++ b/e2e-tests/fixtures/Parcels.ts
@@ -23,15 +23,15 @@ export class Parcels {
 
   async changeSelectedCommandDictionary(firstCommandDictionaryName: string, secondCommandDictionaryName: string) {
     const parcelTableRow = this.page.locator(`.ag-row:has-text("${this.parcelName}")`);
-    const parcelTableRowEditButton = await this.page.locator(
-      `.ag-row:has-text("${this.parcelName}") >> button[aria-label="Edit Parcel"]`,
+    const parcelTableRowOpenButton = await this.page.locator(
+      `.ag-row:has-text("${this.parcelName}") >> button[aria-label="Open Parcel"]`,
     );
 
     parcelTableRow.hover();
-    await parcelTableRowEditButton.waitFor({ state: 'attached' });
-    await parcelTableRowEditButton.waitFor({ state: 'visible' });
-    await expect(parcelTableRowEditButton).toBeVisible();
-    parcelTableRowEditButton.click();
+    await parcelTableRowOpenButton.waitFor({ state: 'attached' });
+    await parcelTableRowOpenButton.waitFor({ state: 'visible' });
+    await expect(parcelTableRowOpenButton).toBeVisible();
+    parcelTableRowOpenButton.click();
 
     this.updatePage(this.page);
     await expect(this.tableRow(this.parcelName)).toBeVisible();

--- a/src/components/parcels/DictionaryTable.svelte
+++ b/src/components/parcels/DictionaryTable.svelte
@@ -163,6 +163,10 @@
    * @param event
    */
   function onRowClicked(event: CustomEvent<DataGridRowSelection<DictionaryMetadata>>) {
+    if (!hasEditPermission) {
+      return;
+    }
+
     const currentValue = selectedDictionaryIds[event.detail.data.id];
 
     selectRow(event.detail.data.id, currentValue === undefined ? true : !currentValue);

--- a/src/components/parcels/ParcelForm.svelte
+++ b/src/components/parcels/ParcelForm.svelte
@@ -64,7 +64,8 @@
   );
 
   $: saveButtonClass = parcelModified && saveButtonEnabled ? 'primary' : 'secondary';
-  $: saveButtonEnabled = parcelCommandDictionaryId !== null && parcelName !== undefined && parcelName !== '';
+  $: saveButtonEnabled =
+    hasPermission && parcelCommandDictionaryId !== null && parcelName !== undefined && parcelName !== '';
   $: parcelModified =
     parcelChannelDictionaryId !== savedParcelChannelDictionaryId ||
     parcelCommandDictionaryId !== savedParcelCommandDictionaryId ||

--- a/src/components/parcels/Parcels.svelte
+++ b/src/components/parcels/Parcels.svelte
@@ -9,7 +9,7 @@
   import SectionTitle from '../../components/ui/SectionTitle.svelte';
   import { parcels } from '../../stores/sequencing';
   import type { User } from '../../types/app';
-  import type { DataGridColumnDef, DataGridRowDoubleClick, DataGridRowSelection, RowId } from '../../types/data-grid';
+  import type { DataGridColumnDef, DataGridRowSelection, RowId } from '../../types/data-grid';
   import type { Parcel } from '../../types/sequencing';
   import effects from '../../utilities/effects';
   import { permissionHandler } from '../../utilities/permissionHandler';
@@ -21,7 +21,7 @@
 
   type CellRendererParams = {
     deleteParcel?: (parcel: Parcel) => void;
-    editParcel?: (parcel: Parcel) => void;
+    viewParcel?: (parcel: Parcel) => void;
   };
   type ParcelCellRendererParams = ICellRendererParams<Parcel> & CellRendererParams;
 
@@ -58,14 +58,13 @@
               content: 'Delete Parcel',
               placement: 'bottom',
             },
-            editCallback: params.editParcel,
-            editTooltip: {
-              content: 'Edit Parcel',
+            hasDeletePermission: params.data ? hasDeletePermission(user, params.data) : false,
+            rowData: params.data,
+            viewCallback: params.viewParcel,
+            viewTooltip: {
+              content: 'Open Parcel',
               placement: 'bottom',
             },
-            hasDeletePermission: params.data ? hasDeletePermission(user, params.data) : false,
-            hasEditPermission: params.data ? hasEditPermission(user, params.data) : false,
-            rowData: params.data,
           },
           target: actionsDiv,
         });
@@ -74,7 +73,7 @@
       },
       cellRendererParams: {
         deleteParcel,
-        editParcel,
+        viewParcel,
       } as CellRendererParams,
       field: 'actions',
       headerName: '',
@@ -113,24 +112,12 @@
     }
   }
 
-  function editParcel({ id }: Pick<Parcel, 'id'>) {
+  function viewParcel({ id }: Pick<Parcel, 'id'>) {
     goto(`${base}/parcels/edit/${id}`);
-  }
-
-  function editParcelContext(event: CustomEvent<RowId[]>) {
-    editParcel({ id: event.detail[0] as number });
-  }
-
-  function onParcelDoubleClick(event: CustomEvent<DataGridRowDoubleClick<Parcel>>) {
-    editParcel(event.detail.data);
   }
 
   function hasDeletePermission(user: User | null, parcel: Parcel) {
     return featurePermissions.parcels.canDelete(user, parcel);
-  }
-
-  function hasEditPermission(user: User | null, parcel: Parcel) {
-    return featurePermissions.parcels.canUpdate(user, parcel);
   }
 
   async function toggleParcel(event: CustomEvent<DataGridRowSelection<Parcel>>) {
@@ -169,16 +156,13 @@
         showLoadingSkeleton
         loading={$parcels === null}
         {columnDefs}
-        hasEdit={true}
-        {hasEditPermission}
         {hasDeletePermission}
         itemDisplayText="Parcel"
         items={filteredParcels}
         {user}
         on:deleteItem={deleteParcelContext}
-        on:editItem={editParcelContext}
         on:rowSelected={toggleParcel}
-        on:rowDoubleClicked={onParcelDoubleClick}
+        on:rowDoubleClicked={event => viewParcel(event.detail.data)}
       />
     {:else}
       <div class="p1 st-typography-label">No Parcels Found</div>


### PR DESCRIPTION
Changes parcel edit -> parcel open and cleans up parcel edit page permissions so users who do not have parcel edit permission can still view parcel details. Closes #1367.

<a id="verification"></a>
## Verification
1. Switch your user role to aerie_admin in the top right of the app
2. Make a parcel by uploading a command dictionary first
3. Verify that parcels can be opened with the expand button in the table on a parcel or via double click on the parcel row. 
4. Verify that parcels can be edited
5. Switch your role to a user
6. Verify that parcels can be opened but not edited
7. Repeat steps 5-6 with the viewer role