### PR TITLE
add file.open annotation to SequenceEditor when opening file, show toast when sanitizing characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@lezer/lr": "^1.4.2",
         "@nasa-jpl/aerie-actions": "1.1.0",
         "@nasa-jpl/aerie-ampcs": "^1.0.5",
-        "@nasa-jpl/aerie-sequence-languages": "1.0.0",
+        "@nasa-jpl/aerie-sequence-languages": "1.0.1",
         "@nasa-jpl/seq-json-schema": "^1.3.1",
         "@nasa-jpl/stellar": "^2.0.0-alpha.30",
         "@nasa-jpl/stellar-svelte": "^2.1.10",
@@ -1374,9 +1374,10 @@
       }
     },
     "node_modules/@nasa-jpl/aerie-sequence-languages": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-sequence-languages/-/aerie-sequence-languages-1.0.0.tgz",
-      "integrity": "sha512-VvKcm9wm9odZgoU6ahec7gnrI511EQAEe2rzA47ULwWGvJL7r6sBOX7QQ9uD6bC4/J49qpSBR6aFXnMQ2kk/6g==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@nasa-jpl/aerie-sequence-languages/-/aerie-sequence-languages-1.0.1.tgz",
+      "integrity": "sha512-DDNmmMuLIwfHTkCl3uXxBJVceNt/RxfIhMB78xA626bYjVOrDpY14ERUPmLQKBCt84sfGGSGW9OJNDPCbCjAEg==",
+      "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.19.0",
         "@codemirror/commands": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@lezer/lr": "^1.4.2",
     "@nasa-jpl/aerie-actions": "1.1.0",
     "@nasa-jpl/aerie-ampcs": "^1.0.5",
-    "@nasa-jpl/aerie-sequence-languages": "1.0.0",
+    "@nasa-jpl/aerie-sequence-languages": "1.0.1",
     "@nasa-jpl/seq-json-schema": "^1.3.1",
     "@nasa-jpl/stellar": "^2.0.0-alpha.30",
     "@nasa-jpl/stellar-svelte": "^2.1.10",

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -104,7 +104,7 @@
     if (editorSequenceView?.state.doc.toString() !== sequenceDefinition) {
       editorSequenceView?.dispatch({
         changes: { from: 0, insert: sequenceDefinition, to: editorSequenceView.state.doc.length },
-        userEvent: "file.open"
+        userEvent: 'file.open',
       });
     }
   }

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -4,7 +4,7 @@
   import { standardKeymap } from '@codemirror/commands';
   import { syntaxTree } from '@codemirror/language';
   import { lintGutter, openLintPanel } from '@codemirror/lint';
-  import { Compartment, EditorState, type Extension } from '@codemirror/state';
+  import { Compartment, EditorState, Transaction, type Extension } from '@codemirror/state';
   import { keymap, type ViewUpdate } from '@codemirror/view';
   import type { SyntaxNode } from '@lezer/common';
   import type {
@@ -104,6 +104,7 @@
     if (editorSequenceView?.state.doc.toString() !== sequenceDefinition) {
       editorSequenceView?.dispatch({
         changes: { from: 0, insert: sequenceDefinition, to: editorSequenceView.state.doc.length },
+        userEvent: "file.open"
       });
     }
   }
@@ -291,6 +292,13 @@
         blockTheme,
         compartmentAdaptation.of(inputEditorExtension),
         compartmentReadonly.of([EditorState.readOnly.of(readOnly || previewOnly || isLoading)]),
+        EditorView.updateListener.of(viewUpdate => {
+          for (const tr of viewUpdate.transactions) {
+            if (tr.annotation(Transaction.userEvent)?.startsWith('sanitize.smartQuotes')) {
+              showSuccessToast('Replaced curly quotes with ASCII quotes, save to accept changes');
+            }
+          }
+        }),
       ],
       parent: editorSequenceDiv,
     });

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -294,7 +294,7 @@
         compartmentReadonly.of([EditorState.readOnly.of(readOnly || previewOnly || isLoading)]),
         EditorView.updateListener.of(viewUpdate => {
           for (const tr of viewUpdate.transactions) {
-            if (tr.annotation(Transaction.userEvent)?.startsWith('sanitize.smartQuotes')) {
+            if (tr.annotation(Transaction.userEvent) === 'sanitize.smartQuotes') {
               showSuccessToast('Replaced curly quotes with ASCII quotes, save to accept changes');
             }
           }

--- a/src/utilities/sequence-editor/adaptation-utils.ts
+++ b/src/utilities/sequence-editor/adaptation-utils.ts
@@ -2,6 +2,7 @@
 import * as cmCommands from '@codemirror/commands';
 import * as cmLanguage from '@codemirror/language';
 import * as cmView from '@codemirror/view';
+import * as cmState from '@codemirror/state';
 
 import type { PhoenixAdaptation } from '@nasa-jpl/aerie-sequence-languages';
 import type { User } from '../../types/app';
@@ -29,7 +30,8 @@ export async function loadSequenceAdaptation(id: number, user: User | null): Pro
     return {
       '@codemirror/commands': cmCommands,
       '@codemirror/language': cmLanguage,
-      '@codemirror/view': cmView,
+      '@codemirror/state': cmState,
+      '@codemirror/view': cmView
     }[id];
   };
   // adaptation code will set `exports.adaptation = adaptation;`

--- a/src/utilities/sequence-editor/adaptation-utils.ts
+++ b/src/utilities/sequence-editor/adaptation-utils.ts
@@ -31,7 +31,7 @@ export async function loadSequenceAdaptation(id: number, user: User | null): Pro
       '@codemirror/commands': cmCommands,
       '@codemirror/language': cmLanguage,
       '@codemirror/state': cmState,
-      '@codemirror/view': cmView
+      '@codemirror/view': cmView,
     }[id];
   };
   // adaptation code will set `exports.adaptation = adaptation;`


### PR DESCRIPTION
Supports sanitizing special characters/smart quotes on document open/paste.

Requires https://github.com/NASA-AMMOS/aerie-sequence-languages/pull/22

Test setup:
1. Checkout `dev/smart-quotes-sanitize-2` branch of aerie-sequence-languages (from PR above)
2. Checkout https://github.com/NASA-AMMOS/aerie-sequence-adaptation-template
3. Use `npm link` or a file dependency to link the adaptation template to the sequence languages branch (it is a dependency of the template)
4. Build the aerie-sequence-languages and then build the sequence adaptation template
5. Upload the adaptation on Dictionaries page and associate it with your workspaces parcel

Testing instructions:
1. upload a file with curly quotes, then open it in the editor and confirm it replaces them on first open
2. start on another file, then switch to a file with curly quotes to confirm it replaces them when switching files
3. paste a command with curly quotes eg. `C ECHO “That’s a ‘magic’ shoe.”` and confirm they get replaced by normal quotes