### PR TITLE
Socket consolidation cleanup

### DIFF
--- a/src/components/workspace/WorkspaceSidebar.svelte
+++ b/src/components/workspace/WorkspaceSidebar.svelte
@@ -267,16 +267,24 @@
                         <label use:tooltip={{ content: 'Workspace Name', placement: 'top' }} for="name">
                           Workspace Name
                         </label>
-                        <InputStellar
-                          autocomplete="off"
-                          sizeVariant="xs"
+                        <div
+                          use:permissionHandler={{
+                            hasPermission: hasEditWorkspacePermission,
+                            permissionError,
+                          }}
                           class="w-full"
-                          name="name"
-                          id="name"
-                          aria-label="name"
-                          value={workspace?.name}
-                          on:change={onWorkspaceNameChange}
-                        />
+                        >
+                          <InputStellar
+                            autocomplete="off"
+                            sizeVariant="xs"
+                            class="w-full"
+                            name="name"
+                            id="name"
+                            aria-label="name"
+                            value={workspace?.name}
+                            on:change={onWorkspaceNameChange}
+                          />
+                        </div>
                       </Input>
                     </fieldset>
                     <fieldset>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -68,7 +68,9 @@
   setContext('user', user);
 </script>
 
-<ConnectionStatusBanner />
+{#if $user}
+  <ConnectionStatusBanner />
+{/if}
 {#if !pluginsEnabled || ($pluginsLoaded && !$pluginsError)}
   <slot />
 {:else}

--- a/src/routes/constraints/+page.ts
+++ b/src/routes/constraints/+page.ts
@@ -1,9 +1,0 @@
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
-
-  return {
-    user,
-  };
-};

--- a/src/routes/constraints/edit/[id]/+page.ts
+++ b/src/routes/constraints/edit/[id]/+page.ts
@@ -17,7 +17,6 @@ export const load: PageLoad = async ({ parent, params }) => {
       if (initialConstraint !== null) {
         return {
           initialConstraint,
-          user,
         };
       }
     }

--- a/src/routes/constraints/new/+page.ts
+++ b/src/routes/constraints/new/+page.ts
@@ -1,9 +1,0 @@
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
-
-  return {
-    user,
-  };
-};

--- a/src/routes/dictionaries/+page.ts
+++ b/src/routes/dictionaries/+page.ts
@@ -1,7 +1,0 @@
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
-
-  return { user };
-};

--- a/src/routes/expansion/+layout.ts
+++ b/src/routes/expansion/+layout.ts
@@ -1,6 +1,0 @@
-import type { LayoutLoad } from './$types';
-
-export const load: LayoutLoad = async ({ parent }) => {
-  const { user } = await parent();
-  return { user };
-};

--- a/src/routes/expansion/rules/+page.ts
+++ b/src/routes/expansion/rules/+page.ts
@@ -1,7 +1,0 @@
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
-
-  return { user };
-};

--- a/src/routes/expansion/rules/edit/[id]/+page.ts
+++ b/src/routes/expansion/rules/edit/[id]/+page.ts
@@ -17,7 +17,6 @@ export const load: PageLoad = async ({ parent, params }) => {
       if (initialRule !== null) {
         return {
           initialRule,
-          user,
         };
       }
     }

--- a/src/routes/expansion/rules/new/+page.ts
+++ b/src/routes/expansion/rules/new/+page.ts
@@ -1,7 +1,0 @@
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
-
-  return { user };
-};

--- a/src/routes/expansion/sets/+page.ts
+++ b/src/routes/expansion/sets/+page.ts
@@ -1,7 +1,0 @@
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
-
-  return { user };
-};

--- a/src/routes/expansion/sets/new/+page.ts
+++ b/src/routes/expansion/sets/new/+page.ts
@@ -6,5 +6,5 @@ export const load: PageLoad = async ({ parent }) => {
 
   const { plans: initialPlans } = await effects.getPlansAndModels(user);
 
-  return { initialPlans, user };
+  return { initialPlans };
 };

--- a/src/routes/external-sources/+layout.ts
+++ b/src/routes/external-sources/+layout.ts
@@ -1,6 +1,0 @@
-import type { LayoutLoad } from './$types';
-
-export const load: LayoutLoad = async ({ parent }) => {
-  const { user } = await parent();
-  return { user };
-};

