### PR TITLE
Sequence Editor Fixes

### DIFF
--- a/src/components/sequencing/SequenceActionCombobox.svelte
+++ b/src/components/sequencing/SequenceActionCombobox.svelte
@@ -5,6 +5,7 @@
   import { Clapperboard } from 'lucide-svelte';
   import { createEventDispatcher, tick } from 'svelte';
   import type { ActionDefinition } from '../../types/actions';
+  import { sanitizeCmdkValue } from '../../utilities/text';
   import ActionMenuItem from '../ui/ActionMenuItem.svelte';
   import Tooltip from '../ui/Tooltip.svelte';
 
@@ -43,7 +44,7 @@
         <Command.Group class="max-h-[300px] overflow-y-auto">
           {#each actions as action}
             <Command.Item
-              value={`${action.action.name} ${action.action.description ?? ''}`}
+              value={sanitizeCmdkValue(`${action.action.name} ${action.action.description ?? ''}`)}
               onSelect={() => {
                 dispatch('runAction', { action: action.action, parameter: action.parameter });
                 closeAndFocusTrigger(ids.trigger);

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -97,9 +97,14 @@
     // trigger reactivity if sequenceFilePath is a string and not if it is null / undefined.
     // In this case, we want to trigger reactivity on all possible values.
     void sequenceFilePath;
-    editorSequenceView?.dispatch({
-      changes: { from: 0, insert: sequenceDefinition, to: editorSequenceView.state.doc.length },
-    });
+    // Skip the dispatch if the editor already has the correct content (e.g., after save),
+    // to avoid resetting the cursor position. Still dispatch on file path changes since
+    // both files could have identical content.
+    if (editorSequenceView?.state.doc.toString() !== sequenceDefinition) {
+      editorSequenceView?.dispatch({
+        changes: { from: 0, insert: sequenceDefinition, to: editorSequenceView.state.doc.length },
+      });
+    }
   }
 
   $: commandFormBuilderGrid = showCommandFormBuilder

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -17,7 +17,7 @@
   import { basicSetup, EditorView } from 'codemirror';
   import { debounce } from 'lodash-es';
   import { FileBracesCorner, PanelBottomClose, PanelBottomOpen } from 'lucide-svelte';
-  import { createEventDispatcher, onMount } from 'svelte';
+  import { createEventDispatcher, onDestroy, onMount } from 'svelte';
   import type { ActionDefinition } from '../../types/actions';
   import { blockTheme } from '../../utilities/codemirror/themes/block';
   import { permissionHandler } from '../../utilities/permissionHandler';
@@ -52,7 +52,8 @@
     downloadOutput: { content: string; filePath: string; filename: string; outputLanguage: OutputLanguage };
     runAction: { action: ActionDefinition; parameter: string };
     save: string;
-    sequence: { filePath: string; input: string; output?: string };
+    sequenceInputUpdate: { filePath: string; input: string };
+    sequenceOutputUpdate: { filePath: string; output?: string };
   }>();
 
   let compartmentAdaptation: Compartment;
@@ -76,8 +77,8 @@
   let outputEditorExtension: Extension = [];
   let previousSequenceFilePath: string = sequenceFilePath;
 
-  // Create debounced listener at component level so we can cancel it when file changes
-  const debouncedSequenceUpdateListener = debounce(sequenceUpdateListener, 250);
+  // Debounce only the expensive output format computation, not the state sync
+  const debouncedOutputUpdate = debounce(updateOutputFormat, 250);
 
   $: commandInfoMapper = sequenceAdaptation.input.commandInfoMapper;
 
@@ -164,13 +165,21 @@
   // Cancel pending debounced events when file path changes to prevent stale events
   // from being dispatched with the wrong file path
   $: if (sequenceFilePath !== previousSequenceFilePath) {
-    debouncedSequenceUpdateListener.cancel();
+    debouncedOutputUpdate.cancel();
     previousSequenceFilePath = sequenceFilePath;
   }
 
-  async function sequenceUpdateListener(viewUpdate: ViewUpdate): Promise<void> {
+  function sequenceUpdateListener(viewUpdate: ViewUpdate): void {
     const sequence = viewUpdate.state.doc.toString();
     disableCopyAndExport = sequence === '';
+    updatedSequenceDefinition = sequence;
+
+    dispatch('sequenceInputUpdate', { filePath: sequenceFilePath, input: sequence });
+
+    debouncedOutputUpdate(sequence);
+  }
+
+  function updateOutputFormat(sequence: string): void {
     let output =
       sequenceName === undefined
         ? undefined
@@ -178,9 +187,8 @@
 
     editorOutputView.dispatch({ changes: { from: 0, insert: output ?? '', to: editorOutputView.state.doc.length } });
 
-    updatedSequenceDefinition = sequence;
     if (output !== undefined) {
-      dispatch('sequence', { filePath: sequenceFilePath, input: sequence, output });
+      dispatch('sequenceOutputUpdate', { filePath: sequenceFilePath, output });
     }
   }
 
@@ -253,8 +261,10 @@
   }
 
   function onSave(): boolean {
-    if (isSequenceDefinitionUpdated) {
-      dispatch('save', updatedSequenceDefinition);
+    const currentSequence = editorSequenceView.state.doc.toString();
+    if (currentSequence !== sequenceDefinition) {
+      updatedSequenceDefinition = currentSequence;
+      dispatch('save', currentSequence);
     }
     return true;
   }
@@ -272,7 +282,11 @@
         EditorView.lineWrapping,
         EditorView.theme({ '.cm-gutter': { 'min-height': '0px' } }),
         lintGutter(),
-        EditorView.updateListener.of(debouncedSequenceUpdateListener),
+        EditorView.updateListener.of(viewUpdate => {
+          if (viewUpdate.docChanged) {
+            sequenceUpdateListener(viewUpdate);
+          }
+        }),
         EditorView.updateListener.of(selectedCommandUpdateListener),
         blockTheme,
         compartmentAdaptation.of(inputEditorExtension),
@@ -294,6 +308,12 @@
       ],
       parent: editorOutputDiv,
     });
