### PR TITLE
Allow sequence name to be chosen during sequence expansion filter application

### DIFF
--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -76,13 +76,13 @@ export class Plan {
   schedulingGoalsModalFilter: Locator;
   schedulingSatisfiedActivity: Locator;
   schedulingStatusSelector: (status: string) => string;
+  sequenceExpansionApplySequenceFilterModal: Locator;
   sequenceExpansionNewButton: Locator;
   sequenceExpansionNewSequenceButton: Locator;
   sequenceExpansionNewSequenceConfirmButton: Locator;
   sequenceExpansionNewSequenceFilterButton: Locator;
   sequenceExpansionNewSequenceName: Locator;
   sequenceExpansionOutputModal: Locator;
-  sequenceExpansionTimeRangeModal: Locator;
   simulateButton: Locator;
   simulationHistoryList: Locator;
   simulationStatusSelector: (status: string) => string;
@@ -164,8 +164,8 @@ export class Plan {
     const sequenceFilterItem = this.page.locator('.sne-items').getByText(sequenceFilterName, { exact: true });
     await sequenceFilterItem.hover();
     await this.page.getByLabel(`Apply '${sequenceFilterName}'`).click();
-    await this.sequenceExpansionTimeRangeModal.waitFor({ state: 'attached' });
-    await this.sequenceExpansionTimeRangeModal.waitFor({ state: 'visible' });
+    await this.sequenceExpansionApplySequenceFilterModal.waitFor({ state: 'attached' });
+    await this.sequenceExpansionApplySequenceFilterModal.waitFor({ state: 'visible' });
     await this.page.getByRole('button', { exact: true, name: 'Confirm' }).click();
     await this.waitForToast('Expansion Sequence Created Successfully');
     await expect(this.page.locator('.sne-items').getByText(`${sequenceFilterName} Sequence`)).toBeVisible();
@@ -620,7 +620,7 @@ export class Plan {
     });
     this.sequenceExpansionNewSequenceName = page.locator('input[name="sequence-name"]');
     this.sequenceExpansionNewSequenceConfirmButton = page.getByRole('button', { exact: true, name: 'Confirm' });
-    this.sequenceExpansionTimeRangeModal = page.locator(`.modal:has-text("Create Sequence from Filter")`);
+    this.sequenceExpansionApplySequenceFilterModal = page.locator(`.modal:has-text("Create Sequence from Filter")`);
     this.sequenceExpansionOutputModal = page.locator(`.modal:has-text("Sequence ID")`);
   }
 

--- a/src/components/modals/ApplySequenceFilterModal.svelte
+++ b/src/components/modals/ApplySequenceFilterModal.svelte
@@ -32,6 +32,7 @@
   }>();
 
   let relevantExpansionSequences: ExpansionSequence[] = [];
+  let confirmIsDisabled = false;
 
   $: startTimeField = field<string>(defaultStartTime, [required, $plugins.time.primary.validate]);
   $: endTimeField = field<string>(defaultEndTime, [required, $plugins.time.primary.validate]);
@@ -45,6 +46,7 @@
   $: relevantExpansionSequences = $expansionSequences.filter(
     sequence => $simulationDatasetId === sequence.simulation_dataset_id,
   );
