### PR TITLE
Add support for uploading activities as JSON

### DIFF
--- a/e2e-tests/data/activities.json
+++ b/e2e-tests/data/activities.json
@@ -1,0 +1,78 @@
+{
+  "activities": [
+    {
+      "anchor_id": null,
+      "anchored_to_start": true,
+      "arguments": {},
+      "id": 3229,
+      "name": "BananaNap",
+      "start_offset": "03:28:50.386",
+      "start_time_ms": 1704079730386,
+      "tags": [],
+      "type": "BananaNap"
+    },
+    {
+      "anchor_id": null,
+      "anchored_to_start": true,
+      "arguments": {
+        "duration": 3154000000000000
+      },
+      "id": 3230,
+      "name": "ControllableDurationActivity",
+      "start_offset": "11:06:17.9",
+      "start_time_ms": 1704107177900,
+      "tags": [],
+      "type": "ControllableDurationActivity"
+    },
+    {
+      "anchor_id": null,
+      "anchored_to_start": true,
+      "arguments": {
+        "producer": "Testing"
+      },
+      "id": 3231,
+      "name": "ChangeProducer",
+      "start_offset": "08:23:12.265",
+      "start_time_ms": 1704097392265,
+      "tags": [],
+      "type": "ChangeProducer"
+    },
+    {
+      "anchor_id": null,
+      "anchored_to_start": true,
+      "arguments": {},
+      "id": 3232,
+      "name": "BananaNap",
+      "start_offset": "03:28:50.386",
+      "start_time_ms": 1704079730386,
+      "tags": [],
+      "type": "BananaNap"
+    },
+    {
+      "anchor_id": 3231,
+      "anchored_to_start": true,
+      "arguments": {
+        "duration": 3154000000000000
+      },
+      "id": 3233,
+      "name": "ControllableDurationActivity",
+      "start_offset": "11:06:17.9",
+      "start_time_ms": 1704137370165,
+      "tags": [],
+      "type": "ControllableDurationActivity"
+    },
+    {
+      "anchor_id": 3229,
+      "anchored_to_start": true,
+      "arguments": {
+        "producer": "Testing"
+      },
+      "id": 3234,
+      "name": "ChangeProducer",
+      "start_offset": "08:23:12.265",
+      "start_time_ms": 1704109922651,
+      "tags": [],
+      "type": "ChangeProducer"
+    }
+  ]
+}

--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -299,7 +299,7 @@ export class Plan {
     await this.panelActivityForm.getByPlaceholder('Enter preset name').blur();
   }
 
