### PR TITLE
Allow derivation group to be changed

### DIFF
--- a/src/components/external-source/ExternalSourceManager.svelte
+++ b/src/components/external-source/ExternalSourceManager.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
   import { base } from '$app/paths';
+  import { Label, Select } from '@nasa-jpl/stellar-svelte';
   import type { ICellRendererParams, ValueGetterParams } from 'ag-grid-community';
   import { X } from 'lucide-svelte';
   import ExternalEventIcon from '../../assets/external-event-box-with-arrow.svg?component';
@@ -10,9 +11,11 @@
     createDerivationGroupError,
     createExternalSourceError,
     creatingExternalSource,
+    derivationGroups,
     externalSources,
     externalSourceTypes,
     planDerivationGroupLinks,
+    planDerivationGroupLinksByPlan,
   } from '../../stores/external-source';
   import { field } from '../../stores/form';
   import { plans } from '../../stores/plans';
@@ -131,6 +134,8 @@
   let selectedSourceTypeParametersMap: ParametersMap = {};
   let selectedSourceId: string | null = null;
   let selectedSourceEventTypes: ExternalEventType[] = [];
+  let selectedSourceDerivationGroup: string | undefined;
+  let selectedSourceTypeDerivationGroups: string[];
 
   // Selected element variables
   let selectedEvent: ExternalEvent | null = null;
@@ -166,6 +171,12 @@
       selectedSource,
     ]);
   }
+
+  $: selectedSourceDerivationGroup = selectedSource?.derivation_group_name;
+
+  $: selectedSourceTypeDerivationGroups = $derivationGroups
+    .filter(derivationGroup => derivationGroup.source_type_name === selectedSource?.source_type_name)
+    .map(derivationGroup => derivationGroup.name);
 
   $: if (selectedSource !== null && Object.keys(selectedSource.attributes).length > 0) {
     // Create an ArgumentsMap for the External Source
@@ -309,7 +320,7 @@
     )
     .then(fetched => (selectedSourceEventTypes = fetched));
 
