### PR TITLE
Remove separate handling of secret parameters in RunActionModal

### DIFF
--- a/src/components/modals/RunActionModal.svelte
+++ b/src/components/modals/RunActionModal.svelte
@@ -44,13 +44,11 @@
     running = true;
     let secretParametersMap: ActionParametersMap = {};
     let nonSecretParametersMap: ActionParametersMap = {};
-    let hasSecrets = false;
 
     // Filter out the secret params to send directly to the action server.
     for (const param of Object.keys(parametersMap)) {
       if (parametersMap[param].schema.type === 'secret') {
         secretParametersMap[param] = argumentsMap[param];
-        hasSecrets = true;
       } else {
         nonSecretParametersMap[param] = argumentsMap[param];
       }
@@ -65,10 +63,6 @@
       actionDefinition.settings,
       user,
     );
-
-    if (actionRunId !== null && hasSecrets) {
-      await effects.sendActionSecretParameters(workspace, secretParametersMap, actionRunId, user);
-    }
 
     running = false;
     dispatch('complete', { actionRunId });


### PR DESCRIPTION
Because we already send the secrets to the action server, this was causing it to be sent twice, which is causing the action server to crash due to an unhandled error.

To test:
1. Create a parcel
2. Create a workspace with the parcel
3. Add an action with secret parameters present to the workspace
4. Run the action
5. Verify that the action run doesn't hang on the "pending" state