### PR TITLE
Compute start_time_ms for plan merge activities

### DIFF
--- a/src/components/plan/PlanMergeReview.svelte
+++ b/src/components/plan/PlanMergeReview.svelte
@@ -27,6 +27,7 @@
   import effects from '../../utilities/effects';
   import { changedKeys, getTarget } from '../../utilities/generic';
   import gql from '../../utilities/gql';
+  import { getUnixEpochTimeFromInterval } from '../../utilities/time';
   import { showMergeReviewEndedModal } from '../../utilities/modal';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
@@ -81,6 +82,14 @@
   let userInitiatedMergeRequestResolution: boolean = false;
   let sourcePlan: PlanForMerging | undefined;
   let targetPlan: PlanForMerging;
+
+  /**
+   * Computes start_time_ms from an activity's start_offset relative to plan start.
+   * This is needed because merge activities come from the DB without the computed start_time_ms.
+   */
+  function computeStartTimeMs(activity: PlanMergeActivityDirectiveSource | PlanMergeActivityDirectiveTarget): number {
+    return getUnixEpochTimeFromInterval(initialPlan.start_time, activity.start_offset);
+  }
 
   $: if (initialPlan && initialMergeRequest && initialMergeRequest.plan_receiving_changes && initialPlan.model) {
     sourcePlan = initialMergeRequest.plan_snapshot_supplying_changes?.plan;
@@ -213,25 +222,29 @@
     const targetTags = selectedNonConflictingActivity.target_tags.map(tag => ({ tag }));
 
     if (selectedNonConflictingActivity.change_type === 'delete') {
+      const target = selectedNonConflictingActivity.target;
       computedTargetActivity =
-        selectedNonConflictingActivity.target !== null
-          ? { ...selectedNonConflictingActivity.target, tags: targetTags }
+        target !== null
+          ? { ...target, start_time_ms: computeStartTimeMs(target), tags: targetTags }
           : null;
       computedSourceActivity = null;
     } else if (selectedNonConflictingActivity.change_type === 'add') {
+      const source = selectedNonConflictingActivity.source;
       computedSourceActivity =
-        selectedNonConflictingActivity.source !== null
-          ? { ...selectedNonConflictingActivity.source, tags: sourceTags }
+        source !== null
+          ? { ...source, start_time_ms: computeStartTimeMs(source), tags: sourceTags }
           : null;
       computedTargetActivity = null;
     } else {
+      const target = selectedNonConflictingActivity.target;
+      const source = selectedNonConflictingActivity.source;
       computedTargetActivity =
-        selectedNonConflictingActivity.target !== null
-          ? { ...selectedNonConflictingActivity.target, tags: targetTags }
+        target !== null
+          ? { ...target, start_time_ms: computeStartTimeMs(target), tags: targetTags }
           : null;
       computedSourceActivity =
-        selectedNonConflictingActivity.source !== null
-          ? { ...selectedNonConflictingActivity.source, tags: sourceTags }
+        source !== null
+          ? { ...source, start_time_ms: computeStartTimeMs(source), tags: sourceTags }
           : null;
     }
 
@@ -246,6 +259,7 @@
     if (selectedConflictingActivity.source) {
       computedSourceActivity = {
         ...selectedConflictingActivity.source,
+        start_time_ms: computeStartTimeMs(selectedConflictingActivity.source),
         tags: selectedConflictingActivity.source_tags.map(tag => ({ tag })),
       };
     } else {
@@ -254,6 +268,7 @@
     if (selectedConflictingActivity.target) {
       computedTargetActivity = {
         ...selectedConflictingActivity.target,
+        start_time_ms: computeStartTimeMs(selectedConflictingActivity.target),
         tags: selectedConflictingActivity.target_tags.map(tag => ({ tag })),
       };
     } else {

--- a/src/components/plan/PlanMergeReview.svelte
+++ b/src/components/plan/PlanMergeReview.svelte
@@ -19,15 +19,20 @@
     PlanMergeActivityDirectiveSource,
     PlanMergeActivityDirectiveTarget,
     PlanMergeConflictingActivity,
+    PlanMergeConflictingActivityDB,
     PlanMergeNonConflictingActivity,
+    PlanMergeNonConflictingActivityDB,
     PlanMergeRequestSchema,
     PlanMergeRequestStatus,
     PlanMergeResolution,
   } from '../../types/plan';
+  import {
+    transformPlanMergeConflictingActivities,
+    transformPlanMergeNonConflictingActivities,
+  } from '../../utilities/activities';
   import effects from '../../utilities/effects';
   import { changedKeys, getTarget } from '../../utilities/generic';
   import gql from '../../utilities/gql';
-  import { getUnixEpochTimeFromInterval } from '../../utilities/time';
   import { showMergeReviewEndedModal } from '../../utilities/modal';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
@@ -40,17 +45,21 @@
   import CssGridGutter from '../ui/CssGridGutter.svelte';
   import PlanMergeReviewUserInfo from './PlanMergeReviewUserInfo.svelte';
 
-  export let initialConflictingActivities: PlanMergeConflictingActivity[] = [];
+  export let initialConflictingActivities: PlanMergeConflictingActivityDB[] = [];
   export let initialMergeRequest: PlanMergeRequestSchema | null;
-  export let initialNonConflictingActivities: PlanMergeNonConflictingActivity[] = [];
+  export let initialNonConflictingActivities: PlanMergeNonConflictingActivityDB[] = [];
   export let initialPlan: Plan;
 
   const user = getUserStore();
 
+  let sourcePlanStartTime: string = initialPlan.start_time;
+  let targetPlanStartTime: string = initialPlan.start_time;
+
   const conflictingMergeActivities = gqlSubscribable<PlanMergeConflictingActivity[]>(
     gql.SUB_PLAN_MERGE_CONFLICTING_ACTIVITIES,
     { merge_request_id: initialMergeRequest?.id },
-    initialConflictingActivities,
+    transformPlanMergeConflictingActivities(initialConflictingActivities, sourcePlanStartTime, targetPlanStartTime),
+    data => transformPlanMergeConflictingActivities(data, sourcePlanStartTime, targetPlanStartTime),
   );
   const mergeRequestStatus = gqlSubscribable<PlanMergeRequestStatus>(
     gql.SUB_PLAN_MERGE_REQUEST_STATUS,
@@ -72,6 +81,7 @@
   let mergeComparisonTargetDiv: HTMLElement | null = null;
   let mergeComparisonScrollOrigin: 'source' | 'target' | null = null;
   let modifications: PlanMergeNonConflictingActivity[] = [];
+  let nonConflictingActivities: PlanMergeNonConflictingActivity[] = [];
   let receivingPlanActivitiesMap: ActivityDirectivesMap = {};
   let selectedActivityId: number | null;
   let selectedConflictingActivity: PlanMergeConflictingActivity | null;
@@ -83,17 +93,20 @@
   let sourcePlan: PlanForMerging | undefined;
   let targetPlan: PlanForMerging;
 
-  /**
-   * Computes start_time_ms from an activity's start_offset relative to plan start.
-   * This is needed because merge activities come from the DB without the computed start_time_ms.
-   */
-  function computeStartTimeMs(activity: PlanMergeActivityDirectiveSource | PlanMergeActivityDirectiveTarget): number {
-    return getUnixEpochTimeFromInterval(initialPlan.start_time, activity.start_offset);
-  }
-
   $: if (initialPlan && initialMergeRequest && initialMergeRequest.plan_receiving_changes && initialPlan.model) {
     sourcePlan = initialMergeRequest.plan_snapshot_supplying_changes?.plan;
     targetPlan = initialMergeRequest.plan_receiving_changes;
+
+    // Set plan start times for activity transformations
+    sourcePlanStartTime = sourcePlan?.start_time ?? initialPlan.start_time;
+    targetPlanStartTime = targetPlan?.start_time ?? initialPlan.start_time;
+
+    // Transform non-conflicting activities with correct start times
+    nonConflictingActivities = transformPlanMergeNonConflictingActivities(
+      initialNonConflictingActivities,
+      sourcePlanStartTime,
+      targetPlanStartTime,
+    );
 
     let supplyingPlanId = sourcePlan?.id ?? -1;
 
@@ -105,7 +118,7 @@
     );
 
     // build up the complete array of snapshotted receiving and supplying directives
-    let { receivingPlanDirectives, supplyingPlanDirectives } = initialConflictingActivities.reduce(
+    let { receivingPlanDirectives, supplyingPlanDirectives } = $conflictingMergeActivities.reduce(
       (
         previous: {
           receivingPlanDirectives: PlanMergeActivityDirective[];
@@ -133,7 +146,7 @@
       { receivingPlanDirectives: [], supplyingPlanDirectives: [] },
     );
 
-    ({ receivingPlanDirectives, supplyingPlanDirectives } = initialNonConflictingActivities.reduce(
+    ({ receivingPlanDirectives, supplyingPlanDirectives } = nonConflictingActivities.reduce(
       (previous, nonConflictingActivity: PlanMergeNonConflictingActivity) => {
         const { source, target } = nonConflictingActivity;
 
@@ -155,11 +168,11 @@
     receivingPlanActivitiesMap = keyBy(receivingPlanDirectives, 'id');
   }
 
-  $: if (initialNonConflictingActivities) {
+  $: if (nonConflictingActivities) {
     // Updated selectedNonConflictingActivity with the refreshed version if needed
     if (selectedNonConflictingActivity) {
       const { activity_id: activityId } = selectedNonConflictingActivity;
-      const selectedActivity = initialNonConflictingActivities.find(merge => merge.activity_id === activityId);
+      const selectedActivity = nonConflictingActivities.find(merge => merge.activity_id === activityId);
       if (selectedActivity) {
         selectedNonConflictingActivity = selectedActivity;
       }
@@ -169,7 +182,7 @@
     additions = [];
     deletions = [];
     modifications = [];
-    initialNonConflictingActivities
+    nonConflictingActivities
       .slice()
       .sort((a, b) => {
         return (a.source?.name || a.target?.name || '').localeCompare(b.source?.name || b.target?.name || '');
@@ -223,21 +236,17 @@
 
     if (selectedNonConflictingActivity.change_type === 'delete') {
       const target = selectedNonConflictingActivity.target;
-      computedTargetActivity =
-        target !== null ? { ...target, start_time_ms: computeStartTimeMs(target), tags: targetTags } : null;
+      computedTargetActivity = target !== null ? { ...target, tags: targetTags } : null;
       computedSourceActivity = null;
     } else if (selectedNonConflictingActivity.change_type === 'add') {
       const source = selectedNonConflictingActivity.source;
-      computedSourceActivity =
-        source !== null ? { ...source, start_time_ms: computeStartTimeMs(source), tags: sourceTags } : null;
+      computedSourceActivity = source !== null ? { ...source, tags: sourceTags } : null;
       computedTargetActivity = null;
     } else {
       const target = selectedNonConflictingActivity.target;
       const source = selectedNonConflictingActivity.source;
-      computedTargetActivity =
-        target !== null ? { ...target, start_time_ms: computeStartTimeMs(target), tags: targetTags } : null;
-      computedSourceActivity =
-        source !== null ? { ...source, start_time_ms: computeStartTimeMs(source), tags: sourceTags } : null;
+      computedTargetActivity = target !== null ? { ...target, tags: targetTags } : null;
+      computedSourceActivity = source !== null ? { ...source, tags: sourceTags } : null;
     }
 
     // Reset comparison scroll positions
@@ -247,11 +256,10 @@
   $: if (selectedConflictingActivity) {
     selectedActivityId = selectedConflictingActivity.activity_id;
     selectedMergeType = 'conflict';
-    // Derive source and target activities
+    // Derive source and target activities (start_time_ms already computed)
     if (selectedConflictingActivity.source) {
       computedSourceActivity = {
         ...selectedConflictingActivity.source,
-        start_time_ms: computeStartTimeMs(selectedConflictingActivity.source),
         tags: selectedConflictingActivity.source_tags.map(tag => ({ tag })),
       };
     } else {
@@ -260,7 +268,6 @@
     if (selectedConflictingActivity.target) {
       computedTargetActivity = {
         ...selectedConflictingActivity.target,
-        start_time_ms: computeStartTimeMs(selectedConflictingActivity.target),
         tags: selectedConflictingActivity.target_tags.map(tag => ({ tag })),
       };
     } else {

--- a/src/components/plan/PlanMergeReview.svelte
+++ b/src/components/plan/PlanMergeReview.svelte
@@ -224,28 +224,20 @@
     if (selectedNonConflictingActivity.change_type === 'delete') {
       const target = selectedNonConflictingActivity.target;
       computedTargetActivity =
-        target !== null
-          ? { ...target, start_time_ms: computeStartTimeMs(target), tags: targetTags }
-          : null;
+        target !== null ? { ...target, start_time_ms: computeStartTimeMs(target), tags: targetTags } : null;
       computedSourceActivity = null;
     } else if (selectedNonConflictingActivity.change_type === 'add') {
       const source = selectedNonConflictingActivity.source;
       computedSourceActivity =
-        source !== null
-          ? { ...source, start_time_ms: computeStartTimeMs(source), tags: sourceTags }
-          : null;
+        source !== null ? { ...source, start_time_ms: computeStartTimeMs(source), tags: sourceTags } : null;
       computedTargetActivity = null;
     } else {
       const target = selectedNonConflictingActivity.target;
       const source = selectedNonConflictingActivity.source;
       computedTargetActivity =
-        target !== null
-          ? { ...target, start_time_ms: computeStartTimeMs(target), tags: targetTags }
-          : null;
+        target !== null ? { ...target, start_time_ms: computeStartTimeMs(target), tags: targetTags } : null;
       computedSourceActivity =
-        source !== null
-          ? { ...source, start_time_ms: computeStartTimeMs(source), tags: sourceTags }
-          : null;
+        source !== null ? { ...source, start_time_ms: computeStartTimeMs(source), tags: sourceTags } : null;
     }
 
     // Reset comparison scroll positions

--- a/src/components/plan/PlanMergeReview.test.ts
+++ b/src/components/plan/PlanMergeReview.test.ts
@@ -6,8 +6,8 @@ import { planModelActivityTypes } from '../../stores/plan';
 import type { Model } from '../../types/model';
 import type {
   Plan,
-  PlanMergeConflictingActivity,
-  PlanMergeNonConflictingActivity,
+  PlanMergeConflictingActivityDB,
+  PlanMergeNonConflictingActivityDB,
   PlanMergeRequestSchema,
 } from '../../types/plan';
 import effects from '../../utilities/effects';
@@ -73,6 +73,7 @@ const mockMergeRequest: PlanMergeRequestSchema = {
     model_id: 1,
     name: 'Demo Plan',
     owner: 'unknown',
+    start_time: '2024-01-01T00:00:00Z',
   },
   plan_snapshot_supplying_changes: {
     plan: {
@@ -84,6 +85,7 @@ const mockMergeRequest: PlanMergeRequestSchema = {
       model_id: 1,
       name: 'Branch 1',
       owner: 'unknown',
+      start_time: '2024-01-01T00:00:00Z',
     },
     snapshot_id: 2,
   },
@@ -164,7 +166,7 @@ describe('PlanMergeReview component', () => {
   });
 
   it('PlanMergeReview component should not throw with conflicting activities when source is delete and target is modify', () => {
-    const initialConflictingActivities: PlanMergeConflictingActivity[] = [
+    const initialConflictingActivities: PlanMergeConflictingActivityDB[] = [
       {
         activity_id: 1,
         change_type_source: 'delete',
@@ -185,7 +187,6 @@ describe('PlanMergeReview component', () => {
           snapshot_id: 1,
           source_scheduling_goal_id: -1,
           start_offset: '23:06:17.622',
-          start_time_ms: 1715731443696,
           tags: [],
           type: 'A_Activity',
         },
@@ -208,14 +209,13 @@ describe('PlanMergeReview component', () => {
           snapshot_id: 1,
           source_scheduling_goal_id: -1,
           start_offset: '36:25:10.489',
-          start_time_ms: 1715731443696,
           tags: [],
           type: 'A_Activity',
         },
         target_tags: [],
       },
     ];
-    const initialNonConflictingActivities: PlanMergeNonConflictingActivity[] = [];
+    const initialNonConflictingActivities: PlanMergeNonConflictingActivityDB[] = [];
 
     const { component } = render(PlanMergeReview, {
       initialConflictingActivities,
@@ -228,7 +228,7 @@ describe('PlanMergeReview component', () => {
   });
 
   it('PlanMergeReview component should not throw with conflicting activities when source is modify and target is delete', () => {
-    const initialConflictingActivities: PlanMergeConflictingActivity[] = [
+    const initialConflictingActivities: PlanMergeConflictingActivityDB[] = [
       {
         activity_id: 1,
         change_type_source: 'modify',
@@ -249,7 +249,6 @@ describe('PlanMergeReview component', () => {
           snapshot_id: 1,
           source_scheduling_goal_id: -1,
           start_offset: '23:06:17.622',
-          start_time_ms: 1715731443696,
           tags: [],
           type: 'A_Activity',
         },
@@ -269,7 +268,6 @@ describe('PlanMergeReview component', () => {
           snapshot_id: 2,
           source_scheduling_goal_id: -1,
           start_offset: '36:25:10.489',
-          start_time_ms: 1715731443696,
           tags: [],
           type: 'A_Activity',
         },
@@ -278,7 +276,7 @@ describe('PlanMergeReview component', () => {
         target_tags: [],
       },
     ];
-    const initialNonConflictingActivities: PlanMergeNonConflictingActivity[] = [];
+    const initialNonConflictingActivities: PlanMergeNonConflictingActivityDB[] = [];
 
     const { component } = render(PlanMergeReview, {
       initialConflictingActivities,
@@ -291,8 +289,8 @@ describe('PlanMergeReview component', () => {
   });
 
   it('PlanMergeReview component should not throw with non-conflicting activities', () => {
-    const initialConflictingActivities: PlanMergeConflictingActivity[] = [];
-    const initialNonConflictingActivities: PlanMergeNonConflictingActivity[] = [
+    const initialConflictingActivities: PlanMergeConflictingActivityDB[] = [];
+    const initialNonConflictingActivities: PlanMergeNonConflictingActivityDB[] = [
       {
         activity_id: 6,
         change_type: 'add',
@@ -311,7 +309,6 @@ describe('PlanMergeReview component', () => {
           snapshot_id: 6,
           source_scheduling_goal_id: -1,
           start_offset: '46:33:39.909',
-          start_time_ms: 1715731443696,
           tags: [],
           type: 'B_Activity',
         },
@@ -340,7 +337,6 @@ describe('PlanMergeReview component', () => {
           snapshot_id: 6,
           source_scheduling_goal_id: -1,
           start_offset: '53:35:33.936',
-          start_time_ms: 1715731443696,
           tags: [],
           type: 'C_Activity',
         },
@@ -364,7 +360,6 @@ describe('PlanMergeReview component', () => {
           snapshot_id: 6,
           source_scheduling_goal_id: -1,
           start_offset: '23:22:32.036',
-          start_time_ms: 1715731443696,
           tags: [],
           type: 'A_Activity',
         },
@@ -385,7 +380,6 @@ describe('PlanMergeReview component', () => {
           snapshot_id: 6,
           source_scheduling_goal_id: -1,
           start_offset: '23:22:32.036',
-          start_time_ms: 1715731443696,
           tags: [],
           type: 'A_Activity',
         },

--- a/src/routes/plans/[id]/merge/+page.ts
+++ b/src/routes/plans/[id]/merge/+page.ts
@@ -1,8 +1,8 @@
 import { base } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
 import type {
-  PlanMergeConflictingActivity,
-  PlanMergeNonConflictingActivity,
+  PlanMergeConflictingActivityDB,
+  PlanMergeNonConflictingActivityDB,
   PlanMergeRequestSchema,
 } from '../../../../types/plan';
 import effects from '../../../../utilities/effects';
@@ -27,8 +27,8 @@ export const load: PageLoad = async ({ parent, params }) => {
         user,
       );
 
-      let initialConflictingActivities: PlanMergeConflictingActivity[] = [];
-      let initialNonConflictingActivities: PlanMergeNonConflictingActivity[] = [];
+      let initialConflictingActivities: PlanMergeConflictingActivityDB[] = [];
+      let initialNonConflictingActivities: PlanMergeNonConflictingActivityDB[] = [];
 
       if (initialMergeRequest) {
         const { id: mergeRequestId } = initialMergeRequest;

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -1,4 +1,4 @@
-import type { ActivityDirective } from './activity';
+import type { ActivityDirective, ActivityDirectiveDB } from './activity';
 import type { UserId } from './app';
 import type { ConstraintPlanSpecification } from './constraint';
 import type { Model } from './model';
@@ -18,10 +18,35 @@ export type PlanInsertInput = Pick<PlanSchema, 'duration' | 'model_id' | 'name' 
 
 export type PlanMergeActivityOutcome = 'add' | 'delete' | 'modify' | 'none';
 
-export type PlanMergeActivityDirective = ActivityDirective & { snapshot_id: number };
+// DB types (what GraphQL returns, without start_time_ms)
+export type PlanMergeActivityDirectiveDB = ActivityDirectiveDB & { snapshot_id: number };
+export type PlanMergeActivityDirectiveSourceDB = Omit<PlanMergeActivityDirectiveDB, 'plan_id'>;
+export type PlanMergeActivityDirectiveTargetDB = PlanMergeActivityDirectiveDB;
 
+export type PlanMergeConflictingActivityDB = {
+  activity_id: number;
+  change_type_source: PlanMergeActivityOutcome;
+  change_type_target: PlanMergeActivityOutcome;
+  merge_base: PlanMergeActivityDirectiveDB;
+  resolution: PlanMergeResolution;
+  source: PlanMergeActivityDirectiveSourceDB | null;
+  source_tags: Tag[];
+  target: PlanMergeActivityDirectiveTargetDB | null;
+  target_tags: Tag[];
+};
+
+export type PlanMergeNonConflictingActivityDB = {
+  activity_id: number;
+  change_type: PlanMergeActivityOutcome;
+  source: PlanMergeActivityDirectiveSourceDB | null;
+  source_tags: Tag[];
+  target: PlanMergeActivityDirectiveTargetDB | null;
+  target_tags: Tag[];
+};
+
+// Computed types (with start_time_ms)
+export type PlanMergeActivityDirective = PlanMergeActivityDirectiveDB & { start_time_ms: number };
 export type PlanMergeActivityDirectiveTarget = PlanMergeActivityDirective;
-
 export type PlanMergeActivityDirectiveSource = Omit<PlanMergeActivityDirective, 'plan_id'>;
 
 export type PlanMergeConflictingActivity = {
@@ -53,7 +78,7 @@ export type PlanMergeRequest = PlanMergeRequestSchema & { pending: boolean; type
 
 export type PlanMergeRequestStatus = 'accepted' | 'in-progress' | 'pending' | 'rejected' | 'withdrawn';
 
-export type PlanForMerging = Pick<PlanSchema, 'id' | 'name' | 'owner' | 'collaborators' | 'model_id'> & {
+export type PlanForMerging = Pick<PlanSchema, 'id' | 'name' | 'owner' | 'collaborators' | 'model_id' | 'start_time'> & {
   model: Pick<Model, 'id' | 'name' | 'owner' | 'version'>;
 };
 
@@ -84,7 +109,7 @@ export type PlanSchema = {
   name: string;
   owner: UserId;
   parent_plan:
-    | (Pick<PlanSchema, 'id' | 'name' | 'owner' | 'collaborators' | 'is_locked' | 'model_id'> & {
+    | (Pick<PlanSchema, 'id' | 'name' | 'owner' | 'collaborators' | 'is_locked' | 'model_id' | 'start_time'> & {
         model: Pick<Model, 'id' | 'name' | 'owner' | 'version'>;
       })
     | null;

--- a/src/utilities/activities.ts
+++ b/src/utilities/activities.ts
@@ -6,7 +6,14 @@ import type {
   ActivityDirectivesMap,
 } from '../types/activity';
 import type { ActivityMetadata, ActivityMetadataKey, ActivityMetadataValue } from '../types/activity-metadata';
-import type { Plan } from '../types/plan';
+import type {
+  Plan,
+  PlanMergeActivityDirectiveDB,
+  PlanMergeConflictingActivity,
+  PlanMergeConflictingActivityDB,
+  PlanMergeNonConflictingActivity,
+  PlanMergeNonConflictingActivityDB,
+} from '../types/plan';
 import type { Span, SpanId, SpanUtilityMaps, SpansMap } from '../types/simulation';
 import type { ActivityTransformDirection } from '../types/time';
 import { getClipboardContent, setClipboardContent } from './clipboard';
@@ -18,6 +25,7 @@ import {
   getIntervalFromDoyRange,
   getIntervalInMs,
   getUnixEpochTime,
+  getUnixEpochTimeFromInterval,
   usToOffset,
 } from './time';
 import { showFailureToast } from './toast';
@@ -178,6 +186,53 @@ export function preprocessActivityDirectiveDB(
     );
   }
   return { ...activityDirectiveDB, start_time_ms };
+}
+
+/**
+ * Transforms a PlanMergeActivityDirectiveDB to PlanMergeActivityDirective by computing start_time_ms.
+ * Works with both source (without plan_id) and target (with plan_id) activity directives.
+ */
+export function transformPlanMergeActivityDirective<T extends Omit<PlanMergeActivityDirectiveDB, 'plan_id'>>(
+  activity: T,
+  planStartTime: string,
+): T & { start_time_ms: number } {
+  return {
+    ...activity,
+    start_time_ms: getUnixEpochTimeFromInterval(planStartTime, activity.start_offset),
+  };
+}
+
+/**
+ * Transforms PlanMergeConflictingActivityDB array to PlanMergeConflictingActivity array
+ * by computing start_time_ms for each activity using their respective plan's start_time.
+ */
+export function transformPlanMergeConflictingActivities(
+  activities: PlanMergeConflictingActivityDB[],
+  sourcePlanStartTime: string,
+  targetPlanStartTime: string,
+): PlanMergeConflictingActivity[] {
+  return activities.map(activity => ({
+    ...activity,
+    merge_base: transformPlanMergeActivityDirective(activity.merge_base, targetPlanStartTime),
+    source: activity.source ? transformPlanMergeActivityDirective(activity.source, sourcePlanStartTime) : null,
+    target: activity.target ? transformPlanMergeActivityDirective(activity.target, targetPlanStartTime) : null,
+  }));
+}
+
+/**
+ * Transforms PlanMergeNonConflictingActivityDB array to PlanMergeNonConflictingActivity array
+ * by computing start_time_ms for each activity using their respective plan's start_time.
+ */
+export function transformPlanMergeNonConflictingActivities(
+  activities: PlanMergeNonConflictingActivityDB[],
+  sourcePlanStartTime: string,
+  targetPlanStartTime: string,
+): PlanMergeNonConflictingActivity[] {
+  return activities.map(activity => ({
+    ...activity,
+    source: activity.source ? transformPlanMergeActivityDirective(activity.source, sourcePlanStartTime) : null,
+    target: activity.target ? transformPlanMergeActivityDirective(activity.target, targetPlanStartTime) : null,
+  }));
 }
 
 export function copyActivityDirectivesToClipboard(sourcePlan: Plan, activities: ActivityDirective[]) {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -164,8 +164,8 @@ import type {
   PlanCollaborator,
   PlanForMerging,
   PlanInsertInput,
-  PlanMergeConflictingActivity,
-  PlanMergeNonConflictingActivity,
+  PlanMergeConflictingActivityDB,
+  PlanMergeNonConflictingActivityDB,
   PlanMergeRequestSchema,
   PlanMergeResolution,
   PlanMetadata,
@@ -4948,10 +4948,10 @@ const effects = {
   async getPlanMergeConflictingActivities(
     mergeRequestId: number,
     user: User | null,
-  ): Promise<PlanMergeConflictingActivity[]> {
+  ): Promise<PlanMergeConflictingActivityDB[]> {
     try {
       const query = convertToQuery(gql.SUB_PLAN_MERGE_CONFLICTING_ACTIVITIES);
-      const data = await reqHasura<PlanMergeConflictingActivity[]>(query, { merge_request_id: mergeRequestId }, user);
+      const data = await reqHasura<PlanMergeConflictingActivityDB[]>(query, { merge_request_id: mergeRequestId }, user);
       const { conflictingActivities } = data;
       if (conflictingActivities != null) {
         logMessage(
@@ -4970,9 +4970,9 @@ const effects = {
   async getPlanMergeNonConflictingActivities(
     mergeRequestId: number,
     user: User | null,
-  ): Promise<PlanMergeNonConflictingActivity[]> {
+  ): Promise<PlanMergeNonConflictingActivityDB[]> {
     try {
-      const data = await reqHasura<PlanMergeNonConflictingActivity[]>(
+      const data = await reqHasura<PlanMergeNonConflictingActivityDB[]>(
         gql.GET_PLAN_MERGE_NON_CONFLICTING_ACTIVITIES,
         {
           merge_request_id: mergeRequestId,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1519,6 +1519,7 @@ const gql = {
             collaborator
           }
           is_locked
+          start_time
         }
         revision
         scheduling_specification {
@@ -2942,6 +2943,7 @@ const gql = {
           collaborators {
             collaborator
           }
+          start_time
         }
         plan_snapshot_supplying_changes {
           plan {
@@ -2957,6 +2959,7 @@ const gql = {
             collaborators {
               collaborator
             }
+            start_time
           }
           snapshot_id
         }
@@ -2984,6 +2987,7 @@ const gql = {
           collaborators {
             collaborator
           }
+          start_time
         }
         plan_snapshot_supplying_changes {
           plan {
@@ -2999,6 +3003,7 @@ const gql = {
             collaborators {
               collaborator
             }
+            start_time
           }
           snapshot_id
         }
@@ -3025,6 +3030,7 @@ const gql = {
           collaborators {
             collaborator
           }
+          start_time
         }
         plan_snapshot_supplying_changes {
           plan {
@@ -3040,6 +3046,7 @@ const gql = {
             collaborators {
               collaborator
             }
+            start_time
           }
           snapshot_id
         }


### PR DESCRIPTION
Fixes missing plan start time in merge review activity comparison that resulted from the caching of start_time_ms in a previous PR.

<a id="verification"></a>
## Verification
1. Make a plan
2. Make a branch off that plan and make some changes
3. Make a merge request from child branch into parent branch
4. Switch to parent branch and begin merge review
5. Ensure that activity start times are displaying properly in merge review activity comparison