### PR TITLE
Clear stale SeqJSON output when switching workspace files

### DIFF
--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -200,12 +200,8 @@
     if (!preserveAdaptationLog) {
       clearWorkspaceAdaptationMessages();
     }
-
     try {
-      output =
-        sequenceName === undefined
-          ? undefined
-          : selectedOutputFormat?.toOutputFormat?.(sequence, phoenixContext, sequenceName);
+      output = selectedOutputFormat?.toOutputFormat?.(sequence, phoenixContext, sequenceName);
     } catch (e) {
       console.error('Adaptation toOutputFormat error:', e);
       if (sequenceFilePath) {
@@ -370,6 +366,9 @@
       ],
       parent: editorOutputDiv,
     });
+
+    // Compute initial output for the starting content (e.g., untitled empty sequence on page load)
+    debouncedOutputUpdate(editorSequenceView.state.doc.toString());
   });
 
   onDestroy(() => {

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -176,6 +176,12 @@
     debouncedOutputUpdate.cancel();
     dispatchLintChange.cancel();
     previousSequenceFilePath = sequenceFilePath;
+
+    // Clear stale output and recompute for the new file
+    if (editorOutputView) {
+      editorOutputView.dispatch({ changes: { from: 0, insert: '', to: editorOutputView.state.doc.length } });
+      debouncedOutputUpdate(editorSequenceView?.state.doc.toString() ?? '');
+    }
   }
 
   function sequenceUpdateListener(viewUpdate: ViewUpdate): void {

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -1055,7 +1055,7 @@
                 previewOnly={!hasEditFilePermission}
                 sequenceAdaptation={$sequenceAdaptation}
                 sequenceDefinition={$activeDocument.originalContent}
-                sequenceName={$activeDocument.fileName ?? undefined}
+                sequenceName={$activeDocument.fileName ?? ''}
                 sequenceFilePath={$activeDocumentPath ?? ''}
                 sequenceOutput={selectedSequenceOutput}
                 shouldListenForKeyboardSave={false}
@@ -1081,7 +1081,7 @@
                 isLoading={$activeDocumentIsLoading}
                 previewOnly={!hasEditFilePermission}
                 shouldListenForKeyboardSave={false}
-                textFileName={$activeDocument.fileName ?? undefined}
+                textFileName={$activeDocument.fileName ?? ''}
                 textFilePath={$activeDocumentPath ?? ''}
                 textFileContent={$activeDocument.originalContent}
                 on:lintChange={onLintChange}

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -336,6 +336,7 @@
     }
 
     // successfully navigated, start loading the file contents
+    selectedSequenceOutput = undefined;
     if (nextPath && workspaceTreeMap[nextPath]) {
       const { filename } = separateFilenameFromPath(nextPath);
       const fileType = workspaceTreeMap[nextPath]?.type ?? null;


### PR DESCRIPTION
When switching between sequence files, the SeqJSON output panel would retain the previous file's content. This happened because the debounced output update was cancelled without scheduling a replacement, and when opening a new blank file the output was never recomputed. This PR also resolves an issue where sequence output format was not being computed and shown for untitled files on page load.

Fixes:
- Clear the output editor and schedule a new computation on file switch
- Reset selectedSequenceOutput when navigating so blank/new sequence files don't inherit stale output from the previous file

Closes #1888 