### PR TITLE
Activity Search Phase 1

### DIFF
--- a/e2e-tests/fixtures/Search.ts
+++ b/e2e-tests/fixtures/Search.ts
@@ -1,0 +1,130 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+/**
+ * Page Object for the cross-plan activity search page (`/search`).
+ */
+export class Search {
+  activityNameInput: Locator;
+  argumentValueInput: Locator;
+  clearFiltersButton: Locator;
+  formReady: Locator;
+  modifiedAfterInput: Locator;
+  modifiedBeforeInput: Locator;
+  noResultsOverlay: Locator;
+  pageInfo: Locator;
+  paginationFirstButton: Locator;
+  paginationLastButton: Locator;
+  paginationNextButton: Locator;
+  paginationPreviousButton: Locator;
+  panelHeader: Locator;
+  planNameInput: Locator;
+  resultsCountLabel: Locator;
+  resultsGrid: Locator;
+  resultsPanel: Locator;
+  resultsRows: Locator;
+  schedulerOnlyCheckbox: Locator;
+  searchButton: Locator;
+  searchingIndicator: Locator;
+  startOffsetMaxInput: Locator;
+  startOffsetMinInput: Locator;
+
+  constructor(public page: Page) {
+    this.updatePage(page);
+  }
+
+  /** Reset all filters and clear results via the "Clear Filters" button. */
+  async clearFilters(): Promise<void> {
+    await this.clearFiltersButton.click();
+  }
+
+  /** Click the row whose Activity Name cell matches `name`. */
+  async clickRow(name: string): Promise<void> {
+    await this.resultsRows.filter({ hasText: name }).first().click();
+  }
+
+  /** Returns the count of currently rendered result rows. */
+  async getResultRowCount(): Promise<number> {
+    return this.resultsRows.count();
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/search', { waitUntil: 'load' });
+    await this.waitForFormReady();
+  }
+
+  /** Navigate to /search with the given query string (deep-link). */
+  async gotoWithParams(params: Record<string, string>): Promise<void> {
+    const qs = new URLSearchParams(params).toString();
+    await this.page.goto(`/search?${qs}`, { waitUntil: 'load' });
+    await this.waitForFormReady();
+  }
+
+  /**
+   * Submit the form and wait for the next search to complete.
+   *
+   * Uses the `data-search-run-id` attribute on the results panel — every
+   * completed search bumps it. We snapshot the value before clicking, then
+   * wait for it to change. This avoids relying on the `Searching…` indicator,
+   * which has a deliberate 500ms reveal delay (to prevent flashing on fast
+   * responses) and isn't observable for sub-500ms searches.
+   */
+  async submitAndWait(): Promise<void> {
+    const before = (await this.resultsPanel.getAttribute('data-search-run-id')) ?? '0';
+    await this.searchButton.click();
+    await expect(this.resultsPanel).not.toHaveAttribute('data-search-run-id', before);
+  }
+
+  updatePage(page: Page): void {
+    this.page = page;
+
+    // Hydration signal: form's `data-search-form-ready` flips to "true" once
+    // SearchPanel finishes its first reactive run (post-mount), which is when
+    // `on:submit` and the bind:value handlers are wired up.
+    this.formReady = page.locator('form[data-search-form-ready="true"]');
+
+    // Form inputs — locate by role + accessible name (matching the visible label)
+    // so tests interact with the form the way a user sees it.
+    this.activityNameInput = page.getByRole('textbox', { name: 'Activity Name' });
+    this.argumentValueInput = page.getByRole('textbox', { name: 'Argument Value' });
+    this.modifiedAfterInput = page.getByRole('textbox', { name: 'Last Modified After' });
+    this.modifiedBeforeInput = page.getByRole('textbox', { name: 'Last Modified Before' });
+    this.startOffsetMinInput = page.getByRole('textbox', { name: 'Start Offset (min)' });
+    this.startOffsetMaxInput = page.getByRole('textbox', { name: 'Start Offset (max)' });
+    this.planNameInput = page.getByRole('textbox', { name: 'Plan Name' });
+    this.schedulerOnlyCheckbox = page.getByRole('checkbox', { name: 'Scheduler-created only' });
+
+    // Buttons
+    this.searchButton = page.getByRole('button', { exact: true, name: 'Search' });
+    this.clearFiltersButton = page.getByRole('button', { name: 'Clear Filters' });
+
+    // Results panel
+    this.panelHeader = page.getByText('Search Results', { exact: true });
+    this.resultsPanel = page.locator('[data-search-run-id]');
+    this.resultsCountLabel = page.locator('span.text-xs.text-muted-foreground').filter({ hasText: ' of ' });
+    this.searchingIndicator = page.locator('span.text-xs').filter({ hasText: 'Searching…' });
+
+    // Grid
+    this.resultsGrid = page.locator('.ag-root-wrapper').last();
+    this.resultsRows = this.resultsGrid.locator('.ag-center-cols-container .ag-row');
+    this.noResultsOverlay = this.resultsGrid.locator('.ag-overlay-no-rows-wrapper');
+
+    // Pagination
+    this.paginationFirstButton = page.getByRole('button', { name: 'First page' });
+    this.paginationPreviousButton = page.getByRole('button', { name: 'Previous page' });
+    this.paginationNextButton = page.getByRole('button', { name: 'Next page' });
+    this.paginationLastButton = page.getByRole('button', { name: 'Last page' });
+    this.pageInfo = page.locator('span').filter({ hasText: /^Page \d+ of/ });
+  }
+
+  /**
+   * Wait until SearchPanel has finished its first reactive run, signaled by
+   * `data-search-form-ready="true"` on the form. Without this, headless
+   * Playwright can click Search before Svelte's `on:submit` listener attaches,
+   * which makes the browser perform a default form GET to `/search?` and
+   * `onSearch` is never called.
+   */
+  async waitForFormReady(): Promise<void> {
+    await expect(this.formReady).toBeVisible();
+  }
+}

--- a/e2e-tests/fixtures/Search.ts
+++ b/e2e-tests/fixtures/Search.ts
@@ -38,9 +38,30 @@ export class Search {
     await this.clearFiltersButton.click();
   }
 
+  /**
+   * Click the per-row "Open in plan" icon button on the row whose Activity Name
+   * cell matches `name`. The button is rendered in the pinned-left container,
+   * not the center container, so we use the grid's row-index attribute to
+   * cross-reference the right row across containers.
+   */
+  async clickOpenInPlanForRow(name: string): Promise<void> {
+    const centerRow = this.resultsRows.filter({ hasText: name }).first();
+    const rowIndex = await centerRow.getAttribute('row-index');
+    if (rowIndex === null) {
+      throw new Error(`Could not resolve row-index for row containing "${name}"`);
+    }
+    const pinnedRow = this.resultsGrid.locator(`.ag-pinned-left-cols-container .ag-row[row-index="${rowIndex}"]`);
+    await pinnedRow.getByRole('button', { name: 'Open in plan' }).click();
+  }
+
   /** Click the row whose Activity Name cell matches `name`. */
   async clickRow(name: string): Promise<void> {
     await this.resultsRows.filter({ hasText: name }).first().click();
+  }
+
+  /** AG Grid column header by visible header name. Use to assert presence or to sort. */
+  columnHeader(headerName: string): Locator {
+    return this.resultsGrid.locator('.ag-header-cell', { hasText: headerName }).first();
   }
 
   /** Returns the count of currently rendered result rows. */

--- a/e2e-tests/tests/search.test.ts
+++ b/e2e-tests/tests/search.test.ts
@@ -311,9 +311,7 @@ test.describe.serial('Activity Search — Cross-Plan ID Collisions', () => {
       await expect(crossPlanSearch.resultsRows).toHaveCount(4);
 
       // Both plans should each contribute two rows (target + anchored).
-      await expect(
-        crossPlanSearch.resultsGrid.getByText(crossPlanSetup.planName, { exact: true }),
-      ).toHaveCount(2);
+      await expect(crossPlanSearch.resultsGrid.getByText(crossPlanSetup.planName, { exact: true })).toHaveCount(2);
       await expect(crossPlanSearch.resultsGrid.getByText(duplicatedPlanName, { exact: true })).toHaveCount(2);
 
       expect(gridProblemMessages).toEqual([]);

--- a/e2e-tests/tests/search.test.ts
+++ b/e2e-tests/tests/search.test.ts
@@ -169,18 +169,59 @@ test.describe.serial('Activity Search', () => {
     await expect(search.resultsRows).toHaveCount(2);
   });
 
-  test('Should open the activity in a new tab when a result row is clicked', async () => {
+  test('Should open the activity in a new tab when the per-row "Open in plan" button is clicked', async () => {
     await search.goto();
     await search.planNameInput.fill(setup.planName);
     await search.activityNameInput.fill(ACTIVITY_NAMES.pick);
     await search.submitAndWait();
     await expect(search.resultsRows).toHaveCount(1);
 
-    const [popup] = await Promise.all([search.page.waitForEvent('popup'), search.clickRow(ACTIVITY_NAMES.pick)]);
+    const [popup] = await Promise.all([
+      search.page.waitForEvent('popup'),
+      search.clickOpenInPlanForRow(ACTIVITY_NAMES.pick),
+    ]);
 
     await popup.waitForLoadState('domcontentloaded');
     expect(popup.url()).toContain(`/plans/${setup.planId}`);
     expect(popup.url()).toContain('activityId=');
     await popup.close();
+  });
+
+  test('Should render Model, Model ID, and Absolute Start Time columns by default', async () => {
+    await search.goto();
+    await search.planNameInput.fill(setup.planName);
+    await search.submitAndWait();
+
+    await expect(search.columnHeader('Model')).toBeVisible();
+    await expect(search.columnHeader('Model ID')).toBeVisible();
+    await expect(search.columnHeader('Absolute Start Time')).toBeVisible();
+  });
+
+  test('Should filter by union of activity types via deep-link multi-select', async () => {
+    // Multi-type filter is array-valued and serialized comma-joined into the URL.
+    // Use the deep-link path to exercise the _in clause without driving the multi-select dropdown UI.
+    await search.gotoWithParams({
+      actType: 'GrowBanana,PickBanana',
+      planName: setup.planName,
+    });
+    await expect(search.resultsPanel).toHaveAttribute('data-search-run-id', /^[1-9]\d*$/);
+
+    await expect(search.resultsRows).toHaveCount(3);
+    await expect(search.resultsGrid.getByText(ACTIVITY_NAMES.grow1, { exact: true })).toBeVisible();
+    await expect(search.resultsGrid.getByText(ACTIVITY_NAMES.grow2, { exact: true })).toBeVisible();
+    await expect(search.resultsGrid.getByText(ACTIVITY_NAMES.pick, { exact: true })).toBeVisible();
+    await expect(search.resultsGrid.getByText(ACTIVITY_NAMES.bake, { exact: true })).toBeHidden();
+  });
+
+  test('Should filter by argument value when typed as a JSON array (subset containment)', async () => {
+    await search.goto();
+    await search.planNameInput.fill(setup.planName);
+    await search.argumentValueInput.fill('[5]');
+    await search.submitAndWait();
+
+    // Type `[5]` would match an arg whose value is a superset like `[1, 2, 5]`.
+    // No activity in this test plan has an array-valued arg, so this should
+    // return zero rows — the assertion is that the query doesn't error.
+    await expect(search.noResultsOverlay).toBeVisible();
   });
 });

--- a/e2e-tests/tests/search.test.ts
+++ b/e2e-tests/tests/search.test.ts
@@ -1,4 +1,4 @@
-import test, { expect } from '@playwright/test';
+import test, { expect, type ConsoleMessage } from '@playwright/test';
 import { Search } from '../fixtures/Search.js';
 import { setupTest, teardownTest, type FullSetupResult } from '../utilities/api.js';
 
@@ -223,5 +223,125 @@ test.describe.serial('Activity Search', () => {
     // No activity in this test plan has an array-valued arg, so this should
     // return zero rows — the assertion is that the query doesn't error.
     await expect(search.noResultsOverlay).toBeVisible();
+  });
+});
+
+// Regression coverage for the cross-plan row-id collision fix. Activity directive
+// ids are unique per-plan but not globally; duplicating a plan produces another
+// plan whose activities have the same numeric ids. Without compound `(plan_id, id)`
+// row keying, the search grid would emit "Grid Problems? Look Here!" console
+// errors and clicking a row from the duplicated plan could navigate to the
+// original plan's url instead.
+test.describe.serial('Activity Search — Cross-Plan ID Collisions', () => {
+  let crossPlanSetup: FullSetupResult;
+  let duplicatedPlanId: number;
+  let duplicatedPlanName: string;
+  let crossPlanSearch: Search;
+  const CROSS_PLAN_ACTIVITY_NAMES = {
+    anchored: 'searchTest_CrossPlan_anchored',
+    target: 'searchTest_CrossPlan_target',
+  };
+
+  test.beforeAll(async ({ browser }) => {
+    crossPlanSetup = await setupTest(browser);
+
+    // Create a target activity and one anchored to it in plan A. The duplicate_plan
+    // mutation produces plan B whose activities re-use plan A's ids — that's the
+    // collision we need to surface to the search grid.
+    const target = await crossPlanSetup.api.createActivityDirective({
+      anchor_id: null,
+      anchored_to_start: true,
+      arguments: { quantity: 1 },
+      metadata: {},
+      name: CROSS_PLAN_ACTIVITY_NAMES.target,
+      plan_id: crossPlanSetup.planId,
+      start_offset: '01:00:00',
+      type: 'GrowBanana',
+    });
+    await crossPlanSetup.api.createActivityDirective({
+      anchor_id: target.id,
+      anchored_to_start: true,
+      arguments: { quantity: 2 },
+      metadata: {},
+      name: CROSS_PLAN_ACTIVITY_NAMES.anchored,
+      plan_id: crossPlanSetup.planId,
+      start_offset: '00:30:00',
+      type: 'GrowBanana',
+    });
+
+    duplicatedPlanName = `${crossPlanSetup.planName}_dup`;
+    const dup = await crossPlanSetup.api.duplicatePlan(crossPlanSetup.planId, duplicatedPlanName);
+    duplicatedPlanId = dup.id;
+
+    crossPlanSearch = new Search(crossPlanSetup.page);
+  });
+
+  test.afterAll(async () => {
+    if (duplicatedPlanId) {
+      try {
+        await crossPlanSetup.api.deletePlan(duplicatedPlanId);
+      } catch {
+        // Ignore cleanup errors — teardownTest still removes the original plan + model.
+      }
+    }
+    await teardownTest(crossPlanSetup);
+  });
+
+  test('Should render 2 rows per plan when search spans the original and its duplicate', async () => {
+    // The DataGrid logs a console.error starting with "Grid Problems? Look Here!"
+    // when two rows share a row id. Capture console output during the search so
+    // we can fail the test if the collision detection trips — that means we
+    // regressed on compound (plan_id, id) keying.
+    const gridProblemMessages: string[] = [];
+    const consoleListener = (msg: ConsoleMessage) => {
+      if (msg.type() === 'error' && msg.text().includes('Grid Problems? Look Here!')) {
+        gridProblemMessages.push(msg.text());
+      }
+    };
+    crossPlanSearch.page.on('console', consoleListener);
+
+    try {
+      await crossPlanSearch.goto();
+      // Filter by activity name substring shared by both plans — yields 4 rows
+      // (2 per plan, same ids per plan thanks to duplicate_plan).
+      await crossPlanSearch.activityNameInput.fill('searchTest_CrossPlan_');
+      await crossPlanSearch.submitAndWait();
+
+      await expect(crossPlanSearch.resultsCountLabel).toContainText('of 4');
+      await expect(crossPlanSearch.resultsRows).toHaveCount(4);
+
+      // Both plans should each contribute two rows (target + anchored).
+      await expect(
+        crossPlanSearch.resultsGrid.getByText(crossPlanSetup.planName, { exact: true }),
+      ).toHaveCount(2);
+      await expect(crossPlanSearch.resultsGrid.getByText(duplicatedPlanName, { exact: true })).toHaveCount(2);
+
+      expect(gridProblemMessages).toEqual([]);
+    } finally {
+      crossPlanSearch.page.off('console', consoleListener);
+    }
+  });
+
+  test('Should open the correct plan when clicking "Open in plan" on a duplicated-plan row', async () => {
+    await crossPlanSearch.goto();
+    // Narrow the search to a single activity name so there are exactly two rows —
+    // one per plan — sharing the same activity directive id. Filtering Plan Name
+    // to the duplicate ensures the row whose Open-in-plan we click is the dup.
+    await crossPlanSearch.activityNameInput.fill(CROSS_PLAN_ACTIVITY_NAMES.target);
+    await crossPlanSearch.planNameInput.fill(duplicatedPlanName);
+    await crossPlanSearch.submitAndWait();
+    await expect(crossPlanSearch.resultsRows).toHaveCount(1);
+
+    const [popup] = await Promise.all([
+      crossPlanSearch.page.waitForEvent('popup'),
+      crossPlanSearch.clickOpenInPlanForRow(CROSS_PLAN_ACTIVITY_NAMES.target),
+    ]);
+
+    await popup.waitForLoadState('domcontentloaded');
+    // The url must point at the *duplicated* plan, not the original — proving
+    // the row's identity wasn't aliased to the original plan's same-id row.
+    expect(popup.url()).toContain(`/plans/${duplicatedPlanId}`);
+    expect(popup.url()).not.toContain(`/plans/${crossPlanSetup.planId}?`);
+    await popup.close();
   });
 });

--- a/e2e-tests/tests/search.test.ts
+++ b/e2e-tests/tests/search.test.ts
@@ -1,0 +1,186 @@
+import test, { expect } from '@playwright/test';
+import { Search } from '../fixtures/Search.js';
+import { setupTest, teardownTest, type FullSetupResult } from '../utilities/api.js';
+
+let setup: FullSetupResult;
+let search: Search;
+
+// We run `addActivity` via the API so the search has known data without depending on
+// the timeline drag UI, and we filter every assertion by the unique plan name so other
+// tests sharing the same backend can't pollute the result set.
+const ACTIVITY_NAMES = {
+  bake: 'searchTest_BakeBananaBread',
+  grow1: 'searchTest_GrowBanana_alpha',
+  grow2: 'searchTest_GrowBanana_beta',
+  pick: 'searchTest_PickBanana',
+};
+
+test.beforeAll(async ({ browser }) => {
+  setup = await setupTest(browser);
+
+  await setup.api.createActivityDirective({
+    anchor_id: null,
+    anchored_to_start: true,
+    arguments: { quantity: 5 },
+    metadata: {},
+    name: ACTIVITY_NAMES.grow1,
+    plan_id: setup.planId,
+    start_offset: '01:00:00',
+    type: 'GrowBanana',
+  });
+  await setup.api.createActivityDirective({
+    anchor_id: null,
+    anchored_to_start: true,
+    arguments: { quantity: 7 },
+    metadata: {},
+    name: ACTIVITY_NAMES.grow2,
+    plan_id: setup.planId,
+    start_offset: '02:00:00',
+    type: 'GrowBanana',
+  });
+  await setup.api.createActivityDirective({
+    anchor_id: null,
+    anchored_to_start: true,
+    arguments: { quantity: 1 },
+    metadata: {},
+    name: ACTIVITY_NAMES.pick,
+    plan_id: setup.planId,
+    start_offset: '03:00:00',
+    type: 'PickBanana',
+  });
+  await setup.api.createActivityDirective({
+    anchor_id: null,
+    anchored_to_start: true,
+    arguments: { tbButter: 2, tbSugar: 1, temperature: 350 },
+    metadata: {},
+    name: ACTIVITY_NAMES.bake,
+    plan_id: setup.planId,
+    start_offset: '04:00:00',
+    type: 'BakeBananaBread',
+  });
+
+  search = new Search(setup.page);
+});
+
+test.afterAll(async () => {
+  await teardownTest(setup);
+});
+
+test.describe.serial('Activity Search', () => {
+  test('Should render the search page with empty results state', async () => {
+    await search.goto();
+    await expect(search.searchButton).toBeVisible();
+    await expect(search.clearFiltersButton).toBeVisible();
+    await expect(search.panelHeader).toBeVisible();
+    await expect(search.noResultsOverlay).toBeVisible();
+  });
+
+  test('Should return all 4 activities for the test plan when filtering by plan name', async () => {
+    await search.goto();
+    await search.planNameInput.fill(setup.planName);
+    await search.submitAndWait();
+
+    await expect(search.resultsCountLabel).toContainText('of 4');
+    await expect(search.resultsRows).toHaveCount(4);
+    for (const name of Object.values(ACTIVITY_NAMES)) {
+      await expect(search.resultsGrid.getByText(name, { exact: true })).toBeVisible();
+    }
+  });
+
+  test('Should filter by activity name substring', async () => {
+    await search.goto();
+    await search.planNameInput.fill(setup.planName);
+    await search.activityNameInput.fill('GrowBanana');
+    await search.submitAndWait();
+
+    await expect(search.resultsRows).toHaveCount(2);
+    await expect(search.resultsGrid.getByText(ACTIVITY_NAMES.grow1, { exact: true })).toBeVisible();
+    await expect(search.resultsGrid.getByText(ACTIVITY_NAMES.grow2, { exact: true })).toBeVisible();
+  });
+
+  test('Should filter by argument value (numeric)', async () => {
+    await search.goto();
+    await search.planNameInput.fill(setup.planName);
+    await search.argumentValueInput.fill('7');
+    await search.submitAndWait();
+
+    await expect(search.resultsRows).toHaveCount(1);
+    await expect(search.resultsGrid.getByText(ACTIVITY_NAMES.grow2, { exact: true })).toBeVisible();
+  });
+
+  test('Should filter by start_offset range', async () => {
+    await search.goto();
+    await search.planNameInput.fill(setup.planName);
+    await search.startOffsetMinInput.fill('02:00:00');
+    await search.startOffsetMaxInput.fill('03:00:00');
+    await search.submitAndWait();
+
+    await expect(search.resultsRows).toHaveCount(2);
+    await expect(search.resultsGrid.getByText(ACTIVITY_NAMES.grow2, { exact: true })).toBeVisible();
+    await expect(search.resultsGrid.getByText(ACTIVITY_NAMES.pick, { exact: true })).toBeVisible();
+  });
+
+  test('Should not show pagination controls when total results fit in one page', async () => {
+    await search.goto();
+    await search.planNameInput.fill(setup.planName);
+    await search.submitAndWait();
+
+    await expect(search.paginationFirstButton).toBeHidden();
+    await expect(search.paginationNextButton).toBeHidden();
+  });
+
+  test('Should clear all filters and reset results', async () => {
+    await search.goto();
+    await search.planNameInput.fill(setup.planName);
+    await search.activityNameInput.fill('GrowBanana');
+    await search.submitAndWait();
+    await expect(search.resultsRows).toHaveCount(2);
+
+    await search.clearFilters();
+
+    await expect(search.planNameInput).toHaveValue('');
+    await expect(search.activityNameInput).toHaveValue('');
+    await expect(search.noResultsOverlay).toBeVisible();
+    // `goto($page.url.pathname, ...)` is async — wait for the URL to drop its query.
+    await expect(search.page).toHaveURL(/\/search$/);
+  });
+
+  test('Should reflect form state in the URL after a search', async () => {
+    await search.goto();
+    await search.planNameInput.fill(setup.planName);
+    await search.activityNameInput.fill('GrowBanana');
+    await search.submitAndWait();
+
+    const url = new URL(search.page.url());
+    expect(url.searchParams.get('planName')).toEqual(setup.planName);
+    expect(url.searchParams.get('actName')).toEqual('GrowBanana');
+  });
+
+  test('Should populate the form and run a search when navigating with deep-link params', async () => {
+    await search.gotoWithParams({
+      actName: 'GrowBanana',
+      planName: setup.planName,
+    });
+    // The deep-link path auto-runs a search on mount; wait for it to complete.
+    await expect(search.resultsPanel).toHaveAttribute('data-search-run-id', /^[1-9]\d*$/);
+
+    await expect(search.planNameInput).toHaveValue(setup.planName);
+    await expect(search.activityNameInput).toHaveValue('GrowBanana');
+    await expect(search.resultsRows).toHaveCount(2);
+  });
+
+  test('Should open the activity in a new tab when a result row is clicked', async () => {
+    await search.goto();
+    await search.planNameInput.fill(setup.planName);
+    await search.activityNameInput.fill(ACTIVITY_NAMES.pick);
+    await search.submitAndWait();
+    await expect(search.resultsRows).toHaveCount(1);
+
+    const [popup] = await Promise.all([search.page.waitForEvent('popup'), search.clickRow(ACTIVITY_NAMES.pick)]);
+
+    await popup.waitForLoadState('domcontentloaded');
+    expect(popup.url()).toContain(`/plans/${setup.planId}`);
+    expect(popup.url()).toContain('activityId=');
+    await popup.close();
+  });
+});

--- a/e2e-tests/utilities/api.ts
+++ b/e2e-tests/utilities/api.ts
@@ -62,10 +62,9 @@ export class AerieApi {
   }
 
   async createActivityDirective(activityDirective: ActivityDirectiveInsertInput): Promise<{ id: number }> {
-    const data = await this.gqlQuery<{ insert_activity_directive_one: { id: number } }>(
-      gql.CREATE_ACTIVITY_DIRECTIVE,
-      { activityDirectiveInsertInput: activityDirective },
-    );
+    const data = await this.gqlQuery<{ insert_activity_directive_one: { id: number } }>(gql.CREATE_ACTIVITY_DIRECTIVE, {
+      activityDirectiveInsertInput: activityDirective,
+    });
     return { id: data.insert_activity_directive_one.id };
   }
 

--- a/e2e-tests/utilities/api.ts
+++ b/e2e-tests/utilities/api.ts
@@ -173,6 +173,14 @@ export class AerieApi {
     await this.gqlQuery(gql.DELETE_TAG, { id });
   }
 
