### PR TITLE
[HOTFIX] Improve Plan External Events Request Efficiency

### DIFF
--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -4619,26 +4619,20 @@ const effects = {
     try {
       const sourceData = await reqHasura<
         {
-          derivation_group: {
-            external_sources: {
-              external_events: {
-                external_event_type: {
-                  attribute_schema: object;
-                  name: string;
-                };
-              }[];
-            }[];
-          };
+          external_events: {
+            external_event_type: {
+              attribute_schema: object;
+              name: string;
+            };
+          }[];
         }[]
       >(gql.GET_PLAN_EVENT_TYPES, { plan_id }, user);
       const types: ExternalEventType[] = [];
       if (sourceData?.plan_derivation_group !== null) {
         for (const group of sourceData.plan_derivation_group) {
-          for (const source of group.derivation_group.external_sources) {
-            for (const event of source.external_events) {
-              if (types.flatMap(et => et.name).includes(event.external_event_type.name) === false) {
-                types.push(event.external_event_type);
-              }
+          for (const event of group.external_events) {
+            if (types.flatMap(et => et.name).includes(event.external_event_type.name) === false) {
+              types.push(event.external_event_type);
             }
           }
         }

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1628,16 +1628,12 @@ const gql = {
   `,
 
   GET_PLAN_EVENT_TYPES: `#graphql
-    query GetPlanEventTypes($plan_id: Int!){
+    query GetPlanEventTypes($plan_id: Int!) {
       ${Queries.PLAN_DERIVATION_GROUP}(where: {plan_id: {_eq: $plan_id}}) {
-        derivation_group {
-          external_sources {
-            external_events {
-              external_event_type {
-                attribute_schema
-                name
-              }
-            }
+        external_events (distinct_on: event_type_name) {
+          external_event_type {
+            name
+            attribute_schema
           }
         }
       }


### PR DESCRIPTION
A minor PR to improve the latency of the request made in the UI to get the event types associated with a given plan. Previously, it involved 5 joins, and invoked latencies on the order of 15 seconds on a recent deployment. This update, following the metadata update suggested [here](https://github.com/NASA-AMMOS/plandev-ui/pull/new/hotfix/plan_derivation_groups_event_relationship), can bring that latency down to around 900ms. 