### PR TITLE
Fix workspace file/folder name path cleaning

### DIFF
--- a/src/components/modals/ImportWorkspaceFileModal.svelte
+++ b/src/components/modals/ImportWorkspaceFileModal.svelte
@@ -7,7 +7,7 @@
   import type { User } from '../../types/app';
   import type { Workspace, WorkspaceNodeEvent } from '../../types/workspace';
   import type { WorkspaceTreeNode } from '../../types/workspace-tree-view';
-  import { cleanPath, joinPath } from '../../utilities/workspaces.js';
+  import { joinPath, removeFirstPathSegment } from '../../utilities/workspaces.js';
   import InputInternal from '../form/Input.svelte';
   import WorkspaceTreeView from '../workspace/WorkspaceTreeView/WorkspaceTreeView.svelte';
   import Modal from './Modal.svelte';
@@ -85,12 +85,14 @@
         filesToUpload = [...selectedFileGroupings.convertableFiles, ...selectedFileGroupings.uploadableFiles];
       }
 
+      // targetDirectory includes workspace name as first segment (e.g., "workspace/folder/subfolder")
+      // Remove it since the API expects paths relative to the workspace root
       dispatch('confirm', {
         filesToConvert,
         filesToUpload,
         shouldKeepOriginalFiles,
         shouldOverwrite,
-        targetDirectory: cleanPath(joinPath([targetDirectory.replace(new RegExp(`^${currentWorkspace.name}`), '')])),
+        targetDirectory: removeFirstPathSegment(targetDirectory),
       });
     }
   }

--- a/src/components/modals/MoveWorkspaceItemModal.svelte
+++ b/src/components/modals/MoveWorkspaceItemModal.svelte
@@ -11,6 +11,7 @@
     getSelectedFilesDisplay,
     getWorkspaceFileFolderDisplay,
     joinPath,
+    removeFirstPathSegment,
     separateFilenameFromPath,
   } from '../../utilities/workspaces';
   import WorkspaceTreeView from '../workspace/WorkspaceTreeView/WorkspaceTreeView.svelte';
@@ -48,18 +49,22 @@
   }
 
   function onMove() {
+    // targetDirectory includes workspace name as first segment (e.g., "workspace/folder/subfolder")
+    // Remove it since the API expects paths relative to the workspace root
     dispatch('confirm', {
       shouldCopy: false,
       shouldOverwrite,
-      targetPath: targetDirectory.replace(new RegExp(`^${currentWorkspace.name}`), ''),
+      targetPath: removeFirstPathSegment(targetDirectory),
     });
   }
 
   function onDuplicate() {
+    // targetDirectory includes workspace name as first segment (e.g., "workspace/folder/subfolder")
+    // Remove it since the API expects paths relative to the workspace root
     dispatch('confirm', {
       shouldCopy: true,
       shouldOverwrite,
-      targetPath: targetDirectory.replace(new RegExp(`^${currentWorkspace.name}`), ''),
+      targetPath: removeFirstPathSegment(targetDirectory),
     });
   }
 </script>

--- a/src/components/modals/NewWorkspaceFolderModal.svelte
+++ b/src/components/modals/NewWorkspaceFolderModal.svelte
@@ -8,7 +8,7 @@
   import type { User } from '../../types/app';
   import type { Workspace, WorkspaceNodeEvent } from '../../types/workspace';
   import type { WorkspaceTreeNode } from '../../types/workspace-tree-view';
-  import { cleanPath, joinPath } from '../../utilities/workspaces.js';
+  import { joinPath, removeFirstPathSegment } from '../../utilities/workspaces.js';
   import WorkspaceTreeView from '../workspace/WorkspaceTreeView/WorkspaceTreeView.svelte';
   import Modal from './Modal.svelte';
   import ModalContent from './ModalContent.svelte';
@@ -35,8 +35,10 @@
   }
 
   function onConfirm() {
+    // folderPath includes workspace name as first segment (e.g., "workspace/folder/subfolder")
+    // Remove it since the API expects paths relative to the workspace root
     dispatch('confirm', {
-      folderPath: cleanPath(joinPath([folderPath.replace(new RegExp(`^${currentWorkspace?.name}`), '.'), folderName])),
+      folderPath: joinPath([removeFirstPathSegment(folderPath), folderName.trim()]),
     });
   }
 

--- a/src/components/modals/NewWorkspaceSequenceModal.svelte
+++ b/src/components/modals/NewWorkspaceSequenceModal.svelte
@@ -8,7 +8,7 @@
   import type { User } from '../../types/app';
   import type { Workspace, WorkspaceNodeEvent } from '../../types/workspace';
   import type { WorkspaceTreeNode } from '../../types/workspace-tree-view';
