### PR TITLE
Fix inconsistent file extension handling in workspaces

### DIFF
--- a/src/components/modals/ImportWorkspaceFileModal.svelte
+++ b/src/components/modals/ImportWorkspaceFileModal.svelte
@@ -7,7 +7,7 @@
   import type { User } from '../../types/app';
   import type { Workspace, WorkspaceNodeEvent } from '../../types/workspace';
   import type { WorkspaceTreeNode } from '../../types/workspace-tree-view';
-  import { joinPath, removeFirstPathSegment } from '../../utilities/workspaces.js';
+  import { doesFilenameMatchExtension, joinPath, removeFirstPathSegment } from '../../utilities/workspaces.js';
   import InputInternal from '../form/Input.svelte';
   import WorkspaceTreeView from '../workspace/WorkspaceTreeView/WorkspaceTreeView.svelte';
   import Modal from './Modal.svelte';
@@ -52,9 +52,7 @@
     selectedFileGroupings = Array.from(files ?? []).reduce(
       (previousFileGroupings: { convertableFiles: File[]; uploadableFiles: File[] }, file) => {
         if (
-          outputLanguageExtensions.findIndex(fileExtension =>
-            file.name.endsWith(`.${fileExtension.replace(/^\./, '')}`),
-          ) > -1
+          outputLanguageExtensions.findIndex(fileExtension => doesFilenameMatchExtension(fileExtension, file.name)) > -1
         ) {
           return {
             ...previousFileGroupings,

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -26,6 +26,7 @@
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { phoenixResources } from '../../utilities/sequence-editor/adaptation-resources';
   import { showFailureToast, showSuccessToast } from '../../utilities/toast';
+  import { replaceFileExtension } from '../../utilities/workspaces';
   import CssGrid from '../ui/CssGrid.svelte';
   import CssGridGutter from '../ui/CssGridGutter.svelte';
   import Panel from '../ui/Panel.svelte';
@@ -241,13 +242,12 @@
 
   function downloadOutputFormat(outputLanguage: OutputLanguage): void {
     const content = editorOutputView.state.doc.toString();
-    // Remove any existing extension and add output extension
-    const outputExt = outputLanguage.fileExtension; // Keep the dot
-    const lastDotIndex = sequenceName.lastIndexOf('.');
 
-    // If there's a dot in the filename, remove everything after it; otherwise keep the whole name
-    const filenameWithoutExt = lastDotIndex > 0 ? sequenceName.slice(0, lastDotIndex) : sequenceName;
-    const filename = filenameWithoutExt + outputExt;
+    const filename = replaceFileExtension(
+      sequenceName,
+      sequenceAdaptation.input.fileExtension,
+      outputLanguage.fileExtension,
+    );
 
     dispatch('downloadOutput', { content, filePath: sequenceFilePath, filename, outputLanguage });
   }

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -320,6 +320,7 @@ import {
 } from './view';
 import {
   cleanPath,
+  doesFilenameMatchExtension,
   findNodeInDirectory,
   flattenWorkspaceTreeWithPaths,
   getWorkspaceFileFolderDisplay,
@@ -328,6 +329,7 @@ import {
   isFileConflictResponse,
   joinPath,
   mapWorkspaceTreePaths,
+  replaceFileExtension,
   separateFilenameFromPath,
   WorkspaceApi,
   type BulkOperationResponses,
@@ -6057,20 +6059,28 @@ const effects = {
         const convertedFiles: File[] = await Promise.all(
           filesToConvert.map(async file => {
             const outputLanguage = sequenceAdaptation.outputs.find(language =>
-              file.name.endsWith(`.${language.fileExtension.replace(/^\./, '')}`),
+              doesFilenameMatchExtension(language.fileExtension, file.name),
             );
 
             if (outputLanguage) {
-              const fileName = file.name.replace(
-                outputLanguage.fileExtension.replace(/^\./, ''),
-                sequenceAdaptation.input.fileExtension.replace(/^\./, ''),
-              );
-              const lastModified = Date.now();
-              const content = await file.text();
-              const convertedContent = outputLanguage.toInputFormat(content, phoenixContext, fileName);
+              try {
+                const fileName = replaceFileExtension(
+                  file.name,
+                  outputLanguage.fileExtension,
+                  sequenceAdaptation.input.fileExtension,
+                );
+                const lastModified = Date.now();
+                const content = await file.text();
+                const convertedContent = outputLanguage.toInputFormat(content, phoenixContext, fileName);
 
-              convertedFileMap[file.name] = fileName;
-              return new File([convertedContent], fileName, { lastModified, type: 'text/plain' });
+                convertedFileMap[file.name] = fileName;
+                return new File([convertedContent], fileName, { lastModified, type: 'text/plain' });
+              } catch (error) {
+                throw Error(
+                  `There was an error trying to convert the file ${file.name}. Please check that it is formatted correctly.`,
+                  { cause: error },
+                );
+              }
             }
 
             return file;

--- a/src/utilities/workspaces.test.ts
+++ b/src/utilities/workspaces.test.ts
@@ -1390,6 +1390,12 @@ describe('Workspace utility function tests', () => {
       expect(doesFilenameMatchExtension('txt', 'file.txt')).toBe(true);
       expect(doesFilenameMatchExtension('seq', 'test.seq')).toBe(true);
       expect(doesFilenameMatchExtension('json', 'data.json')).toBe(true);
+      expect(doesFilenameMatchExtension('seqn.txt', 'sequence.seqn.txt')).toBe(true);
+      expect(doesFilenameMatchExtension('seqn.txt', 'sequence.thing.seqn.txt')).toBe(true);
+      expect(doesFilenameMatchExtension('seqn.txt', 'sequence.seqn.txt.thing')).toBe(false);
+      expect(doesFilenameMatchExtension('seqn.txt', 'sequence.seqn')).toBe(false);
+      expect(doesFilenameMatchExtension('seqn.txt', 'sequence.txt')).toBe(false);
+      expect(doesFilenameMatchExtension('seqn.txt', 'seqn.txt')).toBe(false);
     });
 
     test('Should match extension with leading dot', () => {
@@ -1457,14 +1463,6 @@ describe('Workspace utility function tests', () => {
     test('Should not match if extension appears in middle of filename', () => {
       expect(doesFilenameMatchExtension('txt', 'file-txt.json')).toBe(false);
       expect(doesFilenameMatchExtension('seq', 'sequential.js')).toBe(false);
-    });
-
-    test('Should handle special regex characters in extension', () => {
-      // Note: The function does NOT escape regex special characters
-      // So these are treated as regex patterns, not literal strings
-      expect(doesFilenameMatchExtension('t*t', 'file.tt')).toBe(true); // t*t means "zero or more t" + "t"
-      expect(doesFilenameMatchExtension('t+t', 'file.ttt')).toBe(true); // t+t means "one or more t" + "t"
-      expect(doesFilenameMatchExtension('t*t', 'file.t')).toBe(true); // matches .t (zero t's + t)
     });
 
     test('Should match exact extension only', () => {

--- a/src/utilities/workspaces.test.ts
+++ b/src/utilities/workspaces.test.ts
@@ -9,6 +9,7 @@ import {
   computeMovedFilePath,
   computeTreeFilter,
   defaultTreeSortComparator,
+  doesFilenameMatchExtension,
   findNodeByPath,
   findNodeInDirectory,
   flattenWorkspaceTreeWithPaths,
@@ -21,6 +22,7 @@ import {
   mapWorkspaceTreePaths,
   removeFirstPathSegment,
   removeRedundantNodes,
+  replaceFileExtension,
   separateFilenameFromPath,
   shouldNodeBeVisible,
   sortWorkspaceTree,
@@ -1383,6 +1385,95 @@ describe('Workspace utility function tests', () => {
     });
   });
 
+  describe('doesFileMatchExtension', () => {
+    test('Should match extension without leading dot', () => {
+      expect(doesFilenameMatchExtension('txt', 'file.txt')).toBe(true);
+      expect(doesFilenameMatchExtension('seq', 'test.seq')).toBe(true);
+      expect(doesFilenameMatchExtension('json', 'data.json')).toBe(true);
+    });
+
+    test('Should match extension with leading dot', () => {
+      expect(doesFilenameMatchExtension('.txt', 'file.txt')).toBe(true);
+      expect(doesFilenameMatchExtension('.seq', 'test.seq')).toBe(true);
+      expect(doesFilenameMatchExtension('.json', 'data.json')).toBe(true);
+    });
+
+    test('Should be case-insensitive', () => {
+      expect(doesFilenameMatchExtension('TXT', 'file.txt')).toBe(true);
+      expect(doesFilenameMatchExtension('txt', 'file.TXT')).toBe(true);
+      expect(doesFilenameMatchExtension('TxT', 'file.TxT')).toBe(true);
+      expect(doesFilenameMatchExtension('SEQ', 'test.seq')).toBe(true);
+    });
+
+    test('Should not match wrong extension', () => {
+      expect(doesFilenameMatchExtension('txt', 'file.json')).toBe(false);
+      expect(doesFilenameMatchExtension('seq', 'test.txt')).toBe(false);
+      expect(doesFilenameMatchExtension('json', 'data.xml')).toBe(false);
+    });
+
+    test('Should only match extension at the end of filename', () => {
+      expect(doesFilenameMatchExtension('txt', 'file.txt.bak')).toBe(false);
+      expect(doesFilenameMatchExtension('txt', 'txt.json')).toBe(false);
+    });
+
+    test('Should handle files with multiple dots', () => {
+      expect(doesFilenameMatchExtension('js', 'script.min.js')).toBe(true);
+      expect(doesFilenameMatchExtension('json', 'config.test.json')).toBe(true);
+      expect(doesFilenameMatchExtension('txt', 'my.file.name.txt')).toBe(true);
+    });
+
+    test('Should not match files without extension', () => {
+      expect(doesFilenameMatchExtension('txt', 'README')).toBe(false);
+      expect(doesFilenameMatchExtension('js', 'Makefile')).toBe(false);
+    });
+
+    test('Should not match partial extension', () => {
+      expect(doesFilenameMatchExtension('tx', 'file.txt')).toBe(false);
+      expect(doesFilenameMatchExtension('t', 'file.txt')).toBe(false);
+      expect(doesFilenameMatchExtension('son', 'file.json')).toBe(false);
+    });
+
+    test('Should handle empty filename', () => {
+      expect(doesFilenameMatchExtension('txt', '')).toBe(false);
+    });
+
+    test('Should handle empty extension', () => {
+      expect(doesFilenameMatchExtension('', 'file.')).toBe(true); // matches files ending with a dot
+      expect(doesFilenameMatchExtension('', 'file.txt')).toBe(false);
+      expect(doesFilenameMatchExtension('', 'file')).toBe(false);
+    });
+
+    test('Should handle filename with path', () => {
+      expect(doesFilenameMatchExtension('txt', 'path/to/file.txt')).toBe(true);
+      expect(doesFilenameMatchExtension('seq', 'folder/subfolder/test.seq')).toBe(true);
+      expect(doesFilenameMatchExtension('json', 'a/b/c/data.json')).toBe(true);
+    });
+
+    test('Should handle hidden files (starting with dot)', () => {
+      expect(doesFilenameMatchExtension('json', '.config.json')).toBe(true);
+      expect(doesFilenameMatchExtension('txt', '.gitignore.txt')).toBe(true);
+    });
+
+    test('Should not match if extension appears in middle of filename', () => {
+      expect(doesFilenameMatchExtension('txt', 'file-txt.json')).toBe(false);
+      expect(doesFilenameMatchExtension('seq', 'sequential.js')).toBe(false);
+    });
+
+    test('Should handle special regex characters in extension', () => {
+      // Note: The function does NOT escape regex special characters
+      // So these are treated as regex patterns, not literal strings
+      expect(doesFilenameMatchExtension('t*t', 'file.tt')).toBe(true); // t*t means "zero or more t" + "t"
+      expect(doesFilenameMatchExtension('t+t', 'file.ttt')).toBe(true); // t+t means "one or more t" + "t"
+      expect(doesFilenameMatchExtension('t*t', 'file.t')).toBe(true); // matches .t (zero t's + t)
+    });
+
+    test('Should match exact extension only', () => {
+      expect(doesFilenameMatchExtension('js', 'file.js')).toBe(true);
+      expect(doesFilenameMatchExtension('js', 'file.json')).toBe(false);
+      expect(doesFilenameMatchExtension('js', 'file.jsx')).toBe(false);
+    });
+  });
+
   describe('getCommonPathPrefix', () => {
     test('Should return empty string for empty array', () => {
       const result = getCommonPathPrefix([]);
@@ -1432,6 +1523,93 @@ describe('Workspace utility function tests', () => {
     test('Should handle multiple paths with varying common depths', () => {
       const result = getCommonPathPrefix(['a/b/c/file1.txt', 'a/b/file2.txt', 'a/b/d/file3.txt']);
       expect(result).toBe('a/b');
+    });
+  });
+
+  describe('replaceFileExtension', () => {
+    test('Should replace extension without leading dots', () => {
+      expect(replaceFileExtension('file.txt', 'txt', 'json')).toBe('file.json');
+      expect(replaceFileExtension('test.seq.json', 'seq.json', 'seqN.txt')).toBe('test.seqN.txt');
+      expect(replaceFileExtension('data.xml', 'xml', 'json')).toBe('data.json');
+    });
+
+    test('Should replace extension with leading dots', () => {
+      expect(replaceFileExtension('file.txt', '.txt', '.json')).toBe('file.json');
+      expect(replaceFileExtension('test.seq', '.seq', '.seqN')).toBe('test.seqN');
+      expect(replaceFileExtension('data.xml', '.xml', '.json')).toBe('data.json');
+    });
+
+    test('Should replace extension with mixed dot usage', () => {
+      expect(replaceFileExtension('file.txt', 'txt', '.json')).toBe('file.json');
+      expect(replaceFileExtension('test.seq', '.seq', 'seqN')).toBe('test.seqN');
+    });
+
+    test('Should be case-insensitive when matching extension', () => {
+      expect(replaceFileExtension('file.TXT', 'txt', 'json')).toBe('file.json');
+      expect(replaceFileExtension('test.SEQ', 'seq', 'seqN')).toBe('test.seqN');
+      expect(replaceFileExtension('data.Xml', 'XML', 'json')).toBe('data.json');
+    });
+
+    test('Should not replace if extension does not match', () => {
+      expect(replaceFileExtension('file.txt', 'json', 'xml')).toBe('file.txt');
+      expect(replaceFileExtension('test.seq', 'txt', 'json')).toBe('test.seq');
+      expect(replaceFileExtension('data.xml', 'seq', 'json')).toBe('data.xml');
+    });
+
+    test('Should only replace extension at the end of filename', () => {
+      expect(replaceFileExtension('file.txt.bak', 'txt', 'json')).toBe('file.txt.bak');
+      expect(replaceFileExtension('test.seq.old', 'seq', 'seqN')).toBe('test.seq.old');
+    });
+
+    test('Should handle files with multiple dots correctly', () => {
+      expect(replaceFileExtension('script.min.js', 'min.js', 'ts')).toBe('script.ts');
+      expect(replaceFileExtension('config.test.json', 'json', 'xml')).toBe('config.test.xml');
+      expect(replaceFileExtension('my.file.name.txt', 'txt', 'md')).toBe('my.file.name.md');
+    });
+
+    test('Should not replace if filename has no extension', () => {
+      expect(replaceFileExtension('README', 'txt', 'md')).toBe('README');
+      expect(replaceFileExtension('Makefile', 'txt', 'json')).toBe('Makefile');
+    });
+
+    test('Should handle files with path', () => {
+      expect(replaceFileExtension('path/to/file.txt', 'txt', 'json')).toBe('path/to/file.json');
+      expect(replaceFileExtension('folder/subfolder/test.seq', 'seq', 'seqN')).toBe('folder/subfolder/test.seqN');
+      expect(replaceFileExtension('a/b/c/data.xml', 'xml', 'json')).toBe('a/b/c/data.json');
+    });
+
+    test('Should handle hidden files (starting with dot)', () => {
+      expect(replaceFileExtension('.config.json', 'json', 'xml')).toBe('.config.xml');
+      expect(replaceFileExtension('.gitignore.txt', 'txt', 'bak')).toBe('.gitignore.bak');
+    });
+
+    test('Should not match partial extension', () => {
+      expect(replaceFileExtension('file.txt', 'tx', 'json')).toBe('file.txt');
+      expect(replaceFileExtension('file.txt', 't', 'json')).toBe('file.txt');
+      expect(replaceFileExtension('file.json', 'son', 'xml')).toBe('file.json');
+    });
+
+    test('Should not replace extension in middle of filename', () => {
+      expect(replaceFileExtension('file-txt.json', 'txt', 'xml')).toBe('file-txt.json');
+      expect(replaceFileExtension('sequential.js', 'seq', 'seqN')).toBe('sequential.js');
+    });
+
+    test('Should handle empty filename', () => {
+      expect(replaceFileExtension('', 'txt', 'json')).toBe('');
+    });
+
+    test('Should preserve target extension case', () => {
+      expect(replaceFileExtension('file.txt', 'txt', 'JSON')).toBe('file.JSON');
+      expect(replaceFileExtension('test.seq', 'seq', 'SeqN')).toBe('test.SeqN');
+    });
+
+    test('Should handle complex file extensions', () => {
+      expect(replaceFileExtension('archive.tar.gz', 'gz', 'bz2')).toBe('archive.tar.bz2');
+      expect(replaceFileExtension('script.min.js', 'min.js', 'js')).toBe('script.js');
+    });
+
+    test('Should replace when only extension matches without filename', () => {
+      expect(replaceFileExtension('.txt', 'txt', 'json')).toBe('.json');
     });
   });
 });

--- a/src/utilities/workspaces.ts
+++ b/src/utilities/workspaces.ts
@@ -367,14 +367,24 @@ export function isFileConflictResponse(response: BulkOperationResponse) {
 }
 
 export function doesFilenameMatchExtension(extension: string, filename: string) {
-  return new RegExp(`\\.${extension.replace(/^\./, '')}$`, 'i').test(filename);
+  // Normalize extension to include leading dot
+  const normalizedExtension = extension.startsWith('.') ? extension : `.${extension}`;
+  // Case-insensitive check if filename ends with the extension
+  return filename.toLowerCase().endsWith(normalizedExtension.toLowerCase());
 }
 
 export function replaceFileExtension(filename: string, fromExtension: string, toExtension: string) {
-  return filename.replace(
-    new RegExp(`\\.${fromExtension.replace(/^\./, '')}$`, 'i'),
-    `.${toExtension.replace(/^\./, '')}`,
-  );
+  // Normalize extensions to include leading dots
+  const normalizedFromExtension = fromExtension.startsWith('.') ? fromExtension : `.${fromExtension}`;
+  const normalizedToExtension = toExtension.startsWith('.') ? toExtension : `.${toExtension}`;
+
+  // Check if filename ends with the fromExtension (case-insensitive)
+  if (!doesFilenameMatchExtension(normalizedFromExtension, filename)) {
+    return filename;
+  }
+
+  // Replace only the extension at the end, preserving the original case of the filename
+  return `${filename.slice(0, -normalizedFromExtension.length)}${normalizedToExtension}`;
 }
 
 export const WorkspaceApi = {

--- a/src/utilities/workspaces.ts
+++ b/src/utilities/workspaces.ts
@@ -366,6 +366,17 @@ export function isFileConflictResponse(response: BulkOperationResponse) {
   return response.status === 409;
 }
 
+export function doesFilenameMatchExtension(extension: string, filename: string) {
+  return new RegExp(`\\.${extension.replace(/^\./, '')}$`, 'i').test(filename);
+}
+
+export function replaceFileExtension(filename: string, fromExtension: string, toExtension: string) {
+  return filename.replace(
+    new RegExp(`\\.${fromExtension.replace(/^\./, '')}$`, 'i'),
+    `.${toExtension.replace(/^\./, '')}`,
+  );
+}
+
 export const WorkspaceApi = {
   async createFolder(workspaceId: number, folderPath: string, user: User | null) {
     return reqWorkspace<Workspace>(`${workspaceId}/${folderPath}?type=directory`, 'PUT', null, user, undefined, false);


### PR DESCRIPTION
Addressing two issues reported by @parkerabercrombie -
1. If I upload a file named `test.SEQ.json` I don’t get the option to translate to seqN, but if it’s called `test.seq.json` I do (case sensitivity)
2. If I name my file `test.seqn.txt` and download as SeqJSON I get a file called test.seqn.seq.json - should be `test.seq.json`

<a id="verification"></a>
## Verification

To test upload issue:
1. Create a workspace (no adaptation necessary)
1. Upload a file with the output extension that doesn't quite match the case specified in the adaptation (e.g. test1.SEQ.json)
1. Verify that you are prompted with a choice to convert to the input extension (e.g. .seqN.txt)
1. Check on the checkbox to convert
1. Confirm the upload
1. Verify that the file added has the expected filename (e.g. test1.seqN.txt)

To test download issue:
1. Open a file with the input extension (e.g. test1.seqN.txt)
1. Click the `Output` button above the SequenceEditor
1. Select one of the download options
1. Verify that the file downloaded has the correct filename