--- a/src/routes/external-sources/sources/+page.ts
+++ b/src/routes/external-sources/sources/+page.ts
@@ -1,9 +1,0 @@
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
-
-  return {
-    user,
-  };
-};

--- a/src/routes/external-sources/types/+page.ts
+++ b/src/routes/external-sources/types/+page.ts
@@ -1,9 +1,0 @@
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
-
-  return {
-    user,
-  };
-};

--- a/src/routes/models/+page.ts
+++ b/src/routes/models/+page.ts
@@ -8,6 +8,5 @@ export const load: PageLoad = async ({ parent }) => {
 
   return {
     initialModels,
-    user,
   };
 };

--- a/src/routes/models/[id]/+page.ts
+++ b/src/routes/models/[id]/+page.ts
@@ -15,7 +15,6 @@ export const load: PageLoad = async ({ parent, params }) => {
     if (initialModel) {
       return {
         initialModel,
-        user,
       };
     }
   }

--- a/src/routes/parcels/+page.ts
+++ b/src/routes/parcels/+page.ts
@@ -1,7 +1,0 @@
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
-
-  return { user };
-};

--- a/src/routes/parcels/edit/[id]/+page.ts
+++ b/src/routes/parcels/edit/[id]/+page.ts
@@ -19,7 +19,6 @@ export const load: PageLoad = async ({ parent, params }) => {
       if (initialParcel !== null) {
         return {
           initialParcel,
-          user,
         };
       }
     }

--- a/src/routes/parcels/new/+page.ts
+++ b/src/routes/parcels/new/+page.ts
@@ -1,7 +1,0 @@
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
-
-  return { user };
-};

--- a/src/routes/plans/+page.ts
+++ b/src/routes/plans/+page.ts
@@ -9,6 +9,5 @@ export const load: PageLoad = async ({ parent }) => {
   return {
     models,
     plans,
-    user,
   };
 };

--- a/src/routes/plans/[id]/+page.ts
+++ b/src/routes/plans/[id]/+page.ts
@@ -74,7 +74,6 @@ export const load: PageLoad = async ({ parent, params, url }) => {
         initialPlanSnapshotId,
         initialPlanTags,
         initialView,
-        user,
       };
     }
   }

--- a/src/routes/plans/[id]/merge/+page.ts
+++ b/src/routes/plans/[id]/merge/+page.ts
@@ -41,7 +41,6 @@ export const load: PageLoad = async ({ parent, params }) => {
         initialMergeRequest,
         initialNonConflictingActivities,
         initialPlan,
-        user,
       };
     }
   }

--- a/src/routes/scheduling/+page.ts
+++ b/src/routes/scheduling/+page.ts
@@ -1,9 +1,0 @@
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
-
-  return {
-    user,
-  };
-};

--- a/src/routes/scheduling/conditions/edit/[id]/+page.ts
+++ b/src/routes/scheduling/conditions/edit/[id]/+page.ts
@@ -17,7 +17,6 @@ export const load: PageLoad = async ({ parent, params }) => {
       if (initialCondition !== null) {
         return {
           initialCondition,
-          user,
         };
       }
     }

--- a/src/routes/scheduling/conditions/new/+page.ts
+++ b/src/routes/scheduling/conditions/new/+page.ts
@@ -1,9 +1,0 @@
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
-
-  return {
-    user,
-  };
-};

--- a/src/routes/scheduling/goals/edit/[id]/+page.ts
+++ b/src/routes/scheduling/goals/edit/[id]/+page.ts
@@ -18,7 +18,6 @@ export const load: PageLoad = async ({ parent, params }) => {
       if (initialGoal !== null) {
         return {
           initialGoal,
-          user,
         };
       }
     }

--- a/src/routes/scheduling/goals/new/+page.ts
+++ b/src/routes/scheduling/goals/new/+page.ts
@@ -1,9 +1,0 @@
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
-
-  return {
-    user,
-  };
-};

