### PR TITLE
Implement workspace back button functionality

### DIFF
--- a/e2e-tests/tests/workspace.test.ts
+++ b/e2e-tests/tests/workspace.test.ts
@@ -14,6 +14,7 @@ let setup: BrowserSetupResult;
 let dictionaries: Dictionaries;
 let parcels: Parcels;
 let sequence: { sequenceName: string; sequencePath: string };
+let sequenceB: { sequenceName: string; sequencePath: string };
 let workspace: Workspace;
 let workspaces: Workspaces;
 let workspaceId: string;
@@ -23,6 +24,19 @@ let workspaceForUnauthorized: Workspace;
 // Separate browser contexts for multi-user tests
 let setupAuthorized: BrowserSetupResult; // userA - will be added as collaborator
 let setupUnauthorized: BrowserSetupResult; // userB - not a collaborator
+
+/**
+ * Asserts the three invariants of "this sequence is the active workspace file":
+ * URL matches, the file's row is selected in the tree, and the editor pane has
+ * rendered the file's section title. Used by the back/forward navigation tests.
+ */
+async function expectSequenceActive(seq: { sequenceName: string; sequencePath: string }): Promise<void> {
+  await expect(setup.page).toHaveURL(
+    getWorkspacesUrl(workspace.baseURL, parseInt(workspaceId), `${seq.sequencePath}/${seq.sequenceName}`),
+  );
+  await expect(workspace.getFileRow(seq.sequenceName)).toHaveAttribute('aria-selected', 'true');
+  await expect(setup.page.getByTitle(`${seq.sequencePath}/${seq.sequenceName}`).first()).toBeVisible();
+}
 
 test.beforeAll(async ({ baseURL, browser }) => {
   // Increase global timeout to prevent early test termination
@@ -130,6 +144,49 @@ test.describe.serial('Workspace', () => {
         `${sequence.sequencePath}/${sequence.sequenceName}`,
       ),
     );
+  });
+
+  // The next six tests exercise the workspace's browser-history state machine:
+  // open a second file, walk back/forward, switch to the actions tab and back.
+  // Each transition is verified against three invariants — URL, tree selection,
+  // and the editor pane's rendered section title — via expectSequenceActive.
+  test('Back/forward: create a second sequence and open it builds the back stack', async () => {
+    sequenceB = await workspace.createSequence();
+    await workspace.clearSearch();
+    await workspace.searchForFileAndWait(sequenceB.sequenceName);
+    await workspace.clickFile(sequenceB.sequenceName);
+    await workspace.clearSearch();
+    await expectSequenceActive(sequenceB);
+  });
+
+  test('Back/forward: browser back returns to the previously opened sequence', async () => {
+    await setup.page.goBack();
+    await expectSequenceActive(sequence);
+  });
+
+  test('Back/forward: browser forward returns to the more recent sequence', async () => {
+    await setup.page.goForward();
+    await expectSequenceActive(sequenceB);
+  });
+
+  test('Back/forward: switching to the actions tab updates the URL', async () => {
+    await setup.page.getByLabel('Actions', { exact: true }).click();
+    await expect(setup.page).toHaveURL(/sidebarTab=actions/);
+  });
+
+  test('Back/forward: browser back from actions tab returns to the previously open sequence', async () => {
+    await setup.page.goBack();
+    await expectSequenceActive(sequenceB);
+  });
+
+  test('Back/forward: restore state for downstream tests (sequence A active, B deleted)', async () => {
+    await workspace.searchForFileAndWait(sequence.sequenceName);
+    await workspace.clickFile(sequence.sequenceName);
+    await workspace.clearSearch();
+    await expectSequenceActive(sequence);
+    await workspace.searchForFileAndWait(sequenceB.sequenceName);
+    await workspace.deleteSequence(sequenceB.sequenceName);
+    await workspace.clearSearch();
   });
 
   test('Update the selected sequence content', async () => {

--- a/src/components/sequencing/actions/ActionDetailView.svelte
+++ b/src/components/sequencing/actions/ActionDetailView.svelte
@@ -44,7 +44,6 @@
 
   const dispatch = createEventDispatcher<{
     close: void;
-    dirty: boolean;
     runAction: ActionDefinition;
     viewRun: { runId: number };
   }>();
@@ -167,7 +166,6 @@
       (name !== actionDefinition.name ||
         description !== actionDefinition.description ||
         JSON.stringify(argumentsMap) !== JSON.stringify(actionDefinition.settings));
-    dispatch('dirty', isDirty);
   }
 
   async function save() {
@@ -178,7 +176,6 @@
     await effects.updateActionDefinition(actionDefinition.id, { description, name, settings: argumentsMap }, user);
     saving = false;
     isDirty = false;
-    dispatch('dirty', false);
   }
 
   async function toggleArchive() {

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
   import { browser } from '$app/environment';
-  import { beforeNavigate, goto, replaceState } from '$app/navigation';
+  import { beforeNavigate, goto, pushState, replaceState } from '$app/navigation';
   import { base } from '$app/paths';
   import { page } from '$app/stores';
   import { env } from '$env/dynamic/public';
@@ -133,10 +133,39 @@
 
   type WorkspaceConsoleTab = 'actions' | 'adaptation' | 'linting' | 'logs';
 
-  // Initialize sidebar tab and content mode from URL params before first render to avoid flash
-  const initialActionRunIdParam = $page.url.searchParams.get(SearchParameters.ACTION_RUN_ID);
-  const initialActionIdParam = $page.url.searchParams.get(SearchParameters.ACTION_ID);
-  const initialSidebarTab = $page.url.searchParams.get(SearchParameters.SIDEBAR_TAB);
+  function parseUrlState(url: URL) {
+    const filePath = url.searchParams.get(SearchParameters.SEQUENCE_ID);
+    const actionRunIdParam = url.searchParams.get(SearchParameters.ACTION_RUN_ID);
+    const actionIdParam = url.searchParams.get(SearchParameters.ACTION_ID);
+    const sidebarTabParam = url.searchParams.get(SearchParameters.SIDEBAR_TAB);
+
+    const actionRunId = actionRunIdParam ? parseInt(actionRunIdParam, 10) || null : null;
+    const actionId = actionIdParam ? parseInt(actionIdParam, 10) || null : null;
+
+    let mode: WorkspaceContentMode;
+    let sidebarTab: string;
+    if (actionRunId !== null) {
+      mode = WorkspaceContentMode.ActionRunDetail;
+      sidebarTab = 'actions';
+    } else if (actionId !== null) {
+      mode = WorkspaceContentMode.ActionDetail;
+      sidebarTab = 'actions';
+    } else if (sidebarTabParam === 'actions') {
+      mode = WorkspaceContentMode.ActionRunsList;
+      sidebarTab = 'actions';
+    } else {
+      mode = WorkspaceContentMode.File;
+      sidebarTab = 'files';
+    }
+
+    return { actionId, actionRunId, filePath, mode, sidebarTab };
+  }
+
+  // Initialize state from URL before first render to avoid flash
+  const initialUrlState = parseUrlState($page.url);
+  $workspaceContentMode = initialUrlState.mode;
+  $selectedActionRunId = initialUrlState.actionRunId;
+  $selectedActionDefinitionId = initialUrlState.actionId;
 
   const { initialWorkspace } = data;
   const actionRunsLoading = actionRuns.loading;
@@ -159,8 +188,7 @@
   let commandInfoMapper: CommandInfoMapper | null = null;
   let consolePaneApi: PaneAPI;
   let leftPaneApi: PaneAPI;
-  let leftPanelActiveTab: string =
-    initialActionRunIdParam || initialActionIdParam || initialSidebarTab === 'actions' ? 'actions' : 'files';
+  let leftPanelActiveTab: string = initialUrlState.sidebarTab;
   let rightPaneApi: PaneAPI;
   let rightPanelActiveTab: string = 'metadata';
   let rightPanelCommandNodeName: string | null = null;
@@ -193,28 +221,8 @@
   let workspaceTree: WorkspaceTreeNode | null = null;
   let workspaceTreeMap: WorkspaceTreeMap = {};
   let workspaceFileList: WorkspaceTreeNodeWithFullPath[] = [];
-
-  if (initialActionRunIdParam) {
-    const runId = parseInt(initialActionRunIdParam, 10);
-    if (!isNaN(runId)) {
-      $selectedActionRunId = runId;
-      $workspaceContentMode = WorkspaceContentMode.ActionRunDetail;
-      if (initialActionIdParam) {
-        const actionId = parseInt(initialActionIdParam, 10);
-        if (!isNaN(actionId)) {
-          $selectedActionDefinitionId = actionId;
-        }
-      }
-    }
-  } else if (initialActionIdParam) {
-    const actionId = parseInt(initialActionIdParam, 10);
-    if (!isNaN(actionId)) {
-      $selectedActionDefinitionId = actionId;
-      $workspaceContentMode = WorkspaceContentMode.ActionDetail;
-    }
-  } else if (initialSidebarTab === 'actions') {
-    $workspaceContentMode = WorkspaceContentMode.ActionRunsList;
-  }
+  let isHandlingPopstate: boolean = false;
+  let lastKnownUrl: string = '';
 
   // Programmatic collapse/expand of left sidebar content pane
   $: if (leftPaneApi) {
@@ -373,20 +381,21 @@
     parameterDictionaries = [];
   }
 
-  // Prevent in-app navigation to other routes when there are unsaved changes
+  // Prevent in-app navigation to other routes when there are unsaved changes.
+  // Browser back/forward inside the workspace is handled by the window popstate
+  // listener in onMount; this hook only fires for cross-route navigations and
+  // intra-route shallow pushState (which is initiated by our own click handlers
+  // that already prompt themselves).
   beforeNavigate(({ cancel, to }) => {
     if (!$activeDocumentIsDirty) {
       return;
     }
-    // Allow navigation within the same workspace page (file selection is handled by confirmAndNavigate)
-    if (to?.route.id === $page.route.id) {
-      return;
-    }
-    // Skip for external navigation (tab close, refresh) - handled by beforeunload
     if (to === null) {
       return;
     }
-    // Cancel navigation first, then show async modal and navigate if confirmed
+    if (to.route.id === $page.route.id) {
+      return;
+    }
     cancel();
     showConfirmModal(
       'Leave Page',
@@ -396,24 +405,83 @@
       'Stay on Page',
     ).then(({ confirm }) => {
       if (confirm && to?.url) {
-        // Reset content to allow navigation without re-triggering the modal
         activeDocument.markClean();
         goto(to.url);
       }
     });
   });
 
+  function syncStateFromUrl(url: URL) {
+    const { actionId, actionRunId, filePath, mode, sidebarTab } = parseUrlState(url);
+
+    $workspaceContentMode = mode;
+    $selectedActionRunId = actionRunId;
+    $selectedActionDefinitionId = actionId;
+    leftPanelActiveTab = sidebarTab;
+
+    // Only touch the active file when we're in File mode. Other modes preserve the
+    // previously-loaded file so switching back to File mode shows it again.
+    if (mode === WorkspaceContentMode.File && filePath !== selectedFilePath) {
+      if (filePath === null) {
+        // URL no longer references a file; unload directly to avoid maybeNavigate's
+        // null-path revert behavior.
+        activeDocument.close();
+        selectedFilePath = null;
+      } else {
+        // Flag tells confirmAndNavigate to skip its pushState (URL is already correct).
+        isHandlingPopstate = true;
+        selectedFilePath = filePath;
+      }
+    }
+  }
+
   onMount(() => {
+    lastKnownUrl = window.location.href;
+
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
       if ($activeDocumentIsDirty) {
         event.preventDefault(); // Triggers the native browser confirmation
         event.returnValue = ''; // Required for some older browser compatibility
       }
     };
+
+    // Browser back/forward inside the workspace. SvelteKit's lifecycle hooks don't
+    // fire reliably for shallow pushState entries, so we handle these directly.
+    const handlePopstate = () => {
+      const newUrl = window.location.href;
+      const previousUrl = lastKnownUrl;
+
+      if (!$activeDocumentIsDirty) {
+        syncStateFromUrl(new URL(newUrl));
+        lastKnownUrl = newUrl;
+        return;
+      }
+
+      showConfirmModal(
+        'Navigate Away',
+        'There are unsaved changes. Are you sure you want to navigate away?',
+        'Navigate Away',
+        true,
+        'Keep Editing',
+      ).then(({ confirm }) => {
+        if (confirm) {
+          activeDocument.markClean();
+          syncStateFromUrl(new URL(newUrl));
+          lastKnownUrl = newUrl;
+        } else {
+          // Roll back the URL change so the user stays on the dirty page.
+          window.history.pushState({}, '', previousUrl);
+          lastKnownUrl = previousUrl;
+        }
+      });
+    };
+
     window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('popstate', handlePopstate);
 
     return () => {
       window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('popstate', handlePopstate);
     };
   });
 
@@ -424,21 +492,6 @@
       await tick();
       selectedFilePath = $activeDocumentPath;
       return;
-    }
-    // If we're in a non-file mode, guard against dirty action detail before switching
-    if ($workspaceContentMode !== WorkspaceContentMode.File && actionDetailIsDirty) {
-      const { confirm } = await showConfirmModal(
-        'Navigate Away',
-        'There are unsaved action changes. Are you sure you want to navigate away?',
-        'Navigate Away',
-        true,
-        'Keep Editing',
-      );
-      if (!confirm) {
-        selectedFilePath = $activeDocumentPath;
-        return;
-      }
-      actionDetailIsDirty = false;
     }
     // Switch back to file mode
     $workspaceContentMode = WorkspaceContentMode.File;