+  });
+
+  onDestroy(() => {
+    editorSequenceView?.destroy();
+    editorOutputView?.destroy();
+    debouncedOutputUpdate.cancel();
   });
 </script>
 

--- a/src/components/ui/TextEditor.svelte
+++ b/src/components/ui/TextEditor.svelte
@@ -42,7 +42,7 @@
   let editorView: EditorView;
   let updatedTextContent: string = textFileContent;
   let isTextContentUpdated: boolean = false;
-  let previousIsJSON: boolean = isJSON;
+  let previousIsJSON: boolean | null = null;
 
   // Insert text content - use textFilePath as dependency to ensure editor updates when switching files
   // This handles the case where both old and new files have the same content (e.g., both empty)
@@ -63,12 +63,13 @@
   $: isTextContentUpdated = updatedTextContent !== textFileContent;
 
   $: if (previousIsJSON !== isJSON && editorDiv) {
+    previousIsJSON = isJSON;
+
     if (editorView) {
       editorView.destroy();
     }
     if (isJSON) {
       editorView = new EditorView({
-        doc: textFileContent,
         extensions: [
           basicSetup,
           keymap.of([
@@ -91,7 +92,6 @@
       });
     } else {
       editorView = new EditorView({
-        doc: textFileContent,
         extensions: [
           basicSetup,
           keymap.of([

--- a/src/components/ui/TextEditor.svelte
+++ b/src/components/ui/TextEditor.svelte
@@ -7,9 +7,8 @@
   import { Compartment, EditorState } from '@codemirror/state';
   import { type ViewUpdate, keymap } from '@codemirror/view';
   import { basicSetup, EditorView } from 'codemirror';
-  import { debounce } from 'lodash-es';
   import { File } from 'lucide-svelte';
-  import { createEventDispatcher, onMount } from 'svelte';
+  import { createEventDispatcher, onDestroy, onMount } from 'svelte';
   import type { ActionDefinition } from '../../types/actions';
   import { blockTheme } from '../../utilities/codemirror/themes/block';
   import { permissionHandler } from '../../utilities/permissionHandler';
@@ -44,31 +43,24 @@
   let updatedTextContent: string = textFileContent;
   let isTextContentUpdated: boolean = false;
   let previousIsJSON: boolean = isJSON;
-  let previousTextFilePath: string = textFilePath;
-
-  // Create debounced listener at component level so we can cancel it when file changes
-  const debouncedTextContentUpdateListener = debounce(textContentUpdateListener, 250);
 
   // Insert text content - use textFilePath as dependency to ensure editor updates when switching files
   // This handles the case where both old and new files have the same content (e.g., both empty)
   $: if (editorView) {
     void textFilePath;
-    editorView.dispatch({
-      changes: { from: 0, insert: textFileContent, to: editorView.state.doc.length },
-    });
+    // Skip the dispatch if the editor already has the correct content (e.g., after save),
+    // to avoid resetting the cursor position.
+    if (editorView.state.doc.toString() !== textFileContent) {
+      editorView.dispatch({
+        changes: { from: 0, insert: textFileContent, to: editorView.state.doc.length },
+      });
+    }
   }
   $: editorView?.dispatch({
     effects: compartmentReadonly.reconfigure([EditorState.readOnly.of(readOnly || previewOnly || isLoading)]),
   });
   $: updatedTextContent = textFileContent;
   $: isTextContentUpdated = updatedTextContent !== textFileContent;
-
-  // Cancel pending debounced events when file path changes to prevent stale events
-  // from being dispatched with the wrong file path
-  $: if (textFilePath !== previousTextFilePath) {
-    debouncedTextContentUpdateListener.cancel();
-    previousTextFilePath = textFilePath;
-  }
 
   $: if (previousIsJSON !== isJSON && editorDiv) {
     if (editorView) {
@@ -88,7 +80,11 @@
           lintGutter(),
           json(),
           jsonLinter,
-          EditorView.updateListener.of(debouncedTextContentUpdateListener),
+          EditorView.updateListener.of(viewUpdate => {
+            if (viewUpdate.docChanged) {
+              textContentUpdateListener(viewUpdate);
+            }
+          }),
           compartmentReadonly.of([EditorState.readOnly.of(readOnly || previewOnly || isLoading)]),
         ],
         parent: editorDiv,
@@ -105,7 +101,11 @@
           EditorView.lineWrapping,
           EditorView.theme({ '.cm-gutter': { 'min-height': '0px' } }),
           lintGutter(),
-          EditorView.updateListener.of(debouncedTextContentUpdateListener),
+          EditorView.updateListener.of(viewUpdate => {
+            if (viewUpdate.docChanged) {
+              textContentUpdateListener(viewUpdate);
+            }
+          }),
           compartmentReadonly.of([EditorState.readOnly.of(readOnly || previewOnly || isLoading)]),
         ],
         parent: editorDiv,
@@ -113,10 +113,9 @@
     }
   }
 
-  async function textContentUpdateListener(viewUpdate: ViewUpdate): Promise<void> {
+  function textContentUpdateListener(viewUpdate: ViewUpdate): void {
     const updatedText = viewUpdate.state.doc.toString();
     disableCopyAndExport = updatedText === '';
-
     updatedTextContent = updatedText;
     dispatch('textContentUpdated', { filePath: textFilePath, input: updatedText });
   }
@@ -135,8 +134,10 @@
   }
 
   function onSave(): boolean {
-    if (isTextContentUpdated) {
-      dispatch('save', updatedTextContent);
+    const currentText = editorView.state.doc.toString();
+    if (currentText !== textFileContent) {
+      updatedTextContent = currentText;
+      dispatch('save', currentText);
     }
     return true;
   }
@@ -156,12 +157,20 @@
         EditorView.lineWrapping,
         EditorView.theme({ '.cm-gutter': { 'min-height': '0px' } }),
         lintGutter(),
-        EditorView.updateListener.of(debouncedTextContentUpdateListener),
+        EditorView.updateListener.of(viewUpdate => {
+          if (viewUpdate.docChanged) {
+            textContentUpdateListener(viewUpdate);
+          }
+        }),
         blockTheme,
         compartmentReadonly.of([EditorState.readOnly.of(readOnly || previewOnly || isLoading)]),
       ],
       parent: editorDiv,
     });
+  });
+
+  onDestroy(() => {
+    editorView?.destroy();
   });
 </script>
 

--- a/src/components/workspace/WorkspaceFileBrowser/WorkspaceFileBrowser.svelte
+++ b/src/components/workspace/WorkspaceFileBrowser/WorkspaceFileBrowser.svelte
@@ -205,6 +205,7 @@
     // Auto-expand ancestors of matching nodes so they're visible
     if (result.ancestorPaths.size > 0) {
       expandedPaths = new Set([...expandedPaths, ...result.ancestorPaths]);
+      scheduleRedraw();
     }
   }
 

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -83,6 +83,7 @@
   import {
     computeMovedFilePath,
     downloadWorkspaceNodesAsZip,
+    findNodeAffectingPath,
     flattenWorkspaceTreeWithPaths,
     getAvailableActionsForNodes,
     mapWorkspaceTreePaths,
@@ -556,12 +557,13 @@
 
   async function onDeleteNodes({ detail: { treeNodes } }: CustomEvent<WorkspaceNodesEvent>) {
     if ($workspace) {
-      const shouldUpdateSelectedNode = treeNodes.find(node => node.fullPath === $activeDocumentPath);
+      const affectedNode = findNodeAffectingPath(treeNodes, $activeDocumentPath);
 
       const didDelete = await effects.deleteWorkspaceItems($workspace, treeNodes, $user);
       await refreshWorkspaceContents();
 
-      if (didDelete && shouldUpdateSelectedNode) {
+      if (didDelete && affectedNode) {
+        activeDocument.close();
         selectedFilePath = null;
         confirmAndNavigate(null);
       }
@@ -570,7 +572,7 @@
 
   async function onDownloadNodes({ detail: { treeNodes } }: CustomEvent<WorkspaceNodesEvent>) {
     // Prompt user to save their active file if it is found within treeNodes
-    const containsActiveNode = treeNodes.find(node => node.fullPath === $activeDocumentPath);
+    const containsActiveNode = findNodeAffectingPath(treeNodes, $activeDocumentPath);
 
     // Prompt to save unsaved changes before moving
     if (containsActiveNode && $activeDocumentIsDirty) {
@@ -597,7 +599,7 @@
 
   async function onMoveNodes({ detail: { treeNodes } }: CustomEvent<WorkspaceNodesEvent>) {
     if ($workspace && workspaceTree) {
-      const movedActiveNode = treeNodes.find(node => node.fullPath === $activeDocumentPath);
+      const movedActiveNode = findNodeAffectingPath(treeNodes, $activeDocumentPath);
 
       // Prompt to save unsaved changes before moving
       if (movedActiveNode && $activeDocumentIsDirty) {
@@ -615,8 +617,8 @@
       if (movedActiveNode && result) {
         const { renamedFiles, skippedFiles, targetPath } = result;
         // Don't update selection if the file was skipped
-        if (!skippedFiles.has(movedActiveNode.fullPath)) {
-          const newFilePath = computeMovedFilePath(movedActiveNode.fullPath, minimalNodes, targetPath, renamedFiles);
+        if (!skippedFiles.has($activeDocumentPath!)) {
+          const newFilePath = computeMovedFilePath($activeDocumentPath!, minimalNodes, targetPath, renamedFiles);
           // Wait for tree to render before updating selection (ensures parent folders can expand)
           await tick();
           updateActiveFilePath(newFilePath);
@@ -702,7 +704,7 @@
 
   async function onMoveNodesToWorkspace({ detail: { treeNodes } }: CustomEvent<WorkspaceNodesEvent>) {
     if (initialWorkspace) {
-      const movedActiveNode = treeNodes.find(node => node.fullPath === $activeDocumentPath);
+      const movedActiveNode = findNodeAffectingPath(treeNodes, $activeDocumentPath);
 
       // Prompt to save unsaved changes before moving
       if (movedActiveNode && $activeDocumentIsDirty) {

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -653,9 +653,9 @@
     }
   }
 
-  function onWorkspaceFileUpdated({
-    detail: { filePath, input, output },
-  }: CustomEvent<{ filePath: string; input: string; output?: string }>) {
+  function onWorkspaceInputFileUpdated({
+    detail: { filePath, input },
+  }: CustomEvent<{ filePath: string; input: string }>) {
     // Ignore stale events from a file that is no longer active
     // Note: editors receive ($activeDocumentPath ?? '') so we normalize the comparison
     if (filePath !== ($activeDocumentPath ?? '')) {
@@ -663,6 +663,17 @@
     }
 
     activeDocument.updateContent(input);
+  }
+
+  function onWorkspaceOutputFileUpdated({
+    detail: { filePath, output },
+  }: CustomEvent<{ filePath: string; output?: string }>) {
+    // Ignore stale events from a file that is no longer active
+    // Note: editors receive ($activeDocumentPath ?? '') so we normalize the comparison
+    if (filePath !== ($activeDocumentPath ?? '')) {
+      return;
+    }
+
     if (output) {
       selectedSequenceOutput = output;
     }
@@ -886,16 +897,17 @@
     <CssGridGutter track={1} type="column" />
   {/if}
   <Sidebar.Inset className="min-h-0">
+    {@const isTextOrEmpty = $activeDocumentPath === null || isTextFile(workspaceTreeMap[$activeDocumentPath]?.type)}
+    {@const isSequenceFile =
+      $activeDocument.type !== null && $activeDocument.type === WorkspaceContentType.Sequence}
     <div class="relative grid h-full grid-cols-1 grid-rows-1">
-      {#if $activeDocumentPath === null || isTextFile(workspaceTreeMap[$activeDocumentPath]?.type)}
-        {@const isSequenceFile =
-          $activeDocument.type !== null && $activeDocument.type === WorkspaceContentType.Sequence}
-        {#if showLoadingSpinner}
-          <div class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-background/50">
-            <LoaderCircle size={32} class="animate-spin text-muted-foreground" />
-          </div>
-        {/if}
-        <div class="flex h-full" class:hidden={!isSequenceFile}>
+      {#if showLoadingSpinner && isTextOrEmpty}
+        <div class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-background/50">
+          <LoaderCircle size={32} class="animate-spin text-muted-foreground" />
+        </div>
+      {/if}
+      {#if isTextOrEmpty && isSequenceFile}
+        <div class="flex h-full">
           <SequenceEditor
             {phoenixContext}
             availableActions={availableActionsForActiveFile}
@@ -903,7 +915,7 @@
             isLoading={$activeDocumentIsLoading}
             previewOnly={!hasEditFilePermission}
             sequenceAdaptation={$sequenceAdaptation}
-            sequenceDefinition={isSequenceFile ? $activeDocument.originalContent : ''}
+            sequenceDefinition={$activeDocument.originalContent}
             sequenceName={$activeDocument.fileName ?? undefined}
             sequenceFilePath={$activeDocumentPath ?? ''}
             sequenceOutput={selectedSequenceOutput}
@@ -915,10 +927,12 @@
             on:save={onSaveWorkspaceFile}
             on:downloadInput={onDownloadInput}
             on:downloadOutput={onDownloadOutput}
-            on:sequence={isSequenceFile ? onWorkspaceFileUpdated : undefined}
+            on:sequenceInputUpdate={onWorkspaceInputFileUpdated}
+            on:sequenceOutputUpdate={onWorkspaceOutputFileUpdated}
           />
         </div>
-        <div class="flex h-full" class:hidden={isSequenceFile}>
+      {:else if isTextOrEmpty}
+        <div class="flex h-full">
           <TextEditor
             availableActions={availableActionsForActiveFile}
             includeActions={true}
@@ -928,14 +942,14 @@
             shouldListenForKeyboardSave={false}
             textFileName={$activeDocument.fileName ?? undefined}
             textFilePath={$activeDocumentPath ?? ''}
-            textFileContent={!isSequenceFile ? $activeDocument.originalContent : ''}
+            textFileContent={$activeDocument.originalContent}
             on:runAction={onRunActionOnActiveFile}
             on:save={onSaveWorkspaceFile}
             on:download={onDownloadInput}
-            on:textContentUpdated={!isSequenceFile ? onWorkspaceFileUpdated : undefined}
+            on:textContentUpdated={onWorkspaceInputFileUpdated}
           />
         </div>
-      {:else if $activeDocument.type === WorkspaceContentType.Directory}
+      {:else if $activeDocument.type === WorkspaceContentType.Directory && $activeDocumentPath}
         {@const folderNode = workspaceTreeMap[$activeDocumentPath]}
         {@const folderFiles =
           (folderNode?.contents || []).filter(node => node.type !== WorkspaceContentType.Directory) ?? []}
@@ -959,7 +973,7 @@
             {/if}
           </p>
         </div>
-      {:else}
+      {:else if !isTextOrEmpty}
         <div class="flex w-full flex-col items-center justify-center gap-8 pt-6">
           <TriangleAlert size={70} class="text-muted-foreground" />
           <p class="st-typography-body max-w-prose text-center text-sm text-muted-foreground">

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -234,8 +234,6 @@
     parameterDictionaries = [];
   }
 
-  $: console.log('object :>> ', $activeDocument.type);
-
   // Prevent in-app navigation to other routes when there are unsaved changes
   beforeNavigate(({ cancel, to }) => {
     if (!$activeDocumentIsDirty) {

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -898,8 +898,7 @@
   {/if}
   <Sidebar.Inset className="min-h-0">
     {@const isTextOrEmpty = $activeDocumentPath === null || isTextFile(workspaceTreeMap[$activeDocumentPath]?.type)}
-    {@const isSequenceFile =
-      $activeDocument.type !== null && $activeDocument.type === WorkspaceContentType.Sequence}
+    {@const isSequenceFile = $activeDocument.type !== null && $activeDocument.type === WorkspaceContentType.Sequence}
     <div class="relative grid h-full grid-cols-1 grid-rows-1">
       {#if showLoadingSpinner && isTextOrEmpty}
         <div class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-background/50">

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -90,7 +90,6 @@
     separateFilenameFromPath,
   } from '../../../utilities/workspaces';
   import type { PageData } from './$types';
-  // codemirror dependencies to be injected into the adaptation
 
   export let data: PageData;
 
@@ -146,102 +145,21 @@
   }
 
   // Show loading spinner after a delay to avoid flashing for fast loads
-  $: {
-    if ($activeDocumentIsLoading) {
-      loadingSpinnerTimeout = setTimeout(() => {
-        showLoadingSpinner = true;
-      }, 200);
-    } else {
-      if (loadingSpinnerTimeout) {
-        clearTimeout(loadingSpinnerTimeout);
-        loadingSpinnerTimeout = null;
-      }
-      showLoadingSpinner = false;
+  $: if ($activeDocumentIsLoading) {
+    loadingSpinnerTimeout = setTimeout(() => {
+      showLoadingSpinner = true;
+    }, 200);
+  } else {
+    if (loadingSpinnerTimeout) {
+      clearTimeout(loadingSpinnerTimeout);
+      loadingSpinnerTimeout = null;
     }
+    showLoadingSpinner = false;
   }
 
   $: if (initialWorkspace) {
     $workspaceId = initialWorkspace.id;
     allActionsForWorkspace = Object.values($actionDefinitionsByWorkspace[$workspaceId] || {});
-  }
-
-  const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-    if ($activeDocumentIsDirty) {
-      event.preventDefault(); // Triggers the native browser confirmation
-      event.returnValue = ''; // Required for some older browser compatibility
-    }
-  };
-
-  // Prevent in-app navigation to other routes when there are unsaved changes
-  beforeNavigate(({ cancel, to }) => {
-    if (!$activeDocumentIsDirty) {
-      return;
-    }
-    // Allow navigation within the same workspace page (file selection is handled by confirmAndNavigate)
-    if (to?.route.id === $page.route.id) {
-      return;
-    }
-    // Skip for external navigation (tab close, refresh) - handled by beforeunload
-    if (to === null) {
-      return;
-    }
-    // Cancel navigation first, then show async modal and navigate if confirmed
-    cancel();
-    showConfirmModal(
-      'Leave Page',
-      'There are unsaved changes. Are you sure you want to leave this page?',
-      'Leave Page',
-      true,
-      'Stay on Page',
-    ).then(({ confirm }) => {
-      if (confirm && to?.url) {
-        // Reset content to allow navigation without re-triggering the modal
-        activeDocument.markClean();
-        goto(to.url);
-      }
-    });
-  });
-
-  onMount(() => {
-    window.addEventListener('beforeunload', handleBeforeUnload);
-
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-    };
-  });
-
-  $: if (!isWorkspaceLoading && selectedFilePath !== $activeDocumentPath) {
-    // the UI's selected file doesn't match our actively loaded file, try to navigate to selected
-    maybeNavigate(selectedFilePath);
-  }
-
-  async function maybeNavigate(nextPath: string | null) {
-    // treat `null` as a navigable path so we can intentionally unload the editor file rather than skipping
-    if (nextPath === null) {
-      // wait a tick then revert selected UI to the existing active path
-      await tick();
-      selectedFilePath = $activeDocumentPath;
-      return;
-    }
-    const didNavigate = await confirmAndNavigate(nextPath);
-    if (!didNavigate) {
-      // user decided not to navigate away due to unsaved changes, set selected UI back to active file
-      selectedFilePath = $activeDocumentPath;
-      return;
-    }
-    // successfully navigated, start loading the file contents
-    if (nextPath && workspaceTreeMap[nextPath]) {
-      const { filename } = separateFilenameFromPath(nextPath);
-      const fileType = workspaceTreeMap[nextPath]?.type ?? null;
-      activeDocument.startLoad(nextPath, filename ?? null, fileType);
-      await getSelectedFileContent(nextPath);
-    } else {
-      // navigated to a null/empty file, reset the editor contents
-      activeDocument.close();
-      if (nextPath && !workspaceTreeMap[nextPath]) {
-        showFailureToast('The selected file does not exist in the workspace.');
-      }
-    }
   }
 
   // Re-compute permissions when user, workspace, or active document changes
@@ -305,11 +223,89 @@
     parameterDictionaries,
   };
 
-  $: {
-    if (!commandDictionary) {
-      commandDictionary = null;
-      channelDictionary = null;
-      parameterDictionaries = [];
+  $: if (!isWorkspaceLoading && selectedFilePath !== $activeDocumentPath) {
+    // the UI's selected file doesn't match our actively loaded file, try to navigate to selected
+    maybeNavigate(selectedFilePath);
+  }
+
+  $: if (!commandDictionary) {
+    commandDictionary = null;
+    channelDictionary = null;
+    parameterDictionaries = [];
+  }
+
+  $: console.log('object :>> ', $activeDocument.type);
+
+  // Prevent in-app navigation to other routes when there are unsaved changes
+  beforeNavigate(({ cancel, to }) => {
+    if (!$activeDocumentIsDirty) {
+      return;
+    }
+    // Allow navigation within the same workspace page (file selection is handled by confirmAndNavigate)
+    if (to?.route.id === $page.route.id) {
+      return;
+    }
+    // Skip for external navigation (tab close, refresh) - handled by beforeunload
+    if (to === null) {
+      return;
+    }
+    // Cancel navigation first, then show async modal and navigate if confirmed
+    cancel();
+    showConfirmModal(
+      'Leave Page',
+      'There are unsaved changes. Are you sure you want to leave this page?',
+      'Leave Page',
+      true,
+      'Stay on Page',
+    ).then(({ confirm }) => {
+      if (confirm && to?.url) {
+        // Reset content to allow navigation without re-triggering the modal
+        activeDocument.markClean();
+        goto(to.url);
+      }
+    });
+  });
+
+  onMount(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if ($activeDocumentIsDirty) {
+        event.preventDefault(); // Triggers the native browser confirmation
+        event.returnValue = ''; // Required for some older browser compatibility
+      }
+    };
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  });
+
+  async function maybeNavigate(nextPath: string | null) {
+    // treat `null` as a navigable path so we can intentionally unload the editor file rather than skipping
+    if (nextPath === null) {
+      // wait a tick then revert selected UI to the existing active path
+      await tick();
+      selectedFilePath = $activeDocumentPath;
+      return;
+    }
+    const didNavigate = await confirmAndNavigate(nextPath);
+    if (!didNavigate) {
+      // user decided not to navigate away due to unsaved changes, set selected UI back to active file
+      selectedFilePath = $activeDocumentPath;
+      return;
+    }
+    // successfully navigated, start loading the file contents
+    if (nextPath && workspaceTreeMap[nextPath]) {
+      const { filename } = separateFilenameFromPath(nextPath);
+      const fileType = workspaceTreeMap[nextPath]?.type ?? null;
+      activeDocument.startLoad(nextPath, filename ?? null, fileType);
+      await getSelectedFileContent(nextPath);
+    } else {
+      // navigated to a null/empty file, reset the editor contents
+      activeDocument.close();
+      if (nextPath && !workspaceTreeMap[nextPath]) {
+        showFailureToast('The selected file does not exist in the workspace.');
+      }
     }
   }
 

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -1360,7 +1360,7 @@ const workspacePermissions: Record<WorkspaceKeys, (user: User | null, ...args: a
     return isUserAdmin(user) || getRoleWorkspacePermission(['write_file_directory'], user, workspace);
   },
   createWorkspace: (user: User | null): boolean => {
-    return isUserAdmin(user) || getRoleWorkspacePermission(['create_permission'], user);
+    return isUserAdmin(user) || getRoleWorkspacePermission(['create_workspace'], user);
   },
   deleteFile: (user: User | null, workspace: Workspace): boolean => {
     return isUserAdmin(user) || getRoleWorkspacePermission(['delete_file_directory'], user, workspace);

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -322,8 +322,10 @@ function getRoleWorkspacePermission(queries: string[], user: User | null, worksp
             permission = isUserOwner(user, workspace) || isUserCollaborator(user, workspace);
             break;
           case 'NO_CHECK':
-          default:
             permission = true;
+            break;
+          default:
+            permission = false;
         }
       }
       return prevValue && permission;

--- a/src/utilities/text.test.ts
+++ b/src/utilities/text.test.ts
@@ -1,5 +1,53 @@
-import { expect, test } from 'vitest';
-import { padNumber, pluralize } from './text';
+import { describe, expect, test } from 'vitest';
+import { padNumber, pluralize, sanitizeCmdkValue } from './text';
+
+describe('sanitizeCmdkValue', () => {
+  test('returns plain text unchanged', () => {
+    expect(sanitizeCmdkValue('hello world')).toBe('hello world');
+  });
+
+  test('strips double quotes', () => {
+    expect(sanitizeCmdkValue('call the "Store in Box" action')).toBe('call the Store in Box action');
+  });
+
+  test('strips single quotes', () => {
+    expect(sanitizeCmdkValue("it's a test")).toBe('its a test');
+  });
+
+  test('strips backslashes', () => {
+    expect(sanitizeCmdkValue('path\\to\\file')).toBe('pathtofile');
+  });
+
+  test('strips null bytes', () => {
+    expect(sanitizeCmdkValue('before\0after')).toBe('beforeafter');
+  });
+
+  test('replaces newlines with spaces', () => {
+    expect(sanitizeCmdkValue('line1\nline2')).toBe('line1 line2');
+  });
+
+  test('replaces carriage returns with spaces', () => {
+    expect(sanitizeCmdkValue('line1\r\nline2')).toBe('line1 line2');
+  });
+
+  test('replaces form feeds with spaces', () => {
+    expect(sanitizeCmdkValue('before\fafter')).toBe('before after');
+  });
+
+  test('collapses consecutive newlines into a single space', () => {
+    expect(sanitizeCmdkValue('line1\n\n\nline2')).toBe('line1 line2');
+  });
+
+  test('handles combined problematic characters', () => {
+    expect(sanitizeCmdkValue('Deliver files Generate a "File Delivery List".\nFiles must call "Store to OCS".')).toBe(
+      'Deliver files Generate a File Delivery List. Files must call Store to OCS.',
+    );
+  });
+
+  test('preserves special characters valid in CSS strings', () => {
+    expect(sanitizeCmdkValue('brackets []{}() and symbols @#$%^&*')).toBe('brackets []{}() and symbols @#$%^&*');
+  });
+});
 
 test('pluralize', () => {
   expect(pluralize(0)).toBe('s');

--- a/src/utilities/text.ts
+++ b/src/utilities/text.ts
@@ -1,3 +1,22 @@
+/**
+ * Sanitizes a string for use as a cmdk Command.Item `value` prop.
+ *
+ * cmdk internally uses `querySelector('[data-value="..."]')` with the raw value,
+ * so characters that are invalid in CSS double-quoted string tokens will throw
+ * a SyntaxError and break the component (the menu becomes un-closable).
+ *
+ * See: https://github.com/shadcn-ui/ui/issues/2817
+ *
+ * Strips: quotes (" '), backslashes (\), and null bytes (\0)
+ * Replaces: newlines (\n, \r) and form feeds (\f) with spaces
+ *
+ * Note: We may be able to remove this sanitization if/when we update to
+ *       svelte 5 + new shadcn-svelte that does not use cmdk.
+ */
+export function sanitizeCmdkValue(value: string): string {
+  return value.replace(/["'\\\0]/g, '').replace(/[\n\r\f]+/g, ' ');
+}
+
 export function pluralize(count: number): string {
   return count === 1 ? '' : 's';
 }

--- a/src/utilities/workspaces.ts
+++ b/src/utilities/workspaces.ts
@@ -577,8 +577,7 @@ export function findNodeAffectingPath(
   }
   return nodes.find(
     node =>
-      node.fullPath === path ||
-      (node.type === WorkspaceContentType.Directory && path.startsWith(node.fullPath + '/')),
+      node.fullPath === path || (node.type === WorkspaceContentType.Directory && path.startsWith(node.fullPath + '/')),
   );
 }
 

--- a/src/utilities/workspaces.ts
+++ b/src/utilities/workspaces.ts
@@ -564,6 +564,24 @@ export const WorkspaceApi = {
   },
 };
 
+/**
+ * Finds a node in the list that matches or contains the given path.
+ * A node "affects" a path if it is the path itself, or if it is a parent directory of the path.
+ */
+export function findNodeAffectingPath(
+  nodes: WorkspaceTreeNodeWithFullPath[],
+  path: string | null,
+): WorkspaceTreeNodeWithFullPath | undefined {
+  if (!path) {
+    return undefined;
+  }
+  return nodes.find(
+    node =>
+      node.fullPath === path ||
+      (node.type === WorkspaceContentType.Directory && path.startsWith(node.fullPath + '/')),
+  );
+}
+
 // Find a node in the tree by its path
 export function findNodeByPath(nodes: WorkspaceTreeNode[], targetPath: string): WorkspaceTreeNode | null {
   const pathParts = targetPath.split(PATH_DELIMITER);


### PR DESCRIPTION
This PR addresses several issues with Sequence Editor:

- Fixes content being reverted to a previous state if a change is made and then immediately saved
  - To test:
  1. Make a change in a sequence file and ensure the "Save" button switches from disabled to enabled state
  2. Once the "Save" button is enabled, make another change and immediately save the file via keyboard shortcut (CMD/CTRL + S)
  3. Verify that what is saved is correct and not the version from step i)
- Preserves cursor position when saving files
  - To test:
  1. Make some changes to a sequence file
  2. Place the text cursor in the middle of a line (anywhere as long as it's not at the end of a line)
  3. Save the file
  4. Verify that the cursor is in the same position as before the save
  5. Repeat for a text and then a JSON file
- Improves editor responsiveness by updating the UI immediately on input changes
  - To test:
  1. Verify that after typing a change into an unchanged file immediately switches the "Save" button from disabled to enabled state
- Fixes incorrect txt/json determination when switching from JSON file to an UNKNOWN and then back to a JSON file
  - To test:
  1. Open a JSON file
  2. Then open a BINARY file
  3. Switch back to the JSON file
  4. Verify that JSON highlighting and linting is applied
  5. Open a text file
  6. Verify that no JSON linting is applied
  7. Open a JSON file (can be any JSON file)
  8. Verify that JSON highlighting and linting is correctly applied still
- Fixes the active document not being cleared after the file/folder was deleted directly or by parent folder deletion
  - To test:
   1. Open a file
   2. Delete the file
   3. The editor should revert to the new document view
   4. Open another file within a folder
   5. Delete the parent folder via right click
   6. The editor should revert to the new document view
   7. Repeat this process for move/move to workspace/download nodes.
- Closes https://github.com/NASA-AMMOS/aerie-ui/issues/1877
  - To test:
   1. Open workspace with actions
   2. Edit an action title and description to have quotes, new lines, backslashes, and `\0`
   3. Verify that the actions button in the editor toolbar of an active sequence file is usable and does not throw any errors in the dev console and can be closed.
