### PR TITLE
Ensure goal/constraint procedure revision stickiness in selector

### DIFF
--- a/src/components/constraints/ConstraintListItem.svelte
+++ b/src/components/constraints/ConstraintListItem.svelte
@@ -382,6 +382,7 @@
         }}
       >
         <ContextMenu.Item
+          size="sm"
           on:click={() =>
             window.open(
               `${base}/constraints/edit/${constraint.id}${

--- a/src/components/constraints/ConstraintListItem.svelte
+++ b/src/components/constraints/ConstraintListItem.svelte
@@ -66,7 +66,7 @@
   $: order = constraintPlanSpec.order;
 
   $: {
-    const version = getSpecVersion(constraint, constraintPlanSpec.constraint_revision);
+    version = getSpecVersion(constraint, constraintPlanSpec.constraint_revision);
 
     const schema = version?.parameter_schema;
     if (schema && schema.type === 'struct') {
@@ -99,13 +99,12 @@
   ): Pick<ConstraintDefinition, 'type' | 'revision' | 'parameter_schema' | 'uploaded_jar_id'> | undefined {
     if (revision != null && revision !== '') {
       const revisionNumber = parseInt(`${revision}`);
-      version = constraintMetadata.versions.find(v => v.revision === revisionNumber);
+      return constraintMetadata.versions.find(v => v.revision === revisionNumber);
     } else {
       // if the `constraint_revision` is null, that means to use the latest version of the definition
-      // the query for this constraint returns the versions in descending order, so the first entry in the array should correspond to the latest version
-      version = constraintMetadata.versions[0];
+      // the query for this goal returns the versions in descending order, so the first entry in the array should correspond to the latest version
+      return constraintMetadata.versions[0];
     }
-    return version;
   }
 
   function focusInput() {

--- a/src/components/constraints/ConstraintListItem.svelte
+++ b/src/components/constraints/ConstraintListItem.svelte
@@ -354,7 +354,7 @@
             }}
           >
             <option value={null}>Always use latest</option>
-            {#each revisions as revision, index}
+            {#each revisions as revision, index (revision)}
               <option value={revision}>{revision}{index === 0 ? ' (Latest)' : ''}</option>
             {/each}
           </select>

--- a/src/components/scheduling/goals/SchedulingGoal.svelte
+++ b/src/components/scheduling/goals/SchedulingGoal.svelte
@@ -58,7 +58,7 @@
   }
 
   $: {
-    const version = getSpecVersion(goal, goalPlanSpec.goal_revision);
+    version = getSpecVersion(goal, goalPlanSpec.goal_revision);
 
     const schema = version?.parameter_schema;
 
@@ -102,13 +102,12 @@
     | undefined {
     if (revision != null && revision !== '') {
       const revisionNumber = parseInt(`${revision}`);
-      version = goalMetadata.versions.find(v => v.revision === revisionNumber);
+      return goalMetadata.versions.find(v => v.revision === revisionNumber);
     } else {
       // if the `goal_revision` is null, that means to use the latest version of the definition
       // the query for this goal returns the versions in descending order, so the first entry in the array should correspond to the latest version
-      version = goalMetadata.versions[0];
+      return goalMetadata.versions[0];
     }
-    return version;
   }
 
   function focusInput() {

--- a/src/components/scheduling/goals/SchedulingGoal.svelte
+++ b/src/components/scheduling/goals/SchedulingGoal.svelte
@@ -297,7 +297,7 @@
           }}
         >
           <option value={null}>Always use latest</option>
-          {#each revisions as revision, index}
+          {#each revisions as revision, index (revision)}
             <option value={revision}>{revision}{index === 0 ? ' (Latest)' : ''}</option>
           {/each}
         </select>

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -1219,7 +1219,7 @@ const effects = {
         type: definitionType,
         uploaded_jar_id: jarId,
       };
-      const data = await reqHasura<ConstraintDefinition>(
+      const data = await reqHasura<Pick<ConstraintDefinition, 'constraint_id' | 'definition' | 'revision'> | null>(
         gql.CREATE_CONSTRAINT_DEFINITION,
         { constraintDefinition: constraintDefinitionInsertInput },
         user,
@@ -1228,7 +1228,7 @@ const effects = {
       if (constraintDefinition != null) {
         showSuccessToast('New Constraint Revision Created Successfully');
         logMessage(
-          `Created new constraint revision ${constraintDefinition.revision} for constraint "${constraintDefinition.metadata.name}" (ID=${constraintId}).`,
+          `Created new constraint revision ${constraintDefinition.revision} for constraint ID=${constraintId}.`,
         );
         return constraintDefinition;
       } else {


### PR DESCRIPTION
Procedural goal and constraint invocation revisions not pinned to "always use latest" would not maintain the correct revision in the selector (though the actual db spec was always correct) after the procedure jar was updated and the socket message came back to the UI. In the #each loop when creating list items for goals and constraints, the index was being used as the default key instead of the revision, causing the selector to display the revision that was one ahead of what it should have been since the index of the actual selected revision in the array changed. When the user refreshed the page, the revisions would display correctly since there would be no index-revision mismatch. This PR keys the each loops off revision. Additionally, a small refactor was made to version assignment in goal/constraint list items for clarity. Finally, a small sizing style bug fix was made to the "View Constraint" menu item.

Testing:
1. Create a procedural goal from a jar
2. Update the procedural goal jar to use the same or a different jar to create another revision
3. Associate the goal to an open plan and select the first revision (0) instead of "always use latest"
4. In another tab, update the procedural goal jar again to create another revision
5. Confirm that the selected revision in the plan goal invocation did not change
6. Repeat step 3 once or twice to doubly confirm that the plan goal invocation revision did not change
7. Change the goal revision to be "always use latest"
8. Create another goal revision
9. Confirm that the plan goal invocation revision is still on latest
10. Repeat steps 1-9 with procedural constraints