+  async duplicatePlan(planId: number, newPlanName: string): Promise<{ id: number }> {
+    const data = await this.gqlQuery<{ duplicate_plan: { new_plan_id: number } }>(gql.DUPLICATE_PLAN, {
+      new_plan_name: newPlanName,
+      plan_id: planId,
+    });
+    return { id: data.duplicate_plan.new_plan_id };
+  }
+
   async getPlan(id: number): Promise<unknown> {
     const data = await this.gqlQuery<{ plan: unknown }>(gql.GET_PLAN, { id });
     return data.plan;

--- a/e2e-tests/utilities/api.ts
+++ b/e2e-tests/utilities/api.ts
@@ -62,10 +62,11 @@ export class AerieApi {
   }
 
   async createActivityDirective(activityDirective: ActivityDirectiveInsertInput): Promise<{ id: number }> {
-    const data = await this.gqlQuery<{ createActivityDirective: { id: number } }>(gql.CREATE_ACTIVITY_DIRECTIVE, {
-      activityDirectiveInsertInput: activityDirective,
-    });
-    return { id: data.createActivityDirective.id };
+    const data = await this.gqlQuery<{ insert_activity_directive_one: { id: number } }>(
+      gql.CREATE_ACTIVITY_DIRECTIVE,
+      { activityDirectiveInsertInput: activityDirective },
+    );
+    return { id: data.insert_activity_directive_one.id };
   }
 
   async createConstraint(constraint: ConstraintDefinitionInsertInput): Promise<{ id: number }> {

--- a/src/components/RowVirtualizerFixed.svelte
+++ b/src/components/RowVirtualizerFixed.svelte
@@ -1,15 +1,18 @@
 <svelte:options accessors={true} />
 
 <script lang="ts">
+  type T = $$Generic;
   import { createVirtualizer } from '@tanstack/svelte-virtual';
 
-  export let count: number = 0;
+  export let items: T[] = [];
   export let disabled: boolean = false;
   export let estimatedItemHeight: number = 32;
   export let selectedIndex: number | undefined = undefined;
   export let maxHeight: string = 'unset';
   export let minWidth: string = 'unset';
   export let overscan: number = 5;
+
+  $: count = items.length;
 
   let virtualListEl: HTMLDivElement;
 
@@ -46,11 +49,11 @@
   on:wheel={onScroll}
 >
   <div style=" height: {$virtualizer.getTotalSize()}px;position: relative; width: 100%;">
-    {#each $virtualizer.getVirtualItems() as item, idx (idx)}
+    {#each $virtualizer.getVirtualItems() as item (item.index)}
       <div
         style=" height: {item.size}px; left: 0;position: absolute; top: 0; transform: translateY({item.start}px); width: 100%;"
       >
-        <slot index={item.index} />
+        <slot index={item.index} item={items[item.index]} />
       </div>
     {/each}
   </div>

--- a/src/components/TimelineItemList.svelte
+++ b/src/components/TimelineItemList.svelte
@@ -23,6 +23,13 @@
   import ListItem from './ui/ListItem.svelte';
   import Tag from './ui/Tags/Tag.svelte';
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface $$Slots {
+    button: Record<string, never>;
+    default: { prop: TimelineItemType };
+    header: Record<string, never>;
+  }
+
   export let chartType: ChartType = 'activity';
   export let typeName: 'activity' | 'resource' | 'externalEvent' = 'activity';
   export let typeNamePlural: 'Activities' | 'Resources' | 'External Events' = 'Activities';

--- a/src/components/TimelineItemList.svelte
+++ b/src/components/TimelineItemList.svelte
@@ -270,7 +270,6 @@
     {/if}
     {#if filteredItems.length && !loading}
       <RowVirtualizerFixed items={filteredItems} overscan={100} let:item let:index disabled={activeItemIndex > -1}>
-
         <ListItem
           class={activeItemIndex === index ? 'active' : ''}
           draggable

--- a/src/components/TimelineItemList.svelte
+++ b/src/components/TimelineItemList.svelte
@@ -269,8 +269,8 @@
       </div>
     {/if}
     {#if filteredItems.length && !loading}
-      <RowVirtualizerFixed count={filteredItems.length} overscan={100} let:index disabled={activeItemIndex > -1}>
-        {@const item = filteredItems[index]}
+      <RowVirtualizerFixed items={filteredItems} overscan={100} let:item let:index disabled={activeItemIndex > -1}>
+
         <ListItem
           class={activeItemIndex === index ? 'active' : ''}
           draggable

--- a/src/components/__mocks__/RowVirtualizerFixed.svelte
+++ b/src/components/__mocks__/RowVirtualizerFixed.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+  type T = $$Generic;
   // Simple mock that renders all items without virtualization
-  export let count: number = 0;
+  export let items: T[] = [];
   export let disabled: boolean = false;
   export let estimatedItemHeight: number = 32;
   export let selectedIndex: number | undefined = undefined;
@@ -16,7 +17,7 @@
 </script>
 
 <div class="scroll-container" style:max-height={maxHeight} style:min-width={minWidth}>
-  {#each Array(count) as _, index}
-    <slot {index} />
+  {#each items as item, index}
+    <slot {index} {item} />
   {/each}
 </div>

--- a/src/components/menus/AppMenu.svelte
+++ b/src/components/menus/AppMenu.svelte
@@ -21,6 +21,7 @@
     Info,
     LogOut,
     Network,
+    Search as SearchIcon,
     Tags,
   } from 'lucide-svelte';
   import PlanDevWordmarkDark from '../../assets/plandev-logo-dark.svg?component';
@@ -94,6 +95,10 @@
           <MenuLink className="text-sm py-1.5" href="{base}/external-sources">
             <Boxes size={16} />
             External Sources
+          </MenuLink>
+          <MenuLink className="text-sm py-1.5" href="{base}/search">
+            <SearchIcon size={16} />
+            Activity Search
           </MenuLink>
         </div>
 

--- a/src/components/plan/PlanMergeReview.test.ts
+++ b/src/components/plan/PlanMergeReview.test.ts
@@ -105,6 +105,7 @@ const mockInitialPlan: Plan = {
   id: 1,
   is_locked: true,
   model: {
+    activity_types: [],
     constraint_specification: [],
     created_at: '2023-02-16T00:00:00',
     default_view_id: 0,

--- a/src/components/search/OpenInPlanCell.svelte
+++ b/src/components/search/OpenInPlanCell.svelte
@@ -1,0 +1,21 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { SquareArrowOutUpRight } from 'lucide-svelte';
+
+  export let onClick: () => void = () => {};
+
+  function handleClick(event: MouseEvent) {
+    event.stopPropagation();
+    onClick();
+  }
+</script>
+
+<button
+  type="button"
+  aria-label="Open in plan"
+  class="flex h-full w-full items-center justify-center text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:bg-muted focus-visible:outline-none"
+  on:click={handleClick}
+>
+  <SquareArrowOutUpRight size={14} />
+</button>

--- a/src/components/search/Search.svelte
+++ b/src/components/search/Search.svelte
@@ -9,12 +9,22 @@
   import SearchResults from './SearchResults.svelte';
 
   export let user: User | null;
+
+  let searchPanel: SearchPanel;
+
+  function onPageChange(page: number) {
+    searchPanel?.onSearch(page);
+  }
+
+  function onSortChange() {
+    searchPanel?.onSearch(0);
+  }
 </script>
 
 <CssGrid columns={$searchColumns}>
-  <SearchPanel {user} />
+  <SearchPanel bind:this={searchPanel} {user} />
 
   <CssGridGutter track={1} type="column" />
 
-  <SearchResults {user} activities={$searchResults} />
+  <SearchResults {user} activities={$searchResults} {onPageChange} {onSortChange} />
 </CssGrid>

--- a/src/components/search/Search.svelte
+++ b/src/components/search/Search.svelte
@@ -1,0 +1,20 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { searchColumns, searchResults } from '../../stores/search';
+  import type { User } from '../../types/app';
+  import CssGrid from '../ui/CssGrid.svelte';
+  import CssGridGutter from '../ui/CssGridGutter.svelte';
+  import SearchPanel from './SearchPanel.svelte';
+  import SearchResults from './SearchResults.svelte';
+
+  export let user: User | null;
+</script>
+
+<CssGrid columns={$searchColumns}>
+  <SearchPanel {user} />
+
+  <CssGridGutter track={1} type="column" />
+
+  <SearchResults {user} activities={$searchResults} />
+</CssGrid>

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -1,6 +1,7 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
   import { Button, Input as InputStellar, Label, Select } from '@nasa-jpl/stellar-svelte';
@@ -74,6 +75,7 @@
   let typeOptions: DropdownOptions = [];
   let presetOptions: DropdownOptions = [];
   let userOptions: DropdownOptions = [];
+  let argNameOptions: DropdownOptions = [];
 
   $: orderedModels = [...$models].sort(({ id: idA }, { id: idB }) => idB - idA);
 
@@ -109,12 +111,31 @@
     presetOptions = [{ display: '', value: '' }, ...presetNames.map(name => ({ display: name, value: name }))];
   }
 
+  $: {
+    const sourceModels = selectedModel ? [selectedModel] : ($models ?? []);
+    const paramNames = new Set<string>();
+    for (const model of sourceModels) {
+      for (const type of model?.activity_types ?? []) {
+        if (filters.actType && type.name !== filters.actType) {
+          continue;
+        }
+        for (const paramName of Object.keys(type.parameters ?? {})) {
+          paramNames.add(paramName);
+        }
+      }
+    }
+    argNameOptions = [
+      { display: '', value: '' },
+      ...[...paramNames].sort((a, b) => a.localeCompare(b)).map(name => ({ display: name, value: name })),
+    ];
+  }
+
   $: hasAnyFilter =
     selectedModel !== undefined ||
     Object.entries(filters).some(([k, v]) => (k === 'schedulerCreatedOnly' ? v === true : v !== ''));
 
-  // Initialize from URL on first page load
-  $: if ($page.url) {
+  // Initialize from URL on first page load (browser only — SSR can't navigate)
+  $: if (browser && $page.url) {
     initFromUrl();
   }
 
@@ -126,6 +147,13 @@
       pendingSearch = false;
       onSearch();
     }
+  }
+
+  // Keep URL in sync with current filter form state after init
+  $: if (browser && initialized) {
+    void filters;
+    void selectedModel;
+    updateUrl();
   }
 
   function initFromUrl() {
@@ -262,7 +290,10 @@
       <div class="flex flex-col gap-1">
         <Label size="sm">Mission Model</Label>
         <Select.Root
-          selected={{ label: getDisplayNameForModel(selectedModel), value: selectedModel?.id ?? '' }}
+          selected={{
+            label: selectedModel ? getDisplayNameForModel(selectedModel) : 'All Models',
+            value: selectedModel?.id,
+          }}
           onSelectedChange={v => (selectedModel = $models.find(model => model.id === v?.value))}
           loop={false}
         >
@@ -308,7 +339,6 @@
         <InputStellar
           bind:value={filters.actName}
           id="activity-name-input"
-          placeholder="Activity Name"
           autocomplete="off"
           class="w-full"
           sizeVariant="xs"
@@ -316,14 +346,11 @@
       </div>
 
       <div class="flex flex-col gap-1">
-        <Label size="sm" for="argument-name-input">Argument Name</Label>
-        <InputStellar
-          bind:value={filters.argName}
-          id="argument-name-input"
-          placeholder="Argument Name"
-          autocomplete="off"
-          class="w-full"
-          sizeVariant="xs"
+        <Label size="sm">Argument Name</Label>
+        <SearchableDropdown
+          options={argNameOptions}
+          on:change={e => (filters = { ...filters, argName: e.detail[0]?.toString() ?? '' })}
+          selectedOptionValues={[filters.argName]}
         />
       </div>
       <div class="flex flex-col gap-1">
@@ -331,7 +358,6 @@
         <InputStellar
           bind:value={filters.argValue}
           id="argument-value-input"
-          placeholder="Argument Value"
           autocomplete="off"
           class="w-full"
           sizeVariant="xs"
@@ -391,7 +417,6 @@
         <InputStellar
           bind:value={filters.planName}
           id="plan-name-input"
-          placeholder="Plan Name"
           autocomplete="off"
           class="w-full"
           sizeVariant="xs"
@@ -419,7 +444,7 @@
         </label>
       </div>
 
-      <div class="mt-2 flex flex-col gap-2">
+      <div class="mt-4 flex flex-col gap-2">
         <Button type="button" class="w-full" variant="outline" on:click={clearFilters}>Clear Filters</Button>
         <Button type="submit" class="w-full" disabled={!hasAnyFilter}>Search</Button>
       </div>

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -352,8 +352,8 @@
           <Label size="sm" for="argument-value-input" class="flex items-center gap-1">
             Argument Value
             <Tooltip
-              content="Defaults defined by the mission model are not applied to search filters, so you may need to specify argument values explicitly even if they were not provided when the activity was created. "
-              class="max-h-none max-w-28 whitespace-normal"
+              content="Defaults defined by the mission model are not applied to search filters, so you may need to specify argument values explicitly even if they were not provided when the activity was created."
+              class="max-h-none max-w-md whitespace-normal [&>span]:whitespace-normal"
             >
               <span class="ml-1 cursor-help text-muted-foreground"> <CircleQuestionMark size={14} /></span>
             </Tooltip>

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -192,7 +192,7 @@
     }
   }
 
-  function updateUrl() {
+  function updateUrl(): Promise<void> {
     const params = new URLSearchParams();
     if (selectedModelId !== undefined) {
       params.set('modelId', selectedModelId.toString());
@@ -204,7 +204,7 @@
       }
     }
     const qs = params.toString();
-    goto(qs ? `${$page.url.pathname}?${qs}` : $page.url.pathname, {
+    return goto(qs ? `${$page.url.pathname}?${qs}` : $page.url.pathname, {
       keepFocus: true,
       noScroll: true,
       replaceState: true,
@@ -261,7 +261,7 @@
         searchTotalCount.set(result.totalCount);
       }
 
-      updateUrl();
+      await updateUrl();
     } finally {
       isSearching.set(false);
       searchRunId.update(n => n + 1);

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -282,7 +282,7 @@
 
 <Panel overflowYBody="auto">
   <svelte:fragment slot="header">
-    <SectionTitle>Search for activities across plans</SectionTitle>
+    <SectionTitle>Search for Activities Across Plans</SectionTitle>
   </svelte:fragment>
 
   <svelte:fragment slot="body">
@@ -446,7 +446,7 @@
 
       <div class="mt-4 flex flex-col gap-2">
         <Button type="button" class="w-full" variant="outline" on:click={clearFilters}>Clear Filters</Button>
-        <Button type="submit" class="w-full" disabled={!hasAnyFilter}>Search</Button>
+        <Button type="submit" class="w-full">Search</Button>
       </div>
     </form>
   </svelte:fragment>

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -347,8 +347,8 @@
           </SearchableDropdown>
         </div>
         <div class="flex flex-col gap-1">
-          <Label size="sm" for="argument-value-input"
-            >Argument Value
+          <Label size="sm" for="argument-value-input" class="flex items-center gap-1">
+            Argument Value
             <Tooltip
               content="Defaults defined by the mission model are not applied to search filters, so you may need to specify argument values explicitly even if they were not provided when the activity was created. "
               class="max-h-none max-w-28 whitespace-normal"

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -166,8 +166,7 @@
     initFromUrl();
   }
 
-  $: subscriptionError =
-    $modelsError || $tagsError || $usersError || $presetsError || $goalsError || '';
+  $: subscriptionError = $modelsError || $tagsError || $usersError || $presetsError || $goalsError || '';
 
   // Keep URL in sync with current filter form state after init
   $: if (browser && initialized) {

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -1,11 +1,21 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
+  import { goto } from '$app/navigation';
+  import { page } from '$app/stores';
   import { Button, Input as InputStellar, Label, Select } from '@nasa-jpl/stellar-svelte';
   import { models } from '../../stores/model';
-  import { hasSearched, searchResults } from '../../stores/search';
+  import {
+    hasSearched,
+    PAGE_SIZE,
+    searchCurrentPage,
+    searchOrderBy,
+    searchResults,
+    searchTotalCount,
+  } from '../../stores/search';
   import { gqlSubscribable } from '../../stores/subscribable';
   import { tags } from '../../stores/tags';
+  import { users } from '../../stores/user';
   import type { ActivityPreset } from '../../types/activity';
   import type { User } from '../../types/app';
   import type { DropdownOptions } from '../../types/dropdown';
@@ -25,38 +35,66 @@
     [],
   );
 
+  // Consolidated filter state
+  const DEFAULT_FILTERS = {
+    actName: '',
+    actType: '',
+    argName: '',
+    argValue: '',
+    createdBy: '',
+    lastModifiedAfter: '',
+    lastModifiedBefore: '',
+    planName: '',
+    planOwner: '',
+    preset: '',
+    schedulerCreatedOnly: false,
+    tagValue: '',
+  };
+
+  // Map filter keys to URL param names where they differ
+  const URL_PARAM_OVERRIDES: Partial<Record<keyof typeof DEFAULT_FILTERS, string>> = {
+    schedulerCreatedOnly: 'schedulerOnly',
+    tagValue: 'tag',
+  };
+
+  type FilterKey = keyof typeof DEFAULT_FILTERS;
+
+  function getParamName(key: FilterKey): string {
+    return URL_PARAM_OVERRIDES[key] ?? key;
+  }
+
   let selectedModel: ModelSlim | undefined;
-  let filterActType: string = '';
-  let filterActName: string = '';
-  let filterArgName: string = '';
-  let filterArgValue: string = '';
-  let filterTagValue: string = '';
-  let filterPreset: string = '';
+  let filters = { ...DEFAULT_FILTERS };
+  let initialized = false;
+  let pendingModelId: number | null = null;
+  let pendingSearch = false;
 
   let orderedModels: ModelSlim[] = [];
   let tagOptions: DropdownOptions = [];
   let typeOptions: DropdownOptions = [];
   let presetOptions: DropdownOptions = [];
+  let userOptions: DropdownOptions = [];
 
   $: orderedModels = [...$models].sort(({ id: idA }, { id: idB }) => idB - idA);
 
   $: tagOptions = [{ display: '', value: '' }, ...$tags.map(tag => ({ display: tag.name, value: tag.name }))];
+
+  $: userOptions = [
+    { display: '', value: '' },
+    ...$users.filter((u): u is string => u !== null).map(u => ({ display: u, value: u })),
+  ];
 
   $: {
     const activityTypeNames: string[] = [''];
     if (selectedModel) {
       activityTypeNames.push(...selectedModel.activity_types.map(type => type.name));
     } else {
-      // remove duplicate activity type names across all models
       activityTypeNames.push(
         ...new Set(($models ?? []).flatMap(model => model?.activity_types?.map(type => type.name) ?? [])),
       );
     }
     typeOptions = activityTypeNames
-      .map(type => ({
-        display: type,
-        value: type,
-      }))
+      .map(type => ({ display: type, value: type }))
       .sort((a, b) => a.display.localeCompare(b.display));
   }
 
@@ -68,57 +106,142 @@
           .map(preset => preset.name),
       ),
     ];
-    presetOptions = [{ display: '', value: '' }];
-    presetOptions.push(...presetNames.map(name => ({ display: name, value: name })));
+    presetOptions = [{ display: '', value: '' }, ...presetNames.map(name => ({ display: name, value: name }))];
   }
 
-  async function onSearch() {
-    hasSearched.set(true);
+  $: hasAnyFilter =
+    selectedModel !== undefined ||
+    Object.entries(filters).some(([k, v]) => (k === 'schedulerCreatedOnly' ? v === true : v !== ''));
 
-    const filterArgs: [name: string, value: string | number | boolean][] = [];
-    if (filterArgName || filterArgValue) {
-      if (filterArgValue.toLowerCase() === 'true') {
-        filterArgs.push([filterArgName, true]);
-      } else if (filterArgValue.toLowerCase() === 'false') {
-        filterArgs.push([filterArgName, false]);
-      } else if (!isNaN(Number(filterArgValue))) {
-        filterArgs.push([filterArgName, Number(filterArgValue)]);
+  // Initialize from URL on first page load
+  $: if ($page.url) {
+    initFromUrl();
+  }
+
+  // Resolve pending model ID once models subscription delivers data
+  $: if (pendingModelId !== null && $models.length > 0) {
+    selectedModel = $models.find(m => m.id === pendingModelId);
+    pendingModelId = null;
+    if (pendingSearch) {
+      pendingSearch = false;
+      onSearch();
+    }
+  }
+
+  function initFromUrl() {
+    if (initialized) {
+      return;
+    }
+    initialized = true;
+
+    const params = $page.url.searchParams;
+
+    const modelIdParam = params.get('modelId');
+    if (modelIdParam) {
+      const id = parseInt(modelIdParam);
+      const found = $models.find(m => m.id === id);
+      if (found) {
+        selectedModel = found;
       } else {
-        filterArgs.push([filterArgName, filterArgValue]);
+        pendingModelId = id;
       }
     }
-    const results = await effects.searchActivities(
-      selectedModel?.id,
-      filterActType,
-      filterActName,
-      filterArgs,
-      filterTagValue,
-      filterPreset,
+
+    const updates: Partial<typeof DEFAULT_FILTERS> = {};
+    for (const key of Object.keys(DEFAULT_FILTERS) as FilterKey[]) {
+      const val = params.get(getParamName(key));
+      if (val !== null) {
+        updates[key] = (typeof DEFAULT_FILTERS[key] === 'boolean' ? val === 'true' : val) as never;
+      }
+    }
+    if (Object.keys(updates).length) {
+      filters = { ...filters, ...updates };
+    }
+
+    if (hasAnyFilter) {
+      onSearch();
+    } else if (pendingModelId !== null) {
+      // Model is the only filter; defer search until it resolves
+      pendingSearch = true;
+    }
+  }
+
+  function updateUrl() {
+    const params = new URLSearchParams();
+    if (selectedModel) {
+      params.set('modelId', selectedModel.id.toString());
+    }
+    for (const key of Object.keys(filters) as FilterKey[]) {
+      const val = filters[key];
+      if (val !== '' && val !== false) {
+        params.set(getParamName(key), val.toString());
+      }
+    }
+    const qs = params.toString();
+    goto(qs ? `${$page.url.pathname}?${qs}` : $page.url.pathname, {
+      keepFocus: true,
+      noScroll: true,
+      replaceState: true,
+    });
+  }
+
+  export async function onSearch(pageNumber: number = 0) {
+    hasSearched.set(true);
+    searchCurrentPage.set(pageNumber);
+
+    const filterArgs: [name: string, value: string | number | boolean][] = [];
+    if (filters.argName || filters.argValue) {
+      const v = filters.argValue;
+      if (v.toLowerCase() === 'true') {
+        filterArgs.push([filters.argName, true]);
+      } else if (v.toLowerCase() === 'false') {
+        filterArgs.push([filters.argName, false]);
+      } else if (v !== '' && !isNaN(Number(v))) {
+        filterArgs.push([filters.argName, Number(v)]);
+      } else {
+        filterArgs.push([filters.argName, v]);
+      }
+    }
+
+    const result = await effects.searchActivities(
+      {
+        actName: filters.actName,
+        actType: filters.actType,
+        args: filterArgs,
+        createdBy: filters.createdBy,
+        lastModifiedAfter: filters.lastModifiedAfter,
+        lastModifiedBefore: filters.lastModifiedBefore,
+        modelId: selectedModel?.id,
+        planName: filters.planName,
+        planOwner: filters.planOwner,
+        preset: filters.preset,
+        schedulerCreatedOnly: filters.schedulerCreatedOnly,
+        tagValue: filters.tagValue,
+      },
+      {
+        limit: PAGE_SIZE,
+        offset: pageNumber * PAGE_SIZE,
+        orderBy: $searchOrderBy,
+      },
       user,
     );
-    if (results) {
-      searchResults.set(results);
+
+    if (result) {
+      searchResults.set(result.results);
+      searchTotalCount.set(result.totalCount);
     }
+
+    updateUrl();
   }
 
   function clearFilters() {
     selectedModel = undefined;
-    filterActType = '';
-    filterActName = '';
-    filterArgName = '';
-    filterArgValue = '';
-    filterTagValue = '';
-    filterPreset = '';
+    filters = { ...DEFAULT_FILTERS };
     hasSearched.set(false);
     searchResults.set([]);
-  }
-
-  function onTypeChange(event: CustomEvent) {
-    filterActType = event.detail.length ? (event.detail[0]?.toString() ?? '') : '';
-  }
-
-  function onTagChange(event: CustomEvent) {
-    filterTagValue = event.detail.length ? (event.detail[0]?.toString() ?? '') : '';
+    searchTotalCount.set(0);
+    searchCurrentPage.set(0);
+    goto($page.url.pathname, { keepFocus: true, noScroll: true, replaceState: true });
   }
 
   function getDisplayNameForModel(model?: ModelSlim) {
@@ -127,115 +250,179 @@
     }
     return `${model.name} (Version: ${model.version})`;
   }
-
-  function onPresetChange(event: CustomEvent) {
-    filterPreset = event.detail.length ? (event.detail[0]?.toString() ?? '') : '';
-  }
 </script>
 
-<Panel overflowYBody="hidden">
+<Panel overflowYBody="auto">
   <svelte:fragment slot="header">
     <SectionTitle>Search for activities across plans</SectionTitle>
   </svelte:fragment>
 
   <svelte:fragment slot="body">
-    <form on:submit|preventDefault={onSearch} class="flex flex-col">
-      <fieldset>
-        <Label>Mission Model</Label>
-        <div>
-          <Select.Root
-            selected={{ label: getDisplayNameForModel(selectedModel), value: selectedModel?.id ?? '' }}
-            onSelectedChange={v => (selectedModel = $models.find(model => model.id === v?.value))}
-            loop={false}
+    <form on:submit|preventDefault={() => onSearch()} class="flex flex-col gap-3 p-2">
+      <div class="flex flex-col gap-1">
+        <Label size="sm">Mission Model</Label>
+        <Select.Root
+          selected={{ label: getDisplayNameForModel(selectedModel), value: selectedModel?.id ?? '' }}
+          onSelectedChange={v => (selectedModel = $models.find(model => model.id === v?.value))}
+          loop={false}
+        >
+          <Select.Trigger
+            value={selectedModel?.id}
+            size="xs"
+            aria-label="Select Model"
+            aria-labelledby={null}
+            id="model"
           >
-            <Select.Trigger
-              value={selectedModel?.id}
-              size="xs"
-              aria-label="Select Model"
-              aria-labelledby={null}
-              id="model"
-            >
-              <Select.Value placeholder="Select a model" />
-            </Select.Trigger>
-            <Select.Content
-              class="min-w-[240px] overflow-auto p-0"
-              sameWidth={false}
-              align="start"
-              datatype="number"
-              fitViewport
-            >
-              <Select.Item size="xs" value={undefined} label="All Models" class="flex gap-1">All Models</Select.Item>
-              {#each orderedModels as model (model.id)}
-                <Select.Item size="xs" value={model.id} label={getDisplayNameForModel(model)} class="flex gap-1">
-                  {model.name}
-                  <div class="whitespace-nowrap text-muted-foreground">(Version: {model.version})</div>
-                </Select.Item>
-              {/each}
-            </Select.Content>
-            <Select.Input type="number" name="model" aria-label="Select Model hidden input" />
-          </Select.Root>
-        </div>
-      </fieldset>
-      <fieldset>
-        <Label>Activity Type</Label>
-        <SearchableDropdown options={typeOptions} on:change={onTypeChange} selectedOptionValues={[filterActType]} />
-      </fieldset>
-      <fieldset>
-        <Label for="activity-name-input">Activity Name</Label>
+            <Select.Value placeholder="Select a model" />
+          </Select.Trigger>
+          <Select.Content
+            class="min-w-[240px] overflow-auto p-0"
+            sameWidth={false}
+            align="start"
+            datatype="number"
+            fitViewport
+          >
+            <Select.Item size="xs" value={undefined} label="All Models" class="flex gap-1">All Models</Select.Item>
+            {#each orderedModels as model (model.id)}
+              <Select.Item size="xs" value={model.id} label={getDisplayNameForModel(model)} class="flex gap-1">
+                {model.name}
+                <div class="whitespace-nowrap text-muted-foreground">(Version: {model.version})</div>
+              </Select.Item>
+            {/each}
+          </Select.Content>
+          <Select.Input type="number" name="model" aria-label="Select Model hidden input" />
+        </Select.Root>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <Label size="sm">Activity Type</Label>
+        <SearchableDropdown
+          options={typeOptions}
+          on:change={e => (filters = { ...filters, actType: e.detail[0]?.toString() ?? '' })}
+          selectedOptionValues={[filters.actType]}
+        />
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <Label size="sm" for="activity-name-input">Activity Name</Label>
         <InputStellar
-          bind:value={filterActName}
+          bind:value={filters.actName}
           id="activity-name-input"
           placeholder="Activity Name"
           autocomplete="off"
-          class="w-[300px]"
+          class="w-full"
           sizeVariant="xs"
-          aria-label="Activity Name"
         />
-      </fieldset>
-      <fieldset>
-        <Label for="argument-name-input">Argument Name</Label>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <Label size="sm" for="argument-name-input">Argument Name</Label>
         <InputStellar
-          bind:value={filterArgName}
+          bind:value={filters.argName}
           id="argument-name-input"
           placeholder="Argument Name"
           autocomplete="off"
-          class="w-[300px]"
+          class="w-full"
           sizeVariant="xs"
-          aria-label="Argument Name"
         />
-        <Label for="argument-value-input">Argument Value</Label>
+      </div>
+      <div class="flex flex-col gap-1">
+        <Label size="sm" for="argument-value-input">Argument Value</Label>
         <InputStellar
-          bind:value={filterArgValue}
+          bind:value={filters.argValue}
           id="argument-value-input"
           placeholder="Argument Value"
           autocomplete="off"
-          class="w-[300px]"
-          sizeVariant="xs"
-          aria-label="Argument Value"
-        />
-      </fieldset>
-      <fieldset>
-        <Label for="tag-value-input">Tag Value</Label>
-        <SearchableDropdown options={tagOptions} on:change={onTagChange} selectedOptionValues={[filterTagValue]} />
-      </fieldset>
-      <fieldset>
-        <Label for="preset-name-input">Preset</Label>
-        <SearchableDropdown options={presetOptions} on:change={onPresetChange} selectedOptionValues={[filterPreset]} />
-      </fieldset>
-      <fieldset class="my-4">
-        <Button type="button" class="w-full" on:click={clearFilters}>Clear Filters</Button>
-        <div />
-        <Button
-          type="submit"
           class="w-full"
-          disabled={filterActType === '' &&
-            filterActName === '' &&
-            filterArgName === '' &&
-            filterArgValue === '' &&
-            filterTagValue === '' &&
-            filterPreset === ''}>Search</Button
-        >
-      </fieldset>
+          sizeVariant="xs"
+        />
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <Label size="sm">Tag</Label>
+        <SearchableDropdown
+          options={tagOptions}
+          on:change={e => (filters = { ...filters, tagValue: e.detail[0]?.toString() ?? '' })}
+          selectedOptionValues={[filters.tagValue]}
+        />
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <Label size="sm">Preset</Label>
+        <SearchableDropdown
+          options={presetOptions}
+          on:change={e => (filters = { ...filters, preset: e.detail[0]?.toString() ?? '' })}
+          selectedOptionValues={[filters.preset]}
+        />
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <Label size="sm">Created By</Label>
+        <SearchableDropdown
+          options={userOptions}
+          on:change={e => (filters = { ...filters, createdBy: e.detail[0]?.toString() ?? '' })}
+          selectedOptionValues={[filters.createdBy]}
+        />
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <Label size="sm" for="modified-after-input">Last Modified After</Label>
+        <InputStellar
+          bind:value={filters.lastModifiedAfter}
+          id="modified-after-input"
+          class="w-full"
+          sizeVariant="xs"
+          type="datetime-local"
+        />
+      </div>
+      <div class="flex flex-col gap-1">
+        <Label size="sm" for="modified-before-input">Last Modified Before</Label>
+        <InputStellar
+          bind:value={filters.lastModifiedBefore}
+          id="modified-before-input"
+          class="w-full"
+          sizeVariant="xs"
+          type="datetime-local"
+        />
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <Label size="sm" for="plan-name-input">Plan Name</Label>
+        <InputStellar
+          bind:value={filters.planName}
+          id="plan-name-input"
+          placeholder="Plan Name"
+          autocomplete="off"
+          class="w-full"
+          sizeVariant="xs"
+        />
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <Label size="sm">Plan Owner</Label>
+        <SearchableDropdown
+          options={userOptions}
+          on:change={e => (filters = { ...filters, planOwner: e.detail[0]?.toString() ?? '' })}
+          selectedOptionValues={[filters.planOwner]}
+        />
+      </div>
+
+      <div class="flex items-center gap-2">
+        <label class="flex cursor-pointer items-center gap-2" for="scheduler-only">
+          <input
+            type="checkbox"
+            bind:checked={filters.schedulerCreatedOnly}
+            name="scheduler-only"
+            id="scheduler-only"
+          />
+          <span class="text-xs">Scheduler-created only</span>
+        </label>
+      </div>
+
+      <div class="mt-2 flex flex-col gap-2">
+        <Button type="button" class="w-full" variant="outline" on:click={clearFilters}>Clear Filters</Button>
+        <Button type="submit" class="w-full" disabled={!hasAnyFilter}>Search</Button>
+      </div>
     </form>
   </svelte:fragment>
 </Panel>

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -1,20 +1,76 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import { Button, Input as InputStellar, Label } from '@nasa-jpl/stellar-svelte';
+  import { Button, Input as InputStellar, Label, Select } from '@nasa-jpl/stellar-svelte';
+  import { models } from '../../stores/model';
   import { hasSearched, searchResults } from '../../stores/search';
+  import { gqlSubscribable } from '../../stores/subscribable';
+  import { tags } from '../../stores/tags';
+  import type { ActivityPreset } from '../../types/activity';
   import type { User } from '../../types/app';
+  import type { DropdownOptions } from '../../types/dropdown';
+  import type { ModelSlim } from '../../types/model';
+  import type { GqlSubscribable } from '../../types/subscribable';
   import effects from '../../utilities/effects';
+  import gql from '../../utilities/gql';
   import Panel from '../ui/Panel.svelte';
+  import SearchableDropdown from '../ui/SearchableDropdown.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
 
   export let user: User | null;
 
+  let activityPresets: GqlSubscribable<ActivityPreset[]> = gqlSubscribable<ActivityPreset[]>(
+    gql.SUB_ACTIVITY_PRESETS_ALL,
+    {},
+    [],
+  );
+
+  let selectedModel: ModelSlim | undefined;
   let filterActType: string = '';
   let filterActName: string = '';
   let filterArgName: string = '';
   let filterArgValue: string = '';
   let filterTagValue: string = '';
+  let filterPreset: string = '';
+
+  let orderedModels: ModelSlim[] = [];
+  let tagOptions: DropdownOptions = [];
+  let typeOptions: DropdownOptions = [];
+  let presetOptions: DropdownOptions = [];
+
+  $: orderedModels = [...$models].sort(({ id: idA }, { id: idB }) => idB - idA);
+
+  $: tagOptions = [{ display: '', value: '' }, ...$tags.map(tag => ({ display: tag.name, value: tag.name }))];
+
+  $: {
+    const activityTypeNames: string[] = [''];
+    if (selectedModel) {
+      activityTypeNames.push(...selectedModel.activity_types.map(type => type.name));
+    } else {
+      // remove duplicate activity type names across all models
+      activityTypeNames.push(
+        ...new Set(($models ?? []).flatMap(model => model?.activity_types?.map(type => type.name) ?? [])),
+      );
+    }
+    typeOptions = activityTypeNames
+      .map(type => ({
+        display: type,
+        value: type,
+      }))
+      .sort((a, b) => a.display.localeCompare(b.display));
+  }
+
+  $: {
+    const presetNames = [
+      ...new Set<string>(
+        $activityPresets
+          .filter(preset => selectedModel === undefined || preset.model_id === selectedModel.id)
+          .map(preset => preset.name),
+      ),
+    ];
+    presetOptions = [{ display: '', value: '' }];
+    presetOptions.push(...presetNames.map(name => ({ display: name, value: name })));
+  }
 
   async function onSearch() {
     hasSearched.set(true);
@@ -31,10 +87,49 @@
         filterArgs.push([filterArgName, filterArgValue]);
       }
     }
-    const results = await effects.searchActivities(filterActType, filterActName, filterArgs, filterTagValue, user);
+    const results = await effects.searchActivities(
+      selectedModel?.id,
+      filterActType,
+      filterActName,
+      filterArgs,
+      filterTagValue,
+      filterPreset,
+      user,
+    );
     if (results) {
       searchResults.set(results);
     }
+  }
+
+  function clearFilters() {
+    selectedModel = undefined;
+    filterActType = '';
+    filterActName = '';
+    filterArgName = '';
+    filterArgValue = '';
+    filterTagValue = '';
+    filterPreset = '';
+    hasSearched.set(false);
+    searchResults.set([]);
+  }
+
+  function onTypeChange(event: CustomEvent) {
+    filterActType = event.detail.length ? (event.detail[0]?.toString() ?? '') : '';
+  }
+
+  function onTagChange(event: CustomEvent) {
+    filterTagValue = event.detail.length ? (event.detail[0]?.toString() ?? '') : '';
+  }
+
+  function getDisplayNameForModel(model?: ModelSlim) {
+    if (!model) {
+      return '';
+    }
+    return `${model.name} (Version: ${model.version})`;
+  }
+
+  function onPresetChange(event: CustomEvent) {
+    filterPreset = event.detail.length ? (event.detail[0]?.toString() ?? '') : '';
   }
 </script>
 
@@ -46,16 +141,44 @@
   <svelte:fragment slot="body">
     <form on:submit|preventDefault={onSearch} class="flex flex-col">
       <fieldset>
-        <Label for="activity-type-input">Activity Type</Label>
-        <InputStellar
-          bind:value={filterActType}
-          id="activity-type-input"
-          placeholder="Activity Type"
-          autocomplete="off"
-          class="w-[300px]"
-          sizeVariant="xs"
-          aria-label="Activity Type"
-        />
+        <Label>Mission Model</Label>
+        <div>
+          <Select.Root
+            selected={{ label: getDisplayNameForModel(selectedModel), value: selectedModel?.id ?? '' }}
+            onSelectedChange={v => (selectedModel = $models.find(model => model.id === v?.value))}
+            loop={false}
+          >
+            <Select.Trigger
+              value={selectedModel?.id}
+              size="xs"
+              aria-label="Select Model"
+              aria-labelledby={null}
+              id="model"
+            >
+              <Select.Value placeholder="Select a model" />
+            </Select.Trigger>
+            <Select.Content
+              class="min-w-[240px] overflow-auto p-0"
+              sameWidth={false}
+              align="start"
+              datatype="number"
+              fitViewport
+            >
+              <Select.Item size="xs" value={undefined} label="All Models" class="flex gap-1">All Models</Select.Item>
+              {#each orderedModels as model (model.id)}
+                <Select.Item size="xs" value={model.id} label={getDisplayNameForModel(model)} class="flex gap-1">
+                  {model.name}
+                  <div class="whitespace-nowrap text-muted-foreground">(Version: {model.version})</div>
+                </Select.Item>
+              {/each}
+            </Select.Content>
+            <Select.Input type="number" name="model" aria-label="Select Model hidden input" />
+          </Select.Root>
+        </div>
+      </fieldset>
+      <fieldset>
+        <Label>Activity Type</Label>
+        <SearchableDropdown options={typeOptions} on:change={onTypeChange} selectedOptionValues={[filterActType]} />
       </fieldset>
       <fieldset>
         <Label for="activity-name-input">Activity Name</Label>
@@ -93,17 +216,15 @@
       </fieldset>
       <fieldset>
         <Label for="tag-value-input">Tag Value</Label>
-        <InputStellar
-          bind:value={filterTagValue}
-          id="tag-value-input"
-          placeholder="Tag Value"
-          autocomplete="off"
-          class="w-[300px]"
-          sizeVariant="xs"
-          aria-label="Tag Value"
-        />
+        <SearchableDropdown options={tagOptions} on:change={onTagChange} selectedOptionValues={[filterTagValue]} />
+      </fieldset>
+      <fieldset>
+        <Label for="preset-name-input">Preset</Label>
+        <SearchableDropdown options={presetOptions} on:change={onPresetChange} selectedOptionValues={[filterPreset]} />
       </fieldset>
       <fieldset class="my-4">
+        <Button type="button" class="w-full" on:click={clearFilters}>Clear Filters</Button>
+        <div />
         <Button
           type="submit"
           class="w-full"
@@ -111,7 +232,8 @@
             filterActName === '' &&
             filterArgName === '' &&
             filterArgValue === '' &&
-            filterTagValue === ''}>Search</Button
+            filterTagValue === '' &&
+            filterPreset === ''}>Search</Button
         >
       </fieldset>
     </form>

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -14,6 +14,7 @@
     searchCurrentPage,
     searchOrderBy,
     searchResults,
+    searchRunId,
     searchTotalCount,
   } from '../../stores/search';
   import { gqlSubscribable } from '../../stores/subscribable';
@@ -263,6 +264,7 @@
       updateUrl();
     } finally {
       isSearching.set(false);
+      searchRunId.update(n => n + 1);
     }
   }
 
@@ -290,7 +292,7 @@
   </svelte:fragment>
 
   <svelte:fragment slot="body">
-    <form on:submit|preventDefault={() => onSearch()} class="flex h-full flex-col">
+    <form on:submit|preventDefault={() => onSearch()} class="flex h-full flex-col" data-search-form-ready={initialized}>
       {#if subscriptionError}
         <div class="border-b border-destructive/30 bg-destructive/10 px-4 py-2 text-xs text-destructive">
           Failed to load filter data: {subscriptionError}

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -1,0 +1,119 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { Button, Input as InputStellar, Label } from '@nasa-jpl/stellar-svelte';
+  import { hasSearched, searchResults } from '../../stores/search';
+  import type { User } from '../../types/app';
+  import effects from '../../utilities/effects';
+  import Panel from '../ui/Panel.svelte';
+  import SectionTitle from '../ui/SectionTitle.svelte';
+
+  export let user: User | null;
+
+  let filterActType: string = '';
+  let filterActName: string = '';
+  let filterArgName: string = '';
+  let filterArgValue: string = '';
+  let filterTagValue: string = '';
+
+  async function onSearch() {
+    hasSearched.set(true);
+
+    const filterArgs: [name: string, value: string | number | boolean][] = [];
+    if (filterArgName || filterArgValue) {
+      if (filterArgValue.toLowerCase() === 'true') {
+        filterArgs.push([filterArgName, true]);
+      } else if (filterArgValue.toLowerCase() === 'false') {
+        filterArgs.push([filterArgName, false]);
+      } else if (!isNaN(Number(filterArgValue))) {
+        filterArgs.push([filterArgName, Number(filterArgValue)]);
+      } else {
+        filterArgs.push([filterArgName, filterArgValue]);
+      }
+    }
+    const results = await effects.searchActivities(filterActType, filterActName, filterArgs, filterTagValue, user);
+    if (results) {
+      searchResults.set(results);
+    }
+  }
+</script>
+
+<Panel overflowYBody="hidden">
+  <svelte:fragment slot="header">
+    <SectionTitle>Search for activities across plans</SectionTitle>
+  </svelte:fragment>
+
+  <svelte:fragment slot="body">
+    <form on:submit|preventDefault={onSearch} class="flex flex-col">
+      <fieldset>
+        <Label for="activity-type-input">Activity Type</Label>
+        <InputStellar
+          bind:value={filterActType}
+          id="activity-type-input"
+          placeholder="Activity Type"
+          autocomplete="off"
+          class="w-[300px]"
+          sizeVariant="xs"
+          aria-label="Activity Type"
+        />
+      </fieldset>
+      <fieldset>
+        <Label for="activity-name-input">Activity Name</Label>
+        <InputStellar
+          bind:value={filterActName}
+          id="activity-name-input"
+          placeholder="Activity Name"
+          autocomplete="off"
+          class="w-[300px]"
+          sizeVariant="xs"
+          aria-label="Activity Name"
+        />
+      </fieldset>
+      <fieldset>
+        <Label for="argument-name-input">Argument Name</Label>
+        <InputStellar
+          bind:value={filterArgName}
+          id="argument-name-input"
+          placeholder="Argument Name"
+          autocomplete="off"
+          class="w-[300px]"
+          sizeVariant="xs"
+          aria-label="Argument Name"
+        />
+        <Label for="argument-value-input">Argument Value</Label>
+        <InputStellar
+          bind:value={filterArgValue}
+          id="argument-value-input"
+          placeholder="Argument Value"
+          autocomplete="off"
+          class="w-[300px]"
+          sizeVariant="xs"
+          aria-label="Argument Value"
+        />
+      </fieldset>
+      <fieldset>
+        <Label for="tag-value-input">Tag Value</Label>
+        <InputStellar
+          bind:value={filterTagValue}
+          id="tag-value-input"
+          placeholder="Tag Value"
+          autocomplete="off"
+          class="w-[300px]"
+          sizeVariant="xs"
+          aria-label="Tag Value"
+        />
+      </fieldset>
+      <fieldset class="my-4">
+        <Button
+          type="submit"
+          class="w-full"
+          disabled={filterActType === '' &&
+            filterActName === '' &&
+            filterArgName === '' &&
+            filterArgValue === '' &&
+            filterTagValue === ''}>Search</Button
+        >
+      </fieldset>
+    </form>
+  </svelte:fragment>
+</Panel>

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -4,10 +4,12 @@
   import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
   import { page } from '$app/stores';
-  import { Button, Input as InputStellar, Label, Select } from '@nasa-jpl/stellar-svelte';
+  import { Button, Input as InputStellar, Label } from '@nasa-jpl/stellar-svelte';
+  import { ChevronDown, CircleQuestionMark } from 'lucide-svelte';
   import { models } from '../../stores/model';
   import {
     hasSearched,
+    isSearching,
     PAGE_SIZE,
     searchCurrentPage,
     searchOrderBy,
@@ -15,7 +17,7 @@
     searchTotalCount,
   } from '../../stores/search';
   import { gqlSubscribable } from '../../stores/subscribable';
-  import { tags } from '../../stores/tags';
+  import { tagsStore } from '../../stores/tags';
   import { users } from '../../stores/user';
   import type { ActivityPreset } from '../../types/activity';
   import type { User } from '../../types/app';
@@ -27,14 +29,9 @@
   import Panel from '../ui/Panel.svelte';
   import SearchableDropdown from '../ui/SearchableDropdown.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
+  import Tooltip from '../ui/Tooltip.svelte';
 
   export let user: User | null;
-
-  let activityPresets: GqlSubscribable<ActivityPreset[]> = gqlSubscribable<ActivityPreset[]>(
-    gql.SUB_ACTIVITY_PRESETS_ALL,
-    {},
-    [],
-  );
 
   // Consolidated filter state
   const DEFAULT_FILTERS = {
@@ -49,8 +46,12 @@
     planOwner: '',
     preset: '',
     schedulerCreatedOnly: false,
+    startOffsetMax: '',
+    startOffsetMin: '',
     tagValue: '',
   };
+
+  type FilterKey = keyof typeof DEFAULT_FILTERS;
 
   // Map filter keys to URL param names where they differ
   const URL_PARAM_OVERRIDES: Partial<Record<keyof typeof DEFAULT_FILTERS, string>> = {
@@ -58,28 +59,41 @@
     tagValue: 'tag',
   };
 
-  type FilterKey = keyof typeof DEFAULT_FILTERS;
+  const activityPresets: GqlSubscribable<ActivityPreset[]> = gqlSubscribable<ActivityPreset[]>(
+    gql.SUB_ACTIVITY_PRESETS_ALL,
+    {},
+    [],
+  );
+  const modelsLoading = models.loading;
+  const modelsError = models.error;
+  const tagsLoading = tagsStore.loading;
+  const tagsError = tagsStore.error;
+  const usersLoading = users.loading;
+  const usersError = users.error;
+  const presetsLoading = activityPresets.loading;
+  const presetsError = activityPresets.error;
 
-  function getParamName(key: FilterKey): string {
-    return URL_PARAM_OVERRIDES[key] ?? key;
-  }
-
-  let selectedModel: ModelSlim | undefined;
+  let argNameOptions: DropdownOptions = [];
+  let selectedModelId: number | undefined;
   let filters = { ...DEFAULT_FILTERS };
   let initialized = false;
-  let pendingModelId: number | null = null;
-  let pendingSearch = false;
-
   let orderedModels: ModelSlim[] = [];
+  let modelOptions: DropdownOptions = [];
   let tagOptions: DropdownOptions = [];
   let typeOptions: DropdownOptions = [];
   let presetOptions: DropdownOptions = [];
   let userOptions: DropdownOptions = [];
-  let argNameOptions: DropdownOptions = [];
+
+  $: selectedModel = selectedModelId !== undefined ? $models.find(m => m.id === selectedModelId) : undefined;
 
   $: orderedModels = [...$models].sort(({ id: idA }, { id: idB }) => idB - idA);
 
-  $: tagOptions = [{ display: '', value: '' }, ...$tags.map(tag => ({ display: tag.name, value: tag.name }))];
+  $: modelOptions = [
+    { display: '', value: '' },
+    ...orderedModels.map(m => ({ display: getDisplayNameForModel(m), value: m.id })),
+  ];
+
+  $: tagOptions = [{ display: '', value: '' }, ...$tagsStore.map(tag => ({ display: tag.name, value: tag.name }))];
 
   $: userOptions = [
     { display: '', value: '' },
@@ -130,30 +144,22 @@
     ];
   }
 
-  $: hasAnyFilter =
-    selectedModel !== undefined ||
-    Object.entries(filters).some(([k, v]) => (k === 'schedulerCreatedOnly' ? v === true : v !== ''));
-
   // Initialize from URL on first page load (browser only — SSR can't navigate)
   $: if (browser && $page.url) {
     initFromUrl();
   }
 
-  // Resolve pending model ID once models subscription delivers data
-  $: if (pendingModelId !== null && $models.length > 0) {
-    selectedModel = $models.find(m => m.id === pendingModelId);
-    pendingModelId = null;
-    if (pendingSearch) {
-      pendingSearch = false;
-      onSearch();
-    }
-  }
+  $: subscriptionError = $modelsError || $tagsError || $usersError || $presetsError || '';
 
   // Keep URL in sync with current filter form state after init
   $: if (browser && initialized) {
     void filters;
-    void selectedModel;
+    void selectedModelId;
     updateUrl();
+  }
+
+  function getParamName(key: FilterKey): string {
+    return URL_PARAM_OVERRIDES[key] ?? key;
   }
 
   function initFromUrl() {
@@ -166,13 +172,7 @@
 
     const modelIdParam = params.get('modelId');
     if (modelIdParam) {
-      const id = parseInt(modelIdParam);
-      const found = $models.find(m => m.id === id);
-      if (found) {
-        selectedModel = found;
-      } else {
-        pendingModelId = id;
-      }
+      selectedModelId = parseInt(modelIdParam);
     }
 
     const updates: Partial<typeof DEFAULT_FILTERS> = {};
@@ -186,18 +186,15 @@
       filters = { ...filters, ...updates };
     }
 
-    if (hasAnyFilter) {
+    if (selectedModelId !== undefined || Object.keys(updates).length > 0) {
       onSearch();
-    } else if (pendingModelId !== null) {
-      // Model is the only filter; defer search until it resolves
-      pendingSearch = true;
     }
   }
 
   function updateUrl() {
     const params = new URLSearchParams();
-    if (selectedModel) {
-      params.set('modelId', selectedModel.id.toString());
+    if (selectedModelId !== undefined) {
+      params.set('modelId', selectedModelId.toString());
     }
     for (const key of Object.keys(filters) as FilterKey[]) {
       const val = filters[key];
@@ -216,6 +213,7 @@
   export async function onSearch(pageNumber: number = 0) {
     hasSearched.set(true);
     searchCurrentPage.set(pageNumber);
+    isSearching.set(true);
 
     const filterArgs: [name: string, value: string | number | boolean][] = [];
     if (filters.argName || filters.argValue) {
@@ -231,39 +229,45 @@
       }
     }
 
-    const result = await effects.searchActivities(
-      {
-        actName: filters.actName,
-        actType: filters.actType,
-        args: filterArgs,
-        createdBy: filters.createdBy,
-        lastModifiedAfter: filters.lastModifiedAfter,
-        lastModifiedBefore: filters.lastModifiedBefore,
-        modelId: selectedModel?.id,
-        planName: filters.planName,
-        planOwner: filters.planOwner,
-        preset: filters.preset,
-        schedulerCreatedOnly: filters.schedulerCreatedOnly,
-        tagValue: filters.tagValue,
-      },
-      {
-        limit: PAGE_SIZE,
-        offset: pageNumber * PAGE_SIZE,
-        orderBy: $searchOrderBy,
-      },
-      user,
-    );
+    try {
+      const result = await effects.searchActivities(
+        {
+          actName: filters.actName,
+          actType: filters.actType,
+          args: filterArgs,
+          createdBy: filters.createdBy,
+          lastModifiedAfter: filters.lastModifiedAfter,
+          lastModifiedBefore: filters.lastModifiedBefore,
+          modelId: selectedModelId,
+          planName: filters.planName,
+          planOwner: filters.planOwner,
+          preset: filters.preset,
+          schedulerCreatedOnly: filters.schedulerCreatedOnly,
+          startOffsetMax: filters.startOffsetMax,
+          startOffsetMin: filters.startOffsetMin,
+          tagValue: filters.tagValue,
+        },
+        {
+          limit: PAGE_SIZE,
+          offset: pageNumber * PAGE_SIZE,
+          orderBy: $searchOrderBy,
+        },
+        user,
+      );
 
-    if (result) {
-      searchResults.set(result.results);
-      searchTotalCount.set(result.totalCount);
+      if (result) {
+        searchResults.set(result.results);
+        searchTotalCount.set(result.totalCount);
+      }
+
+      updateUrl();
+    } finally {
+      isSearching.set(false);
     }
-
-    updateUrl();
   }
 
   function clearFilters() {
-    selectedModel = undefined;
+    selectedModelId = undefined;
     filters = { ...DEFAULT_FILTERS };
     hasSearched.set(false);
     searchResults.set([]);
@@ -280,173 +284,205 @@
   }
 </script>
 
-<Panel overflowYBody="auto">
+<Panel overflowYBody="hidden" padBody={false}>
   <svelte:fragment slot="header">
     <SectionTitle>Search for Activities Across Plans</SectionTitle>
   </svelte:fragment>
 
   <svelte:fragment slot="body">
-    <form on:submit|preventDefault={() => onSearch()} class="flex flex-col gap-3 p-2">
-      <div class="flex flex-col gap-1">
-        <Label size="sm">Mission Model</Label>
-        <Select.Root
-          selected={{
-            label: selectedModel ? getDisplayNameForModel(selectedModel) : 'All Models',
-            value: selectedModel?.id,
-          }}
-          onSelectedChange={v => (selectedModel = $models.find(model => model.id === v?.value))}
-          loop={false}
-        >
-          <Select.Trigger
-            value={selectedModel?.id}
-            size="xs"
-            aria-label="Select Model"
-            aria-labelledby={null}
-            id="model"
+    <form on:submit|preventDefault={() => onSearch()} class="flex h-full flex-col">
+      {#if subscriptionError}
+        <div class="border-b border-destructive/30 bg-destructive/10 px-4 py-2 text-xs text-destructive">
+          Failed to load filter data: {subscriptionError}
+        </div>
+      {/if}
+      <div class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-4 py-2">
+        <div class="flex flex-col gap-1">
+          <Label size="sm">Mission Model</Label>
+          <SearchableDropdown
+            options={modelOptions}
+            loading={$modelsLoading}
+            on:change={e => {
+              const v = e.detail[0];
+              selectedModelId = v === '' || v === undefined ? undefined : Number(v);
+            }}
+            selectedOptionValues={[selectedModelId ?? '']}
           >
-            <Select.Value placeholder="Select a model" />
-          </Select.Trigger>
-          <Select.Content
-            class="min-w-[240px] overflow-auto p-0"
-            sameWidth={false}
-            align="start"
-            datatype="number"
-            fitViewport
+            <ChevronDown slot="icon" />
+          </SearchableDropdown>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <Label size="sm">Activity Type</Label>
+          <SearchableDropdown
+            options={typeOptions}
+            loading={$modelsLoading}
+            on:change={e => (filters = { ...filters, actType: e.detail[0]?.toString() ?? '' })}
+            selectedOptionValues={[filters.actType]}
           >
-            <Select.Item size="xs" value={undefined} label="All Models" class="flex gap-1">All Models</Select.Item>
-            {#each orderedModels as model (model.id)}
-              <Select.Item size="xs" value={model.id} label={getDisplayNameForModel(model)} class="flex gap-1">
-                {model.name}
-                <div class="whitespace-nowrap text-muted-foreground">(Version: {model.version})</div>
-              </Select.Item>
-            {/each}
-          </Select.Content>
-          <Select.Input type="number" name="model" aria-label="Select Model hidden input" />
-        </Select.Root>
-      </div>
+            <ChevronDown slot="icon" />
+          </SearchableDropdown>
+        </div>
 
-      <div class="flex flex-col gap-1">
-        <Label size="sm">Activity Type</Label>
-        <SearchableDropdown
-          options={typeOptions}
-          on:change={e => (filters = { ...filters, actType: e.detail[0]?.toString() ?? '' })}
-          selectedOptionValues={[filters.actType]}
-        />
-      </div>
-
-      <div class="flex flex-col gap-1">
-        <Label size="sm" for="activity-name-input">Activity Name</Label>
-        <InputStellar
-          bind:value={filters.actName}
-          id="activity-name-input"
-          autocomplete="off"
-          class="w-full"
-          sizeVariant="xs"
-        />
-      </div>
-
-      <div class="flex flex-col gap-1">
-        <Label size="sm">Argument Name</Label>
-        <SearchableDropdown
-          options={argNameOptions}
-          on:change={e => (filters = { ...filters, argName: e.detail[0]?.toString() ?? '' })}
-          selectedOptionValues={[filters.argName]}
-        />
-      </div>
-      <div class="flex flex-col gap-1">
-        <Label size="sm" for="argument-value-input">Argument Value</Label>
-        <InputStellar
-          bind:value={filters.argValue}
-          id="argument-value-input"
-          autocomplete="off"
-          class="w-full"
-          sizeVariant="xs"
-        />
-      </div>
-
-      <div class="flex flex-col gap-1">
-        <Label size="sm">Tag</Label>
-        <SearchableDropdown
-          options={tagOptions}
-          on:change={e => (filters = { ...filters, tagValue: e.detail[0]?.toString() ?? '' })}
-          selectedOptionValues={[filters.tagValue]}
-        />
-      </div>
-
-      <div class="flex flex-col gap-1">
-        <Label size="sm">Preset</Label>
-        <SearchableDropdown
-          options={presetOptions}
-          on:change={e => (filters = { ...filters, preset: e.detail[0]?.toString() ?? '' })}
-          selectedOptionValues={[filters.preset]}
-        />
-      </div>
-
-      <div class="flex flex-col gap-1">
-        <Label size="sm">Created By</Label>
-        <SearchableDropdown
-          options={userOptions}
-          on:change={e => (filters = { ...filters, createdBy: e.detail[0]?.toString() ?? '' })}
-          selectedOptionValues={[filters.createdBy]}
-        />
-      </div>
-
-      <div class="flex flex-col gap-1">
-        <Label size="sm" for="modified-after-input">Last Modified After</Label>
-        <InputStellar
-          bind:value={filters.lastModifiedAfter}
-          id="modified-after-input"
-          class="w-full"
-          sizeVariant="xs"
-          type="datetime-local"
-        />
-      </div>
-      <div class="flex flex-col gap-1">
-        <Label size="sm" for="modified-before-input">Last Modified Before</Label>
-        <InputStellar
-          bind:value={filters.lastModifiedBefore}
-          id="modified-before-input"
-          class="w-full"
-          sizeVariant="xs"
-          type="datetime-local"
-        />
-      </div>
-
-      <div class="flex flex-col gap-1">
-        <Label size="sm" for="plan-name-input">Plan Name</Label>
-        <InputStellar
-          bind:value={filters.planName}
-          id="plan-name-input"
-          autocomplete="off"
-          class="w-full"
-          sizeVariant="xs"
-        />
-      </div>
-
-      <div class="flex flex-col gap-1">
-        <Label size="sm">Plan Owner</Label>
-        <SearchableDropdown
-          options={userOptions}
-          on:change={e => (filters = { ...filters, planOwner: e.detail[0]?.toString() ?? '' })}
-          selectedOptionValues={[filters.planOwner]}
-        />
-      </div>
-
-      <div class="flex items-center gap-2">
-        <label class="flex cursor-pointer items-center gap-2" for="scheduler-only">
-          <input
-            type="checkbox"
-            bind:checked={filters.schedulerCreatedOnly}
-            name="scheduler-only"
-            id="scheduler-only"
+        <div class="flex flex-col gap-1">
+          <Label size="sm" for="activity-name-input">Activity Name</Label>
+          <InputStellar
+            bind:value={filters.actName}
+            id="activity-name-input"
+            autocomplete="off"
+            class="w-full"
+            sizeVariant="xs"
           />
-          <span class="text-xs">Scheduler-created only</span>
-        </label>
-      </div>
+        </div>
 
-      <div class="mt-4 flex flex-col gap-2">
-        <Button type="button" class="w-full" variant="outline" on:click={clearFilters}>Clear Filters</Button>
+        <div class="flex flex-col gap-1">
+          <Label size="sm">Argument Name</Label>
+          <SearchableDropdown
+            options={argNameOptions}
+            loading={$modelsLoading}
+            on:change={e => (filters = { ...filters, argName: e.detail[0]?.toString() ?? '' })}
+            selectedOptionValues={[filters.argName]}
+          >
+            <ChevronDown slot="icon" />
+          </SearchableDropdown>
+        </div>
+        <div class="flex flex-col gap-1">
+          <Label size="sm" for="argument-value-input"
+            >Argument Value
+            <Tooltip
+              content="Defaults defined by the mission model are not applied to search filters, so you may need to specify argument values explicitly even if they were not provided when the activity was created. "
+              class="max-h-none max-w-28 whitespace-normal"
+            >
+              <span class="ml-1 cursor-help text-muted-foreground"> <CircleQuestionMark size={14} /></span>
+            </Tooltip>
+          </Label>
+          <InputStellar
+            bind:value={filters.argValue}
+            id="argument-value-input"
+            autocomplete="off"
+            class="w-full"
+            sizeVariant="xs"
+          />
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <Label size="sm">Tag</Label>
+          <SearchableDropdown
+            options={tagOptions}
+            loading={$tagsLoading}
+            on:change={e => (filters = { ...filters, tagValue: e.detail[0]?.toString() ?? '' })}
+            selectedOptionValues={[filters.tagValue]}
+          >
+            <ChevronDown slot="icon" />
+          </SearchableDropdown>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <Label size="sm">Preset</Label>
+          <SearchableDropdown
+            options={presetOptions}
+            loading={$presetsLoading}
+            on:change={e => (filters = { ...filters, preset: e.detail[0]?.toString() ?? '' })}
+            selectedOptionValues={[filters.preset]}
+          >
+            <ChevronDown slot="icon" />
+          </SearchableDropdown>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <Label size="sm">Created By</Label>
+          <SearchableDropdown
+            options={userOptions}
+            loading={$usersLoading}
+            on:change={e => (filters = { ...filters, createdBy: e.detail[0]?.toString() ?? '' })}
+            selectedOptionValues={[filters.createdBy]}
+          >
+            <ChevronDown slot="icon" />
+          </SearchableDropdown>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <Label size="sm" for="modified-after-input">Last Modified After</Label>
+          <InputStellar
+            bind:value={filters.lastModifiedAfter}
+            id="modified-after-input"
+            class="w-full"
+            sizeVariant="xs"
+            type="datetime-local"
+          />
+        </div>
+        <div class="flex flex-col gap-1">
+          <Label size="sm" for="modified-before-input">Last Modified Before</Label>
+          <InputStellar
+            bind:value={filters.lastModifiedBefore}
+            id="modified-before-input"
+            class="w-full"
+            sizeVariant="xs"
+            type="datetime-local"
+          />
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <Label size="sm" for="start-offset-min-input">Start Offset (min)</Label>
+          <InputStellar
+            bind:value={filters.startOffsetMin}
+            id="start-offset-min-input"
+            placeholder="e.g., 1 day, 02:30:00"
+            autocomplete="off"
+            class="w-full"
+            sizeVariant="xs"
+          />
+        </div>
+        <div class="flex flex-col gap-1">
+          <Label size="sm" for="start-offset-max-input">Start Offset (max)</Label>
+          <InputStellar
+            bind:value={filters.startOffsetMax}
+            id="start-offset-max-input"
+            placeholder="e.g., 7 days, 24:00:00"
+            autocomplete="off"
+            class="w-full"
+            sizeVariant="xs"
+          />
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <Label size="sm" for="plan-name-input">Plan Name</Label>
+          <InputStellar
+            bind:value={filters.planName}
+            id="plan-name-input"
+            autocomplete="off"
+            class="w-full"
+            sizeVariant="xs"
+          />
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <Label size="sm">Plan Owner</Label>
+          <SearchableDropdown
+            options={userOptions}
+            loading={$usersLoading}
+            on:change={e => (filters = { ...filters, planOwner: e.detail[0]?.toString() ?? '' })}
+            selectedOptionValues={[filters.planOwner]}
+          >
+            <ChevronDown slot="icon" />
+          </SearchableDropdown>
+        </div>
+
+        <div class="flex items-center gap-2">
+          <label class="flex cursor-pointer items-center gap-2" for="scheduler-only">
+            <input
+              type="checkbox"
+              bind:checked={filters.schedulerCreatedOnly}
+              name="scheduler-only"
+              id="scheduler-only"
+            />
+            <span class="text-xs">Scheduler-created only</span>
+          </label>
+        </div>
+      </div>
+      <div class="flex flex-col gap-2 border-t border-border p-3">
         <Button type="submit" class="w-full">Search</Button>
+        <Button type="button" class="w-full" variant="outline" on:click={clearFilters}>Clear Filters</Button>
       </div>
     </form>
   </svelte:fragment>

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -87,6 +87,8 @@
   let filters = { ...DEFAULT_FILTERS };
   let goalOptions: DropdownOptions = [];
   let initialized = false;
+  let searchAbortController: AbortController | null = null;
+  let latestSearchRequestId = 0;
   let orderedModels: ModelSlim[] = [];
   let modelOptions: DropdownOptions = [];
   let tagOptions: DropdownOptions = [];
@@ -255,6 +257,10 @@
     searchCurrentPage.set(pageNumber);
     isSearching.set(true);
 
+    searchAbortController?.abort();
+    searchAbortController = new AbortController();
+    const requestId = ++latestSearchRequestId;
+
     const filterArgs: [name: string, value: string | number | boolean][] = [];
     if (filters.argName || filters.argValue) {
       const v = filters.argValue;
@@ -298,7 +304,13 @@
           orderBy: $searchOrderBy,
         },
         user,
+        searchAbortController.signal,
       );
+
+      // Return early if this response is stale
+      if (requestId !== latestSearchRequestId) {
+        return;
+      }
 
       if (result) {
         searchResults.set(result.results);
@@ -307,8 +319,10 @@
 
       await updateUrl();
     } finally {
-      isSearching.set(false);
-      searchRunId.update(n => n + 1);
+      if (requestId === latestSearchRequestId) {
+        isSearching.set(false);
+        searchRunId.update(n => n + 1);
+      }
     }
   }
 

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -7,6 +7,7 @@
   import { Button, Input as InputStellar, Label } from '@nasa-jpl/stellar-svelte';
   import { ChevronDown, CircleQuestionMark } from 'lucide-svelte';
   import { models } from '../../stores/model';
+  import { schedulingGoalResponses } from '../../stores/scheduling';
   import {
     hasSearched,
     isSearching,
@@ -22,7 +23,7 @@
   import { users } from '../../stores/user';
   import type { ActivityPreset } from '../../types/activity';
   import type { User } from '../../types/app';
-  import type { DropdownOptions } from '../../types/dropdown';
+  import type { DropdownOptions, SelectedDropdownOptionValue } from '../../types/dropdown';
   import type { ModelSlim } from '../../types/model';
   import type { GqlSubscribable } from '../../types/subscribable';
   import effects from '../../utilities/effects';
@@ -37,16 +38,21 @@
   // Consolidated filter state
   const DEFAULT_FILTERS = {
     actName: '',
-    actType: '',
+    actType: [] as string[],
     argName: '',
     argValue: '',
+    createdAfter: '',
+    createdBefore: '',
     createdBy: '',
     lastModifiedAfter: '',
     lastModifiedBefore: '',
+    lastModifiedBy: '',
     planName: '',
     planOwner: '',
+    planTag: '',
     preset: '',
     schedulerCreatedOnly: false,
+    schedulingGoalId: '',
     startOffsetMax: '',
     startOffsetMin: '',
     tagValue: '',
@@ -73,10 +79,13 @@
   const usersError = users.error;
   const presetsLoading = activityPresets.loading;
   const presetsError = activityPresets.error;
+  const goalsLoading = schedulingGoalResponses.loading;
+  const goalsError = schedulingGoalResponses.error;
 
   let argNameOptions: DropdownOptions = [];
   let selectedModelId: number | undefined;
   let filters = { ...DEFAULT_FILTERS };
+  let goalOptions: DropdownOptions = [];
   let initialized = false;
   let orderedModels: ModelSlim[] = [];
   let modelOptions: DropdownOptions = [];
@@ -131,7 +140,7 @@
     const paramNames = new Set<string>();
     for (const model of sourceModels) {
       for (const type of model?.activity_types ?? []) {
-        if (filters.actType && type.name !== filters.actType) {
+        if (filters.actType.length > 0 && !filters.actType.includes(type.name)) {
           continue;
         }
         for (const paramName of Object.keys(type.parameters ?? {})) {
@@ -145,12 +154,20 @@
     ];
   }
 
+  $: goalOptions = [
+    { display: '', value: '' },
+    ...[...$schedulingGoalResponses]
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map(goal => ({ display: `${goal.name} (${goal.id})`, value: goal.id.toString() })),
+  ];
+
   // Initialize from URL on first page load (browser only — SSR can't navigate)
   $: if (browser && $page.url) {
     initFromUrl();
   }
 
-  $: subscriptionError = $modelsError || $tagsError || $usersError || $presetsError || '';
+  $: subscriptionError =
+    $modelsError || $tagsError || $usersError || $presetsError || $goalsError || '';
 
   // Keep URL in sync with current filter form state after init
   $: if (browser && initialized) {
@@ -161,6 +178,16 @@
 
   function getParamName(key: FilterKey): string {
     return URL_PARAM_OVERRIDES[key] ?? key;
+  }
+
+  function onActTypeChange(values: SelectedDropdownOptionValue[]) {
+    filters = {
+      ...filters,
+      actType: values
+        .filter((v): v is string | number => v !== null)
+        .map(v => String(v))
+        .filter(s => s.length > 0),
+    };
   }
 
   function initFromUrl() {
@@ -180,7 +207,16 @@
     for (const key of Object.keys(DEFAULT_FILTERS) as FilterKey[]) {
       const val = params.get(getParamName(key));
       if (val !== null) {
-        updates[key] = (typeof DEFAULT_FILTERS[key] === 'boolean' ? val === 'true' : val) as never;
+        const defaultVal = DEFAULT_FILTERS[key];
+        let parsed: unknown;
+        if (typeof defaultVal === 'boolean') {
+          parsed = val === 'true';
+        } else if (Array.isArray(defaultVal)) {
+          parsed = val.split(',').filter(s => s.length > 0);
+        } else {
+          parsed = val;
+        }
+        updates[key] = parsed as never;
       }
     }
     if (Object.keys(updates).length) {
@@ -199,7 +235,11 @@
     }
     for (const key of Object.keys(filters) as FilterKey[]) {
       const val = filters[key];
-      if (val !== '' && val !== false) {
+      if (Array.isArray(val)) {
+        if (val.length > 0) {
+          params.set(getParamName(key), val.join(','));
+        }
+      } else if (val !== '' && val !== false) {
         params.set(getParamName(key), val.toString());
       }
     }
@@ -236,14 +276,19 @@
           actName: filters.actName,
           actType: filters.actType,
           args: filterArgs,
+          createdAfter: filters.createdAfter,
+          createdBefore: filters.createdBefore,
           createdBy: filters.createdBy,
           lastModifiedAfter: filters.lastModifiedAfter,
           lastModifiedBefore: filters.lastModifiedBefore,
+          lastModifiedBy: filters.lastModifiedBy,
           modelId: selectedModelId,
           planName: filters.planName,
           planOwner: filters.planOwner,
+          planTag: filters.planTag,
           preset: filters.preset,
           schedulerCreatedOnly: filters.schedulerCreatedOnly,
+          schedulingGoalId: filters.schedulingGoalId,
           startOffsetMax: filters.startOffsetMax,
           startOffsetMin: filters.startOffsetMin,
           tagValue: filters.tagValue,
@@ -317,10 +362,11 @@
         <div class="flex flex-col gap-1">
           <Label size="sm">Activity Type</Label>
           <SearchableDropdown
+            allowMultiple={true}
             options={typeOptions}
             loading={$modelsLoading}
-            on:change={e => (filters = { ...filters, actType: e.detail[0]?.toString() ?? '' })}
-            selectedOptionValues={[filters.actType]}
+            on:change={e => onActTypeChange(e.detail)}
+            selectedOptionValues={filters.actType}
           >
             <ChevronDown slot="icon" />
           </SearchableDropdown>
@@ -352,7 +398,7 @@
           <Label size="sm" for="argument-value-input" class="flex items-center gap-1">
             Argument Value
             <Tooltip
-              content="Defaults defined by the mission model are not applied to search filters, so you may need to specify argument values explicitly even if they were not provided when the activity was created."
+              content="Default argument values defined by the mission model are not persisted to activities and cannot be searched."
               class="max-h-none max-w-md whitespace-normal [&>span]:whitespace-normal"
             >
               <span class="ml-1 cursor-help text-muted-foreground"> <CircleQuestionMark size={14} /></span>
@@ -401,6 +447,39 @@
           >
             <ChevronDown slot="icon" />
           </SearchableDropdown>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <Label size="sm">Last Modified By</Label>
+          <SearchableDropdown
+            options={userOptions}
+            loading={$usersLoading}
+            on:change={e => (filters = { ...filters, lastModifiedBy: e.detail[0]?.toString() ?? '' })}
+            selectedOptionValues={[filters.lastModifiedBy]}
+          >
+            <ChevronDown slot="icon" />
+          </SearchableDropdown>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <Label size="sm" for="created-after-input">Created After</Label>
+          <InputStellar
+            bind:value={filters.createdAfter}
+            id="created-after-input"
+            class="w-full"
+            sizeVariant="xs"
+            type="datetime-local"
+          />
+        </div>
+        <div class="flex flex-col gap-1">
+          <Label size="sm" for="created-before-input">Created Before</Label>
+          <InputStellar
+            bind:value={filters.createdBefore}
+            id="created-before-input"
+            class="w-full"
+            sizeVariant="xs"
+            type="datetime-local"
+          />
         </div>
 
         <div class="flex flex-col gap-1">
@@ -465,6 +544,30 @@
             loading={$usersLoading}
             on:change={e => (filters = { ...filters, planOwner: e.detail[0]?.toString() ?? '' })}
             selectedOptionValues={[filters.planOwner]}
+          >
+            <ChevronDown slot="icon" />
+          </SearchableDropdown>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <Label size="sm">Plan Tag</Label>
+          <SearchableDropdown
+            options={tagOptions}
+            loading={$tagsLoading}
+            on:change={e => (filters = { ...filters, planTag: e.detail[0]?.toString() ?? '' })}
+            selectedOptionValues={[filters.planTag]}
+          >
+            <ChevronDown slot="icon" />
+          </SearchableDropdown>
+        </div>
+
+        <div class="flex flex-col gap-1">
+          <Label size="sm">Scheduling Goal</Label>
+          <SearchableDropdown
+            options={goalOptions}
+            loading={$goalsLoading}
+            on:change={e => (filters = { ...filters, schedulingGoalId: e.detail[0]?.toString() ?? '' })}
+            selectedOptionValues={[filters.schedulingGoalId]}
           >
             <ChevronDown slot="icon" />
           </SearchableDropdown>

--- a/src/components/search/SearchResults.svelte
+++ b/src/components/search/SearchResults.svelte
@@ -1,38 +1,101 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import { hasSearched, searchResults } from '../../stores/search';
+  import { Button } from '@nasa-jpl/stellar-svelte';
+  import { ChevronLeft, ChevronRight } from 'lucide-svelte';
+  import { hasSearched, PAGE_SIZE, searchCurrentPage, searchOrderBy, searchTotalCount } from '../../stores/search';
   import type { ActivityDirectiveSearchResult } from '../../types/activity';
   import type { User } from '../../types/app';
+  import { getShortISOForDate } from '../../utilities/time';
   import SingleActionDataGrid from '../ui/DataGrid/SingleActionDataGrid.svelte';
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
 
   export let user: User | null;
-  export let activities: ActivityDirectiveSearchResult[] | null = $searchResults;
+  export let activities: ActivityDirectiveSearchResult[] | null;
+  export let onPageChange: (page: number) => void = () => {};
+  export let onSortChange: () => void = () => {};
 
   const columnDefs = [
     {
       field: 'name',
-      headerName: 'Activity Directive Name',
+      headerName: 'Activity Name',
+      minWidth: 120,
+      resizable: true,
+      sortable: true,
     },
     {
       field: 'type',
       headerName: 'Activity Type',
+      minWidth: 120,
+      resizable: true,
+      sortable: true,
     },
     {
       field: 'plan.name',
       headerName: 'Plan Name',
+      minWidth: 120,
+      resizable: true,
+      sortable: true,
+    },
+    {
+      field: 'plan.owner',
+      headerName: 'Plan Owner',
+      minWidth: 100,
+      resizable: true,
+      sortable: true,
+      width: 100,
     },
     {
       field: 'applied_preset.preset_applied.name',
       headerName: 'Applied Preset',
+      minWidth: 120,
+      resizable: true,
+      sortable: true,
+    },
+    {
+      field: 'start_offset',
+      headerName: 'Start Offset',
+      minWidth: 100,
+      resizable: true,
+      sortable: true,
+    },
+    {
+      field: 'created_by',
+      headerName: 'Created By',
+      minWidth: 100,
+      resizable: true,
+      sortable: true,
     },
     {
       field: 'last_modified_at',
       headerName: 'Last Modified',
+      minWidth: 140,
+      resizable: true,
+      sort: 'desc' as const,
+      sortable: true,
+      valueFormatter: (params: { value: string }) => (params.value ? getShortISOForDate(new Date(params.value)) : ''),
+    },
+    {
+      field: 'last_modified_by',
+      headerName: 'Modified By',
+      minWidth: 100,
+      resizable: true,
+      sortable: true,
+    },
+    {
+      field: 'source_scheduling_goal_id',
+      headerName: 'Sched. Goal ID',
+      minWidth: 100,
+      resizable: true,
+      sortable: true,
     },
   ];
+
+  $: totalPages = Math.max(1, Math.ceil($searchTotalCount / PAGE_SIZE));
+  $: currentPage = $searchCurrentPage;
+  $: startResult = $searchTotalCount > 0 ? currentPage * PAGE_SIZE + 1 : 0;
+  $: endResult = Math.min((currentPage + 1) * PAGE_SIZE, $searchTotalCount);
 
   function getUrlForActivity(activity: ActivityDirectiveSearchResult): string {
     return `/plans/${activity.plan_id}?activityId=${activity.directive_id}`;
@@ -43,24 +106,109 @@
     const url = getUrlForActivity(activity);
     window.open(url, '_blank');
   }
+
+  function fieldToOrderBy(field: string, direction: string): Record<string, unknown> {
+    const parts = field.split('.');
+    let result: Record<string, unknown> = { [parts[parts.length - 1]]: direction };
+    for (let i = parts.length - 2; i >= 0; i--) {
+      result = { [parts[i]]: result };
+    }
+    return result;
+  }
+
+  function onGridSortChanged(event: CustomEvent) {
+    const api = event.detail.api;
+    const sortModel = api.getColumnState().filter((c: { sort: string | null }) => c.sort !== null);
+
+    if (sortModel.length > 0) {
+      const orderBy = sortModel.map((col: { colId: string; sort: string }) => fieldToOrderBy(col.colId, col.sort));
+      searchOrderBy.set(orderBy);
+    } else {
+      searchOrderBy.set([{ last_modified_at: 'desc' }]);
+    }
+
+    onSortChange();
+  }
+
+  function goToPage(page: number) {
+    if (page >= 0 && page < totalPages) {
+      onPageChange(page);
+    }
+  }
 </script>
 
 <Panel overflowYBody="hidden">
   <svelte:fragment slot="header">
-    <SectionTitle>Results</SectionTitle>
+    <div class="flex items-center justify-between">
+      <SectionTitle>Results</SectionTitle>
+      {#if $hasSearched && $searchTotalCount > 0}
+        <span class="text-xs text-muted-foreground">
+          {startResult}-{endResult} of {$searchTotalCount.toLocaleString()}
+        </span>
+      {/if}
+    </div>
   </svelte:fragment>
 
   <svelte:fragment slot="body">
-    <SingleActionDataGrid
-      idKey="directive_id"
-      {columnDefs}
-      items={activities ?? []}
-      {user}
-      itemDisplayText="Search Results"
-      on:rowClicked={onRowClicked}
-      hasDeletePermission={false}
-      loading={$hasSearched && activities === null}
-      noRowsOverlayText="No Results Found"
-    />
+    <div class="flex h-full flex-col">
+      <div class="min-h-0 flex-1">
+        <SingleActionDataGrid
+          idKey="directive_id"
+          {columnDefs}
+          items={activities ?? []}
+          {user}
+          itemDisplayText="Search Results"
+          on:rowClicked={onRowClicked}
+          on:sortChanged={onGridSortChanged}
+          hasDeletePermission={false}
+          loading={$hasSearched && activities === null}
+          noRowsOverlayText="No Results Found"
+        />
+      </div>
+
+      {#if $hasSearched && $searchTotalCount > PAGE_SIZE}
+        <div class="flex items-center justify-center gap-2 border-t border-border px-3 py-2">
+          <Button
+            size="xs"
+            variant="ghost"
+            disabled={currentPage === 0}
+            on:click={() => goToPage(0)}
+            aria-label="First page"
+          >
+            First
+          </Button>
+          <Button
+            size="xs"
+            variant="ghost"
+            disabled={currentPage === 0}
+            on:click={() => goToPage(currentPage - 1)}
+            aria-label="Previous page"
+          >
+            <ChevronLeft size={14} />
+          </Button>
+          <span class="text-xs">
+            Page {currentPage + 1} of {totalPages.toLocaleString()}
+          </span>
+          <Button
+            size="xs"
+            variant="ghost"
+            disabled={currentPage >= totalPages - 1}
+            on:click={() => goToPage(currentPage + 1)}
+            aria-label="Next page"
+          >
+            <ChevronRight size={14} />
+          </Button>
+          <Button
+            size="xs"
+            variant="ghost"
+            disabled={currentPage >= totalPages - 1}
+            on:click={() => goToPage(totalPages - 1)}
+            aria-label="Last page"
+          >
+            Last
+          </Button>
+        </div>
+      {/if}
+    </div>
   </svelte:fragment>
 </Panel>

--- a/src/components/search/SearchResults.svelte
+++ b/src/components/search/SearchResults.svelte
@@ -438,7 +438,6 @@
           bind:dataGrid
           bind:selectedItemIds
           getRowId={getRowKey}
-          idKey="id"
           {columnDefs}
           columnShiftResize
           {columnStates}

--- a/src/components/search/SearchResults.svelte
+++ b/src/components/search/SearchResults.svelte
@@ -3,12 +3,19 @@
 <script lang="ts">
   import { Button } from '@nasa-jpl/stellar-svelte';
   import type { ColumnState } from 'ag-grid-community';
-  import { ChevronLeft, ChevronRight } from 'lucide-svelte';
+  import { ChevronLeft, ChevronRight, LoaderCircle } from 'lucide-svelte';
   import { SEARCH_RESULTS_COLUMN_STATE_KEY } from '../../constants/localStorage';
-  import { hasSearched, PAGE_SIZE, searchCurrentPage, searchOrderBy, searchTotalCount } from '../../stores/search';
+  import {
+    hasSearched,
+    isSearching,
+    PAGE_SIZE,
+    searchCurrentPage,
+    searchOrderBy,
+    searchTotalCount,
+  } from '../../stores/search';
   import type { ActivityDirectiveSearchResult } from '../../types/activity';
   import type { User } from '../../types/app';
-  import { getLocalStorageItem, removeLocalStorageItem, setLocalStorageItem } from '../../utilities/localStorage';
+  import { getLocalStorageItem } from '../../utilities/localStorage';
   import { getShortISOForDate } from '../../utilities/time';
   import ActivityTableMenu from '../activity/ActivityTableMenu.svelte';
   import DataGrid from '../ui/DataGrid/DataGrid.svelte';
@@ -182,7 +189,10 @@
       resizable: true,
       sortable: true,
     },
-  ];
+    // Disable AG Grid's client-side sort on every sortable column — sorting is server-side,
+    // and a no-op local comparator avoids the flash where the visible page would briefly
+    // re-order with the local rows before the server response replaces them.
+  ].map(col => ('sortable' in col && col.sortable ? { ...col, comparator: () => 0 } : col));
 
   const savedColumnStates = getLocalStorageItem<ColumnState[]>(SEARCH_RESULTS_COLUMN_STATE_KEY) ?? [];
   let columnStates: ColumnState[] = savedColumnStates;
@@ -191,6 +201,20 @@
   $: currentPage = $searchCurrentPage;
   $: startResult = $searchTotalCount > 0 ? currentPage * PAGE_SIZE + 1 : 0;
   $: endResult = Math.min((currentPage + 1) * PAGE_SIZE, $searchTotalCount);
+
+  // Show "Searching..." only when the request takes longer than 500ms (avoids flash on fast responses)
+  let showSearchingIndicator = false;
+  let searchingTimeout: ReturnType<typeof setTimeout> | undefined;
+  $: {
+    clearTimeout(searchingTimeout);
+    if ($isSearching) {
+      searchingTimeout = setTimeout(() => {
+        showSearchingIndicator = true;
+      }, 500);
+    } else {
+      showSearchingIndicator = false;
+    }
+  }
 
   function getUrlForActivity(activity: ActivityDirectiveSearchResult): string {
     return `/plans/${activity.plan_id}?activityId=${activity.directive_id}`;
@@ -222,63 +246,33 @@
       searchOrderBy.set([{ last_modified_at: 'desc' }]);
     }
 
-    updateColumnState();
     onSortChange();
   }
 
-  function saveColumnState() {
-    if (columnStates && columnStates.length > 0) {
-      setLocalStorageItem(SEARCH_RESULTS_COLUMN_STATE_KEY, columnStates);
+  // Track grid's live column state (for menu rendering); DataGrid handles localStorage save/clear itself.
+  function onGridColumnStateChange(event: CustomEvent<ColumnState[] | undefined>) {
+    if (event.detail) {
+      columnStates = event.detail;
     }
-  }
-
-  function updateColumnState(updatedColumnStates?: ColumnState[]) {
-    const next = updatedColumnStates ?? dataGrid?.getColumnState();
-    if (next) {
-      columnStates = next;
-      saveColumnState();
-    }
-  }
-
-  function onColumnMoved() {
-    updateColumnState();
-  }
-
-  function onColumnPinned() {
-    updateColumnState();
-  }
-
-  function onColumnResized() {
-    updateColumnState();
-  }
-
-  function onColumnVisible() {
-    updateColumnState();
   }
 
   function onColumnsChanged({
     detail: { columns },
   }: CustomEvent<{ columns: { field: any; isHidden: boolean; name: string }[] }>) {
     const current = dataGrid?.getColumnState() ?? [];
-    const next = current.map(state => ({
+    columnStates = current.map(state => ({
       ...state,
       hide: columns.find(c => c.field === state.colId)?.isHidden ?? state.hide,
     }));
-    updateColumnState(next);
   }
 
   function onShowHideAllColumns({ detail: { hide } }: CustomEvent<{ hide: boolean }>) {
     const current = dataGrid?.getColumnState() ?? [];
-    updateColumnState(current.map(state => ({ ...state, hide })));
+    columnStates = current.map(state => ({ ...state, hide }));
   }
 
   function onResetColumnsFromMenu() {
     dataGrid?.resetColumns();
-  }
-
-  function onColumnsReset() {
-    removeLocalStorageItem(SEARCH_RESULTS_COLUMN_STATE_KEY);
-    columnStates = [];
   }
 
   function goToPage(page: number) {
@@ -291,9 +285,11 @@
 <Panel overflowYBody="hidden">
   <svelte:fragment slot="header">
     <div class="flex w-full items-center justify-between gap-2">
-      <SectionTitle>Results</SectionTitle>
+      <SectionTitle>Search Results</SectionTitle>
       <div class="flex items-center gap-2">
-        {#if $hasSearched && $searchTotalCount > 0}
+        {#if showSearchingIndicator}
+          <span class="text-xs text-muted-foreground">Searching…</span>
+        {:else if $hasSearched && $searchTotalCount > 0}
           <span class="text-xs text-muted-foreground">
             {startResult}-{endResult} of {$searchTotalCount.toLocaleString()}
           </span>
@@ -311,22 +307,24 @@
 
   <svelte:fragment slot="body">
     <div class="flex h-full flex-col">
-      <div class="min-h-0 flex-1">
+      <div class="relative min-h-0 flex-1">
+        {#if showSearchingIndicator}
+          <div class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-background/50">
+            <LoaderCircle size={32} class="animate-spin text-muted-foreground" />
+          </div>
+        {/if}
         <SingleActionDataGrid
           bind:this={resultsGrid}
           idKey="directive_id"
           {columnDefs}
           {columnStates}
+          persistColumnStateKey={SEARCH_RESULTS_COLUMN_STATE_KEY}
           items={activities ?? []}
           {user}
           itemDisplayText="Search Results"
           on:rowClicked={onRowClicked}
           on:sortChanged={onGridSortChanged}
-          on:columnMoved={onColumnMoved}
-          on:columnPinned={onColumnPinned}
-          on:columnResized={onColumnResized}
-          on:columnVisible={onColumnVisible}
-          on:columnsReset={onColumnsReset}
+          on:columnStateChange={onGridColumnStateChange}
           hasDeletePermission={false}
           loading={$hasSearched && activities === null}
           noRowsOverlayText="No Results Found"

--- a/src/components/search/SearchResults.svelte
+++ b/src/components/search/SearchResults.svelte
@@ -1,8 +1,8 @@
 <svelte:options immutable={true} />
 
 <script lang="ts">
-  import { Button } from '@nasa-jpl/stellar-svelte';
-  import type { ColumnState } from 'ag-grid-community';
+  import { Button, ContextMenu } from '@nasa-jpl/stellar-svelte';
+  import type { ColDef, ColumnPinnedType, ColumnState, ICellRendererParams, SortDirection } from 'ag-grid-community';
   import { ChevronLeft, ChevronRight, LoaderCircle } from 'lucide-svelte';
   import { SEARCH_RESULTS_COLUMN_STATE_KEY } from '../../constants/localStorage';
   import {
@@ -14,24 +14,26 @@
     searchRunId,
     searchTotalCount,
   } from '../../stores/search';
-  import type { ActivityDirectiveSearchResult } from '../../types/activity';
+  import type { ActivityDirective, ActivityDirectiveSearchResult } from '../../types/activity';
   import type { User } from '../../types/app';
+  import { copyActivityDirectivesToClipboard } from '../../utilities/activities';
   import { getLocalStorageItem } from '../../utilities/localStorage';
-  import { getShortISOForDate } from '../../utilities/time';
+  import { getDoyTime, getShortISOForDate, getUnixEpochTimeFromInterval } from '../../utilities/time';
   import ActivityTableMenu from '../activity/ActivityTableMenu.svelte';
+  import BulkActionDataGrid from '../ui/DataGrid/BulkActionDataGrid.svelte';
   import DataGrid from '../ui/DataGrid/DataGrid.svelte';
   import { tagsCellRenderer, tagsFilterValueGetter } from '../ui/DataGrid/DataGridTags';
-  import SingleActionDataGrid from '../ui/DataGrid/SingleActionDataGrid.svelte';
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
+  import OpenInPlanCell from './OpenInPlanCell.svelte';
 
   export let user: User | null;
   export let activities: ActivityDirectiveSearchResult[] | null;
   export let onPageChange: (page: number) => void = () => {};
   export let onSortChange: () => void = () => {};
 
-  let resultsGrid: SingleActionDataGrid<ActivityDirectiveSearchResult> | undefined;
-  $: dataGrid = resultsGrid?.dataGrid as DataGrid<ActivityDirectiveSearchResult> | undefined;
+  let dataGrid: DataGrid<ActivityDirectiveSearchResult> | undefined;
+  let selectedItemIds: number[] = [];
 
   const formatTimestamp = (params: { value: string }) =>
     params.value ? getShortISOForDate(new Date(params.value)) : '';
@@ -44,7 +46,38 @@
     return JSON.stringify(args);
   };
 
-  const columnDefs = [
+  function openActivityCellRenderer(params: ICellRendererParams) {
+    const container = document.createElement('div');
+    container.className = 'h-full w-full';
+    new OpenInPlanCell({
+      props: {
+        onClick: () => {
+          if (params.data) {
+            window.open(getUrlForActivity(params.data), '_blank');
+          }
+        },
+      },
+      target: container,
+    });
+    return container;
+  }
+
+  // Column order groups: action → identity → plan/model context → tagging → timing → audit trail → provenance.
+  const columnDefs: ColDef[] = [
+    {
+      cellClass: 'p-0',
+      cellRenderer: openActivityCellRenderer,
+      colId: 'open_in_plan',
+      headerName: '',
+      hide: false,
+      maxWidth: 44,
+      minWidth: 44,
+      pinned: 'left' as ColumnPinnedType,
+      resizable: false,
+      sortable: false,
+      suppressAutoSize: true,
+      width: 44,
+    },
     {
       colId: 'name',
       field: 'name',
@@ -60,6 +93,15 @@
       headerName: 'Activity Type',
       hide: false,
       minWidth: 120,
+      resizable: true,
+      sortable: true,
+    },
+    {
+      colId: 'id',
+      field: 'id',
+      headerName: 'Activity ID',
+      hide: true,
+      minWidth: 80,
       resizable: true,
       sortable: true,
     },
@@ -83,6 +125,46 @@
       width: 100,
     },
     {
+      colId: 'plan_id',
+      field: 'plan_id',
+      headerName: 'Plan ID',
+      hide: true,
+      minWidth: 80,
+      resizable: true,
+      sortable: true,
+    },
+    {
+      colId: 'plan.model.name',
+      headerName: 'Model',
+      hide: false,
+      minWidth: 120,
+      resizable: true,
+      sortable: false,
+      valueGetter: ({ data }: { data?: ActivityDirectiveSearchResult }) => data?.plan.model?.name ?? '',
+    },
+    {
+      colId: 'plan.model.id',
+      headerName: 'Model ID',
+      hide: false,
+      minWidth: 80,
+      resizable: true,
+      sortable: false,
+      valueGetter: ({ data }: { data?: ActivityDirectiveSearchResult }) => data?.plan.model?.id ?? '',
+    },
+    {
+      autoHeight: true,
+      cellRenderer: tagsCellRenderer,
+      colId: 'tags',
+      field: 'tags',
+      filterValueGetter: tagsFilterValueGetter,
+      headerName: 'Tags',
+      hide: false,
+      minWidth: 120,
+      resizable: true,
+      sortable: false,
+      width: 200,
+    },
+    {
       colId: 'applied_preset.preset_applied.name',
       field: 'applied_preset.preset_applied.name',
       headerName: 'Applied Preset',
@@ -101,17 +183,14 @@
       sortable: true,
     },
     {
-      autoHeight: true,
-      cellRenderer: tagsCellRenderer,
-      colId: 'tags',
-      field: 'tags',
-      filterValueGetter: tagsFilterValueGetter,
-      headerName: 'Tags',
+      colId: 'absolute_start_time',
+      headerName: 'Absolute Start Time',
       hide: false,
-      minWidth: 120,
+      minWidth: 180,
       resizable: true,
       sortable: false,
-      width: 200,
+      valueGetter: ({ data }: { data?: ActivityDirectiveSearchResult }) =>
+        data ? getDoyTime(new Date(getUnixEpochTimeFromInterval(data.plan.start_time, data.start_offset))) : '',
     },
     {
       colId: 'arguments',
@@ -144,17 +223,6 @@
       valueFormatter: formatTimestamp,
     },
     {
-      colId: 'last_modified_at',
-      field: 'last_modified_at',
-      headerName: 'Last Modified',
-      hide: false,
-      minWidth: 140,
-      resizable: true,
-      sort: 'desc' as const,
-      sortable: true,
-      valueFormatter: formatTimestamp,
-    },
-    {
       colId: 'last_modified_by',
       field: 'last_modified_by',
       headerName: 'Modified By',
@@ -164,29 +232,31 @@
       sortable: true,
     },
     {
+      colId: 'last_modified_at',
+      field: 'last_modified_at',
+      headerName: 'Last Modified',
+      hide: false,
+      minWidth: 160,
+      resizable: true,
+      sort: 'desc' as SortDirection,
+      sortable: true,
+      valueFormatter: formatTimestamp,
+    },
+    {
+      colId: 'source_scheduling_goal.name',
+      headerName: 'Scheduling Goal',
+      hide: false,
+      minWidth: 140,
+      resizable: true,
+      sortable: false,
+      valueGetter: ({ data }: { data?: ActivityDirectiveSearchResult }) => data?.source_scheduling_goal?.name ?? '',
+    },
+    {
       colId: 'source_scheduling_goal_id',
       field: 'source_scheduling_goal_id',
       headerName: 'Sched. Goal ID',
-      hide: false,
+      hide: true,
       minWidth: 100,
-      resizable: true,
-      sortable: true,
-    },
-    {
-      colId: 'plan_id',
-      field: 'plan_id',
-      headerName: 'Plan ID',
-      hide: true,
-      minWidth: 80,
-      resizable: true,
-      sortable: true,
-    },
-    {
-      colId: 'directive_id',
-      field: 'directive_id',
-      headerName: 'Activity ID',
-      hide: true,
-      minWidth: 80,
       resizable: true,
       sortable: true,
     },
@@ -194,6 +264,9 @@
     // and a no-op local comparator avoids the flash where the visible page would briefly
     // re-order with the local rows before the server response replaces them.
   ].map(col => ('sortable' in col && col.sortable ? { ...col, comparator: () => 0 } : col));
+
+  // The Open-in-plan action column is structural — not a user-hideable data column.
+  const pickerColumnDefs = columnDefs.filter(col => col.colId !== 'open_in_plan');
 
   const savedColumnStates = getLocalStorageItem<ColumnState[]>(SEARCH_RESULTS_COLUMN_STATE_KEY) ?? [];
   let columnStates: ColumnState[] = savedColumnStates;
@@ -218,13 +291,52 @@
   }
 
   function getUrlForActivity(activity: ActivityDirectiveSearchResult): string {
-    return `/plans/${activity.plan_id}?activityId=${activity.directive_id}`;
+    return `/plans/${activity.plan_id}?activityId=${activity.id}`;
   }
 
-  function onRowClicked(event: CustomEvent) {
-    const activity: ActivityDirectiveSearchResult = event.detail.data;
-    const url = getUrlForActivity(activity);
-    window.open(url, '_blank');
+  function getSelectedRows(): ActivityDirectiveSearchResult[] {
+    if (!activities) {
+      return [];
+    }
+    const idSet = new Set(selectedItemIds);
+    return activities.filter(a => idSet.has(a.id));
+  }
+
+  function openSelectedInPlan() {
+    const rows = getSelectedRows();
+    if (rows.length === 1) {
+      window.open(getUrlForActivity(rows[0]), '_blank');
+    }
+  }
+
+  function copySelectedToClipboard() {
+    const rows = getSelectedRows();
+    if (rows.length === 0) {
+      return;
+    }
+    // copyActivityDirectivesToClipboard only reads a narrow subset of ActivityDirective fields
+    // (anchor_id, anchored_to_start, arguments, id, name, start_offset, start_time_ms, tags, type).
+    const mapped = rows.map(row => ({
+      anchor_id: row.anchor_id,
+      anchored_to_start: row.anchored_to_start,
+      arguments: row.arguments,
+      created_at: row.created_at,
+      created_by: row.created_by ?? '',
+      id: row.id,
+      last_modified_arguments_at: row.last_modified_at,
+      last_modified_at: row.last_modified_at,
+      last_modified_by: row.last_modified_by,
+      metadata: row.metadata,
+      name: row.name,
+      plan_id: row.plan_id,
+      source_scheduling_goal_id: row.source_scheduling_goal_id,
+      source_scheduling_goal_invocation_id: null,
+      start_offset: row.start_offset,
+      start_time_ms: getUnixEpochTimeFromInterval(row.plan.start_time, row.start_offset),
+      tags: row.tags as ActivityDirective['tags'],
+      type: row.type,
+    })) as ActivityDirective[];
+    copyActivityDirectivesToClipboard(null, mapped);
   }
 
   function fieldToOrderBy(field: string, direction: string): Record<string, unknown> {
@@ -269,7 +381,8 @@
 
   function onShowHideAllColumns({ detail: { hide } }: CustomEvent<{ hide: boolean }>) {
     const current = dataGrid?.getColumnState() ?? [];
-    columnStates = current.map(state => ({ ...state, hide }));
+    // The open-in-plan action column is structural and must stay visible regardless of "hide all".
+    columnStates = current.map(state => (state.colId === 'open_in_plan' ? state : { ...state, hide }));
   }
 
   function onResetColumnsFromMenu() {
@@ -296,7 +409,7 @@
           </span>
         {/if}
         <ActivityTableMenu
-          {columnDefs}
+          columnDefs={pickerColumnDefs}
           {columnStates}
           on:columns-changed={onColumnsChanged}
           on:columns-reset={onResetColumnsFromMenu}
@@ -314,22 +427,40 @@
             <LoaderCircle size={32} class="animate-spin text-muted-foreground" />
           </div>
         {/if}
-        <SingleActionDataGrid
-          bind:this={resultsGrid}
-          idKey="directive_id"
+        <BulkActionDataGrid
+          bind:dataGrid
+          bind:selectedItemIds
+          idKey="id"
           {columnDefs}
+          columnShiftResize
           {columnStates}
           persistColumnStateKey={SEARCH_RESULTS_COLUMN_STATE_KEY}
           items={activities ?? []}
           {user}
-          itemDisplayText="Search Results"
-          on:rowClicked={onRowClicked}
-          on:sortChanged={onGridSortChanged}
-          on:columnStateChange={onGridColumnStateChange}
           hasDeletePermission={false}
           loading={$hasSearched && activities === null}
           noRowsOverlayText="No Results Found"
-        />
+          pluralItemDisplayText="Activities"
+          showCopyMenu={false}
+          showDeleteMenu={false}
+          singleItemDisplayText="Activity"
+          on:columnStateChange={onGridColumnStateChange}
+          on:rowDoubleClicked={openSelectedInPlan}
+          on:sortChanged={onGridSortChanged}
+        >
+          <svelte:fragment slot="context-menu">
+            {#if selectedItemIds.length === 1}
+              <ContextMenu.Item size="sm" on:click={openSelectedInPlan}>Open in Plan</ContextMenu.Item>
+            {/if}
+            {#if selectedItemIds.length >= 1}
+              <ContextMenu.Item size="sm" on:click={copySelectedToClipboard}>
+                Copy {selectedItemIds.length}
+                {selectedItemIds.length > 1 ? 'Activities' : 'Activity'}
+              </ContextMenu.Item>
+              <ContextMenu.Separator />
+            {/if}
+          </svelte:fragment>
+        </BulkActionDataGrid>
       </div>
 
       {#if $hasSearched && $searchTotalCount > PAGE_SIZE}

--- a/src/components/search/SearchResults.svelte
+++ b/src/components/search/SearchResults.svelte
@@ -2,11 +2,17 @@
 
 <script lang="ts">
   import { Button } from '@nasa-jpl/stellar-svelte';
+  import type { ColumnState } from 'ag-grid-community';
   import { ChevronLeft, ChevronRight } from 'lucide-svelte';
+  import { SEARCH_RESULTS_COLUMN_STATE_KEY } from '../../constants/localStorage';
   import { hasSearched, PAGE_SIZE, searchCurrentPage, searchOrderBy, searchTotalCount } from '../../stores/search';
   import type { ActivityDirectiveSearchResult } from '../../types/activity';
   import type { User } from '../../types/app';
+  import { getLocalStorageItem, removeLocalStorageItem, setLocalStorageItem } from '../../utilities/localStorage';
   import { getShortISOForDate } from '../../utilities/time';
+  import ActivityTableMenu from '../activity/ActivityTableMenu.svelte';
+  import DataGrid from '../ui/DataGrid/DataGrid.svelte';
+  import { tagsCellRenderer, tagsFilterValueGetter } from '../ui/DataGrid/DataGridTags';
   import SingleActionDataGrid from '../ui/DataGrid/SingleActionDataGrid.svelte';
   import Panel from '../ui/Panel.svelte';
   import SectionTitle from '../ui/SectionTitle.svelte';
@@ -16,81 +22,170 @@
   export let onPageChange: (page: number) => void = () => {};
   export let onSortChange: () => void = () => {};
 
+  let resultsGrid: SingleActionDataGrid<ActivityDirectiveSearchResult> | undefined;
+  $: dataGrid = resultsGrid?.dataGrid as DataGrid<ActivityDirectiveSearchResult> | undefined;
+
+  const formatTimestamp = (params: { value: string }) =>
+    params.value ? getShortISOForDate(new Date(params.value)) : '';
+
+  const argumentsValueGetter = (params: { data?: ActivityDirectiveSearchResult }) => {
+    const args = params.data?.arguments;
+    if (!args || Object.keys(args).length === 0) {
+      return '';
+    }
+    return JSON.stringify(args);
+  };
+
   const columnDefs = [
     {
+      colId: 'name',
       field: 'name',
       headerName: 'Activity Name',
+      hide: false,
       minWidth: 120,
       resizable: true,
       sortable: true,
     },
     {
+      colId: 'type',
       field: 'type',
       headerName: 'Activity Type',
+      hide: false,
       minWidth: 120,
       resizable: true,
       sortable: true,
     },
     {
+      colId: 'plan.name',
       field: 'plan.name',
       headerName: 'Plan Name',
+      hide: false,
       minWidth: 120,
       resizable: true,
       sortable: true,
     },
     {
+      colId: 'plan.owner',
       field: 'plan.owner',
       headerName: 'Plan Owner',
+      hide: false,
       minWidth: 100,
       resizable: true,
       sortable: true,
       width: 100,
     },
     {
+      colId: 'applied_preset.preset_applied.name',
       field: 'applied_preset.preset_applied.name',
       headerName: 'Applied Preset',
+      hide: false,
       minWidth: 120,
       resizable: true,
       sortable: true,
     },
     {
+      colId: 'start_offset',
       field: 'start_offset',
       headerName: 'Start Offset',
+      hide: false,
       minWidth: 100,
       resizable: true,
       sortable: true,
     },
     {
+      autoHeight: true,
+      cellRenderer: tagsCellRenderer,
+      colId: 'tags',
+      field: 'tags',
+      filterValueGetter: tagsFilterValueGetter,
+      headerName: 'Tags',
+      hide: false,
+      minWidth: 120,
+      resizable: true,
+      sortable: false,
+      width: 200,
+    },
+    {
+      colId: 'arguments',
+      field: 'arguments',
+      headerName: 'Arguments',
+      hide: true,
+      minWidth: 160,
+      resizable: true,
+      sortable: false,
+      valueGetter: argumentsValueGetter,
+      width: 240,
+    },
+    {
+      colId: 'created_by',
       field: 'created_by',
       headerName: 'Created By',
+      hide: false,
       minWidth: 100,
       resizable: true,
       sortable: true,
     },
     {
+      colId: 'created_at',
+      field: 'created_at',
+      headerName: 'Created At',
+      hide: true,
+      minWidth: 140,
+      resizable: true,
+      sortable: true,
+      valueFormatter: formatTimestamp,
+    },
+    {
+      colId: 'last_modified_at',
       field: 'last_modified_at',
       headerName: 'Last Modified',
+      hide: false,
       minWidth: 140,
       resizable: true,
       sort: 'desc' as const,
       sortable: true,
-      valueFormatter: (params: { value: string }) => (params.value ? getShortISOForDate(new Date(params.value)) : ''),
+      valueFormatter: formatTimestamp,
     },
     {
+      colId: 'last_modified_by',
       field: 'last_modified_by',
       headerName: 'Modified By',
+      hide: false,
       minWidth: 100,
       resizable: true,
       sortable: true,
     },
     {
+      colId: 'source_scheduling_goal_id',
       field: 'source_scheduling_goal_id',
       headerName: 'Sched. Goal ID',
+      hide: false,
       minWidth: 100,
+      resizable: true,
+      sortable: true,
+    },
+    {
+      colId: 'plan_id',
+      field: 'plan_id',
+      headerName: 'Plan ID',
+      hide: true,
+      minWidth: 80,
+      resizable: true,
+      sortable: true,
+    },
+    {
+      colId: 'directive_id',
+      field: 'directive_id',
+      headerName: 'Activity ID',
+      hide: true,
+      minWidth: 80,
       resizable: true,
       sortable: true,
     },
   ];
+
+  const savedColumnStates = getLocalStorageItem<ColumnState[]>(SEARCH_RESULTS_COLUMN_STATE_KEY) ?? [];
+  let columnStates: ColumnState[] = savedColumnStates;
 
   $: totalPages = Math.max(1, Math.ceil($searchTotalCount / PAGE_SIZE));
   $: currentPage = $searchCurrentPage;
@@ -127,7 +222,63 @@
       searchOrderBy.set([{ last_modified_at: 'desc' }]);
     }
 
+    updateColumnState();
     onSortChange();
+  }
+
+  function saveColumnState() {
+    if (columnStates && columnStates.length > 0) {
+      setLocalStorageItem(SEARCH_RESULTS_COLUMN_STATE_KEY, columnStates);
+    }
+  }
+
+  function updateColumnState(updatedColumnStates?: ColumnState[]) {
+    const next = updatedColumnStates ?? dataGrid?.getColumnState();
+    if (next) {
+      columnStates = next;
+      saveColumnState();
+    }
+  }
+
+  function onColumnMoved() {
+    updateColumnState();
+  }
+
+  function onColumnPinned() {
+    updateColumnState();
+  }
+
+  function onColumnResized() {
+    updateColumnState();
+  }
+
+  function onColumnVisible() {
+    updateColumnState();
+  }
+
+  function onColumnsChanged({
+    detail: { columns },
+  }: CustomEvent<{ columns: { field: any; isHidden: boolean; name: string }[] }>) {
+    const current = dataGrid?.getColumnState() ?? [];
+    const next = current.map(state => ({
+      ...state,
+      hide: columns.find(c => c.field === state.colId)?.isHidden ?? state.hide,
+    }));
+    updateColumnState(next);
+  }
+
+  function onShowHideAllColumns({ detail: { hide } }: CustomEvent<{ hide: boolean }>) {
+    const current = dataGrid?.getColumnState() ?? [];
+    updateColumnState(current.map(state => ({ ...state, hide })));
+  }
+
+  function onResetColumnsFromMenu() {
+    dataGrid?.resetColumns();
+  }
+
+  function onColumnsReset() {
+    removeLocalStorageItem(SEARCH_RESULTS_COLUMN_STATE_KEY);
+    columnStates = [];
   }
 
   function goToPage(page: number) {
@@ -139,13 +290,22 @@
 
 <Panel overflowYBody="hidden">
   <svelte:fragment slot="header">
-    <div class="flex items-center justify-between">
+    <div class="flex w-full items-center justify-between gap-2">
       <SectionTitle>Results</SectionTitle>
-      {#if $hasSearched && $searchTotalCount > 0}
-        <span class="text-xs text-muted-foreground">
-          {startResult}-{endResult} of {$searchTotalCount.toLocaleString()}
-        </span>
-      {/if}
+      <div class="flex items-center gap-2">
+        {#if $hasSearched && $searchTotalCount > 0}
+          <span class="text-xs text-muted-foreground">
+            {startResult}-{endResult} of {$searchTotalCount.toLocaleString()}
+          </span>
+        {/if}
+        <ActivityTableMenu
+          {columnDefs}
+          {columnStates}
+          on:columns-changed={onColumnsChanged}
+          on:columns-reset={onResetColumnsFromMenu}
+          on:show-hide-all-columns={onShowHideAllColumns}
+        />
+      </div>
     </div>
   </svelte:fragment>
 
@@ -153,13 +313,20 @@
     <div class="flex h-full flex-col">
       <div class="min-h-0 flex-1">
         <SingleActionDataGrid
+          bind:this={resultsGrid}
           idKey="directive_id"
           {columnDefs}
+          {columnStates}
           items={activities ?? []}
           {user}
           itemDisplayText="Search Results"
           on:rowClicked={onRowClicked}
           on:sortChanged={onGridSortChanged}
+          on:columnMoved={onColumnMoved}
+          on:columnPinned={onColumnPinned}
+          on:columnResized={onColumnResized}
+          on:columnVisible={onColumnVisible}
+          on:columnsReset={onColumnsReset}
           hasDeletePermission={false}
           loading={$hasSearched && activities === null}
           noRowsOverlayText="No Results Found"
@@ -167,39 +334,32 @@
       </div>
 
       {#if $hasSearched && $searchTotalCount > PAGE_SIZE}
-        <div class="flex items-center justify-center gap-2 border-t border-border px-3 py-2">
-          <Button
-            size="xs"
-            variant="ghost"
-            disabled={currentPage === 0}
-            on:click={() => goToPage(0)}
-            aria-label="First page"
-          >
+        <div class="flex items-center justify-center gap-2 border-t border-border px-3 pb-1 pt-2">
+          <Button variant="ghost" disabled={currentPage === 0} on:click={() => goToPage(0)} aria-label="First page">
             First
           </Button>
           <Button
-            size="xs"
+            size="icon"
             variant="ghost"
             disabled={currentPage === 0}
             on:click={() => goToPage(currentPage - 1)}
             aria-label="Previous page"
           >
-            <ChevronLeft size={14} />
+            <ChevronLeft size={16} />
           </Button>
           <span class="text-xs">
             Page {currentPage + 1} of {totalPages.toLocaleString()}
           </span>
           <Button
-            size="xs"
+            size="icon"
             variant="ghost"
             disabled={currentPage >= totalPages - 1}
             on:click={() => goToPage(currentPage + 1)}
             aria-label="Next page"
           >
-            <ChevronRight size={14} />
+            <ChevronRight size={16} />
           </Button>
           <Button
-            size="xs"
             variant="ghost"
             disabled={currentPage >= totalPages - 1}
             on:click={() => goToPage(totalPages - 1)}

--- a/src/components/search/SearchResults.svelte
+++ b/src/components/search/SearchResults.svelte
@@ -1,0 +1,58 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { hasSearched, searchResults } from '../../stores/search';
+  import type { ActivityDirectiveSearchResult } from '../../types/activity';
+  import type { User } from '../../types/app';
+  import SingleActionDataGrid from '../ui/DataGrid/SingleActionDataGrid.svelte';
+  import Panel from '../ui/Panel.svelte';
+  import SectionTitle from '../ui/SectionTitle.svelte';
+
+  export let user: User | null;
+  export let activities: ActivityDirectiveSearchResult[] | null = $searchResults;
+
+  const columnDefs = [
+    {
+      field: 'name',
+      headerName: 'Activity Directive Name',
+    },
+    {
+      field: 'type',
+      headerName: 'Activity Type',
+    },
+    {
+      field: 'plan.name',
+      headerName: 'Plan Name',
+    },
+  ];
+
+  function getUrlForActivity(activity: ActivityDirectiveSearchResult): string {
+    return `/plans/${activity.plan_id}?activityId=${activity.directive_id}`;
+  }
+
+  function onRowClicked(event: CustomEvent) {
+    const activity: ActivityDirectiveSearchResult = event.detail.data;
+    const url = getUrlForActivity(activity);
+    window.open(url, '_blank');
+  }
+</script>
+
+<Panel overflowYBody="hidden">
+  <svelte:fragment slot="header">
+    <SectionTitle>Results</SectionTitle>
+  </svelte:fragment>
+
+  <svelte:fragment slot="body">
+    <SingleActionDataGrid
+      idKey="directive_id"
+      {columnDefs}
+      items={activities ?? []}
+      {user}
+      itemDisplayText="Search Results"
+      on:rowClicked={onRowClicked}
+      hasDeletePermission={false}
+      loading={$hasSearched && activities === null}
+      noRowsOverlayText="No Results Found"
+    />
+  </svelte:fragment>
+</Panel>

--- a/src/components/search/SearchResults.svelte
+++ b/src/components/search/SearchResults.svelte
@@ -33,7 +33,14 @@
   export let onSortChange: () => void = () => {};
 
   let dataGrid: DataGrid<ActivityDirectiveSearchResult> | undefined;
-  let selectedItemIds: number[] = [];
+  // Activity directive ids are unique per-plan but not globally — cross-plan results
+  // can collide. Key rows (and selection) by `${plan_id}:${id}` so AG-Grid never sees
+  // duplicate row IDs and selection state stays scoped to the right source plan.
+  let selectedItemIds: string[] = [];
+
+  function getRowKey(activity: ActivityDirectiveSearchResult): string {
+    return `${activity.plan_id}:${activity.id}`;
+  }
 
   const formatTimestamp = (params: { value: string }) =>
     params.value ? getShortISOForDate(new Date(params.value)) : '';
@@ -298,8 +305,8 @@
     if (!activities) {
       return [];
     }
-    const idSet = new Set(selectedItemIds);
-    return activities.filter(a => idSet.has(a.id));
+    const keySet = new Set(selectedItemIds);
+    return activities.filter(a => keySet.has(getRowKey(a)));
   }
 
   function openSelectedInPlan() {
@@ -430,6 +437,7 @@
         <BulkActionDataGrid
           bind:dataGrid
           bind:selectedItemIds
+          getRowId={getRowKey}
           idKey="id"
           {columnDefs}
           columnShiftResize

--- a/src/components/search/SearchResults.svelte
+++ b/src/components/search/SearchResults.svelte
@@ -11,6 +11,7 @@
     PAGE_SIZE,
     searchCurrentPage,
     searchOrderBy,
+    searchRunId,
     searchTotalCount,
   } from '../../stores/search';
   import type { ActivityDirectiveSearchResult } from '../../types/activity';
@@ -306,7 +307,7 @@
   </svelte:fragment>
 
   <svelte:fragment slot="body">
-    <div class="flex h-full flex-col">
+    <div class="flex h-full flex-col" data-search-run-id={$searchRunId}>
       <div class="relative min-h-0 flex-1">
         {#if showSearchingIndicator}
           <div class="pointer-events-none absolute inset-0 z-10 flex items-center justify-center bg-background/50">

--- a/src/components/search/SearchResults.svelte
+++ b/src/components/search/SearchResults.svelte
@@ -24,6 +24,14 @@
       field: 'plan.name',
       headerName: 'Plan Name',
     },
+    {
+      field: 'applied_preset.preset_applied.name',
+      headerName: 'Applied Preset',
+    },
+    {
+      field: 'last_modified_at',
+      headerName: 'Last Modified',
+    },
   ];
 
   function getUrlForActivity(activity: ActivityDirectiveSearchResult): string {

--- a/src/components/ui/DataGrid/BulkActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/BulkActionDataGrid.svelte
@@ -35,6 +35,8 @@
   export let columnStates: ColumnState[] = [];
   export let columnsToForceRefreshOnDataUpdate: (keyof RowData)[] = [];
   export let dataGrid: DataGrid<RowData> | undefined = undefined;
+  export let persistColumnStateKey: string | null = null;
+  export let transformColumnState: ((state: ColumnState[]) => ColumnState[]) | null = null;
   export let filterExpression: string = '';
   export let hasDeletePermission: PermissionCheck<RowData> | boolean = true;
   export let hasDeletePermissionError: string = 'You do not have permission to delete.';
@@ -177,6 +179,8 @@
   {columnShiftResize}
   {columnStates}
   {columnsToForceRefreshOnDataUpdate}
+  {persistColumnStateKey}
+  {transformColumnState}
   {headerHeight}
   {idKey}
   {getRowId}

--- a/src/components/ui/DataGrid/DataGrid.svelte
+++ b/src/components/ui/DataGrid/DataGrid.svelte
@@ -258,17 +258,18 @@ This has been seen to result in unintended and often glitchy behavior, which oft
    * Manually manipulate the old and newly selected row classes instead of invoking `redrawRows`
    * in order to correctly mark what the current selected row is. Calling `redrawRows` caused cellrenders to
    * lose their current state and be reinitialized. `refreshCells` is not enough to cause ag-grid to recompute
-   * all the row styles
+   * all the row styles.
+   *
+   * AG Grid renders each row in both the center and the pinned-left/right containers, so we must update every
+   * matching element — querySelector only catches the first and leaves the pinned copies with stale classes.
    */
   $: {
-    const previousSelectedRow = gridDiv?.querySelector(`[row-id="${previousSelectedRowId}"]`);
-    if (previousSelectedRow != null) {
-      previousSelectedRow.classList.remove(CURRENT_SELECTED_ROW_CLASS);
-    }
-    const currentSelectedRow = gridDiv?.querySelector(`[row-id="${currentSelectedRowId}"]`);
-    if (currentSelectedRow != null) {
-      currentSelectedRow.classList.add(CURRENT_SELECTED_ROW_CLASS);
-    }
+    gridDiv
+      ?.querySelectorAll(`[row-id="${previousSelectedRowId}"]`)
+      .forEach(row => row.classList.remove(CURRENT_SELECTED_ROW_CLASS));
+    gridDiv
+      ?.querySelectorAll(`[row-id="${currentSelectedRowId}"]`)
+      .forEach(row => row.classList.add(CURRENT_SELECTED_ROW_CLASS));
 
     previousSelectedRowId = currentSelectedRowId;
   }

--- a/src/components/ui/DataGrid/DataGrid.svelte
+++ b/src/components/ui/DataGrid/DataGrid.svelte
@@ -60,6 +60,7 @@
   import { SvelteComponent, createEventDispatcher, onDestroy, onMount, type ComponentEvents } from 'svelte';
   import type { Dispatcher } from '../../../types/component';
   import type { DataGridRowDoubleClick, DataGridRowSelection, RowId, TRowData } from '../../../types/data-grid';
+  import { removeLocalStorageItem, setLocalStorageItem } from '../../../utilities/localStorage';
   import ContextMenuInternal from '../../context-menu/ContextMenu.svelte';
   import ColumnResizeContextMenu from './column-menu/ColumnResizeContextMenu.svelte';
   import DataGridSkeleton from './DataGridSkeleton.svelte';
@@ -113,6 +114,10 @@
   export let columnsToForceRefreshOnDataUpdate: (keyof RowData)[] = [];
   export let columnShiftResize: boolean = false;
   export let columnStates: ColumnState[] = [];
+  /** When set, column state (visibility, order, width, sort, pinning) is persisted to localStorage under this key. */
+  export let persistColumnStateKey: string | null = null;
+  /** Optional transform applied both to loaded saved state (before applying to grid) and live state (before saving). */
+  export let transformColumnState: ((state: ColumnState[]) => ColumnState[]) | null = null;
   export let currentSelectedRowId: RowId | null = null;
   export let filterExpression: string = '';
   export let headerHeight: number = 32;
@@ -356,11 +361,19 @@ This has been seen to result in unintended and often glitchy behavior, which oft
   function onResetColumns() {
     gridApi?.resetColumnState();
     gridApi?.sizeColumnsToFit();
+    if (persistColumnStateKey) {
+      removeLocalStorageItem(persistColumnStateKey);
+    }
     dispatch('columnsReset');
   }
 
   function onColumnStateChange() {
-    dispatch('columnStateChange', gridApi?.getColumnState());
+    const state = gridApi?.getColumnState();
+    dispatch('columnStateChange', state);
+    if (persistColumnStateKey && state) {
+      const toSave = transformColumnState ? transformColumnState(state) : state;
+      setLocalStorageItem(persistColumnStateKey, toSave);
+    }
   }
 
   function onCellContextMenu(event: CellContextMenuEvent<RowData>) {

--- a/src/components/ui/DataGrid/SingleActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/SingleActionDataGrid.svelte
@@ -36,6 +36,8 @@
   export let columnStates: ColumnState[] = [];
   export let columnsToForceRefreshOnDataUpdate: (keyof RowData)[] = [];
   export let dataGrid: DataGrid<RowData> | undefined = undefined;
+  export let persistColumnStateKey: string | null = null;
+  export let transformColumnState: ((state: ColumnState[]) => ColumnState[]) | null = null;
   export let filterExpression: string = '';
   export let hasDeletePermission: PermissionCheck<RowData> | boolean = true;
   export let hasDeletePermissionError: string | ((user: User, data: RowData) => string) | undefined =
@@ -157,6 +159,8 @@
   {columnShiftResize}
   {columnStates}
   {columnsToForceRefreshOnDataUpdate}
+  {persistColumnStateKey}
+  {transformColumnState}
   {filterExpression}
   {headerHeight}
   {idKey}

--- a/src/components/ui/DataGrid/SingleActionDataGrid.svelte
+++ b/src/components/ui/DataGrid/SingleActionDataGrid.svelte
@@ -187,6 +187,8 @@
   on:columnPinned
   on:columnResized
   on:columnStateChange
+  on:columnVisible
+  on:columnsReset
   on:filterChanged
   on:focus={onFocus}
   on:rowClicked

--- a/src/components/ui/SearchableDropdown.svelte
+++ b/src/components/ui/SearchableDropdown.svelte
@@ -34,6 +34,7 @@
   export let disabled: boolean = false;
   export let error: string | undefined = undefined;
   export let hasUpdatePermission: boolean = true;
+  export let loading: boolean = false;
   export let options: DropdownOptions = [];
   export let maxListHeight: string = '300px';
   export let name: string | undefined = undefined;
@@ -85,20 +86,44 @@
   let searchFilter: string = '';
   let selectedOptions: DropdownOptions = [];
   let maxWidth: number = 0;
+  let measureCanvasContext: CanvasRenderingContext2D | null = null;
+  let measureRef: HTMLSpanElement | undefined;
 
-  $: {
-    selectedOptions = [];
-    let maxOptionChars = 0;
-    options.forEach(option => {
-      if (selectedOptionValues.find(value => value === option.value)) {
-        selectedOptions.push(option);
-      }
-      const optionCharacterLength = option.display.toString().length;
-      maxOptionChars = Math.max(maxOptionChars, optionCharacterLength);
-    });
-    // avg char length + 48 padding for the rest of the menu
-    maxWidth = Math.max(50, maxOptionChars * 8 + 48);
+  function getMeasureContext(): CanvasRenderingContext2D | null {
+    if (typeof document === 'undefined') {
+      return null;
+    }
+    if (!measureCanvasContext) {
+      const canvas = document.createElement('canvas');
+      measureCanvasContext = canvas.getContext('2d');
+    }
+    return measureCanvasContext;
   }
+
+  function measureMaxOptionWidth(opts: DropdownOptions): number {
+    const ctx = getMeasureContext();
+    if (!ctx || !measureRef) {
+      return 0;
+    }
+    // Read the actual rendered font from a span that mirrors the option's CSS class —
+    // canvas needs the font in its own string format. One DOM read per measurement pass,
+    // not per option.
+    const cs = getComputedStyle(measureRef);
+    ctx.font = `${cs.fontStyle} ${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`;
+    let max = 0;
+    for (const opt of opts) {
+      const w = ctx.measureText(opt.display.toString()).width;
+      if (w > max) {
+        max = w;
+      }
+    }
+    return max;
+  }
+
+  // Measure the widest option text and add room for the row chrome:
+  //   px-3 (left) + icon 24 + gap 4 + px-3 (right) + scrollbar ~16 + small canvas-vs-browser buffer ~4
+  // = 72px. Re-runs when `options` changes or once `measureRef` is bound on mount.
+  $: maxWidth = measureRef ? Math.max(50, Math.ceil(measureMaxOptionWidth(options)) + 72) : 50;
 
   $: selectedOptions = options.filter(option => {
     return !!selectedOptionValues.find(value => value === option.value);
@@ -174,6 +199,14 @@
 </script>
 
 <div class={rootClasses}>
+  <!-- Hidden ref used to read the option text's computed font for canvas measurement; never visible.
+       Mirrors the classes the real option text inherits (MenuItem applies text-[13px] font-medium). -->
+  <span
+    bind:this={measureRef}
+    class="dropdown-item-text text-[13px] font-medium"
+    aria-hidden="true"
+    style="pointer-events: none; position: absolute; visibility: hidden;"
+  ></span>
   <!-- svelte-ignore a11y-click-events-have-key-events a11y-interactive-supports-focus -->
   <div
     class="selected-display st-input st-select w-full"
@@ -191,8 +224,10 @@
     }}
     use:tooltip={{ content: error || selectTooltip, placement: selectTooltipPlacement }}
   >
-    <span class="selected-display-value" class:error>{label}</span>
-    <button class="icon st-button icon-right" aria-label={name} on:click|stopPropagation={toggleMenu}>
+    <span class="selected-display-value" class:error class:loading-placeholder={loading}>
+      {loading ? 'Loading…' : label}
+    </span>
+    <button type="button" class="icon st-button icon-right" aria-label={name} on:click|stopPropagation={toggleMenu}>
       {#if $$slots.icon}
         <slot name="icon" />
       {:else}
@@ -228,21 +263,23 @@
           </Input>
         </div>
         <RowVirtualizerFixed
-          count={displayedOptions.length}
+          items={displayedOptions}
           overscan={100}
+          estimatedItemHeight={36}
           maxHeight={maxListHeight}
           minWidth="{maxWidth}px"
           selectedIndex={selectedOptions.length
             ? displayedOptions.findIndex(o => o.value === selectedOptions[0].value)
             : undefined}
+          let:item
           let:index
         >
-          {@const displayedOption = displayedOptions[index]}
+          {@const displayedOption = item}
           {@const selected =
             !!selectedOptions.find(o => o.value === displayedOption.value) ||
             (!!showPlaceholderOption && selectedOptions.length === 0 && index === 0)}
           <MenuItem
-            className="py-2"
+            className="min-h-9 py-2"
             {selected}
             use={[
               [
@@ -364,5 +401,10 @@
   .dropdown-item-text {
     overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .selected-display-value.loading-placeholder {
+    color: var(--st-gray-50);
   }
 </style>

--- a/src/components/workspace/WorkspaceFileBrowser/WorkspaceFileBrowser.svelte
+++ b/src/components/workspace/WorkspaceFileBrowser/WorkspaceFileBrowser.svelte
@@ -29,7 +29,7 @@
     WorkspaceTreeNode,
     WorkspaceTreeNodeWithFullPath,
   } from '../../../types/workspace-tree-view';
-  import { getLocalStorageItem, removeLocalStorageItem, setLocalStorageItem } from '../../../utilities/localStorage';
+  import { getLocalStorageItem } from '../../../utilities/localStorage';
   import { featurePermissions } from '../../../utilities/permissions';
   import {
     computeTreeFilter,
@@ -657,17 +657,12 @@
     actionsMenuFocused = event.detail;
   }
 
-  function saveColumnState() {
-    if (columnStates && columnStates.length > 0) {
-      setLocalStorageItem(WORKSPACE_FILE_BROWSER_COLUMN_STATE_KEY, columnStates);
-    }
-  }
-
   function updateColumnState(updatedColumnStates?: ColumnState[]) {
     const columnStatesToUpdate = updatedColumnStates ?? dataGrid?.getColumnState();
     if (columnStatesToUpdate) {
+      // DataGrid handles persistence via persistColumnStateKey + transformColumnState; this just keeps
+      // the local copy in sync for menu rendering and sort-state derivation.
       columnStates = processNameColumnState(columnStatesToUpdate);
-      saveColumnState();
     }
   }
 
@@ -731,7 +726,6 @@
 
   function onResetColumns() {
     nameColumnUserWidth = null;
-    removeLocalStorageItem(WORKSPACE_FILE_BROWSER_COLUMN_STATE_KEY);
     columnStates = [
       { colId: 'name', hide: false },
       ...metadataColumnDefs.map(col => ({
@@ -799,6 +793,8 @@
     class="workspace-file-browser"
     {columnDefs}
     {columnStates}
+    persistColumnStateKey={WORKSPACE_FILE_BROWSER_COLUMN_STATE_KEY}
+    transformColumnState={processNameColumnState}
     columnShiftResize
     getRowId={node => node.fullPath}
     {hasDeletePermission}

--- a/src/constants/localStorage.ts
+++ b/src/constants/localStorage.ts
@@ -1,1 +1,3 @@
 export const WORKSPACE_FILE_BROWSER_COLUMN_STATE_KEY = 'workspace-file-browser-column-state';
+
+export const SEARCH_RESULTS_COLUMN_STATE_KEY = 'search-results-column-state';

--- a/src/enums/gql.ts
+++ b/src/enums/gql.ts
@@ -204,6 +204,7 @@ export enum Queries {
   SCHEDULING_SPECIFICATION = 'scheduling_specification_by_pk',
   SCHEDULING_SPECIFICATION_CONDITIONS = 'scheduling_specification_conditions',
   SCHEDULING_SPECIFICATION_GOALS = 'scheduling_specification_goals',
+  SEARCH_ACTIVITIES = 'search_activities',
   SEEN_SOURCES = 'seen_sources',
   SEQUENCE = 'sequence',
   SEQUENCE_ADAPTATION = 'sequence_adaptation',

--- a/src/routes/search/+layout.svelte
+++ b/src/routes/search/+layout.svelte
@@ -7,7 +7,7 @@
 
 <CssGrid rows="var(--nav-header-height) calc(100vh - var(--nav-header-height))">
   <Nav>
-    <span class="scheduling-title" slot="title">Search</span>
+    <span class="scheduling-title" slot="title">Activity Search</span>
   </Nav>
 
   <slot />

--- a/src/routes/search/+layout.svelte
+++ b/src/routes/search/+layout.svelte
@@ -1,0 +1,14 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import Nav from '../../components/app/Nav.svelte';
+  import CssGrid from '../../components/ui/CssGrid.svelte';
+</script>
+
+<CssGrid rows="var(--nav-header-height) calc(100vh - var(--nav-header-height))">
+  <Nav>
+    <span class="scheduling-title" slot="title">Search</span>
+  </Nav>
+
+  <slot />
+</CssGrid>

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -1,0 +1,13 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import PageTitle from '../../components/app/PageTitle.svelte';
+  import Search from '../../components/search/Search.svelte';
+  import { getUserStore } from '../../stores/user';
+
+  const user = getUserStore();
+</script>
+
+<PageTitle title="Search" />
+
+<Search user={$user} />

--- a/src/routes/search/+page.ts
+++ b/src/routes/search/+page.ts
@@ -1,0 +1,9 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ parent }) => {
+  const { user } = await parent();
+
+  return {
+    user,
+  };
+};

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -1,0 +1,9 @@
+import { writable, type Writable } from 'svelte/store';
+import type { ActivityDirectiveSearchResult } from '../types/activity';
+
+/* Writeable. */
+export const searchColumns: Writable<string> = writable('1fr 3px 1fr');
+
+export const hasSearched: Writable<boolean> = writable(false);
+
+export const searchResults: Writable<ActivityDirectiveSearchResult[] | null> = writable(null);

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -1,9 +1,17 @@
 import { writable, type Writable } from 'svelte/store';
 import type { ActivityDirectiveSearchResult } from '../types/activity';
 
+export const PAGE_SIZE = 50;
+
 /* Writeable. */
-export const searchColumns: Writable<string> = writable('1fr 3px 1fr');
+export const searchColumns: Writable<string> = writable('1fr 3px 4fr');
 
 export const hasSearched: Writable<boolean> = writable(false);
 
 export const searchResults: Writable<ActivityDirectiveSearchResult[] | null> = writable(null);
+
+export const searchTotalCount: Writable<number> = writable(0);
+
+export const searchCurrentPage: Writable<number> = writable(0);
+
+export const searchOrderBy: Writable<Record<string, string>[]> = writable([{ last_modified_at: 'desc' }]);

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -17,3 +17,11 @@ export const searchCurrentPage: Writable<number> = writable(0);
 export const searchOrderBy: Writable<Record<string, string>[]> = writable([{ last_modified_at: 'desc' }]);
 
 export const isSearching: Writable<boolean> = writable(false);
+
+/**
+ * Monotonically increments every time a search completes (success or empty).
+ * Surfaced as a `data-search-sequence` attribute in the results panel so e2e
+ * tests have a deterministic, UI-observable signal to wait on without relying
+ * on the spinner — which is intentionally delayed to avoid flashing.
+ */
+export const searchRunId: Writable<number> = writable(0);

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -18,10 +18,4 @@ export const searchOrderBy: Writable<Record<string, string>[]> = writable([{ las
 
 export const isSearching: Writable<boolean> = writable(false);
 
-/**
- * Monotonically increments every time a search completes (success or empty).
- * Surfaced as a `data-search-sequence` attribute in the results panel so e2e
- * tests have a deterministic, UI-observable signal to wait on without relying
- * on the spinner — which is intentionally delayed to avoid flashing.
- */
 export const searchRunId: Writable<number> = writable(0);

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -15,3 +15,5 @@ export const searchTotalCount: Writable<number> = writable(0);
 export const searchCurrentPage: Writable<number> = writable(0);
 
 export const searchOrderBy: Writable<Record<string, string>[]> = writable([{ last_modified_at: 'desc' }]);
+
+export const isSearching: Writable<boolean> = writable(false);

--- a/src/tests/mocks/activity/mockActivityDirective.ts
+++ b/src/tests/mocks/activity/mockActivityDirective.ts
@@ -1,0 +1,31 @@
+import type { ActivityDirective } from '../../../types/activity';
+
+/**
+ * Build a minimal `ActivityDirective` for use in unit tests. `id` and `plan_id`
+ * are required because most call sites care about identity; everything else
+ * defaults to a low-noise stub and can be overridden as needed.
+ */
+export function makeMockActivityDirective(
+  overrides: Partial<ActivityDirective> & { id: number; plan_id: number },
+): ActivityDirective {
+  return {
+    anchor_id: null,
+    anchored_to_start: true,
+    applied_preset: null,
+    arguments: {},
+    created_at: '2006-07-11T00:00:00',
+    created_by: 'admin',
+    last_modified_arguments_at: '2006-07-11T00:00:00',
+    last_modified_at: '2006-07-11T00:00:00',
+    last_modified_by: 'admin',
+    metadata: {},
+    name: `Activity ${overrides.id}`,
+    source_scheduling_goal_id: null,
+    source_scheduling_goal_invocation_id: null,
+    start_offset: '01:00:00',
+    start_time_ms: 0,
+    tags: [],
+    type: 'foo',
+    ...overrides,
+  };
+}

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -4,8 +4,9 @@ import type { PartialWith, UserId } from './app';
 import type { ActivityDirectiveValidationFailures } from './errors';
 import type { ExpansionRuleSlim } from './expansion';
 import type { ArgumentsMap, ParametersMap } from './parameter';
+import type { PlanSchema } from './plan';
 import type { ValueSchema } from './schema';
-import type { Tag } from './tags';
+import type { Tag, TagsInsertInput } from './tags';
 
 export type ActivityType = {
   computed_attributes_value_schema: ValueSchema;
@@ -131,3 +132,16 @@ export type PlanSnapshotActivity = Omit<ActivityDirective, 'anchor_validations' 
 export type PlanSnapshotActivityDB = Omit<ActivityDirectiveDB, 'anchor_validations' | 'applied_preset' | 'plan_id'> & {
   snapshot_id: number;
 };
+
+export interface ActivityDirectiveSearchResult {
+  applied_preset: AppliedPreset['preset_applied']['name'] | null;
+  arguments: ArgumentsMap;
+  directive_id: number;
+  name: string;
+  plan: Pick<PlanSchema, 'model_id' | 'name'>;
+  plan_id: number;
+  tags: {
+    tag: TagsInsertInput;
+  }[];
+  type: string;
+}

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -133,24 +133,21 @@ export type PlanSnapshotActivityDB = Omit<ActivityDirectiveDB, 'anchor_validatio
   snapshot_id: number;
 };
 
-export interface ActivityDirectiveSearchResult {
-  applied_preset: AppliedPreset['preset_applied']['name'] | null;
-  arguments: ArgumentsMap;
-  created_at: string;
-  created_by: UserId;
-  directive_id: number;
-  last_modified_at: string;
-  last_modified_by: UserId;
-  name: string;
-  plan: Pick<PlanSchema, 'model_id' | 'name' | 'owner' | 'start_time' | 'tags'>;
-  plan_id: number;
-  source_scheduling_goal_id: number | null;
-  start_offset: string;
-  tags: {
-    tag: TagsInsertInput;
-  }[];
-  type: string;
-}
+// What SEARCH_ACTIVITIES returns per row. Extends the DB shape with the joined
+// `plan` / `source_scheduling_goal` selections and overrides fields whose
+// projected shape differs (`applied_preset` traverses through `preset_applied`,
+// `tags` only selects color/name).
+export type ActivityDirectiveSearchResult = Omit<
+  ActivityDirectiveDB,
+  'applied_preset' | 'last_modified_arguments_at' | 'source_scheduling_goal_invocation_id' | 'tags'
+> & {
+  applied_preset: { preset_applied: Pick<ActivityPreset, 'name'> } | null;
+  plan: Pick<PlanSchema, 'model_id' | 'name' | 'owner' | 'start_time' | 'tags'> & {
+    model: { id: number; name: string } | null;
+  };
+  source_scheduling_goal: { id: number; name: string } | null;
+  tags: { tag: TagsInsertInput }[];
+};
 
 export interface ActivitySearchResponse {
   activity_directive: ActivityDirectiveSearchResult[];

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -137,6 +137,7 @@ export interface ActivityDirectiveSearchResult {
   applied_preset: AppliedPreset['preset_applied']['name'] | null;
   arguments: ArgumentsMap;
   directive_id: number;
+  last_modified_at: string;
   name: string;
   plan: Pick<PlanSchema, 'model_id' | 'name'>;
   plan_id: number;

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -136,13 +136,27 @@ export type PlanSnapshotActivityDB = Omit<ActivityDirectiveDB, 'anchor_validatio
 export interface ActivityDirectiveSearchResult {
   applied_preset: AppliedPreset['preset_applied']['name'] | null;
   arguments: ArgumentsMap;
+  created_at: string;
+  created_by: UserId;
   directive_id: number;
   last_modified_at: string;
+  last_modified_by: UserId;
   name: string;
-  plan: Pick<PlanSchema, 'model_id' | 'name'>;
+  plan: Pick<PlanSchema, 'model_id' | 'name' | 'owner' | 'start_time' | 'tags'>;
   plan_id: number;
+  source_scheduling_goal_id: number | null;
+  start_offset: string;
   tags: {
     tag: TagsInsertInput;
   }[];
   type: string;
+}
+
+export interface ActivitySearchResponse {
+  activity_directive: ActivityDirectiveSearchResult[];
+  activity_directive_aggregate: {
+    aggregate: {
+      count: number;
+    };
+  };
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -34,6 +34,7 @@ export type ModelLog = {
 };
 
 export type ModelSchema = {
+  activity_types: { name: string; parameters: ParametersMap }[];
   constraint_specification: ConstraintModelSpecification[];
   created_at: string;
   default_view_id: number | null;
@@ -57,6 +58,7 @@ export type ModelSchema = {
 
 export type ModelSlim = Pick<
   Model,
+  | 'activity_types'
   | 'created_at'
   | 'description'
   | 'id'

--- a/src/utilities/activities.test.ts
+++ b/src/utilities/activities.test.ts
@@ -297,6 +297,7 @@ function getTestPlan(): Plan {
     id: 1,
     is_locked: false,
     model: {
+      activity_types: [],
       constraint_specification: [],
       created_at: '2006-07-11T00:00:00',
       default_view_id: 0,

--- a/src/utilities/activities.test.ts
+++ b/src/utilities/activities.test.ts
@@ -1,5 +1,6 @@
 import { keyBy, reverse } from 'lodash-es';
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { makeMockActivityDirective } from '../tests/mocks/activity/mockActivityDirective';
 import type { ActivityDirective, ActivityDirectiveDB } from '../types/activity';
 import type { Plan } from '../types/plan';
 import type { Span, SpanUtilityMaps, SpansMap } from '../types/simulation';
@@ -7,6 +8,7 @@ import {
   addAbsoluteTimeToRevision,
   bulkShiftActivityDirectivesInPlan,
   computeActivityDirectivesMap,
+  copyActivityDirectivesToClipboard,
   createSpanUtilityMaps,
   getActivityMetadata,
   getAllSpanChildrenIds,
@@ -721,5 +723,84 @@ describe('bulkShiftActivityDirectivesInPlan', () => {
     expect(shiftedRight[0].start_offset === '12:00:00');
     expect(shiftedRight[1].start_offset === '09:00:00'); //Was anchored to activity with id=1 so shift happens automatically
     expect(shiftedRight[2].start_offset === '10:00:00');
+  });
+});
+
+describe('copyActivityDirectivesToClipboard', () => {
+  // Capture the JSON written to clipboard. jsdom doesn't ship navigator.clipboard, so
+  // we stub it inline. setClipboardContent serializes via JSON.stringify(content).
+  let writeTextMock: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(global.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: writeTextMock },
+    });
+  });
+
+  function getClippedActivities(): any[] {
+    expect(writeTextMock).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(writeTextMock.mock.calls[0][0]);
+    return payload.activities;
+  }
+
+  test('single-plan copy preserves intra-selection anchors', () => {
+    // A=1, B=2 anchored to A (both in plan 1). Expect B's anchor preserved.
+    const a = makeMockActivityDirective({ id: 1, plan_id: 1 });
+    const b = makeMockActivityDirective({ anchor_id: 1, id: 2, plan_id: 1, start_offset: '02:00:00' });
+    copyActivityDirectivesToClipboard(null, [a, b]);
+    const clipped = getClippedActivities();
+    expect(clipped).toHaveLength(2);
+    expect(clipped[0]).toMatchObject({ anchor_id: null, id: 1, plan_id: 1 });
+    expect(clipped[1]).toMatchObject({ anchor_id: 1, id: 2, plan_id: 1, start_offset: '02:00:00' });
+  });
+
+  test('strips anchor when anchor target is not in selection', () => {
+    // B=2 anchored to id=99 (not selected). Expect anchor stripped, start_offset reset.
+    const b = makeMockActivityDirective({ anchor_id: 99, id: 2, plan_id: 1, start_offset: '02:00:00' });
+    copyActivityDirectivesToClipboard(null, [b]);
+    const clipped = getClippedActivities();
+    expect(clipped[0]).toMatchObject({ anchor_id: null, id: 2, plan_id: 1, start_offset: '0' });
+  });
+
+  test('cross-plan: anchor_id colliding with another plan id is NOT preserved', () => {
+    // A=5 in plan 1, C=7 anchored to id=5 in plan 2. C's anchor refers to plan 2's id=5
+    // (NOT plan 1's A) — must be stripped despite the id collision in the selection.
+    const a = makeMockActivityDirective({ id: 5, plan_id: 1 });
+    const c = makeMockActivityDirective({ anchor_id: 5, id: 7, plan_id: 2, start_offset: '03:00:00' });
+    copyActivityDirectivesToClipboard(null, [a, c]);
+    const clipped = getClippedActivities();
+    expect(clipped[0]).toMatchObject({ anchor_id: null, id: 5, plan_id: 1 });
+    expect(clipped[1]).toMatchObject({ anchor_id: null, id: 7, plan_id: 2, start_offset: '0' });
+  });
+
+  test('cross-plan: each anchor is scoped to its own plan', () => {
+    // Two parallel anchor chains in different plans, all in selection:
+    // plan 1: A(id=5), C(id=10, anchor=5) — anchor preserved
+    // plan 2: B(id=5), D(id=11, anchor=5) — anchor preserved
+    // C's anchor must end up scoped to plan 1's A, not plan 2's B.
+    const a = makeMockActivityDirective({ id: 5, plan_id: 1 });
+    const b = makeMockActivityDirective({ id: 5, plan_id: 2 });
+    const c = makeMockActivityDirective({ anchor_id: 5, id: 10, plan_id: 1 });
+    const d = makeMockActivityDirective({ anchor_id: 5, id: 11, plan_id: 2 });
+    copyActivityDirectivesToClipboard(null, [a, b, c, d]);
+    const clipped = getClippedActivities();
+    expect(clipped).toHaveLength(4);
+    expect(clipped[0]).toMatchObject({ anchor_id: null, id: 5, plan_id: 1 });
+    expect(clipped[1]).toMatchObject({ anchor_id: null, id: 5, plan_id: 2 });
+    // Anchors are preserved on both rows — the scoping is enforced at paste time via
+    // (plan_id, id) in cloneActivityDirectives' remap (covered in effects.test.ts).
+    expect(clipped[2]).toMatchObject({ anchor_id: 5, id: 10, plan_id: 1 });
+    expect(clipped[3]).toMatchObject({ anchor_id: 5, id: 11, plan_id: 2 });
+  });
+
+  test('payload always carries plan_id per activity', () => {
+    const a = makeMockActivityDirective({ id: 1, plan_id: 7 });
+    const b = makeMockActivityDirective({ id: 2, plan_id: 9 });
+    copyActivityDirectivesToClipboard(null, [a, b]);
+    const clipped = getClippedActivities();
+    expect(clipped.every((c: { plan_id?: number }) => typeof c.plan_id === 'number')).toBe(true);
+    expect(clipped[0].plan_id).toBe(7);
+    expect(clipped[1].plan_id).toBe(9);
   });
 });

--- a/src/utilities/activities.ts
+++ b/src/utilities/activities.ts
@@ -235,7 +235,7 @@ export function transformPlanMergeNonConflictingActivities(
   }));
 }
 
-export function copyActivityDirectivesToClipboard(sourcePlan: Plan, activities: ActivityDirective[]) {
+export function copyActivityDirectivesToClipboard(sourcePlan: Plan | null, activities: ActivityDirective[]) {
   const copiedActivityIds = new Set(activities.map(a => a.id));
   const clippedActivities = activities.map(activity => {
     const anchorInSelection = activity.anchor_id !== null && copiedActivityIds.has(activity.anchor_id);
@@ -254,7 +254,7 @@ export function copyActivityDirectivesToClipboard(sourcePlan: Plan, activities: 
 
   const clipboard = {
     activities: clippedActivities,
-    sourcePlan: sourcePlan.id,
+    sourcePlan: sourcePlan?.id ?? null,
     type: `aerie_activity_directives`,
   };
 
@@ -308,8 +308,11 @@ export async function getActivityDirectivesToPaste(
       const planStart = getUnixEpochTime(destinationPlan.start_time_doy);
       const planEnd = getUnixEpochTime(destinationPlan.end_time_doy);
       const earliestStart = Math.min(...starts);
-      if (earliestStart < planStart || earliestStart > planEnd) {
-        pasteStartingAtTime = planStart; //if out of bounds, paste starting at the start of the plan.
+      // Only fall back to plan start when the caller didn't pick a paste time. A right-click → Paste
+      // at time X must always honor X — cross-plan pastes (e.g. from search results) routinely have
+      // source absolute times far outside the target plan's window.
+      if (pasteStartingAtTime === undefined && (earliestStart < planStart || earliestStart > planEnd)) {
+        pasteStartingAtTime = planStart;
       }
 
       //transpose in time if we're given a time or if it was out of bounds

--- a/src/utilities/activities.ts
+++ b/src/utilities/activities.ts
@@ -236,15 +236,24 @@ export function transformPlanMergeNonConflictingActivities(
 }
 
 export function copyActivityDirectivesToClipboard(sourcePlan: Plan | null, activities: ActivityDirective[]) {
-  const copiedActivityIds = new Set(activities.map(a => a.id));
+  // Activity directive ids are unique per-plan but not globally. When the
+  // selection spans multiple plans (e.g. from cross-plan activity search),
+  // anchor membership must be checked against `(plan_id, id)` — otherwise an
+  // anchor_id from plan B can spuriously match an id from plan A in the same
+  // selection and silently rewire across plans on paste. The clipped payload
+  // also carries the source `plan_id` so the paste-side anchor remap in
+  // `cloneActivityDirectives` can disambiguate same-id activities.
+  const copiedActivityKeys = new Set(activities.map(a => `${a.plan_id}:${a.id}`));
   const clippedActivities = activities.map(activity => {
-    const anchorInSelection = activity.anchor_id !== null && copiedActivityIds.has(activity.anchor_id);
+    const anchorInSelection =
+      activity.anchor_id !== null && copiedActivityKeys.has(`${activity.plan_id}:${activity.anchor_id}`);
     return {
       anchor_id: anchorInSelection ? activity.anchor_id : null,
       anchored_to_start: activity.anchored_to_start,
       arguments: activity.arguments,
       id: activity.id,
       name: activity.name,
+      plan_id: activity.plan_id,
       start_offset: activity.anchor_id !== null && !anchorInSelection ? '0' : activity.start_offset,
       start_time_ms: activity.start_time_ms,
       tags: activity.tags,

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -7217,6 +7217,7 @@ const effects = {
       orderBy: Record<string, string>[];
     },
     user: User | null,
+    signal?: AbortSignal,
   ): Promise<{ results: ActivityDirectiveSearchResult[]; totalCount: number } | null> {
     try {
       const clauses = buildSearchActivitiesWhereClauses(filters);
@@ -7230,6 +7231,7 @@ const effects = {
           searchFilter: { _and: clauses },
         },
         user,
+        signal,
       )) as unknown as ActivitySearchResponse;
 
       if (data.activity_directive) {
@@ -7239,6 +7241,9 @@ const effects = {
         };
       }
     } catch (e) {
+      if ((e as Error)?.name === 'AbortError') {
+        return null;
+      }
       catchError('Search Failed', e as Error);
       showFailureToast('Search Failed');
     }

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -7286,7 +7286,7 @@ const effects = {
 
       const data = await reqHasura<ActivityDirectiveSearchResult[]>(
         gql.SEARCH_ACTIVITIES,
-        { searchFilter: { _and: clauses } },
+        { limit: 500, searchFilter: { _and: clauses } },
         user,
       );
       if (data.activity_directive) {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -847,7 +847,11 @@ const effects = {
         throwPermissionError('clone activity directives into the plan');
       }
 
-      const activityRemap: Record<number, number> = {};
+      // Source activity ids are only unique per-plan, so anchor remap is keyed by
+      // `${source_plan_id}:${id}` — see `copyActivityDirectivesToClipboard`, which
+      // carries `plan_id` per clipped activity for this purpose. Cross-plan pastes
+      // without compound keys would alias same-id rows from different source plans.
+      const activityRemap: Record<string, number> = {};
       const activityDirectivesInsertInput = activities.map(
         ({ anchored_to_start, arguments: activityArguments, metadata, name, start_offset, type }) => {
           const activityDirectiveInsertInput: ActivityDirectiveInsertInput = {
@@ -875,15 +879,18 @@ const effects = {
       if (createdActivities !== null) {
         const { returning: clonedActivitiesReferences } = createdActivities;
         clonedActivitiesReferences.forEach((directive, index) => {
-          const { id } = activities[index];
-          activityRemap[id] = directive.id;
+          const { id, plan_id: sourcePlanId } = activities[index];
+          activityRemap[`${sourcePlanId}:${id}`] = directive.id;
         });
 
         const anchorUpdates = activities
           .filter(({ anchor_id: anchorId }) => anchorId !== null)
-          .map(({ anchor_id: anchorId, id }) => ({
-            _set: { anchor_id: activityRemap[anchorId as number] },
-            where: { id: { _eq: activityRemap[id] }, plan_id: { _eq: (plan as PlanSchema).id } },
+          .map(({ anchor_id: anchorId, id, plan_id: sourcePlanId }) => ({
+            _set: { anchor_id: activityRemap[`${sourcePlanId}:${anchorId as number}`] ?? null },
+            where: {
+              id: { _eq: activityRemap[`${sourcePlanId}:${id}`] },
+              plan_id: { _eq: (plan as PlanSchema).id },
+            },
           }));
 
         await reqHasura<ActivityDirectiveDB>(gql.UPDATE_ACTIVITY_DIRECTIVES, { updates: anchorUpdates }, user);

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -87,6 +87,7 @@ import type {
   ActivityDirectiveInsertInput,
   ActivityDirectiveRevision,
   ActivityDirectiveSearchResult,
+  ActivitySearchResponse,
   ActivityDirectiveSetInput,
   ActivityPreset,
   ActivityPresetId,
@@ -7201,118 +7202,100 @@ const effects = {
   },
 
   async searchActivities(
-    modelId: number | undefined,
-    filterArgType: string,
-    filterActName: string,
-    filterArgs: [name: string, value: string | number | boolean][],
-    filterTagValue: string,
-    filterPreset: string,
+    filters: {
+      actName: string;
+      actType: string;
+      args: [name: string, value: string | number | boolean][];
+      createdBy: string;
+      lastModifiedAfter: string;
+      lastModifiedBefore: string;
+      modelId: number | undefined;
+      planName: string;
+      planOwner: string;
+      preset: string;
+      schedulerCreatedOnly: boolean;
+      tagValue: string;
+    },
+    pagination: {
+      limit: number;
+      offset: number;
+      orderBy: Record<string, string>[];
+    },
     user: User | null,
-  ): Promise<ActivityDirectiveSearchResult[] | null> {
+  ): Promise<{ results: ActivityDirectiveSearchResult[]; totalCount: number } | null> {
     try {
       const clauses = [];
-      if (modelId !== undefined && modelId !== null) {
-        clauses.push({
-          plan: {
-            model_id: {
-              _eq: modelId,
-            },
-          },
-        });
+
+      if (filters.modelId !== undefined && filters.modelId !== null) {
+        clauses.push({ plan: { model_id: { _eq: filters.modelId } } });
       }
-      if (filterArgType) {
-        clauses.push({
-          type: {
-            _eq: filterArgType,
-          },
-        });
+      if (filters.actType) {
+        clauses.push({ type: { _eq: filters.actType } });
       }
-      if (filterActName) {
-        clauses.push({
-          name: {
-            _ilike: `%${filterActName}%`,
-          },
-        });
+      if (filters.actName) {
+        clauses.push({ name: { _ilike: `%${filters.actName}%` } });
       }
-      if (filterTagValue) {
-        clauses.push({
-          tags: {
-            tag: {
-              name: {
-                _eq: filterTagValue,
-              },
-            },
-          },
-        });
+      if (filters.tagValue) {
+        clauses.push({ tags: { tag: { name: { _eq: filters.tagValue } } } });
       }
-      if (filterPreset) {
-        clauses.push({
-          applied_preset: {
-            preset_applied: {
-              name: {
-                _eq: filterPreset,
-              },
-            },
-          },
-        });
+      if (filters.preset) {
+        clauses.push({ applied_preset: { preset_applied: { name: { _eq: filters.preset } } } });
+      }
+      if (filters.createdBy) {
+        clauses.push({ created_by: { _eq: filters.createdBy } });
+      }
+      if (filters.lastModifiedAfter) {
+        // datetime-local values (YYYY-MM-DDTHH:MM) are parsed as local time by JS Date
+        clauses.push({ last_modified_at: { _gte: new Date(filters.lastModifiedAfter).toISOString() } });
+      }
+      if (filters.lastModifiedBefore) {
+        clauses.push({ last_modified_at: { _lte: new Date(filters.lastModifiedBefore).toISOString() } });
+      }
+      if (filters.planName) {
+        clauses.push({ plan: { name: { _ilike: `%${filters.planName}%` } } });
+      }
+      if (filters.planOwner) {
+        clauses.push({ plan: { owner: { _eq: filters.planOwner } } });
+      }
+      if (filters.schedulerCreatedOnly) {
+        clauses.push({ source_scheduling_goal_id: { _is_null: false } });
       }
 
-      for (const [argName, argValue] of filterArgs) {
+      for (const [argName, argValue] of filters.args) {
         if (argName === '' && argValue === '') {
           continue;
         } else if (argName === '') {
-          clauses.push({
-            arguments: {
-              _cast: {
-                String: {
-                  _ilike: `%${argValue}%`,
-                },
-              },
-            },
-          });
+          clauses.push({ arguments: { _cast: { String: { _ilike: `%${argValue}%` } } } });
         } else if (argValue === '') {
-          clauses.push({
-            arguments: {
-              _has_key: argName,
-            },
-          });
+          clauses.push({ arguments: { _has_key: argName } });
         } else if (typeof argValue === 'string') {
-          clauses.push({
-            arguments: {
-              _contains: {
-                [argName]: argValue,
-              },
-            },
-          });
+          clauses.push({ arguments: { _contains: { [argName]: argValue } } });
         } else if (typeof argValue === 'number' || typeof argValue === 'boolean') {
           clauses.push({
             _or: [
-              {
-                arguments: {
-                  _contains: {
-                    [argName]: argValue,
-                  },
-                },
-              },
-              {
-                arguments: {
-                  _contains: {
-                    [argName]: argValue.toString(),
-                  },
-                },
-              },
+              { arguments: { _contains: { [argName]: argValue } } },
+              { arguments: { _contains: { [argName]: argValue.toString() } } },
             ],
           });
         }
       }
 
-      const data = await reqHasura<ActivityDirectiveSearchResult[]>(
+      const data: ActivitySearchResponse = (await reqHasura(
         gql.SEARCH_ACTIVITIES,
-        { limit: 500, searchFilter: { _and: clauses } },
+        {
+          limit: pagination.limit,
+          offset: pagination.offset,
+          orderBy: pagination.orderBy,
+          searchFilter: { _and: clauses },
+        },
         user,
-      );
+      )) as unknown as ActivitySearchResponse;
+
       if (data.activity_directive) {
-        return data.activity_directive;
+        return {
+          results: data.activity_directive,
+          totalCount: data.activity_directive_aggregate?.aggregate?.count ?? 0,
+        };
       }
     } catch (e) {
       catchError('Search Failed', e as Error);

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -86,6 +86,7 @@ import type {
   ActivityDirectiveId,
   ActivityDirectiveInsertInput,
   ActivityDirectiveRevision,
+  ActivityDirectiveSearchResult,
   ActivityDirectiveSetInput,
   ActivityPreset,
   ActivityPresetId,
@@ -7197,6 +7198,105 @@ const effects = {
       catchError('Unable to schedule', e as Error);
       showFailureToast('Scheduling failed');
     }
+  },
+
+  async searchActivities(
+    filterArgType: string,
+    filterActName: string,
+    filterArgs: [name: string, value: string | number | boolean][],
+    filterTagValue: string,
+    user: User | null,
+  ): Promise<ActivityDirectiveSearchResult[] | null> {
+    try {
+      const clauses = [];
+      if (filterArgType) {
+        clauses.push({
+          type: {
+            _eq: filterArgType,
+          },
+        });
+      }
+      if (filterActName) {
+        clauses.push({
+          name: {
+            _ilike: `%${filterActName}%`,
+          },
+        });
+      }
+      if (filterTagValue) {
+        clauses.push({
+          tags: {
+            tag: {
+              name: {
+                _eq: filterTagValue,
+              },
+            },
+          },
+        });
+      }
+
+      for (const [argName, argValue] of filterArgs) {
+        if (argName === '' && argValue === '') {
+          continue;
+        } else if (argName === '') {
+          clauses.push({
+            arguments: {
+              _cast: {
+                String: {
+                  _ilike: `%${argValue}%`,
+                },
+              },
+            },
+          });
+        } else if (argValue === '') {
+          clauses.push({
+            arguments: {
+              _has_key: argName,
+            },
+          });
+        } else if (typeof argValue === 'string') {
+          clauses.push({
+            arguments: {
+              _contains: {
+                [argName]: argValue,
+              },
+            },
+          });
+        } else if (typeof argValue === 'number' || typeof argValue === 'boolean') {
+          clauses.push({
+            _or: [
+              {
+                arguments: {
+                  _contains: {
+                    [argName]: argValue,
+                  },
+                },
+              },
+              {
+                arguments: {
+                  _contains: {
+                    [argName]: argValue.toString(),
+                  },
+                },
+              },
+            ],
+          });
+        }
+      }
+
+      const data = await reqHasura<ActivityDirectiveSearchResult[]>(
+        gql.SEARCH_ACTIVITIES,
+        { searchFilter: { _and: clauses } },
+        user,
+      );
+      if (data.activity_directive) {
+        return data.activity_directive;
+      }
+    } catch (e) {
+      catchError('Search Failed', e as Error);
+      showFailureToast('Search Failed');
+    }
+    return null;
   },
 
   async sendActionSecretParameters(

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -7214,6 +7214,8 @@ const effects = {
       planOwner: string;
       preset: string;
       schedulerCreatedOnly: boolean;
+      startOffsetMax: string;
+      startOffsetMin: string;
       tagValue: string;
     },
     pagination: {
@@ -7259,6 +7261,12 @@ const effects = {
       }
       if (filters.schedulerCreatedOnly) {
         clauses.push({ source_scheduling_goal_id: { _is_null: false } });
+      }
+      if (filters.startOffsetMin) {
+        clauses.push({ start_offset: { _gte: filters.startOffsetMin } });
+      }
+      if (filters.startOffsetMax) {
+        clauses.push({ start_offset: { _lte: filters.startOffsetMax } });
       }
 
       for (const [argName, argValue] of filters.args) {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -7201,14 +7201,25 @@ const effects = {
   },
 
   async searchActivities(
+    modelId: number | undefined,
     filterArgType: string,
     filterActName: string,
     filterArgs: [name: string, value: string | number | boolean][],
     filterTagValue: string,
+    filterPreset: string,
     user: User | null,
   ): Promise<ActivityDirectiveSearchResult[] | null> {
     try {
       const clauses = [];
+      if (modelId !== undefined && modelId !== null) {
+        clauses.push({
+          plan: {
+            model_id: {
+              _eq: modelId,
+            },
+          },
+        });
+      }
       if (filterArgType) {
         clauses.push({
           type: {
@@ -7229,6 +7240,17 @@ const effects = {
             tag: {
               name: {
                 _eq: filterTagValue,
+              },
+            },
+          },
+        });
+      }
+      if (filterPreset) {
+        clauses.push({
+          applied_preset: {
+            preset_applied: {
+              name: {
+                _eq: filterPreset,
               },
             },
           },

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -299,6 +299,7 @@ import {
 } from './modal';
 import { featurePermissions, gatewayPermissions, queryPermissions } from './permissions';
 import { CompoundError, reqActionServer, reqExtension, reqGateway, reqHasura } from './requests';
+import { buildSearchActivitiesWhereClauses, type ActivitySearchFilters } from './searchFilters';
 import { sampleProfiles } from './resources';
 import { convertResponseToMetadata } from './scheduling';
 import { compareEvents } from './simulation';
@@ -7202,22 +7203,7 @@ const effects = {
   },
 
   async searchActivities(
-    filters: {
-      actName: string;
-      actType: string;
-      args: [name: string, value: string | number | boolean][];
-      createdBy: string;
-      lastModifiedAfter: string;
-      lastModifiedBefore: string;
-      modelId: number | undefined;
-      planName: string;
-      planOwner: string;
-      preset: string;
-      schedulerCreatedOnly: boolean;
-      startOffsetMax: string;
-      startOffsetMin: string;
-      tagValue: string;
-    },
+    filters: ActivitySearchFilters,
     pagination: {
       limit: number;
       offset: number;
@@ -7226,67 +7212,7 @@ const effects = {
     user: User | null,
   ): Promise<{ results: ActivityDirectiveSearchResult[]; totalCount: number } | null> {
     try {
-      const clauses = [];
-
-      if (filters.modelId !== undefined && filters.modelId !== null) {
-        clauses.push({ plan: { model_id: { _eq: filters.modelId } } });
-      }
-      if (filters.actType) {
-        clauses.push({ type: { _eq: filters.actType } });
-      }
-      if (filters.actName) {
-        clauses.push({ name: { _ilike: `%${filters.actName}%` } });
-      }
-      if (filters.tagValue) {
-        clauses.push({ tags: { tag: { name: { _eq: filters.tagValue } } } });
-      }
-      if (filters.preset) {
-        clauses.push({ applied_preset: { preset_applied: { name: { _eq: filters.preset } } } });
-      }
-      if (filters.createdBy) {
-        clauses.push({ created_by: { _eq: filters.createdBy } });
-      }
-      if (filters.lastModifiedAfter) {
-        // datetime-local values (YYYY-MM-DDTHH:MM) are parsed as local time by JS Date
-        clauses.push({ last_modified_at: { _gte: new Date(filters.lastModifiedAfter).toISOString() } });
-      }
-      if (filters.lastModifiedBefore) {
-        clauses.push({ last_modified_at: { _lte: new Date(filters.lastModifiedBefore).toISOString() } });
-      }
-      if (filters.planName) {
-        clauses.push({ plan: { name: { _ilike: `%${filters.planName}%` } } });
-      }
-      if (filters.planOwner) {
-        clauses.push({ plan: { owner: { _eq: filters.planOwner } } });
-      }
-      if (filters.schedulerCreatedOnly) {
-        clauses.push({ source_scheduling_goal_id: { _is_null: false } });
-      }
-      if (filters.startOffsetMin) {
-        clauses.push({ start_offset: { _gte: filters.startOffsetMin } });
-      }
-      if (filters.startOffsetMax) {
-        clauses.push({ start_offset: { _lte: filters.startOffsetMax } });
-      }
-
-      for (const [argName, argValue] of filters.args) {
-        if (argName === '' && argValue === '') {
-          continue;
-        } else if (argName === '') {
-          clauses.push({ arguments: { _cast: { String: { _ilike: `%${argValue}%` } } } });
-        } else if (argValue === '') {
-          clauses.push({ arguments: { _has_key: argName } });
-        } else if (typeof argValue === 'string') {
-          clauses.push({ arguments: { _contains: { [argName]: argValue } } });
-        } else if (typeof argValue === 'number' || typeof argValue === 'boolean') {
-          clauses.push({
-            _or: [
-              { arguments: { _contains: { [argName]: argValue } } },
-              { arguments: { _contains: { [argName]: argValue.toString() } } },
-            ],
-          });
-        }
-      }
+      const clauses = buildSearchActivitiesWhereClauses(filters);
 
       const data: ActivitySearchResponse = (await reqHasura(
         gql.SEARCH_ACTIVITIES,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -2053,28 +2053,29 @@ const gql = {
   `,
 
   SEARCH_ACTIVITIES: `#graphql
-    query SearchActivities($searchFilter: activity_directive_bool_exp!) {
-      ${Queries.ACTIVITY_DIRECTIVES}(where: $searchFilter) {
-        name
+    query SearchActivities($searchFilter: activity_directive_bool_exp!, $limit: Int!) {
+      ${Queries.ACTIVITY_DIRECTIVES}(where: $searchFilter, order_by: { start_offset: desc }, limit: $limit) {
+        applied_preset {
+          preset_applied {
+            name
+          }
+        }
+        arguments
         directive_id: id
-        type
+        name
+        last_modified_at
         plan_id
         plan {
           name
           model_id
         }
-        arguments
         tags {
           tag {
             name
             color
           }
         }
-        applied_preset {
-          preset_applied {
-            name
-          }
-        }
+        type
       }
     }
   `,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -2060,6 +2060,8 @@ const gql = {
       $orderBy: [activity_directive_order_by!]
     ) {
       ${Queries.ACTIVITY_DIRECTIVES}(where: $searchFilter, order_by: $orderBy, limit: $limit, offset: $offset) {
+        anchor_id
+        anchored_to_start
         applied_preset {
           preset_applied {
             name
@@ -2068,14 +2070,19 @@ const gql = {
         arguments
         created_at
         created_by
-        directive_id: id
+        id
         last_modified_at
         last_modified_by
+        metadata
         name
         plan_id
         plan {
-          name
+          model: mission_model {
+            id
+            name
+          }
           model_id
+          name
           owner
           start_time
           tags {
@@ -2084,6 +2091,10 @@ const gql = {
               name
             }
           }
+        }
+        source_scheduling_goal {
+          id
+          name
         }
         source_scheduling_goal_id
         start_offset

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -2053,29 +2053,52 @@ const gql = {
   `,
 
   SEARCH_ACTIVITIES: `#graphql
-    query SearchActivities($searchFilter: activity_directive_bool_exp!, $limit: Int!) {
-      ${Queries.ACTIVITY_DIRECTIVES}(where: $searchFilter, order_by: { start_offset: desc }, limit: $limit) {
+    query SearchActivities(
+      $searchFilter: activity_directive_bool_exp!,
+      $limit: Int!,
+      $offset: Int!,
+      $orderBy: [activity_directive_order_by!]
+    ) {
+      ${Queries.ACTIVITY_DIRECTIVES}(where: $searchFilter, order_by: $orderBy, limit: $limit, offset: $offset) {
         applied_preset {
           preset_applied {
             name
           }
         }
         arguments
+        created_at
+        created_by
         directive_id: id
-        name
         last_modified_at
+        last_modified_by
+        name
         plan_id
         plan {
           name
           model_id
+          owner
+          start_time
+          tags {
+            tag {
+              color
+              name
+            }
+          }
         }
+        source_scheduling_goal_id
+        start_offset
         tags {
           tag {
-            name
             color
+            name
           }
         }
         type
+      }
+      activity_directive_aggregate(where: $searchFilter) {
+        aggregate {
+          count
+        }
       }
     }
   `,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -2052,6 +2052,33 @@ const gql = {
     }
   `,
 
+  SEARCH_ACTIVITIES: `#graphql
+    query SearchActivities($searchFilter: activity_directive_bool_exp!) {
+      ${Queries.ACTIVITY_DIRECTIVES}(where: $searchFilter) {
+        name
+        directive_id: id
+        type
+        plan_id
+        plan {
+          name
+          model_id
+        }
+        arguments
+        tags {
+          tag {
+            name
+            color
+          }
+        }
+        applied_preset {
+          preset_applied {
+            name
+          }
+        }
+      }
+    }
+  `,
+
   SIMULATE: `#graphql
     query Simulate($planId: Int!, $force: Boolean!) {
       ${Queries.SIMULATE}(planId: $planId, force: $force) {

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -2265,6 +2265,19 @@ const gql = {
     }
   `,
 
+  SUB_ACTIVITY_PRESETS_ALL: `#graphql
+    subscription SubActivityPresetsAll {
+      ${Queries.ACTIVITY_PRESETS} {
+        id
+        model_id
+        name
+        associated_activity_type
+        arguments
+        owner
+      }
+    }
+  `,
+
   SUB_ACTIVITY_TYPES: `#graphql
     subscription SubActivityTypes($modelId: Int!) {
       ${Queries.ACTIVITY_TYPES}(where: { model_id: { _eq: $modelId } }, order_by: { name: asc }) {
@@ -2751,6 +2764,10 @@ const gql = {
   SUB_MODELS: `#graphql
     subscription SubModels {
       models: ${Queries.MISSION_MODELS}(order_by: { name: asc }) {
+        activity_types {
+          name
+          parameters
+        }
         created_at
         description
         id

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -971,6 +971,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
   SUB_ACTIVITY_PRESETS: (user: User | null): boolean => {
     return isUserAdmin(user) || getPermission([Queries.ACTIVITY_PRESETS], user);
   },
+  SUB_ACTIVITY_PRESETS_ALL: () => true,
   SUB_ACTIVITY_TYPES: () => true,
   SUB_ANCHOR_VALIDATION_STATUS: () => true,
   SUB_CHANNEL_DICTIONARIES: () => true,

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -949,6 +949,9 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
     const queries = [Queries.SCHEDULE];
     return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));
   },
+  SEARCH_ACTIVITIES: (user: User | null): boolean => {
+    return isUserAdmin(user) || getPermission([Queries.SEARCH_ACTIVITIES], user);
+  },
   SIMULATE: (user: User | null, plan: PlanWithOwners, model: ModelWithOwner | null): boolean => {
     const queries = [Queries.SIMULATE];
     return isUserAdmin(user) || (getPermission(queries, user) && getRolePlanPermission(queries, user, plan, model));

--- a/src/utilities/plan.test.ts
+++ b/src/utilities/plan.test.ts
@@ -41,6 +41,7 @@ describe('Plan utility', () => {
             id: 1,
             is_locked: false,
             model: {
+              activity_types: [],
               constraint_specification: [],
               created_at: '2024-01-01T00:00:00',
               default_view_id: 0,
@@ -229,6 +230,7 @@ describe('Plan utility', () => {
             id: 1,
             is_locked: false,
             model: {
+              activity_types: [],
               constraint_specification: [],
               created_at: '2024-01-01T00:00:00',
               default_view_id: 0,
@@ -339,6 +341,7 @@ describe('Plan utility', () => {
         id: 1,
         is_locked: false,
         model: {
+          activity_types: [],
           constraint_specification: [],
           created_at: '2024-01-01T00:00:00',
           default_view_id: 0,

--- a/src/utilities/searchFilters.test.ts
+++ b/src/utilities/searchFilters.test.ts
@@ -281,10 +281,7 @@ describe('buildSearchActivitiesWhereClauses', () => {
       );
       expect(clauses).toHaveLength(2);
       expect(clauses[0]).toEqual({
-        _or: [
-          { arguments: { _contains: { region: 'arctic' } } },
-          { arguments: { _contains: { region: ['arctic'] } } },
-        ],
+        _or: [{ arguments: { _contains: { region: 'arctic' } } }, { arguments: { _contains: { region: ['arctic'] } } }],
       });
       expect(clauses[1]).toEqual({
         _or: [

--- a/src/utilities/searchFilters.test.ts
+++ b/src/utilities/searchFilters.test.ts
@@ -7,16 +7,21 @@ import {
 
 const EMPTY_FILTERS: ActivitySearchFilters = {
   actName: '',
-  actType: '',
+  actType: [],
   args: [],
+  createdAfter: '',
+  createdBefore: '',
   createdBy: '',
   lastModifiedAfter: '',
   lastModifiedBefore: '',
+  lastModifiedBy: '',
   modelId: undefined,
   planName: '',
   planOwner: '',
+  planTag: '',
   preset: '',
   schedulerCreatedOnly: false,
+  schedulingGoalId: '',
   startOffsetMax: '',
   startOffsetMin: '',
   tagValue: '',
@@ -49,10 +54,20 @@ describe('buildSearchActivitiesWhereClauses', () => {
       ]);
     });
 
-    test('Should emit an _eq clause for actType', () => {
-      expect(buildSearchActivitiesWhereClauses(withFilters({ actType: 'GrowBanana' }))).toEqual([
-        { type: { _eq: 'GrowBanana' } },
+    test('Should emit an _in clause for a single actType', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ actType: ['GrowBanana'] }))).toEqual([
+        { type: { _in: ['GrowBanana'] } },
       ]);
+    });
+
+    test('Should emit an _in clause covering every selected actType', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ actType: ['GrowBanana', 'PickBanana'] }))).toEqual([
+        { type: { _in: ['GrowBanana', 'PickBanana'] } },
+      ]);
+    });
+
+    test('Should not emit a type clause when actType is an empty array', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ actType: [] }))).toEqual([]);
     });
 
     test('Should emit a substring _ilike clause for actName', () => {
@@ -112,6 +127,40 @@ describe('buildSearchActivitiesWhereClauses', () => {
         { start_offset: { _lte: '02:00:00' } },
       ]);
     });
+
+    test('Should emit an _eq clause for lastModifiedBy', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ lastModifiedBy: 'alice' }))).toEqual([
+        { last_modified_by: { _eq: 'alice' } },
+      ]);
+    });
+
+    test('Should emit a nested clause for planTag', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ planTag: 'staging' }))).toEqual([
+        { plan: { tags: { tag: { name: { _eq: 'staging' } } } } },
+      ]);
+    });
+
+    test('Should emit a source_scheduling_goal_id _eq clause for schedulingGoalId', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ schedulingGoalId: '42' }))).toEqual([
+        { source_scheduling_goal_id: { _eq: 42 } },
+      ]);
+    });
+  });
+
+  describe('createdAt date range', () => {
+    test('Should convert createdAfter to an ISO string in a _gte clause', () => {
+      const clauses = buildSearchActivitiesWhereClauses(withFilters({ createdAfter: '2026-01-15T08:30' }));
+      expect(clauses).toHaveLength(1);
+      const clause = clauses[0] as { created_at: { _gte: string } };
+      expect(clause.created_at._gte).toEqual(new Date('2026-01-15T08:30').toISOString());
+    });
+
+    test('Should convert createdBefore to an ISO string in a _lte clause', () => {
+      const clauses = buildSearchActivitiesWhereClauses(withFilters({ createdBefore: '2026-02-01T00:00' }));
+      expect(clauses).toHaveLength(1);
+      const clause = clauses[0] as { created_at: { _lte: string } };
+      expect(clause.created_at._lte).toEqual(new Date('2026-02-01T00:00').toISOString());
+    });
   });
 
   describe('lastModified date range', () => {
@@ -147,24 +196,75 @@ describe('buildSearchActivitiesWhereClauses', () => {
       ]);
     });
 
-    test('Should emit a _contains clause for a string value', () => {
+    test('Should emit an _or clause covering both scalar and singleton-array shapes for an unparseable string value', () => {
       expect(buildSearchActivitiesWhereClauses(withFilters({ args: [['region', 'arctic']] }))).toEqual([
-        { arguments: { _contains: { region: 'arctic' } } },
-      ]);
-    });
-
-    test('Should emit an _or clause covering both typed and stringified forms for numeric values', () => {
-      expect(buildSearchActivitiesWhereClauses(withFilters({ args: [['quantity', 5]] }))).toEqual([
         {
-          _or: [{ arguments: { _contains: { quantity: 5 } } }, { arguments: { _contains: { quantity: '5' } } }],
+          _or: [
+            { arguments: { _contains: { region: 'arctic' } } },
+            { arguments: { _contains: { region: ['arctic'] } } },
+          ],
         },
       ]);
     });
 
-    test('Should emit an _or clause covering both typed and stringified forms for boolean values', () => {
+    test('Should parse a numeric string and emit _or covering both scalar and singleton-array shapes', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ args: [['quantity', '5']] }))).toEqual([
+        {
+          _or: [{ arguments: { _contains: { quantity: 5 } } }, { arguments: { _contains: { quantity: [5] } } }],
+        },
+      ]);
+    });
+
+    test('Should parse a boolean string and emit _or covering both scalar and singleton-array shapes', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ args: [['enabled', 'true']] }))).toEqual([
+        {
+          _or: [{ arguments: { _contains: { enabled: true } } }, { arguments: { _contains: { enabled: [true] } } }],
+        },
+      ]);
+    });
+
+    test('Should parse a null string and emit _or covering both scalar and singleton-array shapes', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ args: [['region', 'null']] }))).toEqual([
+        {
+          _or: [{ arguments: { _contains: { region: null } } }, { arguments: { _contains: { region: [null] } } }],
+        },
+      ]);
+    });
+
+    test('Should parse a JSON-array string and emit a single _contains clause (no _or wrapping)', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ args: [['xyz', '[1,2,5]']] }))).toEqual([
+        { arguments: { _contains: { xyz: [1, 2, 5] } } },
+      ]);
+    });
+
+    test('Should parse a JSON-object string and emit a single _contains clause (no _or wrapping)', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ args: [['xyz', '{"a":1}']] }))).toEqual([
+        { arguments: { _contains: { xyz: { a: 1 } } } },
+      ]);
+    });
+
+    test('Should emit an _or covering scalar, stringified, and singleton-array shapes for numeric values', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ args: [['quantity', 5]] }))).toEqual([
+        {
+          _or: [
+            { arguments: { _contains: { quantity: 5 } } },
+            { arguments: { _contains: { quantity: '5' } } },
+            { arguments: { _contains: { quantity: [5] } } },
+            { arguments: { _contains: { quantity: ['5'] } } },
+          ],
+        },
+      ]);
+    });
+
+    test('Should emit an _or covering scalar, stringified, and singleton-array shapes for boolean values', () => {
       expect(buildSearchActivitiesWhereClauses(withFilters({ args: [['enabled', true]] }))).toEqual([
         {
-          _or: [{ arguments: { _contains: { enabled: true } } }, { arguments: { _contains: { enabled: 'true' } } }],
+          _or: [
+            { arguments: { _contains: { enabled: true } } },
+            { arguments: { _contains: { enabled: 'true' } } },
+            { arguments: { _contains: { enabled: [true] } } },
+            { arguments: { _contains: { enabled: ['true'] } } },
+          ],
         },
       ]);
     });
@@ -180,9 +280,19 @@ describe('buildSearchActivitiesWhereClauses', () => {
         }),
       );
       expect(clauses).toHaveLength(2);
-      expect(clauses[0]).toEqual({ arguments: { _contains: { region: 'arctic' } } });
+      expect(clauses[0]).toEqual({
+        _or: [
+          { arguments: { _contains: { region: 'arctic' } } },
+          { arguments: { _contains: { region: ['arctic'] } } },
+        ],
+      });
       expect(clauses[1]).toEqual({
-        _or: [{ arguments: { _contains: { quantity: 3 } } }, { arguments: { _contains: { quantity: '3' } } }],
+        _or: [
+          { arguments: { _contains: { quantity: 3 } } },
+          { arguments: { _contains: { quantity: '3' } } },
+          { arguments: { _contains: { quantity: [3] } } },
+          { arguments: { _contains: { quantity: ['3'] } } },
+        ],
       });
     });
   });
@@ -191,31 +301,35 @@ describe('buildSearchActivitiesWhereClauses', () => {
     test('Should aggregate every populated filter into the result array', () => {
       const clauses = buildSearchActivitiesWhereClauses({
         actName: 'Foo',
-        actType: 'GrowBanana',
+        actType: ['GrowBanana'],
         args: [['quantity', 5]],
+        createdAfter: '2026-01-01T00:00',
+        createdBefore: '2026-06-30T23:59',
         createdBy: 'alice',
         lastModifiedAfter: '2026-01-01T00:00',
         lastModifiedBefore: '2026-12-31T23:59',
+        lastModifiedBy: 'bob',
         modelId: 3,
         planName: 'Cruise',
         planOwner: 'bob',
+        planTag: 'flight-ready',
         preset: 'HighRes',
         schedulerCreatedOnly: true,
+        schedulingGoalId: '42',
         startOffsetMax: '07:00:00',
         startOffsetMin: '01:00:00',
         tagValue: 'critical',
       });
 
-      // 13 top-level filters + 1 args clause
-      expect(clauses).toHaveLength(14);
+      // 18 top-level filters + 1 args clause
+      expect(clauses).toHaveLength(19);
 
       const expected: ActivitySearchClause[] = [
         { plan: { model_id: { _eq: 3 } } },
-        { type: { _eq: 'GrowBanana' } },
+        { type: { _in: ['GrowBanana'] } },
         { name: { _ilike: '%Foo%' } },
         { tags: { tag: { name: { _eq: 'critical' } } } },
         { applied_preset: { preset_applied: { name: { _eq: 'HighRes' } } } },
-        { created_by: { _eq: 'alice' } },
       ];
       for (let i = 0; i < expected.length; i++) {
         expect(clauses[i]).toEqual(expected[i]);

--- a/src/utilities/searchFilters.test.ts
+++ b/src/utilities/searchFilters.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test } from 'vitest';
+import {
+  buildSearchActivitiesWhereClauses,
+  type ActivitySearchClause,
+  type ActivitySearchFilters,
+} from './searchFilters';
+
+const EMPTY_FILTERS: ActivitySearchFilters = {
+  actName: '',
+  actType: '',
+  args: [],
+  createdBy: '',
+  lastModifiedAfter: '',
+  lastModifiedBefore: '',
+  modelId: undefined,
+  planName: '',
+  planOwner: '',
+  preset: '',
+  schedulerCreatedOnly: false,
+  startOffsetMax: '',
+  startOffsetMin: '',
+  tagValue: '',
+};
+
+function withFilters(overrides: Partial<ActivitySearchFilters>): ActivitySearchFilters {
+  return { ...EMPTY_FILTERS, ...overrides };
+}
+
+describe('buildSearchActivitiesWhereClauses', () => {
+  test('Should return an empty array for empty filters', () => {
+    expect(buildSearchActivitiesWhereClauses(EMPTY_FILTERS)).toEqual([]);
+  });
+
+  describe('top-level filters', () => {
+    test('Should emit a model_id clause when modelId is set', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ modelId: 7 }))).toEqual([
+        { plan: { model_id: { _eq: 7 } } },
+      ]);
+    });
+
+    test('Should not emit a model_id clause when modelId is undefined or null', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ modelId: undefined }))).toEqual([]);
+      expect(buildSearchActivitiesWhereClauses(withFilters({ modelId: null as unknown as undefined }))).toEqual([]);
+    });
+
+    test('Should emit a model_id clause when modelId is 0 (valid id)', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ modelId: 0 }))).toEqual([
+        { plan: { model_id: { _eq: 0 } } },
+      ]);
+    });
+
+    test('Should emit an _eq clause for actType', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ actType: 'GrowBanana' }))).toEqual([
+        { type: { _eq: 'GrowBanana' } },
+      ]);
+    });
+
+    test('Should emit a substring _ilike clause for actName', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ actName: 'foo' }))).toEqual([
+        { name: { _ilike: '%foo%' } },
+      ]);
+    });
+
+    test('Should emit a nested clause for tagValue', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ tagValue: 'critical' }))).toEqual([
+        { tags: { tag: { name: { _eq: 'critical' } } } },
+      ]);
+    });
+
+    test('Should emit a nested clause for preset', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ preset: 'HighRes' }))).toEqual([
+        { applied_preset: { preset_applied: { name: { _eq: 'HighRes' } } } },
+      ]);
+    });
+
+    test('Should emit an _eq clause for createdBy', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ createdBy: 'alice' }))).toEqual([
+        { created_by: { _eq: 'alice' } },
+      ]);
+    });
+
+    test('Should emit a substring _ilike clause for planName', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ planName: 'Cruise' }))).toEqual([
+        { plan: { name: { _ilike: '%Cruise%' } } },
+      ]);
+    });
+
+    test('Should emit an _eq clause for planOwner', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ planOwner: 'bob' }))).toEqual([
+        { plan: { owner: { _eq: 'bob' } } },
+      ]);
+    });
+
+    test('Should emit an _is_null:false clause when schedulerCreatedOnly is true', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ schedulerCreatedOnly: true }))).toEqual([
+        { source_scheduling_goal_id: { _is_null: false } },
+      ]);
+    });
+
+    test('Should not emit a clause when schedulerCreatedOnly is false', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ schedulerCreatedOnly: false }))).toEqual([]);
+    });
+
+    test('Should emit start_offset _gte for startOffsetMin', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ startOffsetMin: '01:00:00' }))).toEqual([
+        { start_offset: { _gte: '01:00:00' } },
+      ]);
+    });
+
+    test('Should emit start_offset _lte for startOffsetMax', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ startOffsetMax: '02:00:00' }))).toEqual([
+        { start_offset: { _lte: '02:00:00' } },
+      ]);
+    });
+  });
+
+  describe('lastModified date range', () => {
+    test('Should convert lastModifiedAfter to an ISO string in a _gte clause', () => {
+      const clauses = buildSearchActivitiesWhereClauses(withFilters({ lastModifiedAfter: '2026-01-15T08:30' }));
+      expect(clauses).toHaveLength(1);
+      const clause = clauses[0] as { last_modified_at: { _gte: string } };
+      expect(clause.last_modified_at._gte).toEqual(new Date('2026-01-15T08:30').toISOString());
+    });
+
+    test('Should convert lastModifiedBefore to an ISO string in a _lte clause', () => {
+      const clauses = buildSearchActivitiesWhereClauses(withFilters({ lastModifiedBefore: '2026-02-01T00:00' }));
+      expect(clauses).toHaveLength(1);
+      const clause = clauses[0] as { last_modified_at: { _lte: string } };
+      expect(clause.last_modified_at._lte).toEqual(new Date('2026-02-01T00:00').toISOString());
+    });
+  });
+
+  describe('args filter', () => {
+    test('Should skip a tuple with empty name and empty value', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ args: [['', '']] }))).toEqual([]);
+    });
+
+    test('Should emit an _ilike on the cast string when name is empty and value is set', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ args: [['', 'banana']] }))).toEqual([
+        { arguments: { _cast: { String: { _ilike: '%banana%' } } } },
+      ]);
+    });
+
+    test('Should emit a _has_key clause when name is set and value is empty', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ args: [['quantity', '']] }))).toEqual([
+        { arguments: { _has_key: 'quantity' } },
+      ]);
+    });
+
+    test('Should emit a _contains clause for a string value', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ args: [['region', 'arctic']] }))).toEqual([
+        { arguments: { _contains: { region: 'arctic' } } },
+      ]);
+    });
+
+    test('Should emit an _or clause covering both typed and stringified forms for numeric values', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ args: [['quantity', 5]] }))).toEqual([
+        {
+          _or: [{ arguments: { _contains: { quantity: 5 } } }, { arguments: { _contains: { quantity: '5' } } }],
+        },
+      ]);
+    });
+
+    test('Should emit an _or clause covering both typed and stringified forms for boolean values', () => {
+      expect(buildSearchActivitiesWhereClauses(withFilters({ args: [['enabled', true]] }))).toEqual([
+        {
+          _or: [{ arguments: { _contains: { enabled: true } } }, { arguments: { _contains: { enabled: 'true' } } }],
+        },
+      ]);
+    });
+
+    test('Should emit one clause per non-empty arg tuple in order', () => {
+      const clauses = buildSearchActivitiesWhereClauses(
+        withFilters({
+          args: [
+            ['', ''],
+            ['region', 'arctic'],
+            ['quantity', 3],
+          ],
+        }),
+      );
+      expect(clauses).toHaveLength(2);
+      expect(clauses[0]).toEqual({ arguments: { _contains: { region: 'arctic' } } });
+      expect(clauses[1]).toEqual({
+        _or: [{ arguments: { _contains: { quantity: 3 } } }, { arguments: { _contains: { quantity: '3' } } }],
+      });
+    });
+  });
+
+  describe('combined filters', () => {
+    test('Should aggregate every populated filter into the result array', () => {
+      const clauses = buildSearchActivitiesWhereClauses({
+        actName: 'Foo',
+        actType: 'GrowBanana',
+        args: [['quantity', 5]],
+        createdBy: 'alice',
+        lastModifiedAfter: '2026-01-01T00:00',
+        lastModifiedBefore: '2026-12-31T23:59',
+        modelId: 3,
+        planName: 'Cruise',
+        planOwner: 'bob',
+        preset: 'HighRes',
+        schedulerCreatedOnly: true,
+        startOffsetMax: '07:00:00',
+        startOffsetMin: '01:00:00',
+        tagValue: 'critical',
+      });
+
+      // 13 top-level filters + 1 args clause
+      expect(clauses).toHaveLength(14);
+
+      const expected: ActivitySearchClause[] = [
+        { plan: { model_id: { _eq: 3 } } },
+        { type: { _eq: 'GrowBanana' } },
+        { name: { _ilike: '%Foo%' } },
+        { tags: { tag: { name: { _eq: 'critical' } } } },
+        { applied_preset: { preset_applied: { name: { _eq: 'HighRes' } } } },
+        { created_by: { _eq: 'alice' } },
+      ];
+      for (let i = 0; i < expected.length; i++) {
+        expect(clauses[i]).toEqual(expected[i]);
+      }
+    });
+  });
+});

--- a/src/utilities/searchFilters.ts
+++ b/src/utilities/searchFilters.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure helpers for translating the cross-plan activity search form state into
+ * Hasura `where` clauses. Kept separate from `effects.ts` so the clause logic
+ * can be unit-tested without pulling in the full effects module's dependency
+ * graph (stores, requests, modals, etc.).
+ */
+
+export interface ActivitySearchFilters {
+  actName: string;
+  actType: string;
+  args: [name: string, value: string | number | boolean][];
+  createdBy: string;
+  lastModifiedAfter: string;
+  lastModifiedBefore: string;
+  modelId: number | undefined;
+  planName: string;
+  planOwner: string;
+  preset: string;
+  schedulerCreatedOnly: boolean;
+  startOffsetMax: string;
+  startOffsetMin: string;
+  tagValue: string;
+}
+
+export type ActivitySearchClause = Record<string, unknown>;
+
+/**
+ * Build the array of clauses to AND together for the SEARCH_ACTIVITIES query.
+ *
+ * Each filter contributes at most one clause; falsy values are skipped so the
+ * resulting array contains only the filters the user actually populated. Args
+ * branch on (name, value) presence and value type — see the comments on each
+ * branch for the matching Hasura semantics.
+ */
+export function buildSearchActivitiesWhereClauses(filters: ActivitySearchFilters): ActivitySearchClause[] {
+  const clauses: ActivitySearchClause[] = [];
+
+  if (filters.modelId !== undefined && filters.modelId !== null) {
+    clauses.push({ plan: { model_id: { _eq: filters.modelId } } });
+  }
+  if (filters.actType) {
+    clauses.push({ type: { _eq: filters.actType } });
+  }
+  if (filters.actName) {
+    clauses.push({ name: { _ilike: `%${filters.actName}%` } });
+  }
+  if (filters.tagValue) {
+    clauses.push({ tags: { tag: { name: { _eq: filters.tagValue } } } });
+  }
+  if (filters.preset) {
+    clauses.push({ applied_preset: { preset_applied: { name: { _eq: filters.preset } } } });
+  }
+  if (filters.createdBy) {
+    clauses.push({ created_by: { _eq: filters.createdBy } });
+  }
+  if (filters.lastModifiedAfter) {
+    // datetime-local values (YYYY-MM-DDTHH:MM) are parsed as local time by JS Date
+    clauses.push({ last_modified_at: { _gte: new Date(filters.lastModifiedAfter).toISOString() } });
+  }
+  if (filters.lastModifiedBefore) {
+    clauses.push({ last_modified_at: { _lte: new Date(filters.lastModifiedBefore).toISOString() } });
+  }
+  if (filters.planName) {
+    clauses.push({ plan: { name: { _ilike: `%${filters.planName}%` } } });
+  }
+  if (filters.planOwner) {
+    clauses.push({ plan: { owner: { _eq: filters.planOwner } } });
+  }
+  if (filters.schedulerCreatedOnly) {
+    clauses.push({ source_scheduling_goal_id: { _is_null: false } });
+  }
+  if (filters.startOffsetMin) {
+    clauses.push({ start_offset: { _gte: filters.startOffsetMin } });
+  }
+  if (filters.startOffsetMax) {
+    clauses.push({ start_offset: { _lte: filters.startOffsetMax } });
+  }
+
+  for (const [argName, argValue] of filters.args) {
+    if (argName === '' && argValue === '') {
+      continue;
+    } else if (argName === '') {
+      // Substring search across the JSON-stringified arguments blob
+      clauses.push({ arguments: { _cast: { String: { _ilike: `%${argValue}%` } } } });
+    } else if (argValue === '') {
+      // Just check the key exists, regardless of value
+      clauses.push({ arguments: { _has_key: argName } });
+    } else if (typeof argValue === 'string') {
+      clauses.push({ arguments: { _contains: { [argName]: argValue } } });
+    } else if (typeof argValue === 'number' || typeof argValue === 'boolean') {
+      // JSON values can be stored either as their native type or as a string
+      // representation (depending on how the directive was created), so match
+      // both to avoid false negatives.
+      clauses.push({
+        _or: [
+          { arguments: { _contains: { [argName]: argValue } } },
+          { arguments: { _contains: { [argName]: argValue.toString() } } },
+        ],
+      });
+    }
+  }
+
+  return clauses;
+}

--- a/src/utilities/searchFilters.ts
+++ b/src/utilities/searchFilters.ts
@@ -7,16 +7,21 @@
 
 export interface ActivitySearchFilters {
   actName: string;
-  actType: string;
+  actType: string[];
   args: [name: string, value: string | number | boolean][];
+  createdAfter: string;
+  createdBefore: string;
   createdBy: string;
   lastModifiedAfter: string;
   lastModifiedBefore: string;
+  lastModifiedBy: string;
   modelId: number | undefined;
   planName: string;
   planOwner: string;
+  planTag: string;
   preset: string;
   schedulerCreatedOnly: boolean;
+  schedulingGoalId: string;
   startOffsetMax: string;
   startOffsetMin: string;
   tagValue: string;
@@ -38,8 +43,8 @@ export function buildSearchActivitiesWhereClauses(filters: ActivitySearchFilters
   if (filters.modelId !== undefined && filters.modelId !== null) {
     clauses.push({ plan: { model_id: { _eq: filters.modelId } } });
   }
-  if (filters.actType) {
-    clauses.push({ type: { _eq: filters.actType } });
+  if (filters.actType.length > 0) {
+    clauses.push({ type: { _in: filters.actType } });
   }
   if (filters.actName) {
     clauses.push({ name: { _ilike: `%${filters.actName}%` } });
@@ -50,15 +55,24 @@ export function buildSearchActivitiesWhereClauses(filters: ActivitySearchFilters
   if (filters.preset) {
     clauses.push({ applied_preset: { preset_applied: { name: { _eq: filters.preset } } } });
   }
+  if (filters.createdAfter) {
+    // datetime-local values (YYYY-MM-DDTHH:MM) are parsed as local time by JS Date
+    clauses.push({ created_at: { _gte: new Date(filters.createdAfter).toISOString() } });
+  }
+  if (filters.createdBefore) {
+    clauses.push({ created_at: { _lte: new Date(filters.createdBefore).toISOString() } });
+  }
   if (filters.createdBy) {
     clauses.push({ created_by: { _eq: filters.createdBy } });
   }
   if (filters.lastModifiedAfter) {
-    // datetime-local values (YYYY-MM-DDTHH:MM) are parsed as local time by JS Date
     clauses.push({ last_modified_at: { _gte: new Date(filters.lastModifiedAfter).toISOString() } });
   }
   if (filters.lastModifiedBefore) {
     clauses.push({ last_modified_at: { _lte: new Date(filters.lastModifiedBefore).toISOString() } });
+  }
+  if (filters.lastModifiedBy) {
+    clauses.push({ last_modified_by: { _eq: filters.lastModifiedBy } });
   }
   if (filters.planName) {
     clauses.push({ plan: { name: { _ilike: `%${filters.planName}%` } } });
@@ -66,8 +80,14 @@ export function buildSearchActivitiesWhereClauses(filters: ActivitySearchFilters
   if (filters.planOwner) {
     clauses.push({ plan: { owner: { _eq: filters.planOwner } } });
   }
+  if (filters.planTag) {
+    clauses.push({ plan: { tags: { tag: { name: { _eq: filters.planTag } } } } });
+  }
   if (filters.schedulerCreatedOnly) {
     clauses.push({ source_scheduling_goal_id: { _is_null: false } });
+  }
+  if (filters.schedulingGoalId) {
+    clauses.push({ source_scheduling_goal_id: { _eq: parseInt(filters.schedulingGoalId, 10) } });
   }
   if (filters.startOffsetMin) {
     clauses.push({ start_offset: { _gte: filters.startOffsetMin } });
@@ -86,15 +106,45 @@ export function buildSearchActivitiesWhereClauses(filters: ActivitySearchFilters
       // Just check the key exists, regardless of value
       clauses.push({ arguments: { _has_key: argName } });
     } else if (typeof argValue === 'string') {
-      clauses.push({ arguments: { _contains: { [argName]: argValue } } });
+      // Try to parse as JSON to support typed scalars, arrays, and structs.
+      // Fall back to the literal string when parse fails.
+      let parsed: unknown = argValue;
+      try {
+        parsed = JSON.parse(argValue);
+      } catch {
+        /* keep as string */
+      }
+
+      const isScalar = parsed === null || typeof parsed !== 'object';
+
+      if (isScalar) {
+        // For scalar inputs, also match against singleton-array shape so typing
+        // `5` matches `XYZ: 5` and `XYZ: [1, 2, 5]`.
+        clauses.push({
+          _or: [
+            { arguments: { _contains: { [argName]: parsed } } },
+            { arguments: { _contains: { [argName]: [parsed] } } },
+          ],
+        });
+      } else {
+        // Arrays / structs — let jsonb containment do subset / sub-object matching.
+        clauses.push({ arguments: { _contains: { [argName]: parsed } } });
+      }
     } else if (typeof argValue === 'number' || typeof argValue === 'boolean') {
-      // JSON values can be stored either as their native type or as a string
-      // representation (depending on how the directive was created), so match
-      // both to avoid false negatives.
+      // Typed scalars from the form (numbers / booleans the upstream coerced from
+      // a user-typed string). Match four shapes to cover storage variations and
+      // array-element matching (typing `5` finds `XYZ: [1, 2, 5]`):
+      //   1. typed scalar
+      //   2. stringified scalar (some directives store values as strings)
+      //   3. member of a typed-scalar array
+      //   4. member of a stringified-scalar array
+      const str = argValue.toString();
       clauses.push({
         _or: [
           { arguments: { _contains: { [argName]: argValue } } },
-          { arguments: { _contains: { [argName]: argValue.toString() } } },
+          { arguments: { _contains: { [argName]: str } } },
+          { arguments: { _contains: { [argName]: [argValue] } } },
+          { arguments: { _contains: { [argName]: [str] } } },
         ],
       });
     }


### PR DESCRIPTION
## Summary

New `/search` page for finding activity directives across all plans, plus shared-component improvements that came out of building it.

<img width="1727" height="996" alt="image" src="https://github.com/user-attachments/assets/ed91833d-7603-48f7-82a7-c3b76eedf0c3" />


## Search page

**Filters** (all bookmarkable via URL query params):

- Mission Model
- Activity Type (**multi-select**; narrowed by selected model)
- Activity Name
- Argument Name (typeahead from the selected model's parameter schemas; narrows further with a selected Type)
- Argument Value (tooltip notes mission-model defaults are not applied. Also – typing `5` matches `XYZ: 5` and `XYZ: [1, 2, 5]`; arrays/structs accepted as JSON)
- Tag
- Preset (model-filtered)
- Created By
- Last Modified By
- Created After / Created Before
- Last Modified Before / After
- Start Offset min/max
- Plan Name
- Plan Owner
- Plan Tag
- Scheduling Goal
- Scheduler-created only

**Results**:

- Server-side pagination, 50/page, with aggregate count
- Server-side sort translated from AG Grid column state
- Sticky-footer Search/Clear
- 500ms-delayed spinner overlay during search
- Inline banner for subscription errors
- Per-dropdown loading state

**Columns** (default-visible unless noted):

- Open in plan (pinned-left icon, full-cell click)
- Activity Name, Activity Type, Activity ID *(hidden)*
- Plan Name, Plan Owner, Plan ID *(hidden)*, Model, Model ID
- Tags, Applied Preset
- Start Offset, Absolute Start Time, Arguments *(hidden)*
- Created By, Created At *(hidden)*, Modified By, Last Modified
- Scheduling Goal, Sched. Goal ID *(hidden)*
- Column picker with show/hide all + reset (action column is structural, exempt)
- Visibility, order, width, sort, pinning persisted to localStorage

**Selection & cross-plan copy**:

- Click / cmd-click / shift-click selects rows
- Right-click menu: "Copy N Activities" puts the selection on the clipboard
- "Open in plan" — per-row icon button (always visible, pinned left) and a right-click menu item when exactly one row is selected
- Paste in the target plan via the existing in-plan paste context menu. Cross-plan timing re-grounds correctly (see fixes below but needs review/discussion)


## Shared changes

**DataGrid**:

- New `persistColumnStateKey` + `transformColumnState` props centralize column-state localStorage save/clear
- Forwarded through `BulkActionDataGrid` and `SingleActionDataGrid`
- WSP and SearchResults consume it
- WSP keeps its name-column processing via `transformColumnState`

**SearchableDropdown**:

- Menu width uses canvas `measureText` with font read off a hidden DOM ref (replaces the `maxOptionChars * 8` heuristic that overshot for proportional fonts)
- Items flow through `RowVirtualizerFixed` as a slot prop so menus refresh while open
- New `loading` prop
- Internal toggle button got `type="button"` so Enter inside a sibling input no longer toggles the menu

**RowVirtualizerFixed**:

- `items` prop replaces `count`; slot exposes `item`
- TimelineItemList + mock updated

## Bug fixes & polish

- Cross-plan paste now respects the user's right-click paste-at-time even when source activities' absolute times fall outside the target plan window (previously snapped to plan start). Needs review/discussion. Additionally, copy/paste was modified to keep track of directive origin plan in order to avoid clobbering directives from different plans with the same IDs.
- DataGrid: switched the selected-row class toggle to `querySelectorAll` so pinned-left and center containers stay in sync (fixes two-tone selected row with pinned columns — affects every table with pinned columns, not just search)

## Test plan

- [ ] Filter combinations produce expected results
- [ ] Pagination traverses all pages
- [ ] Each sortable column sorts via server
- [ ] URL state round-trips across refresh
- [ ] Column-picker state persists across reload
- [ ] Error banner appears on subscription failure

## TODO

- [x] e2e tests
- [x] Tooltip for argument name width bugfix
- [x] Multi-select activity type filter
- [x] Multi-select + cross-plan copy flow
- [x] Model / Model ID / Absolute Start Time / Scheduling Goal columns
- [x] Activity ID sort bug fix
- [x] Cross-plan paste-at-time bug fix
- [x] New filters: Last Modified By, Created date range, Plan Tag, Scheduling Goal

## Future Work

Future directions for this work could involve:
- Search on activity instances (spans), requires sorting out which simulation dataset to query for each plan.
- Making use of the activity filter builder paradigm to enable more complex search expressions
- Searching for plans _that contain_ various activities
- Searching for activities similar to the one currently selected in a plan
- Command palette menu integration (once #1824 is completed) for cross-app activity search without needing to start on `/search` page
- Potentially adding a db table/view that would actually give us queryable directive arguments. This has likely been considered in the past but not sure what technical barriers exist.
- Instantiate cross-plan activity search within a plan panel
- Constraint violation search - find activities involved in constraint violations
- Temporal search with absolute times via new computed Hasura field (or two phase query) to resolve absolute times
- Aggregate views to offer summaries of activity type distribution across plans, parameter value distribution for a selected type/argument, etc