### PR TITLE
Fix 'Send to Workspace' functionality with directories

### DIFF
--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -17,7 +17,6 @@ import {
 import type { SeqJson } from '@nasa-jpl/seq-json-schema/types';
 import { chunk } from 'lodash-es';
 import { get } from 'svelte/store';
-import { PATH_DELIMITER } from '../constants/workspaces';
 import { ConstraintDefinitionType } from '../enums/constraint';
 import { DictionaryTypes } from '../enums/dictionaryTypes';
 import { SchedulingDefinitionType } from '../enums/scheduling';
@@ -7275,13 +7274,7 @@ const effects = {
       );
 
       if (confirmNewFile && confirmNewFileValue) {
-        let { filePath: newFilePath } = confirmNewFileValue;
-        // Trim workspace from path to avoid making extra directory
-        if (newFilePath.includes(PATH_DELIMITER)) {
-          const newFilePathContents: Array<string> = newFilePath.split(PATH_DELIMITER);
-          newFilePathContents.shift();
-          newFilePath = newFilePathContents.join(PATH_DELIMITER);
-        }
+        const { filePath: newFilePath } = confirmNewFileValue;
         await WorkspaceApi.saveFile(workspaceId, newFilePath, expandedSequence, false, user);
 
         showSuccessToast('Workspace File Created Successfully');


### PR DESCRIPTION
Currently, if a user attempts to send a sequence to a directory within their workspace they'll see one of two possible outcomes:

1) If the directory is one-level deep, the file will be placed at the top level of the workspace and **not** in the chosen directory.

2) If the directory is multiple levels down, an improper directory tree will be created at the top-level of the workspace to store the sequence.

This is caused by the `if` statement that is removed in this PR which chops the first chunk of the path output by the modal. This was initially added because the path would be output with the workspace name at the beginning of the path which would cause an issue of creating a new directory in the workspace with the workspace's name to save it under, however it does not appear this same quirk still exists. 


https://github.com/user-attachments/assets/c97dcfb7-076e-4d80-8db9-e4abc3143de9