--- a/src/routes/sequence-templates/+page.ts
+++ b/src/routes/sequence-templates/+page.ts
@@ -1,7 +1,0 @@
-import type { PageLoad } from '../$types';
-
-export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
-
-  return { user };
-};

--- a/src/routes/tags/+page.ts
+++ b/src/routes/tags/+page.ts
@@ -8,6 +8,5 @@ export const load: PageLoad = async ({ parent }) => {
 
   return {
     initialTags,
-    user,
   };
 };

--- a/src/routes/workspaces/+page.ts
+++ b/src/routes/workspaces/+page.ts
@@ -1,7 +1,0 @@
-import type { PageLoad } from './$types';
-
-export const load: PageLoad = async ({ parent }) => {
-  const { user } = await parent();
-
-  return { user };
-};

--- a/src/routes/workspaces/[workspaceId]/+layout.ts
+++ b/src/routes/workspaces/[workspaceId]/+layout.ts
@@ -10,6 +10,5 @@ export const load: LayoutLoad = async ({ parent, params }) => {
 
   return {
     initialWorkspace,
-    user,
   };
 };

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -114,6 +114,7 @@
   let hasEditFilePermission: boolean = false;
   let hasEditWorkspacePermission: boolean = false;
   let hasEditWorkspaceCollaboratorsPermission: boolean = false;
+  let hasRunActionPermission: boolean = false;
   let phoenixContext: PhoenixContext;
   let showLoadingSpinner: boolean = false;
   let loadingSpinnerTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -258,6 +259,7 @@
       hasEditFilePermission = featurePermissions.workspace.canUpdate($user, ws);
       availableActionsForActiveFile = [];
     }
+    hasRunActionPermission = featurePermissions.actionRun.canCreate($user, ws);
   }
 
   $: if ($parcel) {
@@ -897,7 +899,7 @@
           <SequenceEditor
             {phoenixContext}
             availableActions={availableActionsForActiveFile}
-            includeActions
+            includeActions={hasRunActionPermission}
             isLoading={$activeDocumentIsLoading}
             previewOnly={!hasEditFilePermission}
             sequenceAdaptation={$sequenceAdaptation}

--- a/src/routes/workspaces/[workspaceId]/actions/+layout.ts
+++ b/src/routes/workspaces/[workspaceId]/actions/+layout.ts
@@ -10,6 +10,5 @@ export const load: LayoutLoad = async ({ parent, params }) => {
 
   return {
     initialWorkspace,
-    user,
   };
 };

--- a/src/routes/workspaces/[workspaceId]/actions/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/actions/+page.svelte
@@ -3,13 +3,16 @@
 <script lang="ts">
   import PageTitle from '../../../../components/app/PageTitle.svelte';
   import Actions from '../../../../components/sequencing/actions/Actions.svelte';
+  import { getUserStore } from '../../../../stores/user';
   import type { PageData } from './$types';
+
+  const user = getUserStore();
 
   export let data: PageData;
 
-  const { initialWorkspace, user } = data;
+  const { initialWorkspace } = data;
 </script>
 
 <PageTitle title="Workspace: {initialWorkspace?.name} - Actions" />
 
-<Actions {user} workspace={initialWorkspace} />
+<Actions user={$user} workspace={initialWorkspace} />

--- a/src/routes/workspaces/[workspaceId]/actions/runs/[runId]/+layout.ts
+++ b/src/routes/workspaces/[workspaceId]/actions/runs/[runId]/+layout.ts
@@ -14,13 +14,11 @@ export const load: LayoutLoad = async ({ parent, params }) => {
     return {
       initialActionRun,
       initialWorkspace,
-      user,
     };
   }
 
   return {
     initialActionRun: null,
     initialWorkspace,
-    user,
   };
 };


### PR DESCRIPTION
Fixes some lingering user role issues and removes some unnecessary files and code after #1741.

- Hide socket connection banner if user is not logged in. Closes #1878 
- Fix permission guard on workspace settings name field
- Hide workspace editor toolbar actions in sequence editor if user does not have permission to run actions in that workspace
- Remove unnecessary user passing from initial page data which resulted in deletion of a significant number of unneeded +page.ts files. 
- Fix user passing in the workspace actions page where the user was previously being pulled from initial data instead of context store.