+  $: confirmIsDisabled = $sequenceNameField.invalid;
 
   function onInputKeydown(event: KeyboardEvent) {
     const { key } = event;
@@ -94,9 +96,9 @@
   </ModalContent>
   <ModalFooter>
     <button class="st-button secondary" on:click={() => dispatch('close')}> Cancel </button>
-    <button class="st-button" on:keydown={onInputKeydown} on:click={onConfirm}> Confirm </button>
+    <button class="st-button" disabled={confirmIsDisabled} on:keydown={onInputKeydown} on:click={onConfirm}> Confirm </button>
   </ModalFooter>
 </Modal>
 
 <style>
-</style>
+</style>``

--- a/src/components/modals/ApplySequenceFilterModal.svelte
+++ b/src/components/modals/ApplySequenceFilterModal.svelte
@@ -34,6 +34,7 @@
   let relevantExpansionSequences: ExpansionSequence[] = [];
   let confirmIsDisabled = false;
 
+  $: sequenceNameField.validateAndSet(defaultSequenceName);
   $: startTimeField = field<string>(defaultStartTime, [required, $plugins.time.primary.validate]);
   $: endTimeField = field<string>(defaultEndTime, [required, $plugins.time.primary.validate]);
   $: sequenceNameField = field<string>(defaultSequenceName, [

--- a/src/components/modals/ApplySequenceFilterModal.svelte
+++ b/src/components/modals/ApplySequenceFilterModal.svelte
@@ -96,9 +96,11 @@
   </ModalContent>
   <ModalFooter>
     <button class="st-button secondary" on:click={() => dispatch('close')}> Cancel </button>
-    <button class="st-button" disabled={confirmIsDisabled} on:keydown={onInputKeydown} on:click={onConfirm}> Confirm </button>
+    <button class="st-button" disabled={confirmIsDisabled} on:keydown={onInputKeydown} on:click={onConfirm}>
+      Confirm
+    </button>
   </ModalFooter>
-</Modal>
+</Modal>``
 
 <style>
-</style>``
+</style>

--- a/src/components/modals/ApplySequenceFilterModal.svelte
+++ b/src/components/modals/ApplySequenceFilterModal.svelte
@@ -7,6 +7,7 @@
   import { plugins } from '../../stores/plugins';
   import { simulationDatasetId } from '../../stores/simulation';
   import type { ExpansionSequence } from '../../types/expansion';
+  import type { FieldStore } from '../../types/form';
   import { tooltip } from '../../utilities/tooltip';
   import { required, unique } from '../../utilities/validators';
   import DatePickerField from '../form/DatePickerField.svelte';
@@ -31,19 +32,25 @@
     confirm: { sequenceName: string; timeRangeEnd: string; timeRangeStart: string };
   }>();
 
+  let sequenceNameField: FieldStore<string>;
+  let startTimeField: FieldStore<string>;
+  let endTimeField: FieldStore<string>;
   let relevantExpansionSequences: ExpansionSequence[] = [];
   let confirmIsDisabled = false;
 
-  $: sequenceNameField.validateAndSet(defaultSequenceName);
   $: startTimeField = field<string>(defaultStartTime, [required, $plugins.time.primary.validate]);
   $: endTimeField = field<string>(defaultEndTime, [required, $plugins.time.primary.validate]);
-  $: sequenceNameField = field<string>(defaultSequenceName, [
-    required,
-    unique(
-      relevantExpansionSequences.map(seq => seq.seq_id),
-      'Sequence name already in use',
-    ),
-  ]);
+  $: {
+    sequenceNameField = field<string>(defaultSequenceName, [
+      required,
+      unique(
+        relevantExpansionSequences.map(seq => seq.seq_id),
+        'Sequence name already in use',
+      ),
+    ]);
+    sequenceNameField.validateAndSet(defaultSequenceName);
+  }
+
   $: relevantExpansionSequences = $expansionSequences.filter(
     sequence => $simulationDatasetId === sequence.simulation_dataset_id,
   );

--- a/src/components/modals/ApplySequenceFilterModal.svelte
+++ b/src/components/modals/ApplySequenceFilterModal.svelte
@@ -108,7 +108,7 @@
       Confirm
     </button>
   </ModalFooter>
-</Modal>``
+</Modal>
 
 <style>
 </style>

--- a/src/components/modals/ApplySequenceFilterModal.svelte
+++ b/src/components/modals/ApplySequenceFilterModal.svelte
@@ -18,7 +18,6 @@
   import ModalFooter from './ModalFooter.svelte';
   import ModalHeader from './ModalHeader.svelte';
 
-  export let height: number = 275;
   export let width: number = 400;
   export let defaultSequenceName: string;
   export let defaultStartTime: string;
@@ -72,7 +71,7 @@
   }
 </script>
 
-<Modal {height} {width} on:close>
+<Modal {width} on:close>
   <ModalHeader on:close>Create Sequence from Filter</ModalHeader>
   <ModalContent>
     <div class="st-typography-body">Select the time range to apply the sequence filter to.</div>

--- a/src/components/modals/ApplySequenceFilterModal.svelte
+++ b/src/components/modals/ApplySequenceFilterModal.svelte
@@ -2,17 +2,24 @@
 
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import { expansionSequences } from '../../stores/expansion';
   import { field } from '../../stores/form';
   import { plugins } from '../../stores/plugins';
-  import { required } from '../../utilities/validators';
+  import { simulationDatasetId } from '../../stores/simulation';
+  import type { ExpansionSequence } from '../../types/expansion';
+  import { tooltip } from '../../utilities/tooltip';
+  import { required, unique } from '../../utilities/validators';
   import DatePickerField from '../form/DatePickerField.svelte';
+  import Field from '../form/Field.svelte';
+  import Input from '../form/Input.svelte';
   import Modal from './Modal.svelte';
   import ModalContent from './ModalContent.svelte';
   import ModalFooter from './ModalFooter.svelte';
   import ModalHeader from './ModalHeader.svelte';
 
-  export let height: number = 225;
+  export let height: number = 275;
   export let width: number = 400;
+  export let defaultSequenceName: string;
   export let defaultStartTime: string;
   export let defaultEndTime: string;
 
@@ -21,11 +28,23 @@
 
   const dispatch = createEventDispatcher<{
     close: void;
-    confirm: { timeRangeEnd: string; timeRangeStart: string };
+    confirm: { sequenceName: string; timeRangeEnd: string; timeRangeStart: string };
   }>();
+
+  let relevantExpansionSequences: ExpansionSequence[] = [];
 
   $: startTimeField = field<string>(defaultStartTime, [required, $plugins.time.primary.validate]);
   $: endTimeField = field<string>(defaultEndTime, [required, $plugins.time.primary.validate]);
+  $: sequenceNameField = field<string>(defaultSequenceName, [
+    required,
+    unique(
+      relevantExpansionSequences.map(seq => seq.seq_id),
+      'Sequence name already in use',
+    ),
+  ]);
+  $: relevantExpansionSequences = $expansionSequences.filter(
+    sequence => $simulationDatasetId === sequence.simulation_dataset_id,
+  );
 
   function onInputKeydown(event: KeyboardEvent) {
     const { key } = event;
@@ -35,7 +54,11 @@
   }
 
   function onConfirm() {
-    dispatch('confirm', { timeRangeEnd: `${$endTimeField.value}Z`, timeRangeStart: `${$startTimeField.value}Z` });
+    dispatch('confirm', {
+      sequenceName: $sequenceNameField.value,
+      timeRangeEnd: `${$endTimeField.value}Z`,
+      timeRangeStart: `${$startTimeField.value}Z`,
+    });
   }
 </script>
 
@@ -62,6 +85,12 @@
         field={endTimeField}
       />
     </fieldset>
+    <Field field={sequenceNameField}>
+      <Input>
+        <label use:tooltip={{ content: 'Sequence Name', placement: 'top' }} for="sequenceName"> Sequence Name </label>
+        <input class="st-input w-full" id="sequenceName" name="sequenceName" />
+      </Input>
+    </Field>
   </ModalContent>
   <ModalFooter>
     <button class="st-button secondary" on:click={() => dispatch('close')}> Cancel </button>

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -262,6 +262,7 @@ import { ErrorTypes } from './errors';
 import { compare, convertToQuery } from './generic';
 import gql, { convertToGQLArray } from './gql';
 import {
+  showApplySequenceFilterModal,
   showBulkShiftActivitiesModal,
   showCancelActionRunModal,
   showConfirmModal,
@@ -289,7 +290,6 @@ import {
   showRenameWorkspaceItemModal,
   showRestorePlanSnapshotModal,
   showRunActionModal,
-  showTimeRangeModal,
   showUpdatePlanMissionModelModal,
   showUploadViewModal,
   showWorkspaceBulkOperationConflictModal,
@@ -524,16 +524,17 @@ const effects = {
     user: User | null,
   ): Promise<void> {
     try {
-      const { confirm: timeConfirmed, value } = await showTimeRangeModal(defaultStartTime, defaultEndtime);
+      const defaultSequenceName: string = `${filter.name} Sequence (Plan ${planId})`;
+      const { confirm: timeConfirmed, value } = await showApplySequenceFilterModal(
+        defaultSequenceName,
+        defaultStartTime,
+        defaultEndtime,
+      );
 
       if (timeConfirmed && value !== undefined) {
-        const { timeRangeEnd, timeRangeStart } = value;
+        const { sequenceName, timeRangeEnd, timeRangeStart } = value;
         if (timeRangeStart !== null && timeRangeEnd !== null) {
-          const sequenceId = await effects.createExpansionSequence(
-            `${filter.name} Sequence (Plan ${planId})`,
-            simulationDatasetId,
-            user,
-          );
+          const sequenceId = await effects.createExpansionSequence(sequenceName, simulationDatasetId, user);
 
           if (!sequenceId) {
             throw Error('Failed to create sequence');

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -1,6 +1,7 @@
 import { browser } from '$app/environment';
 import AboutModal from '../components/modals/AboutModal.svelte';
 import ActionCreationModal from '../components/modals/ActionCreationModal.svelte';
+import ApplySequenceFilterModal from '../components/modals/ApplySequenceFilterModal.svelte';
 import CancelActionRunModal from '../components/modals/CancelActionRunModal.svelte';
 import ConfirmActivityCreationModal from '../components/modals/ConfirmActivityCreationModal.svelte';
 import ConfirmModal from '../components/modals/ConfirmModal.svelte';
@@ -34,7 +35,6 @@ import RestorePlanSnapshotModal from '../components/modals/RestorePlanSnapshotMo
 import RunActionModal from '../components/modals/RunActionModal.svelte';
 import RunActionResultsModal from '../components/modals/RunActionResultsModal.svelte';
 import SavedViewsModal from '../components/modals/SavedViewsModal.svelte';
-import TimeRangeModal from '../components/modals/TimeRangeModal.svelte';
 import TransformActivitiesModal from '../components/modals/TransformActivitiesModal.svelte';
 import UpdatePlanMissionModelModal from '../components/modals/UpdatePlanMissionModelModal.svelte';
 import UploadViewModal from '../components/modals/UploadViewModal.svelte';
@@ -1506,33 +1506,40 @@ export async function showUploadViewModal(): Promise<ModalElementValue<{ definit
 }
 
 /**
- * Shows a TimeRangeModal with the supplied arguments.
+ * Shows an ApplySequenceFilterModal with the supplied arguments.
  */
-export async function showTimeRangeModal(
+export async function showApplySequenceFilterModal(
+  defaultSequenceName: string,
   defaultStartTime: string,
   defaultEndTime: string,
-): Promise<ModalElementValue<{ timeRangeEnd: string | null; timeRangeStart: string | null }>> {
+): Promise<ModalElementValue<{ sequenceName: string; timeRangeEnd: string | null; timeRangeStart: string | null }>> {
   return new Promise(resolve => {
     if (browser) {
       const target: ModalElement | null = document.querySelector('#svelte-modal');
 
       if (target) {
-        const timeRangeModal = new TimeRangeModal({ props: { defaultEndTime, defaultStartTime }, target });
+        const applySequenceFilterModal = new ApplySequenceFilterModal({
+          props: { defaultEndTime, defaultSequenceName, defaultStartTime },
+          target,
+        });
         target.resolve = resolve;
 
-        timeRangeModal.$on('close', () => {
+        applySequenceFilterModal.$on('close', () => {
           target.replaceChildren();
           target.resolve = null;
           resolve({ confirm: false });
-          timeRangeModal.$destroy();
+          applySequenceFilterModal.$destroy();
         });
 
-        timeRangeModal.$on('confirm', (e: CustomEvent<{ timeRangeEnd: string; timeRangeStart: string }>) => {
-          target.replaceChildren();
-          target.resolve = null;
-          resolve({ confirm: true, value: e.detail });
-          timeRangeModal.$destroy();
-        });
+        applySequenceFilterModal.$on(
+          'confirm',
+          (e: CustomEvent<{ sequenceName: string; timeRangeEnd: string; timeRangeStart: string }>) => {
+            target.replaceChildren();
+            target.resolve = null;
+            resolve({ confirm: true, value: e.detail });
+            applySequenceFilterModal.$destroy();
+          },
+        );
       }
     } else {
       resolve({ confirm: false });


### PR DESCRIPTION
Currently, when applying a sequence filter in a plan the name of the outcome sequence is auto-generated in the format of `${filter.name} Sequence (Plan ${plan.id})`. This is problematic as two sequences for the same simulation cannot use the same name, _but_, it should be perfectly legal to apply two separate filters to a plan.

This PR adds a field for the user to enter a name for the output sequence, while still using the previously mentioned format as a default. Validation is also included to not permit overlapping sequence names to be used when applying the sequence filter.