@@ -674,8 +727,13 @@
         return false;
       }
     }
-    // Use replaceState to update URL immediately without triggering SvelteKit navigation
-    replaceState(getWorkspacesUrl(base, $workspaceId, filePath), {});
+    if (isHandlingPopstate) {
+      // URL was already updated by browser back/forward; don't push a duplicate entry
+      isHandlingPopstate = false;
+    } else {
+      pushState(getWorkspacesUrl(base, $workspaceId, filePath), {});
+      lastKnownUrl = window.location.href;
+    }
 
     return true;
   }
@@ -691,6 +749,7 @@
     selectedFilePath = newFilePath;
     // Manually update URL since reactive statement won't trigger (selectedFilePath === $activeDocumentPath)
     replaceState(getWorkspacesUrl(base, $workspaceId, newFilePath), {});
+    lastKnownUrl = window.location.href;
   }
 
   async function saveBeforeOperation(
@@ -1033,11 +1092,6 @@
       activeDocument.markClean();
     }
 
-    // Silently reset dirty action detail state on navigate away
-    if ($workspaceContentMode === WorkspaceContentMode.ActionDetail && actionDetailIsDirty) {
-      actionDetailIsDirty = false;
-    }
-
     $workspaceContentMode = mode;
     if (options?.actionId !== undefined) {
       $selectedActionDefinitionId = options.actionId ?? null;
@@ -1078,7 +1132,8 @@
     }
 
     const query = params.toString();
