### PR TITLE
Proper ConsoleLog text copying support

### DIFF
--- a/src/components/console/views/ConsoleLog.svelte
+++ b/src/components/console/views/ConsoleLog.svelte
@@ -137,7 +137,8 @@
                   class={cn(
                     'uppercase',
                     level === 'error' ? 'text-destructive' : level === 'warn' ? 'text-yellow-600' : 'text-blue-500',
-                  )}>{level}</span>]
+                  )}>{level}</span
+                >]
               </span>
             {/if}
             {#if showType}

--- a/src/components/console/views/ConsoleLog.svelte
+++ b/src/components/console/views/ConsoleLog.svelte
@@ -23,6 +23,7 @@
   let expansionPadding: number = 0;
   let level: string = '';
   let renderedMessage: string = '';
+  let summaryEl: HTMLElement | undefined;
 
   $: expandable = log.data || log.trace || log.cause || log.service ? true : false;
   $: level = (log as LogMessage).level || '';
@@ -68,6 +69,24 @@
       return timestamp; // Return original if any error occurs
     }
   }
+
+  function handleSummaryCopy(e: ClipboardEvent) {
+    // Flex layout splits each chunk (timestamp, [, level, ], message) onto its own line on copy.
+    // Collapse whitespace so a selection within a single summary copies as one readable string.
+    // Multi-row selections are handled by the list-level handler in ./consoleLogCopy.ts, which
+    // walks <details>/<summary>/<pre> — keep that file in sync if you change this template's structure.
+    const selection = window.getSelection();
+    if (!selection || selection.isCollapsed || !summaryEl) {
+      return;
+    }
+    const range = selection.getRangeAt(0);
+    if (!summaryEl.contains(range.startContainer) || !summaryEl.contains(range.endContainer)) {
+      return;
+    }
+    const cleaned = selection.toString().replace(/\s+/g, ' ').trim();
+    e.clipboardData?.setData('text/plain', cleaned);
+    e.preventDefault();
+  }
 </script>
 
 <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
@@ -87,7 +106,7 @@
     }
   }}
 >
