### PR TITLE
Redirect to originally requested page after login

### DIFF
--- a/src/enums/searchParameters.ts
+++ b/src/enums/searchParameters.ts
@@ -1,8 +1,9 @@
 export enum SearchParameters {
   ACTIVITY_ID = 'activityId',
-  MODEL_ID = 'modelId',
   CONSTRAINT_ID = 'constraintId',
+  MODEL_ID = 'modelId',
   REASON = 'reason',
+  REDIRECT_TO = 'redirectTo',
   SIMULATION_DATASET_ID = 'simulationDatasetId',
   SNAPSHOT_ID = 'snapshotId',
   SPAN_ID = 'spanId',

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -41,14 +41,18 @@ const handleJWTAuth: Handle = async ({ event, resolve }) => {
 
   // if we're already on the login page, don't redirect
   // otherwise we get stuck in a redirect loop
-  return event.url.pathname.includes('/login') || event.url.pathname.includes('/auth')
-    ? await resolve(event)
-    : new Response(null, {
-        headers: {
-          location: `${base}/login`,
-        },
-        status: 307,
-      });
+  if (event.url.pathname.includes('/login') || event.url.pathname.includes('/auth')) {
+    return await resolve(event);
+  }
+
+  // Capture the original URL to redirect back after login
+  const redirectTo = encodeURIComponent(event.url.pathname + event.url.search);
+  return new Response(null, {
+    headers: {
+      location: `${base}/login?redirectTo=${redirectTo}`,
+    },
+    status: 307,
+  });
 };
 
 const handleSSOAuth: Handle = async ({ event, resolve }) => {

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -5,7 +5,8 @@ import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async ({ locals, url }) => {
   if (!url.pathname.includes('login') && shouldRedirectToLogin(locals.user)) {
-    redirect(302, base);
+    const redirectTo = encodeURIComponent(url.pathname + url.search);
+    redirect(302, `${base}/login?redirectTo=${redirectTo}`);
   }
   return { ...locals };
 };

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import { goto, invalidateAll } from '$app/navigation';
+  import { goto } from '$app/navigation';
   import { base } from '$app/paths';
   import { page } from '$app/stores';
   import { Button, Input, Label } from '@nasa-jpl/stellar-svelte';
@@ -54,8 +54,9 @@
       const { message, success } = loginResponse;
 
       if (success) {
-        await invalidateAll();
-        await goto(`${base}/plans`);
+        const redirectTo = $page.url.searchParams.get(SearchParameters.REDIRECT_TO);
+        const destination = redirectTo ? decodeURIComponent(redirectTo) : `${base}/plans`;
+        await goto(destination, { invalidateAll: true });
       } else {
         console.log(message);
         error = message ?? null;


### PR DESCRIPTION
When unauthenticated users try to access a protected page, they are now redirected back to that page after successfully logging in, instead of always landing on /plans.

- Add REDIRECT_TO search parameter enum
- Capture original URL in hooks.server.ts and +layout.server.ts redirects
- Use goto with invalidateAll option to avoid flash during navigation