-    replaceState(query ? `${baseUrl}?${query}` : baseUrl, {});
+    pushState(query ? `${baseUrl}?${query}` : baseUrl, {});
+    lastKnownUrl = window.location.href;
   }
 
   function onSelectAction(event: CustomEvent<{ id: number }>) {
@@ -1100,10 +1155,6 @@
     }
     // Ensure panel is open after switching tabs
     sidebarPanelOpen = true;
-  }
-
-  function onActionDetailDirty(event: CustomEvent<boolean>) {
-    actionDetailIsDirty = event.detail;
   }
 
   function onViewActionRun(event: CustomEvent<{ runId: number }>) {
@@ -1333,7 +1384,7 @@
   onMount(async () => {
     if (initialWorkspace) {
       $workspaceId = initialWorkspace.id;
-      selectedFilePath = $page.url.searchParams.get(SearchParameters.SEQUENCE_ID);
+      selectedFilePath = initialUrlState.filePath;
       getWorkspaceContents(initialWorkspace);
     }
     // Wait a tick for paneforge to restore saved sizes from localStorage before showing panels
@@ -1436,7 +1487,6 @@
               workspace={$workspace}
               workspaceFiles={workspaceFileList}
               on:close={() => switchToContentMode(WorkspaceContentMode.ActionRunsList)}
-              on:dirty={onActionDetailDirty}
               on:runAction={onRunActionFromDetailView}
               on:viewRun={onViewActionRun}
             />

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -151,7 +151,6 @@
     'w-[3px] hover:after:bg-neutral-300 hover:after:transition-all hover:after:delay-[400ms] data-[active]:after:bg-neutral-300 data-[active]:after:transition-all';
 
   let activeFileIsInputSequence: boolean = false;
-  let actionDetailIsDirty: boolean = false;
   let activeFileMetadata: WorkspaceFileMetadata | null = null;
   let activeFileIsSequence: boolean = false;
   let availableActionsForActiveFile: ActionParameterPair[] = [];

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -363,12 +363,15 @@
     if (!$activeDocumentIsDirty) {
       return;
     }
+    // Skip for external navigation (tab close, refresh) - handled by beforeunload
     if (to === null) {
       return;
     }
+    // Allow navigation within the same workspace page (file selection is handled by confirmAndNavigate)
     if (to.route.id === $page.route.id) {
       return;
     }
+    // Cancel navigation first, then show async modal and navigate if confirmed
     cancel();
     showConfirmModal(
       'Leave Page',
@@ -378,6 +381,7 @@
       'Stay on Page',
     ).then(({ confirm }) => {
       if (confirm && to?.url) {
+        // Reset content to allow navigation without re-triggering the modal
         activeDocument.markClean();
         goto(to.url);
       }

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -122,7 +122,9 @@
     findNodeAffectingPath,
     flattenWorkspaceTreeWithPaths,
     getAvailableActionsForNodes,
+    isPathInBreadcrumb,
     mapWorkspaceTreePaths,
+    parseUrlState,
     removeRedundantNodes,
     separateFilenameFromPath,
     WorkspaceApi,
@@ -132,34 +134,6 @@
   export let data: PageData;
 
   type WorkspaceConsoleTab = 'actions' | 'adaptation' | 'linting' | 'logs';
-
-  function parseUrlState(url: URL) {
-    const filePath = url.searchParams.get(SearchParameters.SEQUENCE_ID);
-    const actionRunIdParam = url.searchParams.get(SearchParameters.ACTION_RUN_ID);
-    const actionIdParam = url.searchParams.get(SearchParameters.ACTION_ID);
-    const sidebarTabParam = url.searchParams.get(SearchParameters.SIDEBAR_TAB);
-
-    const actionRunId = actionRunIdParam ? parseInt(actionRunIdParam, 10) || null : null;
-    const actionId = actionIdParam ? parseInt(actionIdParam, 10) || null : null;
-
-    let mode: WorkspaceContentMode;
-    let sidebarTab: string;
-    if (actionRunId !== null) {
-      mode = WorkspaceContentMode.ActionRunDetail;
-      sidebarTab = 'actions';
-    } else if (actionId !== null) {
-      mode = WorkspaceContentMode.ActionDetail;
-      sidebarTab = 'actions';
-    } else if (sidebarTabParam === 'actions') {
-      mode = WorkspaceContentMode.ActionRunsList;
-      sidebarTab = 'actions';
-    } else {
-      mode = WorkspaceContentMode.File;
-      sidebarTab = 'files';
-    }
-
-    return { actionId, actionRunId, filePath, mode, sidebarTab };
-  }
 
   // Initialize state from URL before first render to avoid flash
   const initialUrlState = parseUrlState($page.url);
@@ -411,8 +385,44 @@
     });
   });
 
+  // Centralize URL mutation so the lastKnownUrl bookkeeping (used by the popstate
+  // rollback path) can't get out of sync with the pushed URL.
+  function pushUrl(url: string): void {
+    pushState(url, {});
+    lastKnownUrl = window.location.href;
+  }
+  function replaceUrl(url: string): void {
+    replaceState(url, {});
+    lastKnownUrl = window.location.href;
+  }
+
+  // Prompts the user about discarding unsaved file changes. Resolves true if the
+  // user confirmed (and the doc was marked clean); false if they kept editing.
+  async function confirmNavigateAway(): Promise<boolean> {
+    if (!$activeDocumentIsDirty) {
+      return true;
+    }
+    const { confirm } = await showConfirmModal(
+      'Navigate Away',
+      'There are unsaved changes. Are you sure you want to navigate away?',
+      'Navigate Away',
+      true,
+      'Keep Editing',
+    );
+    if (confirm) {
+      activeDocument.markClean();
+    }
+    return confirm;
+  }
+
   function syncStateFromUrl(url: URL) {
     const { actionId, actionRunId, filePath, mode, sidebarTab } = parseUrlState(url);
+
+    // Reset the flag defensively in case the previous popstate set it but the
+    // selectedFilePath reactive never fired to consume it (e.g., the workspace
+    // was reloading at that moment, or the file path already matched). Without
+    // this, a stale flag would suppress the next user-initiated pushUrl.
+    isHandlingPopstate = false;
 
     $workspaceContentMode = mode;
     $selectedActionRunId = actionRunId;
@@ -431,6 +441,15 @@
         // Flag tells confirmAndNavigate to skip its pushState (URL is already correct).
         isHandlingPopstate = true;
         selectedFilePath = filePath;
+
+        // If the new path lives above or outside the current breadcrumb view,
+        // the file browser would filter it out (it only renders descendants of
+        // currentBreadcrumbPath). Pull the breadcrumb up to the file's parent
+        // so the row is visible. Paths *below* the current view are fine — the
+        // tree auto-expands to them via expandToPath in the file browser.
+        if (!isPathInBreadcrumb(filePath, sidebarBreadcrumbPath)) {
+          sidebarBreadcrumbPath = separateFilenameFromPath(filePath).path ?? '';
+        }
       }
     }
   }