-  <summary class="list-none">
+  <summary class="list-none" bind:this={summaryEl} on:copy={handleSummaryCopy}>
     <div
       class={cn(
         'flex gap-0.5 px-4 py-0.5 pl-1',
@@ -108,27 +127,22 @@
           {/if}
           <div class="flex gap-2">
             {#if showTimestamp}
-              <span class="flex flex-shrink-0 text-muted-foreground">
+              <span class="flex-shrink-0 text-muted-foreground">
                 {formatLogShortTimestamp(log.timestamp)}
               </span>
             {/if}
             {#if showLevel && level}
-              <span class="flex">
+              <span class="flex-shrink-0">
                 [<span
                   class={cn(
-                    'flex flex-shrink-0 uppercase',
+                    'uppercase',
                     level === 'error' ? 'text-destructive' : level === 'warn' ? 'text-yellow-600' : 'text-blue-500',
-                  )}
-                >
-                  {level}
-                </span>]
+                  )}>{level}</span>]
               </span>
             {/if}
             {#if showType}
-              <span class="flex">
-                [<span class={cn('flex flex-shrink-0 uppercase text-destructive')}>
-                  {log.type}
-                </span>]
+              <span class="flex-shrink-0">
+                [<span class={cn('uppercase text-destructive')}>{log.type}</span>]
               </span>
             {/if}
           </div>

--- a/src/components/console/views/ConsoleLogs.svelte
+++ b/src/components/console/views/ConsoleLogs.svelte
@@ -7,6 +7,7 @@
   import { ConsoleContextKey, type ConsoleContext } from '../Console.svelte';
   import EmptyState from '../EmptyState.svelte';
   import ConsoleLog from './ConsoleLog.svelte';
+  import { consoleLogCopy } from './consoleLogCopy';
 
   export let autoScroll: boolean = false;
   export let defaultExpanded: boolean = false;
@@ -108,7 +109,12 @@
   <!-- TODO also show counts in dropdown -->
   {#if hasLogs && filteredLogs.length}
     <div class="flex h-full w-full">
-      <div class="flex w-full flex-col overflow-auto py-2" bind:this={scrollContainer} on:scroll={onScroll}>
+      <div
+        class="flex w-full flex-col overflow-auto py-2"
+        bind:this={scrollContainer}
+        on:scroll={onScroll}
+        use:consoleLogCopy
+      >
         {#if filteredLogs.length !== logs.length}
           <div class="mb-1 ml-4 italic text-muted-foreground">{logs.length - filteredLogs.length} hidden</div>
         {/if}

--- a/src/components/console/views/consoleLogCopy.test.ts
+++ b/src/components/console/views/consoleLogCopy.test.ts
@@ -87,10 +87,7 @@ describe('handleConsoleLogCopy', () => {
   });
 
   test('skips expanded content when the row is closed', () => {
-    const container = makeContainer([
-      { pre: 'should-not-appear', summary: 'first' },
-      { summary: 'second' },
-    ]);
+    const container = makeContainer([{ pre: 'should-not-appear', summary: 'first' }, { summary: 'second' }]);
     mockSelectionOver(Array.from(container.querySelectorAll('details')));
 
     const event = makeClipboardEvent();

--- a/src/components/console/views/consoleLogCopy.test.ts
+++ b/src/components/console/views/consoleLogCopy.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { handleConsoleLogCopy } from './consoleLogCopy';
+
+type RowSpec = { open?: boolean; pre?: string; summary: string };
+
+function makeContainer(rows: RowSpec[]): HTMLElement {
+  const container = document.createElement('div');
+  for (const row of rows) {
+    const details = document.createElement('details');
+    if (row.open) {
+      details.setAttribute('open', '');
+    }
+    const summary = document.createElement('summary');
+    summary.textContent = row.summary;
+    details.appendChild(summary);
+    if (row.pre) {
+      const expanded = document.createElement('div');
+      const pre = document.createElement('pre');
+      pre.textContent = row.pre;
+      expanded.appendChild(pre);
+      details.appendChild(expanded);
+    }
+    container.appendChild(details);
+  }
+  document.body.appendChild(container);
+  return container;
+}
+
+function mockSelectionOver(detailsEls: HTMLDetailsElement[]) {
+  const selection = {
+    containsNode: (node: Node) => detailsEls.includes(node as HTMLDetailsElement),
+    getRangeAt: () => ({
+      endContainer: detailsEls[detailsEls.length - 1],
+      startContainer: detailsEls[0],
+    }),
+    isCollapsed: detailsEls.length === 0,
+    toString: () => '',
+  };
+  vi.spyOn(window, 'getSelection').mockReturnValue(selection as unknown as Selection);
+}
+
+function makeClipboardEvent(opts: { defaultPrevented?: boolean } = {}): ClipboardEvent {
+  return {
+    clipboardData: { setData: vi.fn() },
+    defaultPrevented: opts.defaultPrevented ?? false,
+    preventDefault: vi.fn(),
+  } as unknown as ClipboardEvent;
+}
+
+describe('handleConsoleLogCopy', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.body.innerHTML = '';
+  });
+
+  test('multi-row selection emits one cleaned line per summary', () => {
+    const container = makeContainer([
+      { summary: '  10:00:00 AM  [INFO]   first message  ' },
+      { summary: '  10:00:01 AM  [INFO]   second message  ' },
+    ]);
+    mockSelectionOver(Array.from(container.querySelectorAll('details')));
+
+    const event = makeClipboardEvent();
+    handleConsoleLogCopy(event, container);
+
+    expect(event.clipboardData?.setData).toHaveBeenCalledWith(
+      'text/plain',
+      '10:00:00 AM [INFO] first message\n10:00:01 AM [INFO] second message',
+    );
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  test('preserves newlines inside <pre> in expanded rows', () => {
+    const container = makeContainer([
+      { open: true, pre: 'line one\nline two\nline three', summary: '  10:00:00 AM  [ERROR]  boom  ' },
+      { summary: '  10:00:01 AM  [INFO]  next  ' },
+    ]);
+    mockSelectionOver(Array.from(container.querySelectorAll('details')));
+
+    const event = makeClipboardEvent();
+    handleConsoleLogCopy(event, container);
+
+    expect(event.clipboardData?.setData).toHaveBeenCalledWith(
+      'text/plain',
+      '10:00:00 AM [ERROR] boom\nline one\nline two\nline three\n10:00:01 AM [INFO] next',
+    );
+  });
+
+  test('skips expanded content when the row is closed', () => {
+    const container = makeContainer([
+      { pre: 'should-not-appear', summary: 'first' },
+      { summary: 'second' },
+    ]);
+    mockSelectionOver(Array.from(container.querySelectorAll('details')));
+
+    const event = makeClipboardEvent();
+    handleConsoleLogCopy(event, container);
+
+    expect(event.clipboardData?.setData).toHaveBeenCalledWith('text/plain', 'first\nsecond');
+  });
+
+  test('single-row selection that spans summary→expanded gets cleaned summary + preserved <pre>', () => {
+    const container = makeContainer([
+      { open: true, pre: 'trace line one\ntrace line two', summary: '  10:00:00 AM  [ERROR]   boom  ' },
+    ]);
+    const [details] = Array.from(container.querySelectorAll('details'));
+    const summary = details.querySelector('summary')!;
+    const pre = details.querySelector('pre')!;
+
+    // Selection starts inside the summary (cleaned), ends inside the expanded <pre> (preserved).
+    const selection = {
+      containsNode: (node: Node) => node === details,
+      getRangeAt: () => ({ endContainer: pre, startContainer: summary }),
+      isCollapsed: false,
+      toString: () => '',
+    };
+    vi.spyOn(window, 'getSelection').mockReturnValue(selection as unknown as Selection);
+
+    const event = makeClipboardEvent();
+    handleConsoleLogCopy(event, container);
+
+    expect(event.clipboardData?.setData).toHaveBeenCalledWith(
+      'text/plain',
+      '10:00:00 AM [ERROR] boom\ntrace line one\ntrace line two',
+    );
+    expect(event.preventDefault).toHaveBeenCalled();
+  });
+
+  test('single-row selection entirely outside summary bails so native preserves <pre>', () => {
+    const container = makeContainer([{ summary: 'only row' }, { summary: 'other row' }]);
+    const [first] = Array.from(container.querySelectorAll('details'));
+    mockSelectionOver([first]);
+
+    const event = makeClipboardEvent();
+    handleConsoleLogCopy(event, container);
+
+    expect(event.clipboardData?.setData).not.toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  test('bails when the per-summary handler already wrote to the clipboard', () => {
+    const container = makeContainer([{ summary: 'a' }, { summary: 'b' }]);
+    mockSelectionOver(Array.from(container.querySelectorAll('details')));
+
+    const event = makeClipboardEvent({ defaultPrevented: true });
+    handleConsoleLogCopy(event, container);
+
+    expect(event.clipboardData?.setData).not.toHaveBeenCalled();
+  });
+
+  test('bails when the selection touches no rows', () => {
+    const container = makeContainer([{ summary: 'a' }]);
+    mockSelectionOver([]);
+
+    const event = makeClipboardEvent();
+    handleConsoleLogCopy(event, container);
+
+    expect(event.clipboardData?.setData).not.toHaveBeenCalled();
+  });
+
+  test('bails when there is no container', () => {
+    const event = makeClipboardEvent();
+    handleConsoleLogCopy(event, undefined);
+
+    expect(event.clipboardData?.setData).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/console/views/consoleLogCopy.ts
+++ b/src/components/console/views/consoleLogCopy.ts
@@ -1,0 +1,76 @@
+// Copy handler for containers that hold multiple ConsoleLog rows.
+// Each row's summary is rendered with a flex layout that browsers serialize
+// as multiple lines on copy (one per flex item). For multi-row selections
+// we walk the selected <details> rows and emit one cleaned line per summary,
+// preserving newlines inside <pre> blocks in any expanded content.
+//
+// This is structurally coupled to ConsoleLog.svelte's template (<details> /
+// <summary> / expanded <pre> blocks). If that DOM shape changes, update this
+// file too — the per-summary handler in ConsoleLog.svelte has the same caveat.
+export function handleConsoleLogCopy(e: ClipboardEvent, container: HTMLElement | undefined): void {
+  if (!container) {
+    return;
+  }
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed) {
+    return;
+  }
+  const detailsEls = Array.from(container.querySelectorAll('details')).filter(d => selection.containsNode(d, true));
+  if (detailsEls.length === 0) {
+    return;
+  }
+  // The per-summary handler in ConsoleLog runs first for selections inside a single summary.
+  // If it already wrote to the clipboard, don't override.
+  if (e.defaultPrevented) {
+    return;
+  }
+  // Single-row case: bail only when the selection is entirely *outside* the summary
+  // (e.g. inside an expanded <pre>) — native copy preserves newlines there.
+  // A selection that spans summary→expanded falls through and gets row-processed below
+  // so the summary half is cleaned while the <pre> content keeps its newlines.
+  if (detailsEls.length === 1) {
+    const summary = detailsEls[0].querySelector('summary');
+    const range = selection.getRangeAt(0);
+    if (summary && !summary.contains(range.startContainer) && !summary.contains(range.endContainer)) {
+      return;
+    }
+  }
+
+  const lines: string[] = [];
+  for (const row of detailsEls) {
+    const summary = row.querySelector('summary');
+    if (summary) {
+      const t = (summary.textContent ?? '').replace(/\s+/g, ' ').trim();
+      if (t) {
+        lines.push(t);
+      }
+    }
+    if (row.open) {
+      const expanded = Array.from(row.children).find(c => c.tagName !== 'SUMMARY');
+      if (expanded) {
+        for (const child of expanded.children) {
+          if (child.tagName === 'PRE') {
+            lines.push(child.textContent ?? '');
+          } else {
+            const t = (child.textContent ?? '').replace(/\s+/g, ' ').trim();
+            if (t) {
+              lines.push(t);
+            }
+          }
+        }
+      }
+    }
+  }
+  e.clipboardData?.setData('text/plain', lines.join('\n'));
+  e.preventDefault();
+}
+
+// Svelte action for containers that hold one or more ConsoleLog rows.
+// Usage: <div use:consoleLogCopy class="...">{#each logs as log}<ConsoleLog .../>{/each}</div>
+export function consoleLogCopy(node: HTMLElement) {
+  const handler = (e: Event) => handleConsoleLogCopy(e as ClipboardEvent, node);
+  node.addEventListener('copy', handler);
+  return {
+    destroy: () => node.removeEventListener('copy', handler),
+  };
+}

--- a/src/components/sequencing/actions/ActionRunDetailView.svelte
+++ b/src/components/sequencing/actions/ActionRunDetailView.svelte
@@ -29,6 +29,7 @@
   import { formatMS } from '../../../utilities/time';
   import { tooltip } from '../../../utilities/tooltip';
   import ConsoleLog from '../../console/views/ConsoleLog.svelte';
+  import { consoleLogCopy } from '../../console/views/consoleLogCopy';
   import Parameters from '../../parameters/Parameters.svelte';
   import StatusBadge from '../../ui/StatusBadge.svelte';
 
@@ -295,7 +296,11 @@
               }}
               <div class="flex flex-col gap-3 rounded border border-destructive/30 bg-destructive/5 p-4">
                 <h3 class="text-sm font-medium text-destructive">Error</h3>
-                <div class="overflow-auto rounded bg-muted py-2 font-mono text-xs" data-testid="action-run-error-log">
+                <div
+                  class="overflow-auto rounded bg-muted py-2 font-mono text-xs"
+                  data-testid="action-run-error-log"
+                  use:consoleLogCopy
+                >
                   <ConsoleLog log={errorLog} showType={false} showLongTimestamp={false} />
                 </div>
               </div>
@@ -318,7 +323,7 @@
               <h3 class="text-sm font-medium">Logs</h3>
               {#if actionRun.logs}
                 {@const logMessages = parseLogLines(actionRun.logs)}
-                <div class="max-h-[600px] overflow-auto rounded bg-muted py-2 font-mono text-xs">
+                <div class="max-h-[600px] overflow-auto rounded bg-muted py-2 font-mono text-xs" use:consoleLogCopy>
                   {#each logMessages as log}
                     <ConsoleLog {log} defaultExpanded={true} showType={false} showLongTimestamp={false}>
                       <svelte:fragment slot="message" let:message let:expandable let:open>


### PR DESCRIPTION
**Problem.** Copying log rows produced broken text — each chunk (`timestamp`, `[`, `INFO`, `]`, message) on its own line. The flex layout makes each header a block item and browsers insert newlines between block items when serializing a selection.

**Fix.** Two `copy` event handlers normalize the clipboard text:
- per-`<summary>` handler for single-row selections
- `use:consoleLogCopy` Svelte action on list containers for multi-row and summary which expanded selections (preserves `<pre>` newlines)

**Why not just CSS or inline restructure.** CSS alone can't fix the header/message split — flex items are block-level by spec. An inline restructure works but forces giving up the message wrapping behavior and `text-ellipsis` truncation.