-  import { cleanPath, joinPath } from '../../utilities/workspaces';
+  import { joinPath, removeFirstPathSegment } from '../../utilities/workspaces';
   import WorkspaceTreeView from '../workspace/WorkspaceTreeView/WorkspaceTreeView.svelte';
   import Modal from './Modal.svelte';
   import ModalContent from './ModalContent.svelte';
@@ -35,8 +35,10 @@
   }
 
   function onConfirm() {
+    // filePath includes workspace name as first segment (e.g., "workspace/folder/subfolder")
+    // Remove it since the API expects paths relative to the workspace root
     dispatch('confirm', {
-      filePath: cleanPath(joinPath([filePath.replace(new RegExp(`^${currentWorkspace?.name}`), '.'), fileName])),
+      filePath: joinPath([removeFirstPathSegment(filePath), fileName.trim()]),
     });
   }
 

--- a/src/utilities/workspaces.test.ts
+++ b/src/utilities/workspaces.test.ts
@@ -19,6 +19,7 @@ import {
   incrementFilename,
   joinPath,
   mapWorkspaceTreePaths,
+  removeFirstPathSegment,
   removeRedundantNodes,
   separateFilenameFromPath,
   shouldNodeBeVisible,
@@ -96,6 +97,27 @@ describe('Workspace utility function tests', () => {
       expect(joinPath(['foo', '', 'bar'])).toEqual('foo/bar');
       expect(joinPath(['', 'foo', 'bar'])).toEqual('foo/bar');
       expect(joinPath(['', 'foo', 'bar', ''])).toEqual('foo/bar');
+    });
+  });
+
+  describe('removeFirstPathSegment', () => {
+    test('Should remove the first segment from a path', () => {
+      expect(removeFirstPathSegment('workspace/folder/file.txt')).toEqual('folder/file.txt');
+      expect(removeFirstPathSegment('workspace/file.txt')).toEqual('file.txt');
+    });
+
+    test('Should handle workspace names with special characters like parentheses', () => {
+      expect(removeFirstPathSegment('My Workspace (1)/folder/file.txt')).toEqual('folder/file.txt');
+      expect(removeFirstPathSegment('Test (copy)/subfolder')).toEqual('subfolder');
+      expect(removeFirstPathSegment('Project [v2.0]/src/index.ts')).toEqual('src/index.ts');
+    });
+
+    test('Should return empty string when path has only one segment', () => {
+      expect(removeFirstPathSegment('workspace')).toEqual('');
+    });
+
+    test('Should handle empty string', () => {
+      expect(removeFirstPathSegment('')).toEqual('');
     });
   });
 

--- a/src/utilities/workspaces.ts
+++ b/src/utilities/workspaces.ts
@@ -56,6 +56,19 @@ export function joinPath(pathParts: (string | number | boolean)[]) {
   return pathParts.filter(filterEmpty).join(PATH_DELIMITER);
 }
 
+/**
+ * Removes the first path segment (typically the workspace name) from a full path.
+ * Use this when converting UI paths (which include workspace name) to API paths (which are relative to workspace root).
+ *
+ * @param fullPath - Path with workspace name as first segment (e.g., "My Workspace (1)/folder/file.txt")
+ * @returns Path without the first segment (e.g., "folder/file.txt")
+ */
+export function removeFirstPathSegment(fullPath: string): string {
+  const parts = fullPath.split(PATH_DELIMITER);
+  parts.shift();
+  return parts.join(PATH_DELIMITER);
+}
+
 export type TreeSortComparator = (a: WorkspaceTreeNode, b: WorkspaceTreeNode) => number;
 
 /**


### PR DESCRIPTION
A regex was being used to remove the workspace path from the filepath in various workspace file/folder create/move modals.  This regex failed on workspace names with various characters like parentheses, brackets, etc., that were not being escaped and were therefore being incorporated into the regex string. The resulting filepath for something like "Workspace (A)/foo.txt" would be "Workspace (A)/foo.txt" instead of just "foo.txt", causing a folder with the workspace name to be errantly created during file creation. This PR switches the approach to just remove the first path in the filePath instead of using a regex. Additionally, this PR removes trailing spaces from the end of these filePaths since those also caused creation failures. This should close #1781 which may have also been due to a backend bug that no longer exists - this should resolve all known cases of the issue.

<a id="verification"></a>
## Verification

1. Create a workspace with parentheses in the name like "Workspace (a)"
2. Open the workspace and click the plus button and click on new file
3. Create a file in the root called "foo.txt"
4. Ensure the file is created at the root and not in "Workspace (a)/foo.txt"
5. Repeat 1-4 within a folder in the workspace
6. Repeat 1-5 for folder creation
7. Ensure move workspace file/folder and import workspace file function normally