-  $: selectedSourceLinkedDerivationGroupsPlans = $planDerivationGroupLinks.filter(planDerivationGroupLink => {
+  $: selectedSourceLinkedDerivationGroupsPlans = $planDerivationGroupLinksByPlan.filter(planDerivationGroupLink => {
     return planDerivationGroupLink.derivation_group_name === selectedSource?.derivation_group_name;
   });
 
@@ -318,11 +329,19 @@
   // Permissions
   $: hasCreatePermission = featurePermissions.externalSource.canCreate(user);
 
+  async function changeDerivationGroup(newDerivationGroup: string | undefined) {
+    if (!selectedSource || !newDerivationGroup) {
+      return;
+    }
+    await effects.updateSourceDerivationGroup(selectedSource, newDerivationGroup, $planDerivationGroupLinks, user);
+    deselectSource(); // Would actually like this to stay selected, but the table un-selects due to data change
+  }
+
   async function onDeleteExternalSource(selectedSources: ExternalSourceSlim[] | null | undefined) {
     if (selectedSources !== null && selectedSources !== undefined) {
       const deleteExternalSourceResult = await effects.deleteExternalSource(
         selectedSources,
-        $planDerivationGroupLinks,
+        $planDerivationGroupLinksByPlan,
         user,
       );
       if (deleteExternalSourceResult !== undefined && deleteExternalSourceResult !== null) {
@@ -449,16 +468,50 @@
                 value={selectedSource.source_type_name}
               />
             </Input>
-
-            <Input layout="inline">
-              Derivation Group
-              <input
-                class="st-input w-full"
-                disabled={true}
-                name="derivation-group"
-                value={selectedSource.derivation_group_name}
-              />
-            </Input>
+            <div class="grid">
+              <Field field={derivationGroupField}>
+                <Label size="sm" for="derivationGroup">Derivation Group</Label>
+                <div>
+                  <Select.Root
+                    selected={{ label: selectedSourceDerivationGroup, value: selectedSourceDerivationGroup }}
+                    disabled={false}
+                    onSelectedChange={value => {
+                      if (value) {
+                        changeDerivationGroup(value.value);
+                      }
+                    }}
+                  >
+                    <Select.Trigger
+                      value={selectedSourceDerivationGroup}
+                      size="xs"
+                      aria-label="Change Derivation Group"
+                      aria-labelledby={null}
+                      id="derivationGroup"
+                    >
+                      <Select.Value placeholder="Change derivation group" />
+                    </Select.Trigger>
+                    <Select.Content
+                      class="min-w-[240px] overflow-auto p-0"
+                      sameWidth={false}
+                      align="start"
+                      datatype="text"
+                      fitViewport
+                    >
+                      {#each selectedSourceTypeDerivationGroups as derivationGroup}
+                        <Select.Item size="xs" value={derivationGroup} label={derivationGroup} class="flex gap-1">
+                          {derivationGroup}
+                        </Select.Item>
+                      {/each}
+                    </Select.Content>
+                    <Select.Input
+                      type="text"
+                      name="derivationGroup"
+                      aria-label="Change Derivation Group hidden input"
+                    />
+                  </Select.Root>
+                </div>
+              </Field>
+            </div>
 
             <Input layout="inline">
               Owner

--- a/src/components/external-source/ExternalSourcesPanel.svelte
+++ b/src/components/external-source/ExternalSourcesPanel.svelte
@@ -6,7 +6,7 @@
     derivationGroups,
     derivationGroupsAcknowledged,
     externalSources,
-    planDerivationGroupLinks,
+    planDerivationGroupLinksByPlan,
   } from '../../stores/external-source';
   import { plan } from '../../stores/plan';
   import type { User } from '../../types/app';
@@ -50,7 +50,7 @@
     }
   }
 
-  $: linkedDerivationGroupNames = $planDerivationGroupLinks.map(
+  $: linkedDerivationGroupNames = $planDerivationGroupLinksByPlan.map(
     planDerivationGroup => planDerivationGroup.derivation_group_name,
   );
   $: filteredDerivationGroups = $derivationGroups
@@ -66,7 +66,7 @@
       const includesName = group.name.toLocaleLowerCase().includes(filterTextLowerCase);
       return includesName;
     });
-  $: if ($planDerivationGroupLinks) {
+  $: if ($planDerivationGroupLinksByPlan) {
     mappedDerivationGroups = filteredDerivationGroups.reduce(
       (aggMappedDerivationGroups: { [key: string]: DerivationGroup[] }, group) => {
         if (

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -13,7 +13,7 @@
   import {
     derivationGroupVisibilityMap,
     externalSources,
-    planDerivationGroupLinks,
+    planDerivationGroupLinksByPlan,
   } from '../../stores/external-source';
   import { planModelActivityTypes } from '../../stores/plan';
   import {
@@ -519,7 +519,7 @@
       filteredExternalEvents = [];
 
       // Filter what LINKED Derivation Groups are to be shown
-      let filteredDerivationGroups = $planDerivationGroupLinks
+      let filteredDerivationGroups = $planDerivationGroupLinksByPlan
         .filter(
           link => link.plan_id === plan?.id && !($derivationGroupVisibilityMap[link.derivation_group_name] ?? true),
         )

--- a/src/components/timeline/Timeline.svelte
+++ b/src/components/timeline/Timeline.svelte
@@ -7,7 +7,7 @@
   import { afterUpdate, createEventDispatcher, onDestroy, onMount, tick } from 'svelte';
   import { SOURCES, TRIGGERS, dndzone } from 'svelte-dnd-action';
   import { InvalidDate } from '../../constants/time';
-  import { planDerivationGroupLinks } from '../../stores/external-source';
+  import { planDerivationGroupLinksByPlan } from '../../stores/external-source';
   import { plugins } from '../../stores/plugins';
   import { viewAddTimelineRow, viewUpdateTimeline } from '../../stores/views';
   import type { ActivityDirectiveId, ActivityDirectivesMap } from '../../types/activity';
@@ -127,7 +127,7 @@
   });
 
   $: activityDirectives = activityDirectivesMap ? Object.values(activityDirectivesMap) : null;
-  $: derivationGroups = $planDerivationGroupLinks
+  $: derivationGroups = $planDerivationGroupLinksByPlan
     .filter(link => link.plan_id === plan?.id)
     .map(link => link.derivation_group_name);
   $: externalEventsFilteredByDG = externalEvents.filter(externalEvent =>

--- a/src/enums/gql.ts
+++ b/src/enums/gql.ts
@@ -229,6 +229,7 @@ export enum Queries {
   UPDATE_CONSTRAINT_MODEL_SPECIFICATION = 'update_constraint_model_specification_by_pk',
   UPDATE_DERIVATION_GROUP_ACKNOWLEDGED = 'update_plan_derivation_group_by_pk',
   UPDATE_EXPANSION_RULE = 'update_expansion_rule_by_pk',
+  UPDATE_EXTERNAL_SOURCE = 'update_external_source_by_pk',
   UPDATE_MISSION_MODEL = 'update_mission_model_by_pk',
   UPDATE_PARCEL = 'update_parcel_by_pk',
   UPDATE_PLAN_SNAPSHOT = 'update_plan_snapshot_by_pk',

--- a/src/stores/external-source.ts
+++ b/src/stores/external-source.ts
@@ -32,6 +32,12 @@ export const derivationGroups = gqlSubscribable<DerivationGroup[]>(
 );
 export const planDerivationGroupLinks = gqlSubscribable<PlanDerivationGroup[]>(
   gql.SUB_PLAN_DERIVATION_GROUP,
+  {},
+  [],
+  null,
+);
+export const planDerivationGroupLinksByPlan = gqlSubscribable<PlanDerivationGroup[]>(
+  gql.SUB_PLAN_DERIVATION_GROUP_BY_PLAN,
   {
     plan_id: planId,
   },
@@ -68,7 +74,7 @@ export const externalSourceTypeAssociations: Readable<ExternalSourceTypeAssociat
 
 // Reorganization of unacknowledged planDerivationGroupLinks so that it is easy to the derivation groups and when their updates were last acknowledged
 export const derivationGroupsAcknowledged: Readable<Record<string, { last_acknowledged_at: string }>> = derived(
-  planDerivationGroupLinks,
+  planDerivationGroupLinksByPlan,
   $planDerivationGroupLinks => {
     const result: Record<string, { last_acknowledged_at: string }> = {};
     for (const entry of $planDerivationGroupLinks) {
@@ -82,7 +88,7 @@ export const derivationGroupsAcknowledged: Readable<Record<string, { last_acknow
 );
 
 export const selectedPlanDerivationGroupNames: Readable<string[]> = derived(
-  [planDerivationGroupLinks],
+  [planDerivationGroupLinksByPlan],
   ([$planDerivationGroupLinks]) => $planDerivationGroupLinks.map(link => link.derivation_group_name),
 );
 
@@ -91,7 +97,7 @@ export function resetExternalSourceStores(): void {
   createExternalSourceError.set(null);
   createDerivationGroupError.set(null);
   derivationGroupPlanLinkError.set(null);
-  planDerivationGroupLinks.updateValue(() => []);
+  planDerivationGroupLinksByPlan.updateValue(() => []);
 }
 
 function transformDerivationGroups(

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -8404,6 +8404,58 @@ const effects = {
     }
   },
 
+  async updateSourceDerivationGroup(
+    externalSource: ExternalSourceSlim,
+    newDerivationGroupName: string,
+    planDerivationGroupLinks: PlanDerivationGroup[],
+    user: User | null,
+  ): Promise<ExternalSourceSlim> {
+    try {
+      // if (!queryPermissions.UPDATE_DERIVATION_GROUP(user, plan)) { throwPermissionError("update this source's derivation group"); }
+
+      // Check if any plans are using the derivation group this source is a part of
+      const plansUsingDerivationGroup = planDerivationGroupLinks.filter(
+        planDerivationGroupLink =>
+          planDerivationGroupLink.derivation_group_name === externalSource.derivation_group_name,
+      );
+      // If any plans are using this derivation group, warn the user
+      if (plansUsingDerivationGroup.length > 0) {
+        const { confirm } = await showConfirmModal(
+          'Confirm',
+          `There ${plansUsingDerivationGroup.length > 1 ? 'are' : 'is'} currently ${plansUsingDerivationGroup.length}${
+            plansUsingDerivationGroup.length > 1 ? 'plans' : 'plan'
+          } using the derivation group this source is a part of. The events of this source will no longer be included in the current derivation group.`,
+          'Change Derivation Group',
+          true,
+        );
+        if (!confirm) {
+          return externalSource;
+        }
+      }
+
+      const updateVariables = {
+        externalSourceKey: externalSource.key,
+        newDerivationGroup: newDerivationGroupName,
+        originalDerivationGroup: externalSource.derivation_group_name,
+      };
+      const { updated_external_source_by_pk: updatedExternalSource } = await reqHasura<ExternalSourceSlim>(
+        gql.UPDATE_SOURCE_DERIVATION_GROUP,
+        updateVariables,
+        user,
+      );
+      if (!updatedExternalSource) {
+        throw new Error('Derivation Group Update Failed');
+      } else {
+        showSuccessToast('Derivation Group Updated Successfully');
+        return updatedExternalSource;
+      }
+    } catch (e) {
+      catchError('Derivation Group Update Failed', e as Error);
+      showFailureToast('Derivation Group Update Failed');
+      return externalSource;
+    }
+  },
+
   async updateTag(
     id: number,
     tagSetInput: TagsSetInput,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -2875,7 +2875,18 @@ const gql = {
   `,
 
   SUB_PLAN_DERIVATION_GROUP: `#graphql
-    subscription SubPlanExternalSource($plan_id: Int!) {
+    subscription SubPlanDerivationGroups {
+      links: ${Queries.PLAN_DERIVATION_GROUP}(order_by: { plan_id: asc }) {
+        derivation_group_name
+        plan_id
+        acknowledged
+        last_acknowledged_at
+      }
+    }
+  `,
+
+  SUB_PLAN_DERIVATION_GROUP_BY_PLAN: `#graphql
+    subscription SubPlanDerivationGroupByPlan($plan_id: Int!) {
       links: ${Queries.PLAN_DERIVATION_GROUP}(order_by: { plan_id: asc }, where: {plan_id: {_eq: $plan_id}}) {
         derivation_group_name
         plan_id
@@ -4155,6 +4166,34 @@ const gql = {
         arguments
         id
         description
+      }
+    }
+  `,
+
+  UPDATE_SOURCE_DERIVATION_GROUP: `#graphql
+    mutation UpdateSourceDerivationGroup(
+      $externalSourceKey: String!,
+      $originalDerivationGroup: String!,
+      $newDerivationGroup: String!
+    ) {
+      ${Queries.UPDATE_EXTERNAL_SOURCE} (
+        pk_columns: {
+          derivation_group_name: $originalDerivationGroup,
+          key: $externalSourceKey
+        },
+        _set: {
+          derivation_group_name: $newDerivationGroup
+        }
+      ) {
+        attributes
+        created_at
+        derivation_group_name
+        end_time
+        key
+        owner
+        source_type_name
+        start_time
+        valid_at
       }
     }
   `,

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -1005,6 +1005,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
   SUB_PLANS_USER_WRITABLE: () => true,
   SUB_PLAN_DATASET: () => true,
   SUB_PLAN_DERIVATION_GROUP: () => true,
+  SUB_PLAN_DERIVATION_GROUP_BY_PLAN: () => true,
   SUB_PLAN_EXTERNAL_EVENTS_DERIVATION_GROUP: () => true,
   SUB_PLAN_LOCKED: () => true,
   SUB_PLAN_MERGE_CONFLICTING_ACTIVITIES: () => true,
@@ -1292,6 +1293,9 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
   },
   UPDATE_SIMULATION_TEMPLATE: (user: User | null, plan: PlanWithOwners): boolean => {
     return isUserAdmin(user) || (getPermission([Queries.UPDATE_SIMULATION_TEMPLATE], user) && isUserOwner(user, plan));
+  },
+  UPDATE_SOURCE_DERIVATION_GROUP: (user: User | null) => {
+    return isUserAdmin(user) || getPermission([getFunctionPermission(Queries.UPDATE_EXTERNAL_SOURCE)], user);
   },
   UPDATE_TAG: (user: User | null, tag: AssetWithOwner<Tag>): boolean => {
     return isUserAdmin(user) || (getPermission([Queries.UPDATE_TAGS], user) && isUserOwner(user, tag));


### PR DESCRIPTION
`___REQUIRES_AERIE_PR___="1779"`

This PR adds the ability to update the derivation group of an external source through the external source manager. For more information on the change see the `aerie` PR.

When selecting a source in the UI, the user can select a new derivation group through the drop-down that appears in the 'Selected Source' panel. If the original derivation group for the source is currently tied to any plans, the user will receive a warning before changing the group to let them know the events will disappear from any plans using the old derivation group and not the new one.
