### PR TITLE
Add prop to disable Ctrl-S/Cmd-S in workspace editors if global listener is already present

### DIFF
--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -42,6 +42,7 @@
   export let sequenceFilePath: string = '';
   export let sequenceDefinition: string = '';
   export let sequenceOutput: string = '';
+  export let shouldListenForKeyboardSave: boolean = true;
   export let showCommandFormBuilder: boolean = false;
   export let userSequenceEditorColumns: string;
   export let userSequenceEditorColumnsWithFormBuilder: string;
@@ -140,7 +141,7 @@
       doc: sequenceOutput,
       extensions: [
         basicSetup,
-        keymap.of([...standardKeymap, { key: 'Ctrl-s', mac: 'Cmd-s', run: onSave }]),
+        keymap.of([...standardKeymap, shouldListenForKeyboardSave ? { key: 'Ctrl-s', mac: 'Cmd-s', run: onSave } : {}]),
         EditorView.lineWrapping,
         EditorView.theme({ '.cm-gutter': { 'min-height': '0px' } }),
         EditorView.editable.of(false),
@@ -262,7 +263,7 @@
       doc: sequenceDefinition,
       extensions: [
         basicSetup,
-        keymap.of([...standardKeymap, { key: 'Ctrl-s', mac: 'Cmd-s', run: onSave }]),
+        keymap.of([...standardKeymap, shouldListenForKeyboardSave ? { key: 'Ctrl-s', mac: 'Cmd-s', run: onSave } : {}]),
         EditorView.lineWrapping,
         EditorView.theme({ '.cm-gutter': { 'min-height': '0px' } }),
         lintGutter(),

--- a/src/components/ui/TextEditor.svelte
+++ b/src/components/ui/TextEditor.svelte
@@ -24,6 +24,7 @@
   export let isLoading: boolean = false;
   export let previewOnly: boolean = false;
   export let readOnly: boolean = false;
+  export let shouldListenForKeyboardSave: boolean = true;
   export let textFileContent: string = '';
   export let textFilePath: string = '';
   export let textFileName: string = '';
@@ -78,7 +79,10 @@
         doc: textFileContent,
         extensions: [
           basicSetup,
-          keymap.of([...standardKeymap, { key: 'Ctrl-s', mac: 'Cmd-s', run: onSave }]),
+          keymap.of([
+            ...standardKeymap,
+            shouldListenForKeyboardSave ? { key: 'Ctrl-s', mac: 'Cmd-s', run: onSave } : {},
+          ]),
           EditorView.lineWrapping,
           EditorView.theme({ '.cm-gutter': { 'min-height': '0px' } }),
           lintGutter(),
@@ -94,7 +98,10 @@
         doc: textFileContent,
         extensions: [
           basicSetup,
-          keymap.of([...standardKeymap, { key: 'Ctrl-s', mac: 'Cmd-s', run: onSave }]),
+          keymap.of([
+            ...standardKeymap,
+            shouldListenForKeyboardSave ? { key: 'Ctrl-s', mac: 'Cmd-s', run: onSave } : {},
+          ]),
           EditorView.lineWrapping,
           EditorView.theme({ '.cm-gutter': { 'min-height': '0px' } }),
           lintGutter(),
@@ -145,7 +152,7 @@
       doc: textFileContent,
       extensions: [
         basicSetup,
-        keymap.of([...standardKeymap, { key: 'Ctrl-s', mac: 'Cmd-s', run: onSave }]),
+        keymap.of([...standardKeymap, shouldListenForKeyboardSave ? { key: 'Ctrl-s', mac: 'Cmd-s', run: onSave } : {}]),
         EditorView.lineWrapping,
         EditorView.theme({ '.cm-gutter': { 'min-height': '0px' } }),
         lintGutter(),

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -902,6 +902,7 @@
             sequenceName={$activeDocument.fileName ?? undefined}
             sequenceFilePath={$activeDocumentPath ?? ''}
             sequenceOutput={selectedSequenceOutput}
+            shouldListenForKeyboardSave={false}
             showCommandFormBuilder
             userSequenceEditorColumns={$userSequenceEditorColumns}
             userSequenceEditorColumnsWithFormBuilder={$userSequenceEditorColumnsWithFormBuilder}
@@ -919,6 +920,7 @@
             isJSON={$activeDocument.type === WorkspaceContentType.Json}
             isLoading={$activeDocumentIsLoading}
             previewOnly={!hasEditFilePermission}
+            shouldListenForKeyboardSave={false}
             textFileName={$activeDocument.fileName ?? undefined}
             textFilePath={$activeDocumentPath ?? ''}
             textFileContent={!isSequenceFile ? $activeDocument.originalContent : ''}


### PR DESCRIPTION
To test:
1. Create/open a workspace without selecting a file to view
2. Type anything in the empty text editor
3. Ctrl/Cmd + S to trigger a save
4. Enter the file name and click the `Confirm` button
5. Verify that only a success toast is displayed