### PR TITLE
Auto-expand action run logs by default

### DIFF
--- a/src/components/console/views/ConsoleLog.svelte
+++ b/src/components/console/views/ConsoleLog.svelte
@@ -11,6 +11,7 @@
   import { formatMS } from '../../../utilities/time';
 
   export let log: BaseError;
+  export let defaultExpanded: boolean = false;
   export let showLevel: boolean = true;
   export let showTimestamp: boolean = true;
   export let showLongTimestamp: boolean = true;
@@ -18,7 +19,7 @@
 
   let expandable: boolean = false;
   let leftContents: HTMLDivElement;
-  let open: boolean = false;
+  let open: boolean = defaultExpanded;
   let expansionPadding: number = 0;
   let level: string = '';
   let renderedMessage: string = '';

--- a/src/components/console/views/ConsoleLogs.svelte
+++ b/src/components/console/views/ConsoleLogs.svelte
@@ -9,6 +9,7 @@
   import ConsoleLog from './ConsoleLog.svelte';
 
   export let autoScroll: boolean = false;
+  export let defaultExpanded: boolean = false;
   export let emptyStateMessage: string = 'No reported problems';
   export let noMatchingResultsMessage: string = 'No matches';
   export let logs: BaseError[] = [];
@@ -113,13 +114,13 @@
         {/if}
         {#each filteredLogs as log}
           {#if $$slots.message}
-            <ConsoleLog {showLevel} {showTimestamp} {showType} {log}>
+            <ConsoleLog {defaultExpanded} {showLevel} {showTimestamp} {showType} {log}>
               <svelte:fragment slot="message" let:log={slotLog}>
                 <slot name="message" log={slotLog} />
               </svelte:fragment>
             </ConsoleLog>
           {:else}
-            <ConsoleLog {showLevel} {showTimestamp} {showType} {log} />
+            <ConsoleLog {defaultExpanded} {showLevel} {showTimestamp} {showType} {log} />
           {/if}
         {/each}
       </div>

--- a/src/components/sequencing/actions/ActionRunDetailView.svelte
+++ b/src/components/sequencing/actions/ActionRunDetailView.svelte
@@ -320,7 +320,7 @@
                 {@const logMessages = parseLogLines(actionRun.logs)}
                 <div class="max-h-[600px] overflow-auto rounded bg-muted py-2 font-mono text-xs">
                   {#each logMessages as log}
-                    <ConsoleLog {log} showType={false} showLongTimestamp={false}>
+                    <ConsoleLog {log} defaultExpanded={true} showType={false} showLongTimestamp={false}>
                       <svelte:fragment slot="message" let:message let:expandable let:open>
                         {#if expandable && !open}
                           <!-- "preview" text for expandable logs, ellipsize to one line -->


### PR DESCRIPTION
Adds `defaultExpanded` prop to `ConsoleLog` and `ConsoleLogs` and sets it to true for action run logs.