### PR TITLE
Improve simulation panel performance

### DIFF
--- a/src/components/simulation/SimulationHistoryDataset.svelte
+++ b/src/components/simulation/SimulationHistoryDataset.svelte
@@ -43,6 +43,7 @@
   }>();
   const planDuration = planEndTimeMs - planStartTimeMs;
 
+  let argumentsExpanded: boolean = false;
   let endTimeText: string = '';
   let extent: string | null = '';
   let formParameters: FormParameter[] = [];
@@ -109,8 +110,10 @@
         }
       }
     }
+  }
 
-    // get the complete set of parameters and their defaults
+  // Load parameters only when arguments are expanded for performance
+  $: if (argumentsExpanded) {
     formParameters = getFormParameters(
       modelParametersMap,
       simulationDataset.arguments,
@@ -200,11 +203,14 @@
       defaultExpanded={false}
       title="Arguments"
       tooltipContent="Arguments for this simulation"
+      on:collapse={e => (argumentsExpanded = !e.detail)}
     >
-      {#if formParameters.length}
-        <Parameters {formParameters} parameterType="simulation" disabled={true} />
-      {:else}
-        <div class="p-1">No simulation arguments found</div>
+      {#if argumentsExpanded}
+        {#if formParameters.length}
+          <Parameters {formParameters} parameterType="simulation" disabled={true} />
+        {:else}
+          <div class="p-1">No simulation arguments found</div>
+        {/if}
       {/if}
     </Collapse>
     {#if !simulationLoadable}

--- a/src/components/ui/Card.svelte
+++ b/src/components/ui/Card.svelte
@@ -61,6 +61,7 @@
     border: 1px solid var(--st-gray-20);
     border-radius: 4px;
     color: var(--st-gray-70);
+    contain: layout style paint;
     cursor: pointer;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Improves simulation panel performance when viewing a plan with a significant number of simulations. Previously when viewing a plan with many simulations, switching to the simulations panel within a plan could be extremely slow to load and performance of the whole page could degrade. This PR adds lazy loading for simulation history dataset card parameters and optimizes some CSS properties of the cards to improve rendering performance. Virtualization could be added if additional performance is required in the future.

<a id="verification"></a>
## Verification
- Make a plan
- Force re-run simulation using the re-run button as many times as you can handle (pretend its cookie clicker!) to generate 50-100 simulations.
- Switch out of the simulation panel and then back in and ensure that there is no lag on simulation panel load time and that sim history card arguments are still viewable.