### PR TITLE
Ensure blank sequence opened on new page shows correct right side tabs

### DIFF
--- a/e2e-tests/fixtures/Workspace.ts
+++ b/e2e-tests/fixtures/Workspace.ts
@@ -279,7 +279,7 @@ export class Workspace {
     this.metadataCancelButton = page.locator('.user-metadata-editor + div').getByRole('button', { name: 'Cancel' });
     this.metadataPanel = page.locator('.user-metadata-editor').first();
     this.metadataSaveButton = page.locator('.user-metadata-editor + div').getByRole('button', { name: 'Save' });
-    this.metadataTabButton = page.getByRole('button', { name: 'Metadata' });
+    this.metadataTabButton = page.getByRole('button', { exact: true, name: 'Metadata' });
     this.navButtonSequences = page.locator('.nav-button:has-text("Sequences")');
     this.navButtonSequencesMenu = this.navButtonSequences.getByRole('menu');
     this.page = page;

--- a/e2e-tests/fixtures/Workspace.ts
+++ b/e2e-tests/fixtures/Workspace.ts
@@ -49,8 +49,11 @@ export class Workspace {
     await this.searchInput.clear();
   }
 
-  async clickFile(name: string): Promise<void> {
-    await this.workspaceFileGrid.getByRole('row', { name }).click();
+  async clickFile(name: string, options?: { force?: boolean }): Promise<void> {
+    // `force: true` is for callers that expect the click to immediately summon a modal
+    // (e.g. unsaved-changes confirmation) — Playwright's hit-test would otherwise see the
+    // modal backdrop and retry until timeout, even though the original click registered.
+    await this.workspaceFileGrid.getByRole('row', { name }).click(options);
   }
 
   async createFolder(folderPath?: string): Promise<string> {

--- a/e2e-tests/fixtures/Workspace.ts
+++ b/e2e-tests/fixtures/Workspace.ts
@@ -225,12 +225,15 @@ export class Workspace {
 
   /**
    * Open the right-side metadata panel by clicking the metadata tab icon.
-   * If the panel is already open on the metadata tab, this is a no-op.
+   * If the panel is already open on the metadata tab, this is a no-op — clicking again
+   * would toggle the panel closed.
    */
   async openMetadataPanel(): Promise<void> {
-    // Click the Metadata tab button in the right icon rail
-    await this.metadataTabButton.click();
-    // Wait for the metadata panel content to appear
+    // The icon rail button sets data-active="true" iff metadata tab is active AND panel is open.
+    const isAlreadyOpen = (await this.metadataTabButton.getAttribute('data-active')) === 'true';
+    if (!isAlreadyOpen) {
+      await this.metadataTabButton.click();
+    }
     await this.page.getByText('User metadata', { exact: true }).waitFor({ state: 'visible', timeout: 5000 });
   }
 

--- a/e2e-tests/tests/workspace.test.ts
+++ b/e2e-tests/tests/workspace.test.ts
@@ -83,6 +83,14 @@ test.describe.serial('Workspace', () => {
     await workspace.pageLoadingLocatorWithData.waitFor({ state: 'detached' });
   });
 
+  test('Right icon rail shows sequence tabs when workspace loads with no file selected', async () => {
+    // With no file in the URL the page defaults to a SequenceEditor, so the right
+    // icon rail should expose Selected Command and Command Dictionary tabs alongside Metadata.
+    await expect(setup.page.getByRole('button', { exact: true, name: 'Metadata' })).toBeVisible();
+    await expect(setup.page.getByRole('button', { exact: true, name: 'Selected Command' })).toBeVisible();
+    await expect(setup.page.getByRole('button', { exact: true, name: 'Command Dictionary' })).toBeVisible();
+  });
+
   test('Workspace header menu should be accessible', async () => {
     await expect(workspace.workspaceContextMenuButton).toBeVisible();
     await workspace.openWorkspaceContextMenu();

--- a/e2e-tests/tests/workspace.test.ts
+++ b/e2e-tests/tests/workspace.test.ts
@@ -287,7 +287,7 @@ test.describe.serial('Workspace', () => {
 
     // Try to navigate to second file
     await workspace.searchForFileAndWait(file2);
-    await workspace.clickFile(file2);
+    await workspace.clickFile(file2, { force: true });
 
     // Should show confirmation modal
     const modal = setup.page.locator('#modal-container');

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -279,14 +279,21 @@
   $: activeFileIsSequence =
     $activeDocumentPath === null ||
     ($activeDocument.type !== null && $activeDocument.type === WorkspaceContentType.Sequence);
+  $: selectedFileIsSequence =
+    $activeDocumentPath !== null &&
+    $activeDocument.type !== null &&
+    $activeDocument.type === WorkspaceContentType.Sequence;
   $: commandInfoMapper = $sequenceAdaptation.input.commandInfoMapper;
   $: isFileReadOnly = activeFileMetadata?.readOnly ?? false;
 
-  // Switch right panel tab when file type changes
-  let previousActiveFileIsSequence: boolean = activeFileIsSequence;
-  $: if (activeFileIsSequence !== previousActiveFileIsSequence) {
-    previousActiveFileIsSequence = activeFileIsSequence;
-    if (!activeFileIsSequence) {
+  // Switch right panel tab when the selected file's sequence-ness changes.
+  // Driven by selectedFileIsSequence (narrow) rather than activeFileIsSequence (wide),
+  // so the empty/no-file state — which renders SequenceEditor as a default canvas — does
+  // not suppress the tab switch when the user actually picks a sequence file.
+  let previousSelectedFileIsSequence: boolean = selectedFileIsSequence;
+  $: if (selectedFileIsSequence !== previousSelectedFileIsSequence) {
+    previousSelectedFileIsSequence = selectedFileIsSequence;
+    if (!selectedFileIsSequence) {
       rightPanelActiveTab = 'metadata';
     } else {
       rightPanelActiveTab = 'command';

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -142,6 +142,7 @@
   const resizableHandleClass =
     'w-[3px] hover:after:bg-neutral-300 hover:after:transition-all hover:after:delay-[400ms] data-[active]:after:bg-neutral-300 data-[active]:after:transition-all';
 
+  let actionDetailIsDirty: boolean = false;
   let availableActionsForActiveFile: ActionParameterPair[] = [];
   let panelsReady: boolean = false;
   let allActionsForWorkspace: ActionDefinition[] = [];
@@ -180,7 +181,6 @@
   let workspaceTree: WorkspaceTreeNode | null = null;
   let workspaceTreeMap: WorkspaceTreeMap = {};
   let workspaceFileList: WorkspaceTreeNodeWithFullPath[] = [];
-  let actionDetailIsDirty: boolean = false;
 
   if (initialActionRunIdParam) {
     const runId = parseInt(initialActionRunIdParam, 10);
@@ -279,21 +279,14 @@
   $: activeFileIsSequence =
     $activeDocumentPath === null ||
     ($activeDocument.type !== null && $activeDocument.type === WorkspaceContentType.Sequence);
-  $: selectedFileIsSequence =
-    $activeDocumentPath !== null &&
-    $activeDocument.type !== null &&
-    $activeDocument.type === WorkspaceContentType.Sequence;
   $: commandInfoMapper = $sequenceAdaptation.input.commandInfoMapper;
   $: isFileReadOnly = activeFileMetadata?.readOnly ?? false;
 
-  // Switch right panel tab when the selected file's sequence-ness changes.
-  // Driven by selectedFileIsSequence (narrow) rather than activeFileIsSequence (wide),
-  // so the empty/no-file state — which renders SequenceEditor as a default canvas — does
-  // not suppress the tab switch when the user actually picks a sequence file.
-  let previousSelectedFileIsSequence: boolean = selectedFileIsSequence;
-  $: if (selectedFileIsSequence !== previousSelectedFileIsSequence) {
-    previousSelectedFileIsSequence = selectedFileIsSequence;
-    if (!selectedFileIsSequence) {
+  // Drafts count as sequences, so the tab flips to 'command' on initial draft load too.
+  let previousActiveFileIsSequence: boolean = activeFileIsSequence;
+  $: if (activeFileIsSequence !== previousActiveFileIsSequence) {
+    previousActiveFileIsSequence = activeFileIsSequence;
+    if (!activeFileIsSequence) {
       rightPanelActiveTab = 'metadata';
     } else {
       rightPanelActiveTab = 'command';

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -277,9 +277,8 @@
 
   $: activeFileMetadata = ($activeDocumentPath && workspaceTreeMap[$activeDocumentPath]?.metadata) || null;
   $: activeFileIsSequence =
-    $activeDocumentPath !== null &&
-    $activeDocument.type !== null &&
-    $activeDocument.type === WorkspaceContentType.Sequence;
+    $activeDocumentPath === null ||
+    ($activeDocument.type !== null && $activeDocument.type === WorkspaceContentType.Sequence);
   $: commandInfoMapper = $sequenceAdaptation.input.commandInfoMapper;
   $: isFileReadOnly = activeFileMetadata?.readOnly ?? false;
 
@@ -1410,9 +1409,6 @@
           {:else}
             {@const isTextOrEmpty =
               $activeDocumentPath === null || isTextFile(workspaceTreeMap[$activeDocumentPath]?.type)}
-            {@const isSequenceFile =
-              $activeDocumentPath === null ||
-              ($activeDocument.type !== null && $activeDocument.type === WorkspaceContentType.Sequence)}
             <div class="relative grid h-full grid-cols-1 grid-rows-1">
               {#if showLoadingSpinner && isTextOrEmpty}
                 <div
@@ -1421,7 +1417,7 @@
                   <LoaderCircle size={32} class="animate-spin text-muted-foreground" />
                 </div>
               {/if}
-              {#if isTextOrEmpty && isSequenceFile}
+              {#if isTextOrEmpty && activeFileIsSequence}
                 <div class="flex h-full">
                   <SequenceEditor
                     bind:this={sequenceEditorRef}

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -142,6 +142,7 @@
   const resizableHandleClass =
     'w-[3px] hover:after:bg-neutral-300 hover:after:transition-all hover:after:delay-[400ms] data-[active]:after:bg-neutral-300 data-[active]:after:transition-all';
 
+  let activeFileIsSequence: boolean = false;
   let actionDetailIsDirty: boolean = false;
   let availableActionsForActiveFile: ActionParameterPair[] = [];
   let panelsReady: boolean = false;
@@ -276,8 +277,6 @@
   }
 
   $: activeFileMetadata = ($activeDocumentPath && workspaceTreeMap[$activeDocumentPath]?.metadata) || null;
-  // "Sequence mode" — true when the editor pane is rendering a SequenceEditor. A blank-load
-  // (no file open) counts as sequence mode because we default to an empty SequenceEditor.
   $: activeFileIsSequence =
     $activeDocumentPath === null ||
     ($activeDocument.type !== null && $activeDocument.type === WorkspaceContentType.Sequence);

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -276,17 +276,17 @@
   }
 
   $: activeFileMetadata = ($activeDocumentPath && workspaceTreeMap[$activeDocumentPath]?.metadata) || null;
+  // "Sequence mode" — true when the editor pane is rendering a SequenceEditor. A blank-load
+  // (no file open) counts as sequence mode because we default to an empty SequenceEditor.
   $: activeFileIsSequence =
-    $activeDocumentPath !== null &&
-    $activeDocument.type !== null &&
-    $activeDocument.type === WorkspaceContentType.Sequence;
-  // True whenever the editor pane is rendering a SequenceEditor — including the draft file
-  // default case. Drives whether the right rail exposes the Selected Command / Command
-  // Dictionary tabs, independent of the strict file-type check above which drives tab transitions.
-  $: editorShowsSequence = $activeDocumentPath === null || activeFileIsSequence;
+    $activeDocumentPath === null ||
+    ($activeDocument.type !== null && $activeDocument.type === WorkspaceContentType.Sequence);
   $: commandInfoMapper = $sequenceAdaptation.input.commandInfoMapper;
   $: isFileReadOnly = activeFileMetadata?.readOnly ?? false;
 
+  // Auto-switch the right-panel tab only when the editor crosses between sequence mode and
+  // non-sequence mode. Switching between two sequence files (or between blank and a sequence
+  // file) preserves whatever tab the user last chose.
   let previousActiveFileIsSequence: boolean = activeFileIsSequence;
   $: if (activeFileIsSequence !== previousActiveFileIsSequence) {
     previousActiveFileIsSequence = activeFileIsSequence;
@@ -1421,7 +1421,7 @@
                   <LoaderCircle size={32} class="animate-spin text-muted-foreground" />
                 </div>
               {/if}
-              {#if isTextOrEmpty && editorShowsSequence}
+              {#if isTextOrEmpty && activeFileIsSequence}
                 <div class="flex h-full">
                   <SequenceEditor
                     bind:this={sequenceEditorRef}
@@ -1543,7 +1543,7 @@
               filePath={$activeDocumentPath}
               fileMetadata={activeFileMetadata}
               hasEditPermission={hasEditFilePermission}
-              isSequenceFile={editorShowsSequence}
+              isSequenceFile={activeFileIsSequence}
               {phoenixContext}
               {commandInfoMapper}
               on:updateUserMetadata={onUpdateUserMetadata}
@@ -1558,7 +1558,7 @@
           bind:activeTab={rightPanelActiveTab}
           bind:panelOpen={rightPanelOpen}
           commandNodeName={rightPanelCommandNodeName}
-          isSequenceFile={editorShowsSequence}
+          isSequenceFile={activeFileIsSequence}
         />
       {/if}
     </div>

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -277,12 +277,16 @@
 
   $: activeFileMetadata = ($activeDocumentPath && workspaceTreeMap[$activeDocumentPath]?.metadata) || null;
   $: activeFileIsSequence =
-    $activeDocumentPath === null ||
-    ($activeDocument.type !== null && $activeDocument.type === WorkspaceContentType.Sequence);
+    $activeDocumentPath !== null &&
+    $activeDocument.type !== null &&
+    $activeDocument.type === WorkspaceContentType.Sequence;
+  // True whenever the editor pane is rendering a SequenceEditor — including the draft file
+  // default case. Drives whether the right rail exposes the Selected Command / Command
+  // Dictionary tabs, independent of the strict file-type check above which drives tab transitions.
+  $: editorShowsSequence = $activeDocumentPath === null || activeFileIsSequence;
   $: commandInfoMapper = $sequenceAdaptation.input.commandInfoMapper;
   $: isFileReadOnly = activeFileMetadata?.readOnly ?? false;
 
-  // Drafts count as sequences, so the tab flips to 'command' on initial draft load too.
   let previousActiveFileIsSequence: boolean = activeFileIsSequence;
   $: if (activeFileIsSequence !== previousActiveFileIsSequence) {
     previousActiveFileIsSequence = activeFileIsSequence;
@@ -1417,7 +1421,7 @@
                   <LoaderCircle size={32} class="animate-spin text-muted-foreground" />
                 </div>
               {/if}
-              {#if isTextOrEmpty && activeFileIsSequence}
+              {#if isTextOrEmpty && editorShowsSequence}
                 <div class="flex h-full">
                   <SequenceEditor
                     bind:this={sequenceEditorRef}
@@ -1539,7 +1543,7 @@
               filePath={$activeDocumentPath}
               fileMetadata={activeFileMetadata}
               hasEditPermission={hasEditFilePermission}
-              isSequenceFile={activeFileIsSequence}
+              isSequenceFile={editorShowsSequence}
               {phoenixContext}
               {commandInfoMapper}
               on:updateUserMetadata={onUpdateUserMetadata}
@@ -1554,7 +1558,7 @@
           bind:activeTab={rightPanelActiveTab}
           bind:panelOpen={rightPanelOpen}
           commandNodeName={rightPanelCommandNodeName}
-          isSequenceFile={activeFileIsSequence}
+          isSequenceFile={editorShowsSequence}
         />
       {/if}
     </div>


### PR DESCRIPTION
This fixes the issue where the selected command and command dictionary right side tabs were not being shown after workspace page load with no file in the url (blank sequence)