-  async fillExternalDatasetFileInput(importFilePath: string) {
+  async fillFileInput(importFilePath: string) {
     const inputFile = this.page.locator('input[name="file"]');
     await setFileInputByFilepath(this.page, inputFile, importFilePath);
   }
@@ -620,10 +620,18 @@ export class Plan {
     this.sequenceExpansionOutputModal = page.locator(`.modal:has-text("Sequence ID")`);
   }
 
+  async uploadActivities(importFilePath: string) {
+    await this.panelActivityTypes.getByRole('tab', { exact: true, name: 'Activities' }).click();
+    await this.panelActivityTypes.getByRole('button', { exact: true, name: 'Upload Activities' }).click();
+    await this.fillFileInput(importFilePath);
+    await expect(this.panelActivityTypes.getByRole('button', { exact: true, name: 'Upload' })).toBeEnabled();
+    await this.panelActivityTypes.getByRole('button', { exact: true, name: 'Upload' }).click();
+  }
+
   async uploadExternalDatasets(importFilePath: string) {
     await this.panelActivityTypes.getByRole('tab', { exact: true, name: 'Resources' }).click();
     await this.panelActivityTypes.getByRole('button', { exact: true, name: 'Upload Resources' }).click();
-    await this.fillExternalDatasetFileInput(importFilePath);
+    await this.fillFileInput(importFilePath);
     await expect(this.panelActivityTypes.getByRole('button', { exact: true, name: 'Upload' })).toBeEnabled();
     await this.panelActivityTypes.getByRole('button', { exact: true, name: 'Upload' }).click();
   }

--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -300,7 +300,11 @@ export class Plan {
   }
 
   async fillFileInput(importFilePath: string) {
-    const inputFile = this.page.locator('input[name="file"]');
+    const inputFile = this.page
+      .getByRole('tabpanel')
+      .filter({ hasText: 'Activity, Resource, Event Types' })
+      .first()
+      .locator('input[name="file"]');
     await setFileInputByFilepath(this.page, inputFile, importFilePath);
   }
 

--- a/e2e-tests/tests/plan-activities-resources-external-events.test.ts
+++ b/e2e-tests/tests/plan-activities-resources-external-events.test.ts
@@ -12,7 +12,7 @@ test.afterAll(async () => {
   await teardownTest(setup);
 });
 
-test.describe.serial('Plan Resources', () => {
+test.describe.serial('Plan Activities, Resources, External Events', () => {
   test('Uploading external plan dataset file - JSON', async () => {
     await setup.plan.uploadExternalDatasets('e2e-tests/data/external-dataset.json');
     await expect(setup.plan.panelActivityTypes.getByText('/awake')).toBeVisible();
@@ -24,5 +24,14 @@ test.describe.serial('Plan Resources', () => {
     await expect(setup.plan.panelActivityTypes.getByText('TotalPower')).toBeVisible();
     await expect(setup.plan.panelActivityTypes.getByText('BatteryStateOfCharge')).toBeVisible();
     await expect(setup.plan.panelActivityTypes.getByText('Temperature')).toBeVisible();
+  });
+
+  test('Uploading activities', async () => {
+    await plan.uploadActivities('e2e-tests/data/activities.json');
+    await expect(plan.panelActivityDirectivesTable.getByRole('row', { name: 'BananaNap' })).toHaveCount(2);
+    await expect(plan.panelActivityDirectivesTable.getByRole('row', { name: 'ChangeProducer' })).toHaveCount(2);
+    await expect(
+      plan.panelActivityDirectivesTable.getByRole('row', { name: 'ControllableDurationActivity' }),
+    ).toHaveCount(2);
   });
 });

--- a/e2e-tests/tests/plan-activities-resources-external-events.test.ts
+++ b/e2e-tests/tests/plan-activities-resources-external-events.test.ts
@@ -27,11 +27,11 @@ test.describe.serial('Plan Activities, Resources, External Events', () => {
   });
 
   test('Uploading activities', async () => {
-    await plan.uploadActivities('e2e-tests/data/activities.json');
-    await expect(plan.panelActivityDirectivesTable.getByRole('row', { name: 'BananaNap' })).toHaveCount(2);
-    await expect(plan.panelActivityDirectivesTable.getByRole('row', { name: 'ChangeProducer' })).toHaveCount(2);
+    await setup.plan.uploadActivities('e2e-tests/data/activities.json');
+    await expect(setup.plan.panelActivityDirectivesTable.getByRole('row', { name: 'BananaNap' })).toHaveCount(2);
+    await expect(setup.plan.panelActivityDirectivesTable.getByRole('row', { name: 'ChangeProducer' })).toHaveCount(2);
     await expect(
-      plan.panelActivityDirectivesTable.getByRole('row', { name: 'ControllableDurationActivity' }),
+      setup.plan.panelActivityDirectivesTable.getByRole('row', { name: 'ControllableDurationActivity' }),
     ).toHaveCount(2);
   });
 });

--- a/e2e-tests/tests/plan-activities.test.ts
+++ b/e2e-tests/tests/plan-activities.test.ts
@@ -81,7 +81,7 @@ test.describe.serial('Plan Activities', () => {
 
     await setFileInputByFilepath(
       setup.page,
-      setup.page.locator('input[type="file"]'),
+      setup.page.locator('.parameter-base-path').locator('input[type="file"]'),
       './e2e-tests/data/valid-view.json',
     );
 

--- a/e2e-tests/tests/plan-activities.test.ts
+++ b/e2e-tests/tests/plan-activities.test.ts
@@ -81,12 +81,11 @@ test.describe.serial('Plan Activities', () => {
 
     await setFileInputByFilepath(
       setup.page,
-      setup.page.locator('.parameter-base-path').locator('input[type="file"]'),
+      setup.page.getByRole('tabpanel').filter({ hasText: 'Selected Activity' }).first().locator('input[type="file"]'),
       './e2e-tests/data/valid-view.json',
     );
 
     const errorBadge = await setup.page.locator('.input-error-badge-root');
-
     expect(errorBadge).not.toBeAttached();
   });
 

--- a/src/components/ActivityList.svelte
+++ b/src/components/ActivityList.svelte
@@ -1,13 +1,53 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import { planModelActivityTypes, subsystemTags } from '../stores/plan';
+  import CloseIcon from '@nasa-jpl/stellar/icons/close.svg?component';
+  import UploadIcon from '@nasa-jpl/stellar/icons/upload.svg?component';
+  import { plan, planModelActivityTypes, subsystemTags } from '../stores/plan';
   import type { ActivityType } from '../types/activity';
+  import type { User } from '../types/app';
   import type { TimelineItemType } from '../types/timeline';
+  import effects from '../utilities/effects';
+  import { permissionHandler } from '../utilities/permissionHandler';
+  import { featurePermissions } from '../utilities/permissions';
+  import { tooltip } from '../utilities/tooltip';
   import TimelineItemList from './TimelineItemList.svelte';
+  import Input from './form/Input.svelte';
+
+  export let user: User | null;
+
+  const uploadPermissionError: string = 'You do not have permission to upload activities.';
+
+  let hasUploadPermission: boolean = false;
+  let isUploadVisible: boolean = false;
+  let uploadFiles: FileList | undefined;
+  let uploadFileInput: HTMLInputElement;
+
+  $: if (user !== null && $plan !== null) {
+    hasUploadPermission = featurePermissions.activityDirective.canCreate(user, $plan);
+  }
 
   function getFilterValueFromItem(item: TimelineItemType) {
     return (item as ActivityType).subsystem_tag?.id ?? -1;
+  }
+
+  function onShowUpload() {
+    isUploadVisible = true;
+  }
+
+  function onHideUpload() {
+    isUploadVisible = false;
+  }
+
+  async function onUpload() {
+    if (uploadFiles !== undefined) {
+      if ($plan && uploadFiles?.length) {
+        await effects.uploadActivities($plan, uploadFiles, user);
+      }
+      uploadFileInput.value = '';
+      uploadFiles = undefined;
+      onHideUpload();
+    }
   }
 </script>
 
@@ -19,4 +59,86 @@
   {getFilterValueFromItem}
   filterOptions={$subsystemTags.map(s => ({ color: s.color || '', label: s.name, value: s.id }))}
   filterName="Subsystem"
-/>
+>
+  <div slot="header" class="upload-container" hidden={!isUploadVisible}>
+    <button class="close-upload" type="button" on:click={onHideUpload}>
+      <CloseIcon />
+    </button>
+    <Input layout="stacked">
+      <label class="st-typography-body" for="file">Activity File</label>
+      <input
+        class="w-full text-xs"
+        name="file"
+        type="file"
+        accept="application/json,.csv,.txt"
+        bind:files={uploadFiles}
+        bind:this={uploadFileInput}
+        use:permissionHandler={{
+          hasPermission: hasUploadPermission,
+          permissionError: uploadPermissionError,
+        }}
+      />
+    </Input>
+    <div class="upload-button-container">
+      <button
+        class="st-button secondary"
+        disabled={!uploadFiles?.length}
+        on:click={onUpload}
+        use:permissionHandler={{
+          hasPermission: hasUploadPermission,
+          permissionError: uploadPermissionError,
+        }}
+      >
+        Upload
+      </button>
+    </div>
+  </div>
+  <svelte:fragment slot="button">
+    <button
+      class="st-button secondary"
+      on:click={onShowUpload}
+      use:permissionHandler={{
+        hasPermission: hasUploadPermission,
+        permissionError: uploadPermissionError,
+      }}
+      use:tooltip={{ content: 'Upload Activities' }}
+    >
+      <UploadIcon />
+    </button>
+  </svelte:fragment>
+</TimelineItemList>
+
+<style>
+  .upload-container {
+    background: var(--st-gray-15);
+    border-radius: 5px;
+    margin: 5px;
+    padding: 8px 11px 8px;
+    position: relative;
+  }
+
+  .upload-container[hidden] {
+    display: none;
+  }
+
+  .upload-container {
+    display: grid;
+    row-gap: 8px;
+  }
+
+  .upload-container :global(.upload-button-container) {
+    display: flex;
+    flex-flow: row-reverse;
+  }
+
+  .upload-container :global(.close-upload) {
+    background: none;
+    border: 0;
+    cursor: pointer;
+    height: 1.3rem;
+    padding: 0;
+    position: absolute;
+    right: 3px;
+    top: 3px;
+  }
+</style>

--- a/src/components/ActivityList.svelte
+++ b/src/components/ActivityList.svelte
@@ -68,7 +68,7 @@
       <label class="st-typography-body" for="file">Activity File</label>
       <input
         class="w-full text-xs"
-        name="file"
+        name="activity-file"
         type="file"
         accept="application/json,.csv,.txt"
         bind:files={uploadFiles}

--- a/src/components/ActivityList.svelte
+++ b/src/components/ActivityList.svelte
@@ -68,7 +68,7 @@
       <label class="st-typography-body" for="file">Activity File</label>
       <input
         class="w-full text-xs"
-        name="activity-file"
+        name="file"
         type="file"
         accept="application/json,.csv,.txt"
         bind:files={uploadFiles}

--- a/src/components/activity/TimelineItemsPanel.svelte
+++ b/src/components/activity/TimelineItemsPanel.svelte
@@ -32,7 +32,7 @@
         <Tab class="timeline-items-tab text-xs"><ExternalEventIcon /> Events</Tab>
       </svelte:fragment>
       <TabPanel>
-        <ActivityList />
+        <ActivityList {user} />
       </TabPanel>
       <TabPanel>
         <ResourceList {user} />

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -8486,6 +8486,33 @@ const effects = {
     return null;
   },
 
+  async uploadActivities(plan: Plan, files: FileList, user: User | null): Promise<number | null> {
+    try {
+      if (!gatewayPermissions.ADD_ACTIVITIES(user, plan)) {
+        throwPermissionError('add activities');
+      }
+
+      const file: File = files[0];
+
+      const body = new FormData();
+      body.append('plan_id', `${plan.id}`);
+      body.append('activity_file', file, file.name);
+
+      const uploadedActivities = await reqGateway<number | null>('/uploadActivities', 'POST', body, user, true);
+
+      if (uploadedActivities != null) {
+        showSuccessToast('Activities Uploaded Successfully');
+        logMessage(`Uploaded activites from file '${file.name}'`);
+        return uploadedActivities;
+      }
+      throw Error('Uploaded activities not found');
+    } catch (e) {
+      catchError('Unable to upload activities', e as Error);
+      showFailureToast('Activity Upload Failed');
+      return null;
+    }
+  },
+
   async uploadDictionary(
     dictionary: string,
     user: User | null,

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -8488,7 +8488,7 @@ const effects = {
 
   async uploadActivities(plan: Plan, files: FileList, user: User | null): Promise<number | null> {
     try {
-      if (!gatewayPermissions.ADD_ACTIVITIES(user, plan)) {
+      if (!gatewayPermissions.CREATE_ACTIVITY_DIRECTIVES(user, plan)) {
         throwPermissionError('add activities');
       }
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -8502,7 +8502,7 @@ const effects = {
 
       if (uploadedActivities != null) {
         showSuccessToast('Activities Uploaded Successfully');
-        logMessage(`Uploaded activites from file '${file.name}'`);
+        logMessage(`Uploaded ${uploadedActivities} activites from file '${file.name}'`);
         return uploadedActivities;
       }
       throw Error('Uploaded activities not found');

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -1909,4 +1909,3 @@ export {
   isUserViewer,
   queryPermissions,
 };
-

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -1311,14 +1311,14 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
 };
 
 const gatewayPermissions = {
-  ADD_ACTIVITIES: (user: User | null, plan: PlanWithOwners): boolean => {
-    const queries = [getFunctionPermission(Queries.INSERT_ACTIVITY_DIRECTIVES)];
+  ADD_EXTERNAL_DATASET: (user: User | null, plan: PlanWithOwners): boolean => {
+    const queries = [getFunctionPermission(Queries.ADD_EXTERNAL_DATASET)];
     return (
       isUserAdmin(user) || (getPermission(queries, user) && (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
   },
-  ADD_EXTERNAL_DATASET: (user: User | null, plan: PlanWithOwners): boolean => {
-    const queries = [getFunctionPermission(Queries.ADD_EXTERNAL_DATASET)];
+  CREATE_ACTIVITY_DIRECTIVES: (user: User | null, plan: PlanWithOwners): boolean => {
+    const queries = [getFunctionPermission(Queries.INSERT_ACTIVITY_DIRECTIVES)];
     return (
       isUserAdmin(user) || (getPermission(queries, user) && (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
     );
@@ -1909,3 +1909,4 @@ export {
   isUserViewer,
   queryPermissions,
 };
+

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -1311,6 +1311,12 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
 };
 
 const gatewayPermissions = {
+  ADD_ACTIVITIES: (user: User | null, plan: PlanWithOwners): boolean => {
+    const queries = [getFunctionPermission(Queries.INSERT_ACTIVITY_DIRECTIVES)];
+    return (
+      isUserAdmin(user) || (getPermission(queries, user) && (isPlanOwner(user, plan) || isPlanCollaborator(user, plan)))
+    );
+  },
   ADD_EXTERNAL_DATASET: (user: User | null, plan: PlanWithOwners): boolean => {
     const queries = [getFunctionPermission(Queries.ADD_EXTERNAL_DATASET)];
     return (


### PR DESCRIPTION
```___REQUIRES_GATEWAY_PR___="138"``` 

This PR adds the ability to ingest a bulk set of activities into an existing plan, utilizing the plan JSON format and the UI components from resource upload. The format of the file is expected as the plan JSON, but only including the `activities`.

https://github.com/user-attachments/assets/d343fd6a-bc86-44d4-8b1d-2300a4823706

This also introduces an end-point to Gateway, `/uploadActivities`, which handles the actual upload of the activities. Note that the file itself is not saved, just parsed.

## Steps
1) Run the Gateway PR linked
2) Login to Aerie
3) Upload Banananation model
4) Create a plan for 2026-01-08 => 2026-01-10 using the Banananation model
5) Open the plan and navigate to the 'Activities' tab of the 'Activities, Resource, Event Types' panel
6) Click the upload button
7) Select the example file: [ActivityUploadTest.json](https://github.com/user-attachments/files/24533988/ActivityUploadTest.json)
8) Click 'Upload'
9) 3 activities should now be populated on the timeline

