### PR TITLE
UI for constraint violation messages

### DIFF
--- a/src/components/constraints/ConstraintListItem.svelte
+++ b/src/components/constraints/ConstraintListItem.svelte
@@ -432,7 +432,7 @@
         <div class="violations">
           {#each constraintResponse?.results?.violations as violation}
             {#each violation.windows as window}
-              <ConstraintViolationButton {window} />
+              <ConstraintViolationButton message={violation.message} {window} />
             {/each}
           {/each}
         </div>

--- a/src/components/constraints/ConstraintViolationButton.svelte
+++ b/src/components/constraints/ConstraintViolationButton.svelte
@@ -8,14 +8,17 @@
   import { formatDate, getDoyTimeComponents, validateTime } from '../../utilities/time';
 
   export let window: TimeRange;
+  export let message: string | null | undefined = undefined;
 
   let isDoyPattern = false;
+  let violationMessage: string = '';
   let startDateString: string = '';
   let endDateString: string = '';
 
   $: startDateString = formatDate(new Date(window.start), $plugins.time.primary.format);
   $: endDateString = formatDate(new Date(window.end), $plugins.time.primary.format);
   $: isDoyPattern = validateTime(startDateString, TimeTypes.ABSOLUTE);
+  $: violationMessage = message?.trim() ?? '';
 
   function zoomToViolation(window: TimeRange): void {
     $viewTimeRange = window;
@@ -23,45 +26,63 @@
 </script>
 
 <button class="st-button tertiary violation-button" on:click={() => zoomToViolation(window)}>
-  <div>
-    {#if isDoyPattern}
-      {@const {
-        doy: startDoy,
-        hours: startHours,
-        mins: startMins,
-        msecs: startMsecs,
-        secs: startSecs,
-        year: startYear,
-      } = getDoyTimeComponents(new Date(window.start))}
-      {startYear}-<span class="st-typography-bold">{startDoy}</span> T {startHours}:{startMins}:{startSecs}.{startMsecs}
-      {$plugins.time.primary.label}
-    {:else}
-      {startDateString}
-    {/if}
+  <div class="violation-time-range">
+    <div>
+      {#if isDoyPattern}
+        {@const {
+          doy: startDoy,
+          hours: startHours,
+          mins: startMins,
+          msecs: startMsecs,
+          secs: startSecs,
+          year: startYear,
+        } = getDoyTimeComponents(new Date(window.start))}
+        {startYear}-<span class="st-typography-bold">{startDoy}</span> T {startHours}:{startMins}:{startSecs}.{startMsecs}
+        {$plugins.time.primary.label}
+      {:else}
+        {startDateString}
+      {/if}
+    </div>
+    <div class="separator">–</div>
+    <div>
+      {#if isDoyPattern}
+        {@const {
+          doy: endDoy,
+          hours: endHours,
+          mins: endMins,
+          msecs: endMsecs,
+          secs: endSecs,
+          year: endYear,
+        } = getDoyTimeComponents(new Date(window.end))}
+        {endYear}-<span class="st-typography-bold">{endDoy}</span> T {endHours}:{endMins}:{endSecs}.{endMsecs}
+        {$plugins.time.primary.label}
+      {:else}
+        {endDateString}
+      {/if}
+    </div>
   </div>
-  <div class="separator">–</div>
-  <div>
-    {#if isDoyPattern}
-      {@const {
-        doy: endDoy,
-        hours: endHours,
-        mins: endMins,
-        msecs: endMsecs,
-        secs: endSecs,
-        year: endYear,
-      } = getDoyTimeComponents(new Date(window.end))}
-      {endYear}-<span class="st-typography-bold">{endDoy}</span> T {endHours}:{endMins}:{endSecs}.{endMsecs}
-      {$plugins.time.primary.label}
-    {:else}
-      {endDateString}
-    {/if}
-  </div>
+  {#if violationMessage}
+    <div class="violation-message st-typography-label">
+      {violationMessage}
+    </div>
+  {/if}
 </button>
 
 <style>
-  .violation-button {
-    font-variant: tabular-nums;
+  .violation-time-range {
+    display: flex;
     gap: 8px;
+  }
+
+  .violation-message {
+    white-space: normal;
+  }
+
+  .violation-button {
+    align-items: flex-start;
+    flex-direction: column;
+    font-variant: tabular-nums;
+    gap: 4px;
     height: auto;
     justify-content: flex-start;
     letter-spacing: 0px;

--- a/src/components/constraints/ConstraintViolationButton.svelte.test.ts
+++ b/src/components/constraints/ConstraintViolationButton.svelte.test.ts
@@ -1,0 +1,42 @@
+import { cleanup, render } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ConstraintViolationButton from './ConstraintViolationButton.svelte';
+
+vi.mock('../../stores/plan', async () => {
+  const { writable } = await import('svelte/store');
+
+  return {
+    viewTimeRange: writable({ end: 0, start: 0 }),
+  };
+});
+
+describe('ConstraintViolationButton component', () => {
+  const window = {
+    end: Date.UTC(2026, 4, 6, 10, 41, 19, 175),
+    start: Date.UTC(2026, 4, 6, 0, 0, 0, 0),
+  };
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the violation time range', () => {
+    const { getByRole } = render(ConstraintViolationButton, { window });
+
+    expect(getByRole('button').textContent).toContain('2026-126');
+    expect(getByRole('button').textContent).toContain('10:41:19.175');
+  });
+
+  it('renders a violation message when provided', () => {
+    const message = 'Fruit count is outside of boundaries: [5, 10]';
+    const button = render(ConstraintViolationButton, { message, window });
+
+    expect(button.getByText(message)).toBeTruthy();
+  });
+
+  it('does not render a blank violation message', () => {
+    const { container } = render(ConstraintViolationButton, { message: '   ', window });
+
+    expect(container.querySelector('.violation-message')).toBeNull();
+  });
+});

--- a/src/components/timeline/ConstraintViolations.svelte
+++ b/src/components/timeline/ConstraintViolations.svelte
@@ -4,7 +4,7 @@
   import type { ScaleTime } from 'd3-scale';
   import { select } from 'd3-selection';
   import { createEventDispatcher, onMount } from 'svelte';
-  import type { ConstraintResultWithName } from '../../types/constraint';
+  import type { ConstraintResultWithName, ConstraintViolation } from '../../types/constraint';
   import type { RowMouseOverEvent, TimeRange } from '../../types/timeline';
 
   export let constraintResults: ConstraintResultWithName[] = [];
@@ -87,6 +87,8 @@
       const constraintResultsWithViolations: ConstraintResultWithName[] = [];
 
       for (const constraintResult of constraintResults || []) {
+        const hoveredViolations: ConstraintViolation[] = [];
+
         for (const constraintViolation of constraintResult.violations || []) {
           const { windows } = constraintViolation;
           let count = 0;
@@ -100,8 +102,15 @@
           }
 
           if (count > 0) {
-            constraintResultsWithViolations.push(constraintResult);
+            hoveredViolations.push(constraintViolation);
           }
+        }
+
+        if (hoveredViolations.length) {
+          constraintResultsWithViolations.push({
+            ...constraintResult,
+            violations: hoveredViolations,
+          });
         }
       }
 

--- a/src/components/timeline/TimelineTooltip.svelte
+++ b/src/components/timeline/TimelineTooltip.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
   import { select } from 'd3-selection';
-  import { groupBy } from 'lodash-es';
+  import { escape as escapeHtml, groupBy } from 'lodash-es';
   import { onMount } from 'svelte';
   import DirectiveIcon from '../../assets/timeline-directive.svg?raw';
   import SpanIcon from '../../assets/timeline-span.svg?raw';
@@ -413,15 +413,38 @@
   }
 
   function textForConstraintViolation(constraintViolation: ConstraintResultWithName): string {
+    const messages = [
+      ...new Set(
+        (constraintViolation.violations ?? [])
+          .map(({ message }) => message?.trim())
+          .filter((message): message is string => Boolean(message)),
+      ),
+    ];
+
     return `
       <div class='tooltip-row-container'>
         <div class='st-typography-bold' style='color: var(--st-gray-10)'>Constraint Violation</div>
         <div class='tooltip-row'>
           <span>Name:</span>
           <span class='tooltip-value-row'>
-            <span class='tooltip-value-highlight st-typography-medium'>${constraintViolation.constraintName}</span>
+            <span class='tooltip-value-highlight st-typography-medium'>${escapeHtml(constraintViolation.constraintName)}</span>
           </span>
         </div>
+        ${
+          messages.length
+            ? `<div class='tooltip-row'>
+                <span>Message${messages.length > 1 ? 's' : ''}:</span>
+                <span class='tooltip-value-row' style='align-items: flex-start; flex-direction: column; max-width: 360px;'>
+                  ${messages
+                    .map(
+                      message =>
+                        `<span class='tooltip-value-highlight tooltip-value-multiline st-typography-medium'>${escapeHtml(message)}</span>`,
+                    )
+                    .join('')}
+                </span>
+              </div>`
+            : ''
+        }
       </div>
     `;
   }

--- a/src/css/tooltip.css
+++ b/src/css/tooltip.css
@@ -64,6 +64,11 @@
   width: min-content;
 }
 
+.tooltip-row .tooltip-value-multiline {
+  white-space: normal;
+  width: auto;
+}
+
 .tooltip,
 .tippy-content {
   color: var(--st-white);

--- a/src/types/constraint.ts
+++ b/src/types/constraint.ts
@@ -86,6 +86,7 @@ export type ConstraintType = 'model' | 'plan';
 
 export type ConstraintViolation = {
   activityInstanceIds: number[];
+  message?: string | null;
   windows: TimeRange[];
 };
 

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -83,6 +83,7 @@ const gql = {
               start
             }
             violations {
+              message
               activityInstanceIds
               windows {
                 end


### PR DESCRIPTION
`___REQUIRES_AERIE_PR___="1782"`


## Description
This adds basic UI in two places for supporting the new Constraint violation messages now returned by the backend in https://github.com/NASA-AMMOS/plandev/pull/1782

- Requests the new `message` field on constraint violations from the `CheckConstraints` gql response
- Shows violation messages in the **timeline hover tooltip** when hovering over red violation ranges
- Filters timeline hover payloads down to the specific violation windows under the cursor, so overlapping violations can show the right message(s)
- Shows violation messages under violation time ranges in the constraints **panel** when present


## Verification
- Unit test for violations panel: src/components/constraints/ConstraintViolationButton.svelte.test.ts
- manual testing:
  1. In the `plandev` repo, check out the `fix/return-violation-messages` branch and run `./gradlew e2eTest:buildAllProcedureJars` to build the example constraint JARs
  2. Run this version of the UI, go to Constraints page and upload a JAR constraint, use `e2e-tests/build/libs/FruitThresholdConstraint.jar`
  3. Make an example plan using the `banananation` mission model, go to Constraints panel -> Manage Constraints and add the "FruitThresholdConstraint"
  4. Run sim and check constraints to get a violation.
  5. You should see the message "fruit count is outside of boundaries" in the Constraints panel under Violations and in the violation tooltip
  6. Repeat with more violations if you want to test multiple/overlapping messages
  
  
<img width="630" height="205" alt="image" src="https://github.com/user-attachments/assets/8c6c8563-cbf9-40a2-88c2-511d0dfdec3e" />

  