### PR TITLE
Default new workspace items to current selection

### DIFF
--- a/src/components/workspace/WorkspaceSidebar.svelte
+++ b/src/components/workspace/WorkspaceSidebar.svelte
@@ -14,6 +14,7 @@
   import { getTarget } from '../../utilities/generic';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { tooltip } from '../../utilities/tooltip';
+  import { getFolderPathForNode } from '../../utilities/workspaces';
   import Input from '../form/Input.svelte';
   import Loading from '../Loading.svelte';
   import ActionSidebarList from '../sequencing/actions/ActionSidebarList.svelte';
@@ -64,6 +65,10 @@
   let lastRefreshTime: Date = new Date();
   let wasLoading: boolean = false;
 
+  // Folder context of the primary selection: the selected folder itself, or a file's parent folder.
+  // `null` when nothing is selected, in which case callers fall back to `currentBreadcrumbPath`.
+  $: selectedFolderPath = getFolderPathForNode(workspaceTree?.contents ?? [], selectedFilePath);
+
   $: if (isWorkspaceLoading) {
     wasLoading = true;
   } else if (wasLoading) {
@@ -79,15 +84,15 @@
   }
 
   function onNewFolder() {
-    dispatch('newFolder', currentBreadcrumbPath);
+    dispatch('newFolder', selectedFolderPath ?? currentBreadcrumbPath);
   }
 
   function onNewFile() {
-    dispatch('newFile', currentBreadcrumbPath);
+    dispatch('newFile', selectedFolderPath ?? currentBreadcrumbPath);
   }
 
   function onImportFile() {
-    dispatch('importFile', currentBreadcrumbPath);
+    dispatch('importFile', selectedFolderPath ?? currentBreadcrumbPath);
   }
 
   function onWorkspaceCollaboratorsCreate(event: CustomEvent<WorkspaceCollaborator[]>) {

--- a/src/components/workspace/WorkspaceSidebar.svelte
+++ b/src/components/workspace/WorkspaceSidebar.svelte
@@ -63,6 +63,7 @@
 
   let didWorkspaceUpdate: boolean = false;
   let lastRefreshTime: Date = new Date();
+  let selectedFolderPath: string | null = null;
   let wasLoading: boolean = false;
 
   // Folder context of the primary selection: the selected folder itself, or a file's parent folder.

--- a/src/utilities/workspaces.test.ts
+++ b/src/utilities/workspaces.test.ts
@@ -14,6 +14,7 @@ import {
   flattenWorkspaceTreeWithPaths,
   getAvailableActionsForNodes,
   getCommonPathPrefix,
+  getFolderPathForNode,
   getSelectedFilesDisplay,
   getWorkspaceFileFolderDisplay,
   hasReadonlyInTree,
@@ -940,6 +941,49 @@ describe('Workspace utility function tests', () => {
     test('Should return null for empty tree', () => {
       const result = findNodeByPath([], 'file.txt');
       expect(result).toBeNull();
+    });
+  });
+
+  describe('getFolderPathForNode', () => {
+    const testTree: WorkspaceTreeNode[] = [
+      { name: 'file.txt', type: WorkspaceContentType.Text },
+      {
+        contents: [
+          { name: 'nested.txt', type: WorkspaceContentType.Text },
+          {
+            contents: [{ name: 'deep.seq', type: WorkspaceContentType.Sequence }],
+            name: 'subfolder',
+            type: WorkspaceContentType.Directory,
+          },
+        ],
+        name: 'folder',
+        type: WorkspaceContentType.Directory,
+      },
+    ];
+
+    test('Should return the folder path itself when the node is a folder', () => {
+      expect(getFolderPathForNode(testTree, 'folder')).toBe('folder');
+      expect(getFolderPathForNode(testTree, 'folder/subfolder')).toBe('folder/subfolder');
+    });
+
+    test('Should return the parent folder path when the node is a file', () => {
+      expect(getFolderPathForNode(testTree, 'folder/nested.txt')).toBe('folder');
+      expect(getFolderPathForNode(testTree, 'folder/subfolder/deep.seq')).toBe('folder/subfolder');
+    });
+
+    test('Should return empty string when a root-level file is selected', () => {
+      expect(getFolderPathForNode(testTree, 'file.txt')).toBe('');
+    });
+
+    test('Should return null when targetPath is null or empty', () => {
+      expect(getFolderPathForNode(testTree, null)).toBeNull();
+      expect(getFolderPathForNode(testTree, '')).toBeNull();
+    });
+
+    test('Should return null when the node cannot be resolved', () => {
+      expect(getFolderPathForNode(testTree, 'nonexistent')).toBeNull();
+      expect(getFolderPathForNode(testTree, 'folder/missing')).toBeNull();
+      expect(getFolderPathForNode([], 'folder')).toBeNull();
     });
   });
 

--- a/src/utilities/workspaces.ts
+++ b/src/utilities/workspaces.ts
@@ -669,6 +669,25 @@ export function findNodeByPath(nodes: WorkspaceTreeNode[], targetPath: string): 
   return currentNode;
 }
 
+/**
+ * Returns the folder path associated with a node at `targetPath`:
+ * the path itself if the node is a folder, or its parent folder path if the node is a file.
+ * Returns `null` if the path is empty or the node cannot be resolved.
+ */
+export function getFolderPathForNode(nodes: WorkspaceTreeNode[], targetPath: string | null): string | null {
+  if (!targetPath) {
+    return null;
+  }
+  const node = findNodeByPath(nodes, targetPath);
+  if (node == null) {
+    return null;
+  }
+  if (node.type === WorkspaceContentType.Directory) {
+    return targetPath;
+  }
+  return targetPath.split(PATH_DELIMITER).slice(0, -1).join(PATH_DELIMITER);
+}
+
 export interface TreeFilterResult {
   /** Paths of ancestors that should remain visible to show matching descendants */
   ancestorPaths: Set<string>;


### PR DESCRIPTION
The workspace `+` menu (New File / New Folder / Upload File) now starts in the primary selection's folder: the selected folder itself, or a selected file's parent. Falls back to the navigated breadcrumb folder when nothing is selected. Closes #1915 

## Testing
- [x] Select a folder, click `+` -> modal starts in that folder
- [x] Select a file in a subfolder, click `+` -> modal starts in the file's parent
- [x] Click `+` with no selection -> modal starts at the breadcrumb folder
- [x] Right-click context menu still creates relative to the right-clicked node
