### PR TITLE
Prevent  file switching from affecting undo history

### DIFF
--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -109,6 +109,7 @@
     // both files could have identical content.
     if (editorSequenceView?.state.doc.toString() !== sequenceDefinition) {
       editorSequenceView?.dispatch({
+        annotations: [Transaction.addToHistory.of(false)], // Prevent this change from being added to the undo history
         changes: { from: 0, insert: sequenceDefinition, to: editorSequenceView.state.doc.length },
         userEvent: 'file.open',
       });

--- a/src/components/ui/TextEditor.svelte
+++ b/src/components/ui/TextEditor.svelte
@@ -4,7 +4,7 @@
   import { standardKeymap } from '@codemirror/commands';
   import { json, jsonParseLinter } from '@codemirror/lang-json';
   import { linter, lintGutter } from '@codemirror/lint';
-  import { Compartment, EditorState } from '@codemirror/state';
+  import { Compartment, EditorState, Transaction } from '@codemirror/state';
   import { type ViewUpdate, keymap } from '@codemirror/view';
   import { basicSetup, EditorView } from 'codemirror';
   import { debounce } from 'lodash-es';
@@ -57,6 +57,7 @@
     // to avoid resetting the cursor position.
     if (editorView.state.doc.toString() !== textFileContent) {
       editorView.dispatch({
+        annotations: [Transaction.addToHistory.of(false)], // Prevent this change from being added to the undo history
         changes: { from: 0, insert: textFileContent, to: editorView.state.doc.length },
       });
     }


### PR DESCRIPTION
<a id="verification"></a>
## Verification

1. Open a workspace
2. Open a file with text
3. Hit CMD/CTRL + Z
4. Verify that the contents of the file did not update