### PR TITLE
Fix overflowing activity changelog icon and use lucide icon

### DIFF
--- a/src/components/activity/ActivityDirectiveChangelog.svelte
+++ b/src/components/activity/ActivityDirectiveChangelog.svelte
@@ -1,7 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import HistoryIcon from '@nasa-jpl/stellar/icons/history.svg?component';
+  import { History } from 'lucide-svelte';
   import { createEventDispatcher, onMount } from 'svelte';
   import { activityArgumentDefaultsMap } from '../../stores/activities';
   import { plan } from '../../stores/plan';
@@ -233,7 +233,7 @@
         on:click|stopPropagation={() => dispatch('closeChangelog')}
         use:tooltip={{ content: 'Close Activity Changelog', placement: 'top' }}
       >
-        <HistoryIcon />
+        <History size={16} />
       </button>
     </div>
   </div>

--- a/src/components/activity/ActivityDirectiveForm.svelte
+++ b/src/components/activity/ActivityDirectiveForm.svelte
@@ -3,9 +3,9 @@
 <script lang="ts">
   import CheckIcon from '@nasa-jpl/stellar/icons/check.svg?component';
   import CloseIcon from '@nasa-jpl/stellar/icons/close.svg?component';
-  import HistoryIcon from '@nasa-jpl/stellar/icons/history.svg?component';
   import PenIcon from '@nasa-jpl/stellar/icons/pen.svg?component';
   import { keyBy } from 'lodash-es';
+  import { History } from 'lucide-svelte';
   import { createEventDispatcher } from 'svelte';
   import { PlanStatusMessages } from '../../enums/planStatusMessages';
   import { activityArgumentDefaultsMap } from '../../stores/activities';
@@ -510,7 +510,7 @@
           on:click|stopPropagation={() => dispatch('viewChangelog')}
           use:tooltip={{ content: 'View Activity Changelog', placement: 'top' }}
         >
-          <HistoryIcon />
+          <History size={16} />
         </button>
       </div>
     </div>


### PR DESCRIPTION
Before:
<img width="401" height="142" alt="image" src="https://github.com/user-attachments/assets/a6b2acad-f580-4ea4-b76e-33e556f512f7" />


After:
<img width="433" height="145" alt="image" src="https://github.com/user-attachments/assets/9a094807-8cfb-471d-b167-02ea1b49bdf4" />
