### PR TITLE
Make delete button for permanent confirm modal actions red

### DIFF
--- a/src/components/modals/ConfirmModal.svelte
+++ b/src/components/modals/ConfirmModal.svelte
@@ -45,7 +45,12 @@
     <button class="st-button secondary" on:click={() => dispatch('close')}>
       {cancelText}
     </button>
-    <button class="st-button" on:click={() => dispatch('confirm')}>
+    <button
+      class="st-button {!actionCanBeUndone
+        ? 'bg-destructive text-destructive-foreground hover:!bg-destructive/90'
+        : ''}"
+      on:click={() => dispatch('confirm')}
+    >
       {confirmText}
     </button>
   </ModalFooter>

--- a/src/components/modals/ConfirmModal.svelte
+++ b/src/components/modals/ConfirmModal.svelte
@@ -38,7 +38,7 @@
   <ModalContent>
     <span>{message}</span>
     {#if !actionCanBeUndone}
-      <i>This action cannot be undone.</i>
+      <strong>This action cannot be undone.</strong>
     {/if}
   </ModalContent>
   <ModalFooter>

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -4070,9 +4070,9 @@ const effects = {
       }
 
       const { confirm } = await showConfirmModal(
-        'Delete',
-        `This will permanently delete the selected ${typeDisplayString.toLowerCase()} from the workspace: ${workspace.name}`,
-        'Delete Permanently',
+        `Permanently Delete ${typeDisplayString}`,
+        `This will permanently delete the selected ${typeDisplayString.toLowerCase()} from the "${workspace.name}" workspace.`,
+        `Permanently Delete`,
       );
 
       let responses: BulkOperationResponses = [];


### PR DESCRIPTION
Partly addresses #1896 

<a id="verification"></a>
## Verification
1. Make a workspace
2. Make a file in the workspace
3. Initiate file deletion by right clicking on the file in the workspace file browser and selecting the "Delete" menu option
4. Verify that the "Delete" button is red