@@ -447,25 +466,18 @@
 
     // Browser back/forward inside the workspace. SvelteKit's lifecycle hooks don't
     // fire reliably for shallow pushState entries, so we handle these directly.
+    // Cross-route popstates (back/forward out of this workspace) are handled by
+    // beforeNavigate above — we early-return here to avoid stacking two modals.
     const handlePopstate = () => {
       const newUrl = window.location.href;
-      const previousUrl = lastKnownUrl;
-
-      if (!$activeDocumentIsDirty) {
-        syncStateFromUrl(new URL(newUrl));
-        lastKnownUrl = newUrl;
+      const expectedPathname = `${base}/workspaces/${$workspaceId}`;
+      if (new URL(newUrl).pathname !== expectedPathname) {
         return;
       }
+      const previousUrl = lastKnownUrl;
 
-      showConfirmModal(
-        'Navigate Away',
-        'There are unsaved changes. Are you sure you want to navigate away?',
-        'Navigate Away',
-        true,
-        'Keep Editing',
-      ).then(({ confirm }) => {
-        if (confirm) {
-          activeDocument.markClean();
+      confirmNavigateAway().then(confirmed => {
+        if (confirmed) {
           syncStateFromUrl(new URL(newUrl));
           lastKnownUrl = newUrl;
         } else {
@@ -521,6 +533,11 @@
       activeDocument.close();
       if (nextPath && !workspaceTreeMap[nextPath]) {
         showFailureToast('The selected file does not exist in the workspace.');
+        // Clear selectedFilePath and clean up the stale URL so the reactive
+        // doesn't re-fire (which would push a new history entry and clobber the
+        // browser's forward stack) and so a reload doesn't re-toast.
+        selectedFilePath = null;
+        replaceUrl(getWorkspacesUrl(base, $workspaceId, null));
       }
     }
   }
@@ -621,8 +638,14 @@
     }
 
     if (content === null) {
-      // File may have been deleted or renamed — refresh tree so the UI self-corrects
+      // File may have been deleted or renamed — refresh tree so the UI self-corrects.
+      // Also clear selectedFilePath + the stale URL inline (same reason as the
+      // "doesn't exist in tree" branch in maybeNavigate): otherwise the
+      // selectedFilePath reactive re-fires after close() sets $activeDocumentPath
+      // to null, which would push a duplicate entry and clobber the forward stack.
       activeDocument.close();
+      selectedFilePath = null;
+      replaceUrl(getWorkspacesUrl(base, $workspaceId, null));
       refreshWorkspaceContents();
       return;
     }
@@ -714,27 +737,15 @@
   }
 
   async function confirmAndNavigate(filePath: string | null) {
-    if ($activeDocumentIsDirty) {
-      const { confirm } = await showConfirmModal(
-        'Navigate Away',
-        `There are unsaved changes. Are you sure you want navigate away from the current file?`,
-        'Navigate Away',
-        true,
-        'Keep Editing',
-      );
-
-      if (!confirm) {
-        return false;
-      }
+    if (!(await confirmNavigateAway())) {
+      return false;
     }
     if (isHandlingPopstate) {
       // URL was already updated by browser back/forward; don't push a duplicate entry
       isHandlingPopstate = false;
     } else {
-      pushState(getWorkspacesUrl(base, $workspaceId, filePath), {});
-      lastKnownUrl = window.location.href;
+      pushUrl(getWorkspacesUrl(base, $workspaceId, filePath));
     }
-
     return true;
   }
 
@@ -748,8 +759,7 @@
     activeDocument.updatePath(newFilePath, filename ?? undefined, newType);
     selectedFilePath = newFilePath;
     // Manually update URL since reactive statement won't trigger (selectedFilePath === $activeDocumentPath)
-    replaceState(getWorkspacesUrl(base, $workspaceId, newFilePath), {});
-    lastKnownUrl = window.location.href;
+    replaceUrl(getWorkspacesUrl(base, $workspaceId, newFilePath));
   }
 
   async function saveBeforeOperation(
@@ -1129,11 +1139,14 @@
       params.set(SearchParameters.ACTION_ID, String($selectedActionDefinitionId));
     } else if (mode === WorkspaceContentMode.ActionRunsList) {
       params.set(SearchParameters.SIDEBAR_TAB, 'actions');
+    } else if (mode === WorkspaceContentMode.File && $activeDocumentPath) {
+      // Preserve the currently-open file in the URL so a reload (or browser
+      // back to this entry) still shows it.
+      params.set(SearchParameters.SEQUENCE_ID, $activeDocumentPath);
     }
 
     const query = params.toString();
-    pushState(query ? `${baseUrl}?${query}` : baseUrl, {});
-    lastKnownUrl = window.location.href;
+    pushUrl(query ? `${baseUrl}?${query}` : baseUrl);
   }
 
   function onSelectAction(event: CustomEvent<{ id: number }>) {
@@ -1162,7 +1175,12 @@
   }
 
   function onActionRunBack() {
-    // Navigate back to the previous action view
+    // Navigate back to the previous action view. We intentionally use
+    // switchToContentMode (which pushes a forward history entry) rather than
+    // history.back(). The action-run-detail → action-detail transition is a
+    // forward action conceptually, not a reversal of a browser navigation, so
+    // pushing keeps the back stack consistent across users who arrived here
+    // via a deep link vs. a click.
     if ($selectedActionDefinitionId !== null) {
       switchToContentMode(WorkspaceContentMode.ActionDetail, { actionId: $selectedActionDefinitionId });
     } else {

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -508,6 +508,21 @@
     $workspaceContentMode = WorkspaceContentMode.File;
     $selectedActionDefinitionId = null;
 
+    // If the target isn't in the tree (typo'd URL, deleted, etc.), replace the
+    // current entry directly. Going through confirmAndNavigate would pushUrl
+    // first and then replace on top — leaving a stale "non-existent file" entry
+    // on top of whatever the browser already added (e.g., a typed URL), which
+    // would intercept the next back-press and make it feel like history is lost.
+    if (!workspaceTreeMap[nextPath]) {
+      activeDocument.close();
+      showFailureToast('The selected file does not exist in the workspace.');
+      selectedFilePath = null;
+      replaceUrl(getWorkspacesUrl(base, $workspaceId, null));
+      // Consume the popstate flag explicitly since we skipped confirmAndNavigate.
+      isHandlingPopstate = false;
+      return;
+    }
+
     const didNavigate = await confirmAndNavigate(nextPath);
     if (!didNavigate) {
       // user decided not to navigate away due to unsaved changes, set selected UI back to active file
@@ -522,23 +537,10 @@
 
     // successfully navigated, start loading the file contents
     selectedSequenceOutput = undefined;
-    if (nextPath && workspaceTreeMap[nextPath]) {
-      const { filename } = separateFilenameFromPath(nextPath);
-      const fileType = workspaceTreeMap[nextPath]?.type ?? null;
-      activeDocument.startLoad(nextPath, filename ?? null, fileType);
-      await getSelectedFileContent(nextPath);
-    } else {
-      // navigated to a null/empty file, reset the editor contents
-      activeDocument.close();
-      if (nextPath && !workspaceTreeMap[nextPath]) {
-        showFailureToast('The selected file does not exist in the workspace.');
-        // Clear selectedFilePath and clean up the stale URL so the reactive
-        // doesn't re-fire (which would push a new history entry and clobber the
-        // browser's forward stack) and so a reload doesn't re-toast.
-        selectedFilePath = null;
-        replaceUrl(getWorkspacesUrl(base, $workspaceId, null));
-      }
-    }
+    const { filename } = separateFilenameFromPath(nextPath);
+    const fileType = workspaceTreeMap[nextPath]?.type ?? null;
+    activeDocument.startLoad(nextPath, filename ?? null, fileType);
+    await getSelectedFileContent(nextPath);
   }
 
   function resetRefreshInterval() {

--- a/src/utilities/workspaces.test.ts
+++ b/src/utilities/workspaces.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable sort-keys */
 import { afterAll, afterEach, describe, expect, test, vi } from 'vitest';
-import { WorkspaceContentType } from '../enums/workspace';
+import { WorkspaceContentMode, WorkspaceContentType } from '../enums/workspace';
 import type { ActionDefinition } from '../types/actions';
 import type { WorkspaceTreeNode, WorkspaceTreeNodeWithFullPath } from '../types/workspace-tree-view';
 import * as requests from './requests';
@@ -19,8 +19,10 @@ import {
   getWorkspaceFileFolderDisplay,
   hasReadonlyInTree,
   incrementFilename,
+  isPathInBreadcrumb,
   joinPath,
   mapWorkspaceTreePaths,
+  parseUrlState,
   removeFirstPathSegment,
   removeRedundantNodes,
   replaceFileExtension,
@@ -1824,6 +1826,123 @@ describe('Workspace utility function tests', () => {
       };
 
       expect(hasReadonlyInTree(node)).toBe(true);
+    });
+  });
+
+  describe('parseUrlState', () => {
+    const url = (query: string = ''): URL => new URL(`http://localhost/workspaces/1${query ? `?${query}` : ''}`);
+
+    test('bare workspace URL → File mode, files tab, all nullable fields null', () => {
+      expect(parseUrlState(url())).toEqual({
+        actionId: null,
+        actionRunId: null,
+        filePath: null,
+        mode: WorkspaceContentMode.File,
+        sidebarTab: 'files',
+      });
+    });
+
+    test('sequenceId param → File mode with filePath set', () => {
+      expect(parseUrlState(url('sequenceId=folder/file.seq'))).toEqual({
+        actionId: null,
+        actionRunId: null,
+        filePath: 'folder/file.seq',
+        mode: WorkspaceContentMode.File,
+        sidebarTab: 'files',
+      });
+    });
+
+    test('actionRunId param → ActionRunDetail mode, actions tab', () => {
+      expect(parseUrlState(url('actionRunId=42'))).toEqual({
+        actionId: null,
+        actionRunId: 42,
+        filePath: null,
+        mode: WorkspaceContentMode.ActionRunDetail,
+        sidebarTab: 'actions',
+      });
+    });
+
+    test('actionRunId + actionId → ActionRunDetail with both ids', () => {
+      expect(parseUrlState(url('actionRunId=42&actionId=7'))).toEqual({
+        actionId: 7,
+        actionRunId: 42,
+        filePath: null,
+        mode: WorkspaceContentMode.ActionRunDetail,
+        sidebarTab: 'actions',
+      });
+    });
+
+    test('actionId alone → ActionDetail mode', () => {
+      expect(parseUrlState(url('actionId=7'))).toEqual({
+        actionId: 7,
+        actionRunId: null,
+        filePath: null,
+        mode: WorkspaceContentMode.ActionDetail,
+        sidebarTab: 'actions',
+      });
+    });
+
+    test('sidebarTab=actions alone → ActionRunsList mode', () => {
+      expect(parseUrlState(url('sidebarTab=actions'))).toEqual({
+        actionId: null,
+        actionRunId: null,
+        filePath: null,
+        mode: WorkspaceContentMode.ActionRunsList,
+        sidebarTab: 'actions',
+      });
+    });
+
+    test('id of 0 is preserved (regression: parseInt(...) || null mapped 0 → null)', () => {
+      const state = parseUrlState(url('actionId=0'));
+      expect(state.actionId).toBe(0);
+      expect(state.mode).toBe(WorkspaceContentMode.ActionDetail);
+    });
+
+    test('non-numeric id → null and falls through to File mode', () => {
+      const state = parseUrlState(url('actionId=not-a-number'));
+      expect(state.actionId).toBeNull();
+      expect(state.mode).toBe(WorkspaceContentMode.File);
+    });
+
+    test('action params win over sidebarTab=actions', () => {
+      expect(parseUrlState(url('actionId=7&sidebarTab=actions')).mode).toBe(WorkspaceContentMode.ActionDetail);
+    });
+
+    test('action params win over sequenceId, but filePath is still returned', () => {
+      const state = parseUrlState(url('actionId=7&sequenceId=keep-me.seq'));
+      expect(state.mode).toBe(WorkspaceContentMode.ActionDetail);
+      expect(state.actionId).toBe(7);
+      expect(state.filePath).toBe('keep-me.seq');
+    });
+  });
+
+  describe('isPathInBreadcrumb', () => {
+    test('root breadcrumb contains every path', () => {
+      expect(isPathInBreadcrumb('', '')).toBe(true);
+      expect(isPathInBreadcrumb('file', '')).toBe(true);
+      expect(isPathInBreadcrumb('a/b/c', '')).toBe(true);
+    });
+
+    test('strict descendant is in breadcrumb', () => {
+      expect(isPathInBreadcrumb('a/b', 'a')).toBe(true);
+      expect(isPathInBreadcrumb('a/b/c', 'a')).toBe(true);
+      expect(isPathInBreadcrumb('a/b/c', 'a/b')).toBe(true);
+    });
+
+    test('breadcrumb path itself is NOT in breadcrumb (file browser does not render the cwd folder as a row)', () => {
+      expect(isPathInBreadcrumb('a', 'a')).toBe(false);
+      expect(isPathInBreadcrumb('a/b', 'a/b')).toBe(false);
+    });
+
+    test('sibling or unrelated path is not in breadcrumb', () => {
+      expect(isPathInBreadcrumb('b', 'a')).toBe(false);
+      expect(isPathInBreadcrumb('a/b', 'x')).toBe(false);
+      expect(isPathInBreadcrumb('ab/c', 'a')).toBe(false); // prefix-without-slash trap
+    });
+
+    test('path above breadcrumb is not in breadcrumb', () => {
+      expect(isPathInBreadcrumb('a', 'a/b')).toBe(false);
+      expect(isPathInBreadcrumb('a/b', 'a/b/c')).toBe(false);
     });
   });
 });

--- a/src/utilities/workspaces.ts
+++ b/src/utilities/workspaces.ts
@@ -1,7 +1,8 @@
 import type { ActionValueSchema } from '@nasa-jpl/aerie-actions';
 import JSZip from 'jszip';
 import { PATH_DELIMITER } from '../constants/workspaces';
-import { WorkspaceContentType } from '../enums/workspace';
+import { SearchParameters } from '../enums/searchParameters';
+import { WorkspaceContentMode, WorkspaceContentType } from '../enums/workspace';
 import type { ActionDefinition } from '../types/actions';
 import type { User } from '../types/app';
 import type { ActionParameterPair, Workspace, WorkspaceInsertInput } from '../types/workspace';
@@ -55,6 +56,65 @@ export function separateFilenameFromPath(filePath: string): { filename: string; 
 
 export function cleanPath(path: string | null = '') {
   return (path ?? '').replace(/^\.{0,2}\//, '').replace(/\/$/, '');
+}
+
+export interface WorkspaceUrlState {
+  actionId: number | null;
+  actionRunId: number | null;
+  filePath: string | null;
+  mode: WorkspaceContentMode;
+  sidebarTab: string;
+}
+
+function parseIdParam(raw: string | null): number | null {
+  if (raw === null) {
+    return null;
+  }
+  const n = parseInt(raw, 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+/**
+ * Derive workspace navigation state from a URL's search params. Single source
+ * of truth for the URL-driven slice of the workspace page — the page applies
+ * these to stores/let-vars on initial mount and on popstate.
+ */
+export function parseUrlState(url: URL): WorkspaceUrlState {
+  const filePath = url.searchParams.get(SearchParameters.SEQUENCE_ID);
+  const actionRunId = parseIdParam(url.searchParams.get(SearchParameters.ACTION_RUN_ID));
+  const actionId = parseIdParam(url.searchParams.get(SearchParameters.ACTION_ID));
+  const sidebarTabParam = url.searchParams.get(SearchParameters.SIDEBAR_TAB);
+
+  let mode: WorkspaceContentMode;
+  let sidebarTab: string;
+  if (actionRunId !== null) {
+    mode = WorkspaceContentMode.ActionRunDetail;
+    sidebarTab = 'actions';
+  } else if (actionId !== null) {
+    mode = WorkspaceContentMode.ActionDetail;
+    sidebarTab = 'actions';
+  } else if (sidebarTabParam === 'actions') {
+    mode = WorkspaceContentMode.ActionRunsList;
+    sidebarTab = 'actions';
+  } else {
+    mode = WorkspaceContentMode.File;
+    sidebarTab = 'files';
+  }
+
+  return { actionId, actionRunId, filePath, mode, sidebarTab };
+}
+
+/**
+ * Whether `path` is visible within the file-browser when its breadcrumb is
+ * pointing at `breadcrumb`. The browser renders strict descendants of
+ * `breadcrumb` (or every top-level entry when at root), so the breadcrumb
+ * folder itself is NOT considered "in" the view.
+ */
+export function isPathInBreadcrumb(path: string, breadcrumb: string): boolean {
+  if (breadcrumb === '') {
+    return true;
+  }
+  return path.startsWith(`${breadcrumb}/`);
 }
 
 export function joinPath(pathParts: (string | number | boolean)[]) {


### PR DESCRIPTION
## Summary
Adds working browser-history navigation to the workspace page. Browser back/forward now switches between files, mode switches (file/actions tab), and folder-drill-in, with an unsaved-changes prompt when needed.

## Visible UX Changes
- **Browser back/forward** now navigates between previously-opened files and the actions tab. Previously these were dead links where back-press inside the workspace would jump out of the workspace entirely.
- **Unsaved-changes prompt** fires on browser back/forward of a dirty file (in addition to the existing prompt for cross-route navigation). "Keep Editing" rolls the URL back; "Navigate Away" proceeds.
- **Deep links** to files (`?sequenceId=...`) and action mode (`?actionId=...`, `?actionRunId=...`, `?sidebarTab=actions`) are reflected in the URL and survive reloads.
- **Stale URLs** (e.g., back to a file that was deleted) show a toast, unload the editor, and clean up the URL — without clobbering the forward history.
- **Folder browser breadcrumb** adjusts on browser back when the destination file/folder lives above or outside the current view, so the row is visible in the tree rather than hidden under a stale cwd.

## Verification 
- new unit tests in `src/utilities/workspaces.test.ts`
- new e2e tests in `e2e-tests/tests/workspace.test.ts`

