### PR TITLE
Timeline resource streaming

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -33,6 +33,7 @@ npx playwright install
 #### Auth failures
 
 If several tests are failing due to auth issues, you may need to clear your Playwright cache first:
+
 ```sh
 npm run test:e2e:clear-cache
 ```

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -30,6 +30,13 @@ If this is your first time running the tests you may need to install the Playwri
 npx playwright install
 ```
 
+#### Auth failures
+
+If several tests are failing due to auth issues, you may need to clear your Playwright cache first:
+```sh
+npm run test:e2e:clear-cache
+```
+
 #### New backend service:
 
 If a new backend service has been added to PlanDev, make sure to update the [docker-compose-test.yml](../docker-compose-test.yml) in order for the CI to be able to spin up the backend correctly.

--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -467,6 +467,7 @@ export class Plan {
   async goto(planId = this.plans.planId) {
     await this.page.goto(`/plans/${planId}`, { waitUntil: 'load' });
     await this.page.waitForURL(`/plans/${planId}`, { waitUntil: 'load' });
+    await this.planTitle.waitFor({ state: 'visible' });
     await this.waitForTimelineLoading();
   }
 

--- a/e2e-tests/tests/model-derivation-group.test.ts
+++ b/e2e-tests/tests/model-derivation-group.test.ts
@@ -116,14 +116,15 @@ test.describe.serial('Model Derivation Group Linking', () => {
     // now, create a new plan
     await setup.plans.goto();
     await setup.page.waitForURL(`${baseURL}/plans`, { timeout: 3000 });
-    await setup.plans.createPlan('secondPlan', setup.modelName);
+    const newPlanName = 'secondPlan';
+    await setup.plans.createPlan(newPlanName, setup.modelName);
     newPlan = new Plan(
       setup.page,
       setup.plans,
       setup.constraints,
       setup.schedulingGoals,
       setup.schedulingConditions,
-      setup.planName,
+      newPlanName,
     );
     newPlanId = Number(setup.plans.planId);
 

--- a/e2e-tests/tests/model-derivation-group.test.ts
+++ b/e2e-tests/tests/model-derivation-group.test.ts
@@ -89,6 +89,7 @@ test.afterAll(async () => {
 
 test.describe.serial('Model Derivation Group Linking', () => {
   test('Derivation groups can be linked to a model and show in plan', async ({ baseURL }) => {
+    test.setTimeout(60 * 1000);
     // check the current plan...
     await originalPlan.goto();
     await setup.page.waitForURL(`${baseURL}/plans/${originalPlanId}`, { timeout: 3000 });

--- a/e2e-tests/tests/plan-external-source.test.ts
+++ b/e2e-tests/tests/plan-external-source.test.ts
@@ -1,6 +1,7 @@
 import test, { expect } from '@playwright/test';
 import { ExternalSources } from '../fixtures/ExternalSources.js';
 import { PanelNames, Plan } from '../fixtures/Plan.js';
+import { anyCanvasHasContent } from '../utilities/canvas.js';
 import {
   cleanupApiResources,
   closeBrowserResources,
@@ -157,22 +158,7 @@ test.describe.serial('Plan External Sources', () => {
   });
 
   test('Zero-duration events are properly drawn in the timeline', async () => {
-    // Get the current timeline canvas' pixels - use a set to just determine that non-0 RGB values exist
-    const doPixelsExist: boolean = await setup.page.evaluate(() => {
-      const canvas = document.querySelector('canvas');
-      if (canvas !== null && canvas !== undefined) {
-        const context = canvas.getContext('2d');
-        if (context !== null && context !== undefined) {
-          const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
-          const pixelData = Array.from(imageData.data);
-          return pixelData.length > 0 ? true : false;
-          // Assert that the number of unique RGB pixel values for the canvas is more than 0 (i.e., not empty)
-        }
-      }
-      return false;
-    });
-
-    expect(doPixelsExist).toBeTruthy();
+    expect(await anyCanvasHasContent(setup.page, '[data-component-name="TimelinePanel"] canvas')).toBeTruthy();
   });
 
   test('Linked derivation groups should be expandable in panel', async () => {

--- a/e2e-tests/tests/simulation.test.ts
+++ b/e2e-tests/tests/simulation.test.ts
@@ -70,4 +70,24 @@ test.describe.serial('Simulation', async () => {
     await setup.plan.addActivityByDragAndDrop();
     await setup.plan.waitForSimulationStatus(Status.Modified);
   });
+
+  // Catches gross regressions in the streaming-profile pipeline that the unit
+  // tests can't see: actually exercises real Hasura cursors / interval ordering
+  // / WS reconnects via graphql-ws across a real sim → resimulate cycle, then
+  // asserts the global timeline status indicator never enters its error state
+  // and the timeline panel stays mounted. The "blank plot after resimulate"
+  // bug specifically isn't directly assertable here without canvas-pixel
+  // inspection or test hooks (deliberately avoided) — that's covered by the
+  // resimulate-fast unit test in src/stores/profile.test.ts. This e2e is a
+  // smoke test that the pipeline doesn't broadly fall over on real backend.
+  test(`Streaming pipeline survives a sim → resimulate cycle without timeline errors`, async () => {
+    const timelineErrorIndicator = setup.plan.page.getByRole('status', { name: 'Timeline data error' });
+
+    await setup.plan.runSimulation();
+    await expect(timelineErrorIndicator).not.toBeVisible();
+
+    await setup.plan.reRunSimulation();
+    await expect(timelineErrorIndicator).not.toBeVisible();
+    await expect(setup.plan.panelTimeline).toBeVisible();
+  });
 });

--- a/e2e-tests/tests/simulation.test.ts
+++ b/e2e-tests/tests/simulation.test.ts
@@ -2,6 +2,7 @@ import test, { expect } from '@playwright/test';
 import { Status } from '../../src/enums/status.js';
 import { PanelNames } from '../fixtures/Plan.js';
 import { setupTest, teardownTest, type FullSetupResult } from '../utilities/api.js';
+import { anyCanvasHasContent } from '../utilities/canvas.js';
 
 let setup: FullSetupResult;
 
@@ -61,33 +62,36 @@ test.describe.serial('Simulation', async () => {
     await setup.plan.showPanel(PanelNames.SIMULATION, true);
   });
 
+  // Smoke test for the windowed-pull pipeline: indicator settles cleanly and
+  // canvases render non-transparent content (catches the "blank plot" bug an
+  // indicator-only check would miss).
+  test(`Streaming pipeline: indicator settles + canvases render across two re-sims`, async () => {
+    const timelineErrorIndicator = setup.plan.page.getByRole('status', { name: 'Timeline data error' });
+    const timelineLoadingIndicator = setup.plan.page.getByRole('status', { name: 'Timeline loading' });
+    const timelineCanvasContent = () =>
+      anyCanvasHasContent(setup.page, '[data-component-name="TimelinePanel"] canvas');
+
+    await setup.plan.reRunSimulation();
+    await expect(timelineErrorIndicator).not.toBeVisible();
+    await expect(timelineLoadingIndicator).not.toBeVisible();
+    await expect.poll(timelineCanvasContent, { timeout: 10000 }).toBe(true);
+
+    await setup.plan.reRunSimulation();
+    await expect(timelineErrorIndicator).not.toBeVisible();
+    await expect(timelineLoadingIndicator).not.toBeVisible();
+    await expect.poll(timelineCanvasContent, { timeout: 10000 }).toBe(true);
+  });
+
   test(`Plans with an invalid activity should fail simulation`, async () => {
+    const timelineLoadingIndicator = setup.plan.page.getByRole('status', { name: 'Timeline loading' });
     await setup.plan.addActivityByDragAndDrop('BakeBananaBread');
     await setup.plan.runSimulation(Status.Failed);
+    // Regression: indicator must settle for terminal-null sims too.
+    await expect(timelineLoadingIndicator).not.toBeVisible();
   });
 
   test(`Modified plans should indicate that simulation is out of date`, async () => {
     await setup.plan.addActivityByDragAndDrop();
     await setup.plan.waitForSimulationStatus(Status.Modified);
-  });
-
-  // Catches gross regressions in the streaming-profile pipeline that the unit
-  // tests can't see: actually exercises real Hasura cursors / interval ordering
-  // / WS reconnects via graphql-ws across a real sim → resimulate cycle, then
-  // asserts the global timeline status indicator never enters its error state
-  // and the timeline panel stays mounted. The "blank plot after resimulate"
-  // bug specifically isn't directly assertable here without canvas-pixel
-  // inspection or test hooks (deliberately avoided) — that's covered by the
-  // resimulate-fast unit test in src/stores/profile.test.ts. This e2e is a
-  // smoke test that the pipeline doesn't broadly fall over on real backend.
-  test(`Streaming pipeline survives a sim → resimulate cycle without timeline errors`, async () => {
-    const timelineErrorIndicator = setup.plan.page.getByRole('status', { name: 'Timeline data error' });
-
-    await setup.plan.runSimulation();
-    await expect(timelineErrorIndicator).not.toBeVisible();
-
-    await setup.plan.reRunSimulation();
-    await expect(timelineErrorIndicator).not.toBeVisible();
-    await expect(setup.plan.panelTimeline).toBeVisible();
   });
 });

--- a/e2e-tests/tests/simulation.test.ts
+++ b/e2e-tests/tests/simulation.test.ts
@@ -68,8 +68,7 @@ test.describe.serial('Simulation', async () => {
   test(`Streaming pipeline: indicator settles + canvases render across two re-sims`, async () => {
     const timelineErrorIndicator = setup.plan.page.getByRole('status', { name: 'Timeline data error' });
     const timelineLoadingIndicator = setup.plan.page.getByRole('status', { name: 'Timeline loading' });
-    const timelineCanvasContent = () =>
-      anyCanvasHasContent(setup.page, '[data-component-name="TimelinePanel"] canvas');
+    const timelineCanvasContent = () => anyCanvasHasContent(setup.page, '[data-component-name="TimelinePanel"] canvas');
 
     await setup.plan.reRunSimulation();
     await expect(timelineErrorIndicator).not.toBeVisible();

--- a/e2e-tests/utilities/canvas.ts
+++ b/e2e-tests/utilities/canvas.ts
@@ -1,0 +1,25 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * True if any canvas matched by `selector` has a pixel with non-zero alpha.
+ * Stronger than checking the canvas exists — a transparent canvas would
+ * pass that. Pair with `expect.poll` for post-async-update checks.
+ */
+export function anyCanvasHasContent(page: Page, selector: string = 'canvas'): Promise<boolean> {
+  return page.evaluate(sel => {
+    const canvases = document.querySelectorAll<HTMLCanvasElement>(sel);
+    for (const canvas of Array.from(canvases)) {
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        continue;
+      }
+      const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+      for (let i = 3; i < data.length; i += 4) {
+        if (data[i] > 0) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }, selector);
+}

--- a/src/components/ResourceList.svelte
+++ b/src/components/ResourceList.svelte
@@ -4,12 +4,7 @@
   import CloseIcon from '@nasa-jpl/stellar/icons/close.svg?component';
   import UploadIcon from '@nasa-jpl/stellar/icons/upload.svg?component';
   import { plan } from '../stores/plan';
-  import {
-    allResourceTypes,
-    fetchingResourcesExternal,
-    resourceTypesLoading,
-    simulationDatasetId,
-  } from '../stores/simulation';
+  import { allResourceTypes, resourceTypesLoading, simulationDatasetId } from '../stores/simulation';
   import type { User } from '../types/app';
   import type { ResourceType } from '../types/simulation';
   import type { TimelineItemType } from '../types/timeline';
@@ -34,7 +29,7 @@
   let loading: boolean = false;
 
   $: resourceDataTypes = [...new Set($allResourceTypes.map(t => t.schema.type))];
-  $: loading = $fetchingResourcesExternal || $resourceTypesLoading;
+  $: loading = $resourceTypesLoading;
   $: if (user !== null && $plan !== null) {
     hasUploadPermission = featurePermissions.externalResources.canCreate(user, $plan);
   }

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -254,8 +254,13 @@
       }
 
       const isExternal = !$resourceTypes.find(type => type.name === name);
+      // External datasets are matched by the simulation_dataset *id* (what
+      // plan_dataset.simulation_dataset_id references), whereas internal
+      // profiles are fetched by dataset_id. These are distinct id spaces;
+      // passing dataset_id to the external factory makes its sim-tied
+      // plan_dataset row preference silently never match.
       const subscription = isExternal
-        ? createExternalResourceSubscription(simulationDatasetId, name, plan.start_time, user)
+        ? createExternalResourceSubscription(simulationDataset.id, name, plan.start_time, user)
         : createProfileSubscription(simulationDatasetId, name, simProfileStartYmd, user);
       const type: 'external' | 'internal' = isExternal ? 'external' : 'internal';
       // subscription.store.subscribe() runs its callback immediately,

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -14,13 +14,9 @@
     planDerivationGroupLinks,
   } from '../../stores/external-source';
   import { planModelActivityTypes } from '../../stores/plan';
+  import { createExternalResourceSubscription } from '../../stores/externalResource';
   import { createProfileSubscription } from '../../stores/profile';
-  import {
-    externalResources,
-    fetchingResourcesExternal,
-    resourceTypes,
-    resourceTypesLoading,
-  } from '../../stores/simulation';
+  import { resourceTypes, resourceTypesLoading } from '../../stores/simulation';
   import { selectedRow, viewAddFilterToRow } from '../../stores/views';
   import type {
     ActivityDirective,
@@ -218,7 +214,7 @@
     }
   });
 
-  $: if (plan && simulationDataset !== null && layers && $externalResources && !$resourceTypesLoading) {
+  $: if (plan && simulationDataset !== null && layers && !$resourceTypesLoading) {
     const simulationDatasetId = simulationDataset.dataset_id;
     const resourceNamesSet = new Set<string>();
     layers.map(layer => {
@@ -230,14 +226,10 @@
     });
     const resourceNames = Array.from(resourceNamesSet);
 
-    // Cancel and delete unused and stale requests as well as any external resources that
-    // are not in the list of current external resources
+    // Drop entries no longer referenced by any layer or whose sim dataset
+    // changed. Both factories own their own registry cleanup on unsubscribe.
     Object.entries(resourceRequestMap).forEach(([key, value]) => {
-      if (
-        resourceNames.indexOf(key) < 0 ||
-        value.simulationDatasetId !== simulationDatasetId ||
-        (value.type === 'external' && !$resourceTypes.find(type => type.name === name))
-      ) {
+      if (resourceNames.indexOf(key) < 0 || value.simulationDatasetId !== simulationDatasetId) {
         value.unsubscribe?.();
         delete resourceRequestMap[key];
         resourceRequestMap = { ...resourceRequestMap };
@@ -246,63 +238,42 @@
 
     const startTimeYmd = simulationDataset?.simulation_start_time ?? plan.start_time;
     resourceNames.forEach(name => {
-      // Check if resource is external
+      if (
+        resourceRequestMap[name] &&
+        simulationDatasetId === resourceRequestMap[name].simulationDatasetId &&
+        resourceRequestMap[name].unsubscribe
+      ) {
+        return;
+      }
+
       const isExternal = !$resourceTypes.find(type => type.name === name);
-      if (isExternal) {
-        // Handle external datasets separately as they are globally loaded and subscribed to
-        let resource = null;
-        if (!$fetchingResourcesExternal) {
-          resource = $externalResources.find(resource => resource.name === name) || null;
-        }
-        let error = !resource && !$fetchingResourcesExternal ? 'External Profile not Found' : '';
+      const subscription = isExternal
+        ? createExternalResourceSubscription(simulationDatasetId, name, startTimeYmd, user)
+        : createProfileSubscription(simulationDatasetId, name, startTimeYmd, user);
+      const type: 'external' | 'internal' = isExternal ? 'external' : 'internal';
+      // Declared before .subscribe() so the closure in `unsubscribe` below
+      // doesn't lean on TDZ-via-const initialization order.
+      let storeUnsubscribe: (() => void) | null = null;
+      storeUnsubscribe = subscription.store.subscribe(({ error, loading, resource }) => {
         resourceRequestMap = {
           ...resourceRequestMap,
           [name]: {
             ...resourceRequestMap[name],
             error,
-            loading: $fetchingResourcesExternal,
+            loading,
             resource,
             simulationDatasetId,
-            type: 'external',
+            type,
+            unsubscribe: () => {
+              storeUnsubscribe?.();
+              subscription.unsubscribe();
+            },
           },
         };
-      } else {
-        // Skip if a profile subscription already exists for this (name, simulationDatasetId)
-        if (
-          resourceRequestMap[name] &&
-          simulationDatasetId === resourceRequestMap[name].simulationDatasetId &&
-          resourceRequestMap[name].unsubscribe
-        ) {
-          return;
-        }
-
-        // The sub watches simulationDataset.status itself to drive its
-        // closing-value logic and stream-sub lifecycle: while the sim is
-        // running it terminates at the last received segment; once status
-        // goes terminal it honours header.duration so lines close to plan
-        // end. No coordination needed from this caller.
-        const subscription = createProfileSubscription(simulationDatasetId, name, startTimeYmd, user);
-        const storeUnsubscribe = subscription.store.subscribe(({ error, loading, resource }) => {
-          resourceRequestMap = {
-            ...resourceRequestMap,
-            [name]: {
-              ...resourceRequestMap[name],
-              error,
-              loading,
-              resource,
-              simulationDatasetId,
-              type: 'internal',
-              unsubscribe: () => {
-                storeUnsubscribe();
-                subscription.unsubscribe();
-              },
-            },
-          };
-        });
-      }
+      });
     });
   } else if (simulationDataset === null) {
-    Object.entries(resourceRequestMap).forEach(([_key, value]) => {
+    Object.values(resourceRequestMap).forEach(value => {
       value.unsubscribe?.();
     });
     resourceRequestMap = {};
@@ -367,10 +338,8 @@
     });
     loadedResources = newLoadedResources;
     resourceLoadingErrors = newLoadingErrors;
-    // Use the per-request loading flag rather than counting loaded+errored vs
-    // total. A request with both data (e.g. from prefetch) and a streaming
-    // error would otherwise be double-counted, leaving anyResourcesLoading
-    // perpetually true and overlapping the loading + error indicators.
+    // Use per-request loading flag, not loaded+errored vs total: a request
+    // with both data and an error would be double-counted and stick true.
     anyResourcesLoading = anyLoading;
   }
 

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -8,6 +8,7 @@
   import FilterWithXIcon from '../../assets/filter-with-x.svg?component';
   import { ViewDefaultDiscreteOptions } from '../../constants/view';
   import { activityArgumentDefaultsMap } from '../../stores/activities';
+  import { selectedExternalEventsRaw } from '../../stores/external-event';
   import {
     derivationGroupVisibilityMap,
     externalSources,
@@ -149,6 +150,12 @@
     };
     zoom: D3ZoomEvent<HTMLCanvasElement, any>;
   }>();
+
+  // External events stream in via a single plan-wide subscription, so these loading
+  // and error flags are shared across all rows that render an external event layer
+  // (unlike resources, which subscribe per row).
+  const externalEventsLoading = selectedExternalEventsRaw.loading;
+  const externalEventsError = selectedExternalEventsRaw.error;
 
   let blur: FocusEvent;
   let contextmenu: MouseEvent;
@@ -921,7 +928,7 @@
         </g>
       </svg>
       <!-- Loading indicator -->
-      {#if (hasResourceLayer && anyResourcesLoading) || (hasActivityLayerFilters && (!activityDirectivesMap || !spansMap))}
+      {#if (hasResourceLayer && anyResourcesLoading) || (hasActivityLayerFilters && (!activityDirectivesMap || !spansMap)) || (hasExternalEventsLayer && $externalEventsLoading)}
         <div class="layer-message loading st-typography-label">Loading...</div>
       {/if}
       <!-- Empty state -->
@@ -933,6 +940,10 @@
         <div class="layer-message error st-typography-label">
           Failed to load profiles for {resourceLoadingErrors.length} layer{pluralize(resourceLoadingErrors.length)}
         </div>
+      {/if}
+      <!-- External event error indicator -->
+      {#if hasExternalEventsLayer && $externalEventsError}
+        <div class="layer-message error st-typography-label">Failed to load external events</div>
       {/if}
       <!-- Layers of Canvas Visualizations. -->
       <div class="layers" style="width: {drawWidth}px">

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -4,18 +4,17 @@
   import type { ScaleTime } from 'd3-scale';
   import { select, type Selection } from 'd3-selection';
   import { zoom as d3Zoom, zoomIdentity, type D3ZoomEvent, type ZoomBehavior, type ZoomTransform } from 'd3-zoom';
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, onDestroy } from 'svelte';
   import FilterWithXIcon from '../../assets/filter-with-x.svg?component';
   import { ViewDefaultDiscreteOptions } from '../../constants/view';
-  import { Status } from '../../enums/status';
   import { activityArgumentDefaultsMap } from '../../stores/activities';
-  import { catchError, logMessage } from '../../stores/errors';
   import {
     derivationGroupVisibilityMap,
     externalSources,
     planDerivationGroupLinks,
   } from '../../stores/external-source';
   import { planModelActivityTypes } from '../../stores/plan';
+  import { createProfileSubscription } from '../../stores/profile';
   import {
     externalResources,
     fetchingResourcesExternal,
@@ -66,8 +65,6 @@
   import { getExternalEventRowId } from '../../utilities/externalEvents';
   import { classNames } from '../../utilities/generic';
   import { showConfirmActivityCreationModal } from '../../utilities/modal';
-  import { sampleProfiles } from '../../utilities/resources';
-  import { getSimulationStatus } from '../../utilities/simulation';
   import { pluralize } from '../../utilities/text';
   import { getDoyTime } from '../../utilities/time';
   import {
@@ -241,111 +238,82 @@
         value.simulationDatasetId !== simulationDatasetId ||
         (value.type === 'external' && !$resourceTypes.find(type => type.name === name))
       ) {
-        value.controller?.abort();
+        value.unsubscribe?.();
         delete resourceRequestMap[key];
         resourceRequestMap = { ...resourceRequestMap };
       }
     });
 
-    // Only update if simulation is complete
-    if (
-      getSimulationStatus(simulationDataset) === Status.Complete ||
-      getSimulationStatus(simulationDataset) === Status.Canceled
-    ) {
-      const startTimeYmd = simulationDataset?.simulation_start_time ?? plan.start_time;
-      resourceNames.forEach(async name => {
-        // Check if resource is external
-        const isExternal = !$resourceTypes.find(type => type.name === name);
-        if (isExternal) {
-          // Handle external datasets separately as they are globally loaded and subscribed to
-          let resource = null;
-          if (!$fetchingResourcesExternal) {
-            resource = $externalResources.find(resource => resource.name === name) || null;
-          }
-          let error = !resource && !$fetchingResourcesExternal ? 'External Profile not Found' : '';
+    const startTimeYmd = simulationDataset?.simulation_start_time ?? plan.start_time;
+    resourceNames.forEach(name => {
+      // Check if resource is external
+      const isExternal = !$resourceTypes.find(type => type.name === name);
+      if (isExternal) {
+        // Handle external datasets separately as they are globally loaded and subscribed to
+        let resource = null;
+        if (!$fetchingResourcesExternal) {
+          resource = $externalResources.find(resource => resource.name === name) || null;
+        }
+        let error = !resource && !$fetchingResourcesExternal ? 'External Profile not Found' : '';
+        resourceRequestMap = {
+          ...resourceRequestMap,
+          [name]: {
+            ...resourceRequestMap[name],
+            error,
+            loading: $fetchingResourcesExternal,
+            resource,
+            simulationDatasetId,
+            type: 'external',
+          },
+        };
+      } else {
+        // Skip if a profile subscription already exists for this (name, simulationDatasetId)
+        if (
+          resourceRequestMap[name] &&
+          simulationDatasetId === resourceRequestMap[name].simulationDatasetId &&
+          resourceRequestMap[name].unsubscribe
+        ) {
+          return;
+        }
 
+        // The sub watches simulationDataset.status itself to drive its
+        // closing-value logic and stream-sub lifecycle: while the sim is
+        // running it terminates at the last received segment; once status
+        // goes terminal it honours header.duration so lines close to plan
+        // end. No coordination needed from this caller.
+        const subscription = createProfileSubscription(simulationDatasetId, name, startTimeYmd, user);
+        const storeUnsubscribe = subscription.store.subscribe(({ error, loading, resource }) => {
           resourceRequestMap = {
             ...resourceRequestMap,
             [name]: {
               ...resourceRequestMap[name],
               error,
-              loading: $fetchingResourcesExternal,
+              loading,
               resource,
               simulationDatasetId,
-              type: 'external',
-            },
-          };
-        } else {
-          // Skip matching resources requests that have already been added for this simulation
-          if (
-            resourceRequestMap[name] &&
-            simulationDatasetId === resourceRequestMap[name].simulationDatasetId &&
-            (resourceRequestMap[name].loading || resourceRequestMap[name].error || resourceRequestMap[name].resource)
-          ) {
-            return;
-          }
-
-          const controller = new AbortController();
-          resourceRequestMap = {
-            ...resourceRequestMap,
-            [name]: {
-              ...resourceRequestMap[name],
-              controller,
-              error: '',
-              loading: true,
-              resource: null,
-              simulationDatasetId,
               type: 'internal',
+              unsubscribe: () => {
+                storeUnsubscribe();
+                subscription.unsubscribe();
+              },
             },
           };
-
-          let resource = null;
-          let error = '';
-          let aborted = false;
-          try {
-            const startTime = performance.now();
-            const response = await effects.getResource(simulationDatasetId, name, user, controller.signal);
-            const { profile } = response;
-            if (profile && profile.length === 1) {
-              resource = sampleProfiles([profile[0]], startTimeYmd)[0];
-              logMessage(
-                `Retrieved profile ${name} (${profile[0].profile_segments.length} segment${pluralize(profile[0].profile_segments.length)}) for simulation ${simulationDatasetId}.`,
-                '',
-                performance.now() - startTime,
-              );
-            } else {
-              throw new Error('Profile not Found');
-            }
-          } catch (e) {
-            const err = e as Error;
-            if (err.name === 'AbortError') {
-              aborted = true;
-            } else {
-              catchError(`Profile Download Failed for ${name}`, e as Error);
-              error = err.message;
-            }
-          } finally {
-            if (!aborted) {
-              resourceRequestMap = {
-                ...resourceRequestMap,
-                [name]: {
-                  ...resourceRequestMap[name],
-                  error,
-                  loading: false,
-                  resource,
-                },
-              };
-            }
-          }
-        }
-      });
-    }
+        });
+      }
+    });
   } else if (simulationDataset === null) {
     Object.entries(resourceRequestMap).forEach(([_key, value]) => {
-      value.controller?.abort();
+      value.unsubscribe?.();
     });
     resourceRequestMap = {};
   }
+
+  onDestroy(() => {
+    Object.values(resourceRequestMap).forEach(value => {
+      value.unsubscribe?.();
+    });
+    resourceRequestMap = {};
+  });
 
   $: onDragenter(dragenter);
   $: onDragleave(dragleave);
@@ -385,6 +353,7 @@
   $: if (resourceRequestMap) {
     const newLoadedResources: Resource[] = [];
     const newLoadingErrors: string[] = [];
+    let anyLoading = false;
     Object.values(resourceRequestMap).forEach(resourceRequest => {
       if (resourceRequest.resource) {
         newLoadedResources.push(resourceRequest.resource);
@@ -392,14 +361,17 @@
       if (resourceRequest.error) {
         newLoadingErrors.push(resourceRequest.error);
       }
+      if (resourceRequest.loading) {
+        anyLoading = true;
+      }
     });
     loadedResources = newLoadedResources;
     resourceLoadingErrors = newLoadingErrors;
-
-    // Consider row to be loading if the number of completed resource requests (loaded or error state)
-    // is not equal to the total number of resource requests
-    anyResourcesLoading =
-      loadedResources.length + resourceLoadingErrors.length !== Object.keys(resourceRequestMap).length;
+    // Use the per-request loading flag rather than counting loaded+errored vs
+    // total. A request with both data (e.g. from prefetch) and a streaming
+    // error would otherwise be double-counted, leaving anyResourcesLoading
+    // perpetually true and overlapping the loading + error indicators.
+    anyResourcesLoading = anyLoading;
   }
 
   // Compute scale domains for axes since it is optionally defined in the view

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -14,8 +14,8 @@
     externalSources,
     planDerivationGroupLinks,
   } from '../../stores/external-source';
-  import { planModelActivityTypes } from '../../stores/plan';
   import { createExternalResourceSubscription } from '../../stores/externalResource';
+  import { planModelActivityTypes } from '../../stores/plan';
   import { createProfileSubscription } from '../../stores/profile';
   import { resourceTypes, resourceTypesLoading } from '../../stores/simulation';
   import { selectedRow, viewAddFilterToRow } from '../../stores/views';
@@ -243,7 +243,7 @@
       }
     });
 
-    const startTimeYmd = simulationDataset?.simulation_start_time ?? plan.start_time;
+    const simProfileStartYmd = simulationDataset?.simulation_start_time ?? plan.start_time;
     resourceNames.forEach(name => {
       if (
         resourceRequestMap[name] &&
@@ -255,8 +255,8 @@
 
       const isExternal = !$resourceTypes.find(type => type.name === name);
       const subscription = isExternal
-        ? createExternalResourceSubscription(simulationDatasetId, name, startTimeYmd, user)
-        : createProfileSubscription(simulationDatasetId, name, startTimeYmd, user);
+        ? createExternalResourceSubscription(simulationDatasetId, name, plan.start_time, user)
+        : createProfileSubscription(simulationDatasetId, name, simProfileStartYmd, user);
       const type: 'external' | 'internal' = isExternal ? 'external' : 'internal';
       // Declared before .subscribe() so the closure in `unsubscribe` below
       // doesn't lean on TDZ-via-const initialization order.

--- a/src/components/timeline/Row.svelte
+++ b/src/components/timeline/Row.svelte
@@ -258,8 +258,10 @@
         ? createExternalResourceSubscription(simulationDatasetId, name, plan.start_time, user)
         : createProfileSubscription(simulationDatasetId, name, simProfileStartYmd, user);
       const type: 'external' | 'internal' = isExternal ? 'external' : 'internal';
-      // Declared before .subscribe() so the closure in `unsubscribe` below
-      // doesn't lean on TDZ-via-const initialization order.
+      // subscription.store.subscribe() runs its callback immediately,
+      // before it returns. That callback creates an unsubscribe function
+      // that references this variable — so it must already exist.
+      // Declaring it (= null) before subscribing avoids referencing it before it's assigned.
       let storeUnsubscribe: (() => void) | null = null;
       storeUnsubscribe = subscription.store.subscribe(({ error, loading, resource }) => {
         resourceRequestMap = {

--- a/src/components/timeline/TimelinePanel.svelte
+++ b/src/components/timeline/TimelinePanel.svelte
@@ -50,6 +50,7 @@
   import Panel from '../ui/Panel.svelte';
   import PanelHeaderActions from '../ui/PanelHeaderActions.svelte';
   import Timeline from './Timeline.svelte';
+  import TimelineStatusIndicator from './TimelineStatusIndicator.svelte';
   import TimelineViewControls from './TimelineViewControls.svelte';
 
   export let user: User | null;
@@ -181,7 +182,10 @@
 
 <Panel padBody={false}>
   <svelte:fragment slot="header">
-    <div class="st-typography-medium timeline-title">Timeline</div>
+    <div class="timeline-title-group">
+      <div class="st-typography-medium timeline-title">Timeline</div>
+      <TimelineStatusIndicator />
+    </div>
     <PanelHeaderActions>
       <div class="header-actions timeline-icon-tray">
         <TimelineViewControls
@@ -280,6 +284,10 @@
 </Panel>
 
 <style>
+  .timeline-title-group {
+    align-items: center;
+    display: flex;
+  }
   .timeline-title {
     padding: 0px 4px;
     user-select: none;

--- a/src/components/timeline/TimelineStatusIndicator.svelte
+++ b/src/components/timeline/TimelineStatusIndicator.svelte
@@ -7,6 +7,7 @@
   import { activityDirectivesDB } from '../../stores/activities';
   import { constraintRuns } from '../../stores/constraints';
   import { selectedExternalEventsRaw } from '../../stores/external-event';
+  import { schedulingAnalysisStatus } from '../../stores/scheduling';
   import { initialSpansLoading, simulationStatus } from '../../stores/simulation';
   import { timelineResourcesErroring, timelineResourcesLoading } from '../../stores/timelineResourceStatus';
   import { tooltip } from '../../utilities/tooltip';
@@ -20,6 +21,14 @@
     $simulationStatus => $simulationStatus === Status.Pending || $simulationStatus === Status.Incomplete,
   );
 
+  // Scheduling produces new activities and typically re-simulates, so keep the
+  // indicator up while a scheduling run is in flight.
+  const schedulingRunning: Readable<boolean> = derived(
+    schedulingAnalysisStatus,
+    $schedulingAnalysisStatus =>
+      $schedulingAnalysisStatus === Status.Pending || $schedulingAnalysisStatus === Status.Incomplete,
+  );
+
   const loading: Readable<boolean> = derived(
     [
       timelineResourcesLoading,
@@ -28,6 +37,7 @@
       constraintRuns.loading,
       selectedExternalEventsRaw.loading,
       simulationStreaming,
+      schedulingRunning,
     ],
     values => values.some(Boolean),
   );

--- a/src/components/timeline/TimelineStatusIndicator.svelte
+++ b/src/components/timeline/TimelineStatusIndicator.svelte
@@ -1,0 +1,71 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { LoaderCircle, TriangleAlert } from 'lucide-svelte';
+  import { derived, type Readable } from 'svelte/store';
+  import { activityDirectivesDB } from '../../stores/activities';
+  import { constraintRuns } from '../../stores/constraints';
+  import { selectedExternalEventsRaw } from '../../stores/external-event';
+  import { profilesErroring, profilesLoading } from '../../stores/profile';
+  import { fetchingResourcesExternal, initialSpansLoading } from '../../stores/simulation';
+  import { tooltip } from '../../utilities/tooltip';
+
+  type StatusError = { message: string; source: string };
+
+  // Aggregate loading/error from every timeline data source. Inline rather than
+  // a dedicated store — only consumer is this indicator.
+  const loading: Readable<boolean> = derived(
+    [
+      profilesLoading,
+      fetchingResourcesExternal,
+      initialSpansLoading,
+      activityDirectivesDB.loading,
+      constraintRuns.loading,
+      selectedExternalEventsRaw.loading,
+    ],
+    values => values.some(Boolean),
+  );
+
+  const errors: Readable<StatusError[]> = derived(
+    [profilesErroring, activityDirectivesDB.error, constraintRuns.error, selectedExternalEventsRaw.error],
+    ([profileErrs, directivesErr, constraintsErr, eventsErr]) => {
+      const out: StatusError[] = [];
+      profileErrs.forEach(e => out.push({ message: e.error, source: `Profile ${e.name}` }));
+      if (directivesErr) {
+        out.push({ message: directivesErr, source: 'Activity directives' });
+      }
+      if (constraintsErr) {
+        out.push({ message: constraintsErr, source: 'Constraint runs' });
+      }
+      if (eventsErr) {
+        out.push({ message: eventsErr, source: 'External events' });
+      }
+      return out;
+    },
+  );
+
+  $: errorCount = $errors.length;
+  $: hasError = errorCount > 0;
+  $: errorTooltip = hasError ? $errors.map(e => `${e.source}: ${e.message}`).join('\n') : '';
+</script>
+
+{#if hasError}
+  <div
+    class="ml-2 inline-flex items-center gap-1 text-destructive"
+    use:tooltip={{ content: errorTooltip, placement: 'bottom' }}
+    role="status"
+    aria-label="Timeline data error"
+  >
+    <TriangleAlert size={14} />
+    <span class="text-xs font-medium">{errorCount}</span>
+  </div>
+{:else if $loading}
+  <div
+    class="ml-2 inline-flex items-center text-muted-foreground"
+    use:tooltip={{ content: 'Loading timeline data…', placement: 'bottom' }}
+    role="status"
+    aria-label="Timeline loading"
+  >
+    <LoaderCircle size={14} class="animate-spin" />
+  </div>
+{/if}

--- a/src/components/timeline/TimelineStatusIndicator.svelte
+++ b/src/components/timeline/TimelineStatusIndicator.svelte
@@ -3,34 +3,43 @@
 <script lang="ts">
   import { LoaderCircle, TriangleAlert } from 'lucide-svelte';
   import { derived, type Readable } from 'svelte/store';
+  import { Status } from '../../enums/status';
   import { activityDirectivesDB } from '../../stores/activities';
   import { constraintRuns } from '../../stores/constraints';
   import { selectedExternalEventsRaw } from '../../stores/external-event';
-  import { profilesErroring, profilesLoading } from '../../stores/profile';
-  import { fetchingResourcesExternal, initialSpansLoading } from '../../stores/simulation';
+  import { initialSpansLoading, simulationStatus } from '../../stores/simulation';
+  import { timelineResourcesErroring, timelineResourcesLoading } from '../../stores/timelineResourceStatus';
   import { tooltip } from '../../utilities/tooltip';
 
   type StatusError = { message: string; source: string };
 
-  // Aggregate loading/error from every timeline data source. Inline rather than
-  // a dedicated store — only consumer is this indicator.
+  // Profile subs flip out of `loading` on first batch; without this the
+  // indicator would hide mid-sim while data is still streaming.
+  const simulationStreaming: Readable<boolean> = derived(
+    simulationStatus,
+    $simulationStatus => $simulationStatus === Status.Pending || $simulationStatus === Status.Incomplete,
+  );
+
   const loading: Readable<boolean> = derived(
     [
-      profilesLoading,
-      fetchingResourcesExternal,
+      timelineResourcesLoading,
       initialSpansLoading,
       activityDirectivesDB.loading,
       constraintRuns.loading,
       selectedExternalEventsRaw.loading,
+      simulationStreaming,
     ],
     values => values.some(Boolean),
   );
 
   const errors: Readable<StatusError[]> = derived(
-    [profilesErroring, activityDirectivesDB.error, constraintRuns.error, selectedExternalEventsRaw.error],
-    ([profileErrs, directivesErr, constraintsErr, eventsErr]) => {
+    [timelineResourcesErroring, activityDirectivesDB.error, constraintRuns.error, selectedExternalEventsRaw.error],
+    ([resourceErrs, directivesErr, constraintsErr, eventsErr]) => {
       const out: StatusError[] = [];
-      profileErrs.forEach(e => out.push({ message: e.error, source: `Profile ${e.name}` }));
+      resourceErrs.forEach(e => {
+        const label = e.kind === 'external' ? 'External profile' : 'Profile';
+        out.push({ message: e.error, source: `${label} ${e.name}` });
+      });
       if (directivesErr) {
         out.push({ message: directivesErr, source: 'Activity directives' });
       }
@@ -46,6 +55,8 @@
 
   $: errorCount = $errors.length;
   $: hasError = errorCount > 0;
+  // `\n` renders as a line break — tooltip.css sets white-space: pre-line
+  // on .tippy-content globally.
   $: errorTooltip = hasError ? $errors.map(e => `${e.source}: ${e.message}`).join('\n') : '';
 </script>
 

--- a/src/enums/gql.ts
+++ b/src/enums/gql.ts
@@ -193,7 +193,6 @@ export enum Queries {
   PLAN_SNAPSHOTS = 'plan_snapshot',
   PLAN_SNAPSHOT_ACTIVITIES = 'plan_snapshot_activities',
   PROFILES = 'profile',
-  PROFILE_SEGMENT_STREAM = 'profile_segment_stream',
   RESOURCE_TYPES = 'resource_type',
   RESTORE_ACTIVITY_FROM_CHANGELOG = 'restoreActivityFromChangelog',
   RESTORE_FROM_SNAPSHOT = 'restore_from_snapshot',

--- a/src/enums/gql.ts
+++ b/src/enums/gql.ts
@@ -193,6 +193,7 @@ export enum Queries {
   PLAN_SNAPSHOTS = 'plan_snapshot',
   PLAN_SNAPSHOT_ACTIVITIES = 'plan_snapshot_activities',
   PROFILES = 'profile',
+  PROFILE_SEGMENT_STREAM = 'profile_segment_stream',
   RESOURCE_TYPES = 'resource_type',
   RESTORE_ACTIVITY_FROM_CHANGELOG = 'restoreActivityFromChangelog',
   RESTORE_FROM_SNAPSHOT = 'restore_from_snapshot',

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -120,8 +120,6 @@
   import {
     enableSimulation,
     externalResourceNames,
-    externalResources,
-    fetchingResourcesExternal,
     initialSpansLoading,
     resetSimulationStores,
     resourceTypes,
@@ -205,7 +203,6 @@
   let selectedSimulationStatus: Status | null;
   let windowWidth = 1600;
   let simulationDataAbortController: AbortController;
-  let resourcesExternalAbortController: AbortController;
   let schedulingStatusText: string = '';
   let lastSimulationDatasetId: number | null = null;
   let consolePaneApi: PaneAPI;
@@ -399,35 +396,17 @@
   // before the view loads would read `$view === null` and stay false until the next view change.
   $: hasUpdateViewPermission = $view !== null ? featurePermissions.view.canUpdate($user, $view) : false;
 
-  $: if ($planId > -1 && $planStartTimeYmd && $planDatasets) {
-    const datasetNames = [];
-
+  // External profile names. The actual profile data is fetched on demand
+  // per visible row by createExternalResourceSubscription (see
+  // stores/externalResource.ts), driven off the same planDatasets sub.
+  $: if ($planDatasets) {
+    const names = new Set<string>();
     for (const dataset of $planDatasets) {
       for (const profile of dataset.dataset.profiles) {
-        datasetNames.push(profile.name);
+        names.add(profile.name);
       }
     }
-
-    $externalResourceNames = [...new Set(datasetNames)];
-
-    resourcesExternalAbortController?.abort();
-    resourcesExternalAbortController = new AbortController();
-    $fetchingResourcesExternal = true;
-    $externalResources = [];
-    effects
-      .getResourcesExternal(
-        $planId,
-        $simulationDatasetId > -1 ? $simulationDatasetId : null,
-        $planStartTimeYmd,
-        get(user),
-        resourcesExternalAbortController.signal,
-      )
-      .then(({ aborted, resources }) => {
-        if (!aborted) {
-          $externalResources = resources;
-          $fetchingResourcesExternal = false;
-        }
-      });
+    $externalResourceNames = [...names];
   }
 
   $: if ($planId > -1) {
@@ -462,6 +441,9 @@
     simulationDataAbortController?.abort();
     $spans = null;
     $simulationEvents = null;
+    // Only the Complete branch fetches spans; clear the flag in every other
+    // branch so the global indicator doesn't spin forever on failed/no-sim.
+    $initialSpansLoading = false;
   }
 
   $: compactNavMode = windowWidth < 1200;
@@ -502,8 +484,8 @@
   $: if (typeof $planModelId === 'number' && browser) {
     // Asynchronously fetch resource types
     $resourceTypesLoading = true;
-    effects.getResourceTypes($planModelId, get(user)).then(initialResourceTypes => {
-      $resourceTypes = initialResourceTypes;
+    effects.getResourceTypes($planModelId, get(user)).then(modelResourceTypes => {
+      $resourceTypes = modelResourceTypes;
       $resourceTypesLoading = false;
     });
   }

--- a/src/stores/__mocks__/plan.mock.ts
+++ b/src/stores/__mocks__/plan.mock.ts
@@ -2,6 +2,7 @@ import { derived, writable, type Readable, type Writable } from 'svelte/store';
 import type { ActivityType } from '../../types/activity';
 import type { ModelSlim } from '../../types/model';
 import type { Plan, PlanMergeRequest, PlanMetadata } from '../../types/plan';
+import type { PlanDataset } from '../../types/simulation';
 import type { Tag } from '../../types/tags';
 import type { TimeRange } from '../../types/timeline';
 
@@ -57,6 +58,8 @@ export const planEndTimeDoy: Readable<string> = derived(plan, $plan => $plan?.en
 /* Subscriptions. */
 
 export const activityTypes = writable<ActivityType[]>([]);
+
+export const planDatasets = writable<PlanDataset[]>([]);
 
 export const planTags = writable<Tag[]>([]);
 

--- a/src/stores/externalResource.test.ts
+++ b/src/stores/externalResource.test.ts
@@ -235,9 +235,7 @@ describe('createExternalResourceSubscription', () => {
 
     // Duration grows (backend appended more segments). Trigger via a
     // metadata push with the new duration.
-    getExternalProfileSegmentsSinceMock.mockResolvedValueOnce(
-      segments([{ start_offset: '00:01:00', value: 'C' }]),
-    );
+    getExternalProfileSegmentsSinceMock.mockResolvedValueOnce(segments([{ start_offset: '00:01:00', value: 'C' }]));
     planDatasetsValue.set([
       makePlanDataset({ datasetId: 1, profiles: [makeProfile({ duration: '00:02:00', id: 11, name: 'r' })] }),
     ]);
@@ -269,9 +267,7 @@ describe('createExternalResourceSubscription', () => {
   });
 
   test('profile-row switch resets accumulator and refetches with sentinel offset', async () => {
-    getExternalProfileSegmentsSinceMock.mockResolvedValueOnce(
-      segments([{ start_offset: '00:00:30', value: 'A' }]),
-    );
+    getExternalProfileSegmentsSinceMock.mockResolvedValueOnce(segments([{ start_offset: '00:00:30', value: 'A' }]));
 
     const profileA = makeProfile({ duration: '00:01:00', id: 11, name: 'r' });
     planDatasetsValue.set([makePlanDataset({ datasetId: 1, profiles: [profileA] })]);
@@ -286,9 +282,7 @@ describe('createExternalResourceSubscription', () => {
     // A different profile under the same name (different id and dataset)
     // wins on the next tick. Accumulator must reset and refetch with the
     // sentinel.
-    getExternalProfileSegmentsSinceMock.mockResolvedValueOnce(
-      segments([{ start_offset: '00:00:00', value: 'B' }]),
-    );
+    getExternalProfileSegmentsSinceMock.mockResolvedValueOnce(segments([{ start_offset: '00:00:00', value: 'B' }]));
     const profileB = makeProfile({ duration: '00:01:00', id: 99, name: 'r' });
     planDatasetsValue.set([makePlanDataset({ datasetId: 2, profiles: [profileB] })]);
     await flushPromises();

--- a/src/stores/externalResource.test.ts
+++ b/src/stores/externalResource.test.ts
@@ -1,0 +1,340 @@
+import { writable, type Subscriber, type Writable } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { PlanDataset, Profile, ProfileSegment, Resource } from '../types/simulation';
+
+const getExternalProfileSegmentsSinceMock = vi.fn();
+vi.mock('../utilities/effects', () => ({
+  default: {
+    getExternalProfileSegmentsSince: (...args: any[]) => getExternalProfileSegmentsSinceMock(...args),
+  },
+}));
+
+// A planDatasets mock that mimics the gqlSubscribable shape used by the
+// factory: a primary store + a `.loading` substore. We can't import the real
+// gqlSubscribable here because it pulls in `$env/dynamic/public` via the
+// shared WebSocket client, which Vitest can't satisfy.
+type PlanDatasetsMock = {
+  _setLoading: (v: boolean) => void;
+  loading: { subscribe: (s: Subscriber<boolean>) => () => void };
+  set: (v: PlanDataset[]) => void;
+  subscribe: (s: Subscriber<PlanDataset[]>) => () => void;
+};
+
+const planDatasetsValue: Writable<PlanDataset[]> = writable([]);
+const planDatasetsLoading: Writable<boolean> = writable(true);
+const planDatasetsMock: PlanDatasetsMock = {
+  _setLoading: v => planDatasetsLoading.set(v),
+  loading: { subscribe: planDatasetsLoading.subscribe },
+  set: v => planDatasetsValue.set(v),
+  subscribe: planDatasetsValue.subscribe,
+};
+vi.mock('./plan', () => ({
+  planDatasets: planDatasetsMock,
+}));
+
+vi.mock('./errors', () => ({
+  catchError: vi.fn(),
+  logMessage: vi.fn(),
+}));
+
+function makeProfile(opts: { duration: string; id: number; name: string }): Profile {
+  return {
+    dataset_id: 0,
+    duration: opts.duration,
+    id: opts.id,
+    name: opts.name,
+    profile_segments: [],
+    type: { schema: { type: 'string' } as any, type: 'discrete' },
+  };
+}
+
+function makePlanDataset(opts: {
+  datasetId: number;
+  offset?: string;
+  profiles: Profile[];
+  simDatasetId?: number | null;
+}): PlanDataset {
+  return {
+    dataset: { profiles: opts.profiles },
+    dataset_id: opts.datasetId,
+    offset_from_plan_start: opts.offset ?? '00:00:00',
+    simulation_dataset_id: opts.simDatasetId ?? null,
+  };
+}
+
+function segments(specs: Array<{ start_offset: string; value: any }>): ProfileSegment[] {
+  return specs.map(s => ({
+    dataset_id: 0,
+    dynamics: s.value,
+    is_gap: false,
+    profile_id: 0,
+    start_offset: s.start_offset,
+  }));
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe('createExternalResourceSubscription', () => {
+  let createExternalResourceSubscription: typeof import('./externalResource').createExternalResourceSubscription;
+  // Track subs across the test so afterEach can clean up even if a test
+  // fails before its inline unsubscribe — a leaked sub would steal mock
+  // slots from the next test.
+  let activeSubs: Array<{ unsubscribe: () => void }> = [];
+  function makeSub(...args: Parameters<typeof createExternalResourceSubscription>) {
+    const sub = createExternalResourceSubscription(...args);
+    activeSubs.push(sub);
+    return sub;
+  }
+
+  beforeEach(async () => {
+    getExternalProfileSegmentsSinceMock.mockReset();
+    planDatasetsValue.set([]);
+    planDatasetsLoading.set(true);
+    vi.resetModules();
+    // Dynamic import so vi.resetModules() takes effect — the factory closes
+    // over the mocked planDatasets/effects at import time.
+    const mod = await import('./externalResource');
+    createExternalResourceSubscription = mod.createExternalResourceSubscription;
+  });
+
+  afterEach(() => {
+    activeSubs.forEach(s => s.unsubscribe());
+    activeSubs = [];
+    getExternalProfileSegmentsSinceMock.mockReset();
+  });
+
+  test('settling → found: first fetch resolves to a Resource', async () => {
+    getExternalProfileSegmentsSinceMock.mockResolvedValue(
+      segments([
+        { start_offset: '00:00:00', value: 'A' },
+        { start_offset: '00:01:00', value: 'B' },
+      ]),
+    );
+
+    // Sub created while planDatasets is still loading — must stay in
+    // loading state and NOT flash an error.
+    const sub = makeSub(-1, 'r', '2024-01-01T00:00:00', null);
+    let last: any = null;
+    sub.store.subscribe(s => {
+      last = s;
+    });
+    await flushPromises();
+
+    expect(last.loading).toBe(true);
+    expect(last.error).toBe('');
+
+    // Subscription settles with a populated planDatasets that has the name.
+    const profile = makeProfile({ duration: '00:02:00', id: 7, name: 'r' });
+    planDatasetsValue.set([makePlanDataset({ datasetId: 1, profiles: [profile] })]);
+    planDatasetsLoading.set(false);
+    await flushPromises();
+
+    expect(last.loading).toBe(false);
+    expect(last.error).toBe('');
+    expect(last.resource).not.toBeNull();
+    expect((last.resource as Resource).values.length).toBeGreaterThan(0);
+  });
+
+  test('race-defer: settling → missing → found does NOT surface the missing error', async () => {
+    getExternalProfileSegmentsSinceMock.mockResolvedValue(segments([{ start_offset: '00:00:00', value: 'A' }]));
+
+    const profile = makeProfile({ duration: '00:01:00', id: 9, name: 'r' });
+    const sub = makeSub(-1, 'r', '2024-01-01T00:00:00', null);
+    const seen: Array<{ error: string; loading: boolean }> = [];
+    sub.store.subscribe(s => {
+      seen.push({ error: s.error, loading: s.loading });
+    });
+
+    // The actual race: gqlSubscribable.next() flips `.loading` before the
+    // value subscribers fire, so the derived briefly sees loading=false +
+    // value=[]. Emulate that ordering: flip loading first (within the same
+    // synchronous frame), then set the value. The microtask defer should
+    // cancel the missing emit.
+    planDatasetsLoading.set(false);
+    planDatasetsValue.set([makePlanDataset({ datasetId: 1, profiles: [profile] })]);
+    await flushPromises();
+
+    expect(seen.every(s => s.error === '')).toBe(true);
+  });
+
+  test('settled missing → error fires after microtask', async () => {
+    const sub = makeSub(-1, 'r', '2024-01-01T00:00:00', null);
+    let last: any = null;
+    sub.store.subscribe(s => {
+      last = s;
+    });
+
+    // Settle with no matching profile and let the microtask run.
+    planDatasetsValue.set([makePlanDataset({ datasetId: 1, profiles: [] })]);
+    planDatasetsLoading.set(false);
+    await flushPromises();
+
+    expect(last.error).toBe('Resource not found in attached external datasets');
+    expect(last.loading).toBe(false);
+    expect(last.resource).toBeNull();
+  });
+
+  test('sim-tied plan_dataset row is preferred over plan-level (null sim) row', async () => {
+    getExternalProfileSegmentsSinceMock.mockResolvedValue(segments([{ start_offset: '00:00:00', value: 'A' }]));
+
+    const profile = makeProfile({ duration: '00:02:00', id: 11, name: 'r' });
+    planDatasetsValue.set([
+      makePlanDataset({ datasetId: 1, profiles: [profile], simDatasetId: null }),
+      makePlanDataset({ datasetId: 2, profiles: [profile], simDatasetId: 42 }),
+    ]);
+    planDatasetsLoading.set(false);
+
+    const sub = makeSub(42, 'r', '2024-01-01T00:00:00', null);
+    sub.store.subscribe(() => {});
+    await flushPromises();
+
+    expect(getExternalProfileSegmentsSinceMock).toHaveBeenCalled();
+    const [firstCall] = getExternalProfileSegmentsSinceMock.mock.calls;
+    expect(firstCall[0]).toBe(2); // datasetId from the sim-tied row, not the plan-level one
+  });
+
+  test('plan-level (null sim) row is preferred over a non-matching sim row', async () => {
+    getExternalProfileSegmentsSinceMock.mockResolvedValue(segments([{ start_offset: '00:00:00', value: 'A' }]));
+
+    const profile = makeProfile({ duration: '00:02:00', id: 11, name: 'r' });
+    planDatasetsValue.set([
+      makePlanDataset({ datasetId: 3, profiles: [profile], simDatasetId: 99 }),
+      makePlanDataset({ datasetId: 4, profiles: [profile], simDatasetId: null }),
+    ]);
+    planDatasetsLoading.set(false);
+
+    // sub watches sim 42; neither row matches, so plan-level (datasetId=4) wins.
+    const sub = makeSub(42, 'r', '2024-01-01T00:00:00', null);
+    sub.store.subscribe(() => {});
+    await flushPromises();
+
+    const [firstCall] = getExternalProfileSegmentsSinceMock.mock.calls;
+    expect(firstCall[0]).toBe(4);
+  });
+
+  test('duration advance triggers a refetch with the last seen offset as sinceOffset', async () => {
+    getExternalProfileSegmentsSinceMock.mockResolvedValueOnce(
+      segments([
+        { start_offset: '00:00:00', value: 'A' },
+        { start_offset: '00:00:30', value: 'B' },
+      ]),
+    );
+
+    const profile = makeProfile({ duration: '00:01:00', id: 11, name: 'r' });
+    planDatasetsValue.set([makePlanDataset({ datasetId: 1, profiles: [profile] })]);
+    planDatasetsLoading.set(false);
+
+    const sub = makeSub(-1, 'r', '2024-01-01T00:00:00', null);
+    sub.store.subscribe(() => {});
+    await flushPromises();
+
+    expect(getExternalProfileSegmentsSinceMock.mock.calls[0][2]).toBe('-00:00:01');
+
+    // Duration grows (backend appended more segments). Trigger via a
+    // metadata push with the new duration.
+    getExternalProfileSegmentsSinceMock.mockResolvedValueOnce(
+      segments([{ start_offset: '00:01:00', value: 'C' }]),
+    );
+    planDatasetsValue.set([
+      makePlanDataset({ datasetId: 1, profiles: [makeProfile({ duration: '00:02:00', id: 11, name: 'r' })] }),
+    ]);
+    await flushPromises();
+
+    expect(getExternalProfileSegmentsSinceMock.mock.calls[1][2]).toBe('00:00:30');
+  });
+
+  test('unchanged metadata does NOT trigger a refetch', async () => {
+    getExternalProfileSegmentsSinceMock.mockResolvedValueOnce(segments([{ start_offset: '00:00:00', value: 'A' }]));
+
+    const profile = makeProfile({ duration: '00:01:00', id: 11, name: 'r' });
+    planDatasetsValue.set([makePlanDataset({ datasetId: 1, profiles: [profile] })]);
+    planDatasetsLoading.set(false);
+
+    const sub = makeSub(-1, 'r', '2024-01-01T00:00:00', null);
+    sub.store.subscribe(() => {});
+    await flushPromises();
+
+    expect(getExternalProfileSegmentsSinceMock).toHaveBeenCalledTimes(1);
+
+    // Re-emit identical metadata (same duration, same row). Should not
+    // re-refetch — would otherwise hammer the backend on every metadata
+    // tick during ingestion.
+    planDatasetsValue.set([makePlanDataset({ datasetId: 1, profiles: [profile] })]);
+    await flushPromises();
+
+    expect(getExternalProfileSegmentsSinceMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('profile-row switch resets accumulator and refetches with sentinel offset', async () => {
+    getExternalProfileSegmentsSinceMock.mockResolvedValueOnce(
+      segments([{ start_offset: '00:00:30', value: 'A' }]),
+    );
+
+    const profileA = makeProfile({ duration: '00:01:00', id: 11, name: 'r' });
+    planDatasetsValue.set([makePlanDataset({ datasetId: 1, profiles: [profileA] })]);
+    planDatasetsLoading.set(false);
+
+    const sub = makeSub(-1, 'r', '2024-01-01T00:00:00', null);
+    sub.store.subscribe(() => {});
+    await flushPromises();
+
+    expect(getExternalProfileSegmentsSinceMock.mock.calls[0][2]).toBe('-00:00:01');
+
+    // A different profile under the same name (different id and dataset)
+    // wins on the next tick. Accumulator must reset and refetch with the
+    // sentinel.
+    getExternalProfileSegmentsSinceMock.mockResolvedValueOnce(
+      segments([{ start_offset: '00:00:00', value: 'B' }]),
+    );
+    const profileB = makeProfile({ duration: '00:01:00', id: 99, name: 'r' });
+    planDatasetsValue.set([makePlanDataset({ datasetId: 2, profiles: [profileB] })]);
+    await flushPromises();
+
+    expect(getExternalProfileSegmentsSinceMock.mock.calls[1][0]).toBe(2);
+    expect(getExternalProfileSegmentsSinceMock.mock.calls[1][1]).toBe(99);
+    expect(getExternalProfileSegmentsSinceMock.mock.calls[1][2]).toBe('-00:00:01');
+  });
+
+  test('refetch error surfaces in state', async () => {
+    getExternalProfileSegmentsSinceMock.mockRejectedValue(new Error('boom'));
+
+    const profile = makeProfile({ duration: '00:01:00', id: 11, name: 'r' });
+    planDatasetsValue.set([makePlanDataset({ datasetId: 1, profiles: [profile] })]);
+    planDatasetsLoading.set(false);
+
+    const sub = makeSub(-1, 'r', '2024-01-01T00:00:00', null);
+    let last: any = null;
+    sub.store.subscribe(s => {
+      last = s;
+    });
+    await flushPromises();
+
+    expect(last.error).toBe('boom');
+    expect(last.loading).toBe(false);
+  });
+
+  test('dispose during in-flight refetch: no state mutations after unsubscribe', async () => {
+    let resolveFetch: (v: ProfileSegment[] | null) => void = () => {};
+    getExternalProfileSegmentsSinceMock.mockReturnValue(new Promise<ProfileSegment[] | null>(r => (resolveFetch = r)));
+
+    const profile = makeProfile({ duration: '00:01:00', id: 11, name: 'r' });
+    planDatasetsValue.set([makePlanDataset({ datasetId: 1, profiles: [profile] })]);
+    planDatasetsLoading.set(false);
+
+    const sub = makeSub(-1, 'r', '2024-01-01T00:00:00', null);
+    let updates = 0;
+    sub.store.subscribe(() => {
+      updates++;
+    });
+    const baseline = updates;
+
+    sub.unsubscribe();
+    resolveFetch(segments([{ start_offset: '00:00:00', value: 'A' }]));
+    await flushPromises();
+
+    expect(updates).toBe(baseline);
+  });
+});

--- a/src/stores/externalResource.test.ts
+++ b/src/stores/externalResource.test.ts
@@ -2,6 +2,15 @@ import { writable, type Subscriber, type Writable } from 'svelte/store';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { PlanDataset, Profile, ProfileSegment, Resource } from '../types/simulation';
 
+// required for tests which transitively import `$env/dynamic/public` - unavailable in the vitest environment
+vi.mock('$env/dynamic/public', () => ({
+  env: {
+    PUBLIC_HASURA_CLIENT_URL: 'http://test/hasura',
+    PUBLIC_HASURA_SERVER_URL: 'http://test/hasura',
+    PUBLIC_WORKSPACE_CLIENT_URL: 'http://test/ws',
+  },
+}));
+
 const getExternalProfileSegmentsSinceMock = vi.fn();
 vi.mock('../utilities/effects', () => ({
   default: {
@@ -29,7 +38,15 @@ const planDatasetsMock: PlanDatasetsMock = {
   subscribe: planDatasetsValue.subscribe,
 };
 vi.mock('./plan', () => ({
+  plan: writable({}),
   planDatasets: planDatasetsMock,
+  planEndTimeDoy: writable(''),
+  planId: writable(1),
+  planModelId: writable(1),
+  planModelRevision: writable(1),
+  planRevision: writable(1),
+  planStartTimeMs: writable(''),
+  planStartTimeYmd: writable(''),
 }));
 
 vi.mock('./errors', () => ({

--- a/src/stores/externalResource.ts
+++ b/src/stores/externalResource.ts
@@ -2,7 +2,7 @@ import { derived, writable, type Readable } from 'svelte/store';
 import type { User } from '../types/app';
 import type { Profile, ProfileSegment, Resource } from '../types/simulation';
 import effects from '../utilities/effects';
-import { sampleProfiles } from '../utilities/resources';
+import { INITIAL_SINCE, sampleProfiles } from '../utilities/resources';
 import { catchError } from './errors';
 import { planDatasets } from './plan';
 import {
@@ -16,11 +16,6 @@ export type ExternalResourceSubscription = {
   store: Readable<TimelineResourceState>;
   unsubscribe: () => void;
 };
-
-// First-fetch sentinel: smaller than any real start_offset, so the windowed
-// query returns every existing segment. Postgres interval syntax (HH:MM:SS) —
-// Hasura's interval scalar rejects ISO 8601.
-const INITIAL_SINCE = '-00:00:01';
 
 type ProfileMetadata = {
   datasetId: number;

--- a/src/stores/externalResource.ts
+++ b/src/stores/externalResource.ts
@@ -1,0 +1,275 @@
+import { derived, writable, type Readable } from 'svelte/store';
+import type { User } from '../types/app';
+import type { Profile, ProfileSegment, Resource } from '../types/simulation';
+import effects from '../utilities/effects';
+import { sampleProfiles } from '../utilities/resources';
+import { catchError } from './errors';
+import { planDatasets } from './plan';
+import {
+  acquireTimelineResource,
+  releaseTimelineResource,
+  setTimelineResourceState,
+  type TimelineResourceState,
+} from './timelineResourceStatus';
+
+export type ExternalResourceSubscription = {
+  store: Readable<TimelineResourceState>;
+  unsubscribe: () => void;
+};
+
+// First-fetch sentinel: smaller than any real start_offset, so the windowed
+// query returns every existing segment. Postgres interval syntax (HH:MM:SS) —
+// Hasura's interval scalar rejects ISO 8601.
+const INITIAL_SINCE = '-00:00:01';
+
+type ProfileMetadata = {
+  datasetId: number;
+  duration: string;
+  offsetFromPlanStart: string;
+  profileId: number;
+  type: Profile['type'];
+};
+
+/**
+ * Per-(simDatasetId, name) live view of an external dataset resource.
+ * Mirrors createProfileSubscription: subscribes to a metadata source
+ * (planDatasets), windowed-pulls segments past the last seen start_offset
+ * whenever metadata advances, accumulates, and re-samples into a Resource.
+ *
+ * `simDatasetId` is the current simulation's dataset id (or -1 for plan-
+ * level). It's used to pick *which* plan_dataset row owns this name when
+ * multiple rows define it — preferring the row tied to the active sim, then
+ * the plan-level (null) row.
+ */
+export function createExternalResourceSubscription(
+  simDatasetId: number,
+  name: string,
+  planStartTimeYmd: string,
+  user: User | null,
+): ExternalResourceSubscription {
+  const initialState: TimelineResourceState = { error: '', loading: true, resource: null };
+  acquireTimelineResource(simDatasetId, name);
+  setTimelineResourceState(simDatasetId, name, 'external', initialState);
+  const state = writable<TimelineResourceState>(initialState);
+  function setState(next: TimelineResourceState) {
+    state.set(next);
+    setTimelineResourceState(simDatasetId, name, 'external', next);
+  }
+
+  const accumulator: ProfileSegment[] = [];
+  let sinceOffset = INITIAL_SINCE;
+  let resolved = false;
+  let lastError = '';
+  let inFlight = false;
+  // Re-fire once from the finally block if a refetch was requested while
+  // another was in flight, so we don't miss the tail if the request
+  // happened to be the last meaningful trigger (e.g. ingestion finished
+  // while we were already fetching).
+  let pendingRefetch = false;
+  // Tracks the metadata snapshot we last refetched against, so we only
+  // refire when duration advances or the chosen plan_dataset row changes.
+  let lastMeta: ProfileMetadata | null = null;
+  let currentMeta: ProfileMetadata | null = null;
+  let disposed = false;
+  const abortController = new AbortController();
+  const unsubscribers: Array<() => void> = [];
+
+  // Live metadata slice: pick the right plan_dataset row for (simDatasetId,
+  // name). Preference order: sim-matching > plan-level (null sim) > first
+  // encountered. Also surfaces "settling" so we don't flash a "not found"
+  // error during the initial subscription bootstrap.
+  type MetaResolution = { kind: 'settling' } | { kind: 'missing' } | { kind: 'found'; meta: ProfileMetadata };
+
+  type Candidate = { datasetId: number; offset: string; profile: Profile };
+
+  const metadata: Readable<MetaResolution> = derived(
+    [planDatasets, planDatasets.loading],
+    ([$planDatasets, $loading]): MetaResolution => {
+      if ($loading) {
+        return { kind: 'settling' };
+      }
+      let plan: Candidate | null = null;
+      let planLevel: Candidate | null = null;
+      let fallback: Candidate | null = null;
+      for (const pd of $planDatasets) {
+        const profile = pd.dataset.profiles.find(p => p.name === name);
+        if (!profile) {
+          continue;
+        }
+        const candidate: Candidate = { datasetId: pd.dataset_id, offset: pd.offset_from_plan_start, profile };
+        const simId = pd.simulation_dataset_id;
+        if (simDatasetId > -1 && simId === simDatasetId) {
+          plan = candidate;
+          break;
+        }
+        if (simId === null && planLevel === null) {
+          planLevel = candidate;
+        }
+        if (fallback === null) {
+          fallback = candidate;
+        }
+      }
+      const picked = plan ?? planLevel ?? fallback;
+      if (!picked) {
+        return { kind: 'missing' };
+      }
+      return {
+        kind: 'found',
+        meta: {
+          datasetId: picked.datasetId,
+          duration: picked.profile.duration,
+          offsetFromPlanStart: picked.offset,
+          profileId: picked.profile.id,
+          type: picked.profile.type,
+        },
+      };
+    },
+  );
+
+  function emit() {
+    if (disposed) {
+      return;
+    }
+    let resource: Resource | null = null;
+    if (currentMeta && resolved) {
+      const synthesised: Profile = {
+        dataset_id: currentMeta.datasetId,
+        duration: currentMeta.duration,
+        id: currentMeta.profileId,
+        name,
+        profile_segments: accumulator,
+        type: currentMeta.type,
+      };
+      resource = sampleProfiles([synthesised], planStartTimeYmd, currentMeta.offsetFromPlanStart)[0] ?? null;
+    }
+    const nextState: TimelineResourceState = { error: lastError, loading: !resolved && !lastError, resource };
+    setState(nextState);
+  }
+
+  async function refetch() {
+    if (disposed || !currentMeta) {
+      return;
+    }
+    if (inFlight) {
+      pendingRefetch = true;
+      return;
+    }
+    inFlight = true;
+    try {
+      const segments = await effects.getExternalProfileSegmentsSince(
+        currentMeta.datasetId,
+        currentMeta.profileId,
+        sinceOffset,
+        user,
+        abortController.signal,
+      );
+      if (disposed) {
+        return;
+      }
+      if (segments && segments.length > 0) {
+        accumulator.push(...segments);
+        sinceOffset = segments[segments.length - 1].start_offset;
+      }
+      resolved = true;
+      lastError = '';
+      emit();
+    } catch (e) {
+      if (disposed) {
+        return;
+      }
+      const err = e as Error;
+      if (err.name === 'AbortError') {
+        return;
+      }
+      lastError = err.message || 'External profile fetch failed';
+      emit();
+    } finally {
+      inFlight = false;
+      if (pendingRefetch && !disposed) {
+        pendingRefetch = false;
+        refetch();
+      }
+    }
+  }
+
+  function resetForNewProfile() {
+    accumulator.length = 0;
+    sinceOffset = INITIAL_SINCE;
+    resolved = false;
+  }
+
+  // Race-defer for missing: gqlSubscribable.next() flips `.loading` to
+  // false BEFORE propagating the new value to subscribers. So the derived
+  // briefly sees `{loading: false, planDatasets: []}` on the first tick and
+  // would emit 'missing' just before the value update arrives as 'found'.
+  // Defer the missing verdict by a microtask so a synchronously-following
+  // 'found' can cancel it. Genuine misconfigs still surface — the microtask
+  // flushes with `pendingMissing` still true.
+  let pendingMissing = false;
+
+  unsubscribers.push(
+    metadata.subscribe(next => {
+      if (disposed) {
+        return;
+      }
+      if (next.kind === 'settling') {
+        pendingMissing = false;
+        return;
+      }
+      if (next.kind === 'missing') {
+        pendingMissing = true;
+        queueMicrotask(() => {
+          if (disposed || !pendingMissing) {
+            return;
+          }
+          pendingMissing = false;
+          currentMeta = null;
+          lastMeta = null;
+          resetForNewProfile();
+          lastError = 'Resource not found in attached external datasets';
+          catchError(`Unable to load resource "${name}"`, new Error(lastError));
+          emit();
+        });
+        return;
+      }
+      pendingMissing = false;
+      const { meta } = next;
+      currentMeta = meta;
+      // If we switched to a different profile row (different dataset or id),
+      // reset accumulator and sinceOffset before refetching.
+      const switched =
+        lastMeta !== null && (lastMeta.datasetId !== meta.datasetId || lastMeta.profileId !== meta.profileId);
+      if (switched) {
+        resetForNewProfile();
+      }
+      const durationAdvanced = lastMeta === null || lastMeta.duration !== meta.duration;
+      lastMeta = meta;
+      // Assumption: external profiles only grow via `duration` advancement.
+      // If a backend ever appends segments without bumping duration, those
+      // segments are silently missed here — refetches are gated on duration.
+      // Static-at-write-time today; revisit if a "live external dataset"
+      // feature ships.
+      if (switched || durationAdvanced || !resolved) {
+        refetch();
+      } else if (lastError) {
+        // Re-emit to clear lingering error if metadata is now clean.
+        emit();
+      }
+      // Otherwise: meta unchanged, no error pending, no need to re-sample
+      // the full accumulator and re-push identical state downstream.
+    }),
+  );
+
+  return {
+    store: { subscribe: state.subscribe },
+    unsubscribe: () => {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      releaseTimelineResource(simDatasetId, name);
+      abortController.abort();
+      unsubscribers.forEach(unsub => unsub());
+    },
+  };
+}

--- a/src/stores/externalResource.ts
+++ b/src/stores/externalResource.ts
@@ -3,7 +3,7 @@ import type { User } from '../types/app';
 import type { Profile, ProfileSegment, Resource } from '../types/simulation';
 import effects from '../utilities/effects';
 import { INITIAL_SINCE, sampleProfiles } from '../utilities/resources';
-import { catchError } from './errors';
+import { catchError } from './console';
 import { planDatasets } from './plan';
 import {
   acquireTimelineResource,
@@ -222,7 +222,7 @@ export function createExternalResourceSubscription(
           lastMeta = null;
           resetForNewProfile();
           lastError = 'Resource not found in attached external datasets';
-          catchError(`Unable to load resource "${name}"`, new Error(lastError));
+          catchError('log', `Unable to load resource "${name}"`, new Error(lastError));
           emit();
         });
         return;

--- a/src/stores/profile.test.ts
+++ b/src/stores/profile.test.ts
@@ -2,6 +2,15 @@ import { writable, type Writable } from 'svelte/store';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { Profile, Resource, SimulationDataset } from '../types/simulation';
 
+// required for tests which transitively import `$env/dynamic/public` - unavailable in the vitest environment
+vi.mock('$env/dynamic/public', () => ({
+  env: {
+    PUBLIC_HASURA_CLIENT_URL: 'http://test/hasura',
+    PUBLIC_HASURA_SERVER_URL: 'http://test/hasura',
+    PUBLIC_WORKSPACE_CLIENT_URL: 'http://test/ws',
+  },
+}));
+
 const getProfileSinceMock = vi.fn();
 vi.mock('../utilities/effects', () => ({
   default: {
@@ -12,6 +21,10 @@ vi.mock('../utilities/effects', () => ({
 const simulationDatasetMock: Writable<SimulationDataset | null> = writable(null);
 vi.mock('./simulation', () => ({
   simulationDataset: simulationDatasetMock,
+  simulationDatasetLatestId: writable(null),
+  simulationDatasetsPlan: writable(null),
+  spanUtilityMaps: writable({}),
+  spansMap: writable({}),
 }));
 
 // Stub: `./errors` transitively pulls `$env/dynamic/public` via requests.ts.

--- a/src/stores/profile.test.ts
+++ b/src/stores/profile.test.ts
@@ -1,78 +1,11 @@
 import { writable, type Writable } from 'svelte/store';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import type { Profile, ProfileSegment, Resource, SimulationDataset } from '../types/simulation';
+import type { Profile, Resource, SimulationDataset } from '../types/simulation';
 
-// Integration tests for createProfileSubscription's state machine. The pure
-// helpers (dedupNewSegments, pickEffectiveDuration) live in utilities/profile
-// and are tested there in isolation. These tests cover the COORDINATION bugs
-// — what happens when prefetch / waitForProfile / streaming-sub / sim-status
-// interleave in adversarial ways. The resimulate-fast scenario is the one
-// that bit us in production; the dispose test is the standard "no leaks"
-// guard; the sim-flip test pins the closing-value swap.
-
-type MockSub<T> = {
-  emit: (raw: any) => void;
-  error: { subscribe: (cb: (v: string) => void) => () => void };
-  loading: { subscribe: (cb: (v: boolean) => void) => () => void };
-  query: string;
-  setError: (e: string) => void;
-  setLoading: (l: boolean) => void;
-  subscribe: (cb: (v: T) => void) => () => void;
-};
-
-const subInstances: MockSub<any>[] = [];
-
-vi.mock('./subscribable', () => ({
-  gqlSubscribable: vi.fn((query: string, _vars: any, initial: any, transformer?: (raw: any) => any) => {
-    let value = initial;
-    let loading = true;
-    let error = '';
-    const subs = new Set<(v: any) => void>();
-    const loadingSubs = new Set<(v: boolean) => void>();
-    const errorSubs = new Set<(v: string) => void>();
-    const instance: MockSub<any> = {
-      emit: raw => {
-        value = transformer ? transformer(raw) : raw;
-        subs.forEach(s => s(value));
-      },
-      error: {
-        subscribe: cb => {
-          errorSubs.add(cb);
-          cb(error);
-          return () => errorSubs.delete(cb);
-        },
-      },
-      loading: {
-        subscribe: cb => {
-          loadingSubs.add(cb);
-          cb(loading);
-          return () => loadingSubs.delete(cb);
-        },
-      },
-      query,
-      setError: e => {
-        error = e;
-        errorSubs.forEach(s => s(e));
-      },
-      setLoading: l => {
-        loading = l;
-        loadingSubs.forEach(s => s(l));
-      },
-      subscribe: cb => {
-        subs.add(cb);
-        cb(value);
-        return () => subs.delete(cb);
-      },
-    };
-    subInstances.push(instance);
-    return instance;
-  }),
-}));
-
-const getProfileMock = vi.fn();
+const getProfileSinceMock = vi.fn();
 vi.mock('../utilities/effects', () => ({
   default: {
-    getProfile: (...args: any[]) => getProfileMock(...args),
+    getProfileSince: (...args: any[]) => getProfileSinceMock(...args),
   },
 }));
 
@@ -81,11 +14,27 @@ vi.mock('./simulation', () => ({
   simulationDataset: simulationDatasetMock,
 }));
 
-function setSimRunning(datasetId: number) {
-  simulationDatasetMock.set({ canceled: false, dataset_id: datasetId, status: 'incomplete' } as SimulationDataset);
+// Stub: `./errors` transitively pulls `$env/dynamic/public` via requests.ts.
+vi.mock('./errors', () => ({
+  catchError: vi.fn(),
+  logMessage: vi.fn(),
+}));
+
+function setSimRunning(datasetId: number, extent: string = '00:00:00') {
+  simulationDatasetMock.set({
+    canceled: false,
+    dataset_id: datasetId,
+    extent: { extent },
+    status: 'incomplete',
+  } as SimulationDataset);
 }
-function setSimComplete(datasetId: number) {
-  simulationDatasetMock.set({ canceled: false, dataset_id: datasetId, status: 'success' } as SimulationDataset);
+function setSimComplete(datasetId: number, extent: string = '00:10:00') {
+  simulationDatasetMock.set({
+    canceled: false,
+    dataset_id: datasetId,
+    extent: { extent },
+    status: 'success',
+  } as SimulationDataset);
 }
 
 function makeProfile(opts: { duration: string; segments: Array<{ start_offset: string; value: any }> }): Profile {
@@ -105,10 +54,6 @@ function makeProfile(opts: { duration: string; segments: Array<{ start_offset: s
   };
 }
 
-function findSubByQuery(matcher: string): MockSub<any> | undefined {
-  return subInstances.find(s => s.query.includes(matcher));
-}
-
 async function flushPromises() {
   await Promise.resolve();
   await new Promise(resolve => setTimeout(resolve, 0));
@@ -116,124 +61,198 @@ async function flushPromises() {
 
 describe('createProfileSubscription', () => {
   let createProfileSubscription: typeof import('./profile').createProfileSubscription;
+  // Track subs so afterEach cleanup runs even if a test fails before its
+  // inline unsubscribe — a leaked sub would steal mockResolvedValueOnce
+  // slots from the next test.
+  let activeSubs: Array<{ unsubscribe: () => void }> = [];
+  function makeSub(...args: Parameters<typeof createProfileSubscription>) {
+    const sub = createProfileSubscription(...args);
+    activeSubs.push(sub);
+    return sub;
+  }
 
   beforeEach(async () => {
-    subInstances.length = 0;
-    getProfileMock.mockReset();
+    getProfileSinceMock.mockReset();
     simulationDatasetMock.set(null);
+    // `simulationDatasetMock` is module-scoped (top of file) so it survives
+    // resetModules — both the prior import and the fresh import below see
+    // the same writable. The fresh import is what we resubscribe against
+    // for each test.
     vi.resetModules();
     const mod = await import('./profile');
     createProfileSubscription = mod.createProfileSubscription;
   });
 
   afterEach(() => {
-    subInstances.length = 0;
+    activeSubs.forEach(s => s.unsubscribe());
+    activeSubs = [];
+    getProfileSinceMock.mockReset();
   });
 
-  // Regression test for the resimulate-on-fast-model bug: prefetch ran before
-  // the profile row existed, the live header sub delivered the row only after
-  // the sim had already terminated, and the streaming sub never opened — so
-  // accumulator stayed empty and the plot rendered nothing.
-  test('resimulate-fast: prefetch null + sim terminal at header-arrival opens stream for backfill', async () => {
-    getProfileMock.mockResolvedValue(null);
-    setSimRunning(1);
-    const sub = createProfileSubscription(1, 'r', '2024-01-01T00:00:00', null);
+  test('first refetch with full data emits a Resource and clears loading', async () => {
+    const profile = makeProfile({
+      duration: '00:02:00',
+      segments: [{ start_offset: '00:00:00', value: 'A' }],
+    });
+    getProfileSinceMock.mockResolvedValue(profile);
+    setSimComplete(1);
+
+    const sub = makeSub(1, 'r', '2024-01-01T00:00:00', null);
     let last: any;
     sub.store.subscribe(s => {
       last = s;
     });
     await flushPromises();
 
-    // Prefetch returned null → live header sub is open, no streaming sub yet.
-    expect(findSubByQuery('SubProfileHeader')).toBeDefined();
-    expect(findSubByQuery('SubProfileSegmentsStream')).toBeUndefined();
-
-    // Sim races to completion before header sub fires.
-    setSimComplete(1);
-    await flushPromises();
-
-    // Header sub eventually fires with the profile row.
-    const headerSub = findSubByQuery('SubProfileHeader')!;
-    headerSub.emit([{ dataset_id: 1, duration: '00:10:00', id: 7, name: 'r', type: { schema: {}, type: 'discrete' } }]);
-    await flushPromises();
-
-    // Even though sim is now terminal, the streaming sub MUST open to backfill
-    // segments — header sub doesn't carry segment columns and prefetch already
-    // returned null.
-    const streamSub = findSubByQuery('SubProfileSegmentsStream');
-    expect(streamSub).toBeDefined();
-
-    // Stream delivers existing segments (server returns rows past initial cursor
-    // regardless of sim status).
-    streamSub!.emit([
-      { dataset_id: 1, dynamics: 'A', is_gap: false, profile_id: 7, start_offset: '00:00:00' },
-      { dataset_id: 1, dynamics: 'B', is_gap: false, profile_id: 7, start_offset: '00:01:00' },
-    ] as ProfileSegment[]);
-    streamSub!.setLoading(false);
-    await flushPromises();
-
-    expect(last.resource).not.toBeNull();
-    expect((last.resource as Resource).values.length).toBeGreaterThan(0);
     expect(last.loading).toBe(false);
-
+    expect(last.error).toBe('');
+    expect(last.resource).not.toBeNull();
     sub.unsubscribe();
   });
 
-  test('sim flips terminal mid-stream: closing value swaps from lastOffset to header.duration', async () => {
-    const profile = makeProfile({
-      duration: '00:10:00',
-      segments: [{ start_offset: '00:00:00', value: 'A' }],
-    });
-    getProfileMock.mockResolvedValue(profile);
+  test('null response keeps loading true; subsequent tick refetches and resolves', async () => {
+    getProfileSinceMock.mockResolvedValueOnce(null);
     setSimRunning(1);
-    const sub = createProfileSubscription(1, 'r', '2024-01-01T00:00:00', null);
+    const sub = makeSub(1, 'r', '2024-01-01T00:00:00', null);
     let last: any;
     sub.store.subscribe(s => {
       last = s;
     });
     await flushPromises();
 
-    const streamSub = findSubByQuery('SubProfileSegmentsStream')!;
-    streamSub.emit([
-      { dataset_id: 1, dynamics: 'B', is_gap: false, profile_id: 7, start_offset: '00:01:00' },
-    ] as ProfileSegment[]);
-    streamSub.setLoading(false);
+    expect(last.loading).toBe(true);
+    expect(last.resource).toBeNull();
+
+    getProfileSinceMock.mockResolvedValueOnce(
+      makeProfile({ duration: '00:10:00', segments: [{ start_offset: '00:00:00', value: 'A' }] }),
+    );
+    setSimRunning(1, '00:00:30');
+    await flushPromises();
+
+    expect(last.loading).toBe(false);
+    expect(last.resource).not.toBeNull();
+    sub.unsubscribe();
+  });
+
+  test('subsequent refetch passes the last seen start_offset as sinceOffset', async () => {
+    getProfileSinceMock.mockResolvedValueOnce(
+      makeProfile({
+        duration: '00:10:00',
+        segments: [
+          { start_offset: '00:00:00', value: 'A' },
+          { start_offset: '00:01:00', value: 'B' },
+        ],
+      }),
+    );
+    setSimRunning(1);
+    const sub = makeSub(1, 'r', '2024-01-01T00:00:00', null);
+    sub.store.subscribe(() => {});
+    await flushPromises();
+
+    expect(getProfileSinceMock.mock.calls[0][2]).toBe('-00:00:01');
+
+    getProfileSinceMock.mockResolvedValueOnce(
+      makeProfile({ duration: '00:10:00', segments: [{ start_offset: '00:02:00', value: 'C' }] }),
+    );
+    setSimRunning(1, '00:02:00');
+    await flushPromises();
+
+    expect(getProfileSinceMock.mock.calls[1][2]).toBe('00:01:00');
+    sub.unsubscribe();
+  });
+
+  test('sim flips terminal: closing value swaps from lastOffset to header.duration', async () => {
+    getProfileSinceMock.mockResolvedValueOnce(
+      makeProfile({ duration: '00:10:00', segments: [{ start_offset: '00:01:00', value: 'A' }] }),
+    );
+    setSimRunning(1);
+    const sub = makeSub(1, 'r', '2024-01-01T00:00:00', null);
+    let last: any;
+    sub.store.subscribe(s => {
+      last = s;
+    });
     await flushPromises();
 
     const startMs = new Date('2024-01-01T00:00:00').getTime();
     let values = (last.resource as Resource).values;
-    // Streaming → closing at last segment offset (1m).
+    // Streaming: closing at last segment offset (1m).
     expect(values[values.length - 1].x).toBe(startMs + 60000);
 
+    getProfileSinceMock.mockResolvedValueOnce(makeProfile({ duration: '00:10:00', segments: [] }));
     setSimComplete(1);
     await flushPromises();
 
     values = (last.resource as Resource).values;
-    // Terminal → closing at header.duration (10m).
+    // Terminal: closing at header.duration (10m).
     expect(values[values.length - 1].x).toBe(startMs + 600000);
-
     sub.unsubscribe();
   });
 
-  test('dispose during pending prefetch: no state mutations after unsubscribe', async () => {
-    let resolvePrefetch: (v: Profile | null) => void = () => {};
-    getProfileMock.mockReturnValue(new Promise<Profile | null>(r => (resolvePrefetch = r)));
-    setSimRunning(1);
-    const sub = createProfileSubscription(1, 'r', '2024-01-01T00:00:00', null);
-
-    let updatesAfterUnsubscribe = 0;
-    sub.store.subscribe(() => {
-      updatesAfterUnsubscribe++;
+  // Regression: terminal sim + null profile must clear loading (no ticks
+  // will fire to retry).
+  test('terminal sim with null profile resolves loading instead of getting stuck', async () => {
+    getProfileSinceMock.mockResolvedValue(null);
+    setSimComplete(1);
+    const sub = makeSub(1, 'r', '2024-01-01T00:00:00', null);
+    let last: any;
+    sub.store.subscribe(s => {
+      last = s;
     });
-    const baseline = updatesAfterUnsubscribe;
-
-    sub.unsubscribe();
-    resolvePrefetch(makeProfile({ duration: '00:10:00', segments: [{ start_offset: '00:00:00', value: 'A' }] }));
     await flushPromises();
 
-    // No store update fired post-unsubscribe.
-    expect(updatesAfterUnsubscribe).toBe(baseline);
-    // No streaming sub was opened either.
-    expect(findSubByQuery('SubProfileSegmentsStream')).toBeUndefined();
+    expect(last.loading).toBe(false);
+    expect(last.error).toBe('');
+    expect(last.resource).toBeNull();
+  });
+
+  test('refetch error surfaces in state', async () => {
+    getProfileSinceMock.mockRejectedValue(new Error('boom'));
+    setSimRunning(1);
+    const sub = makeSub(1, 'r', '2024-01-01T00:00:00', null);
+    let last: any;
+    sub.store.subscribe(s => {
+      last = s;
+    });
+    await flushPromises();
+
+    expect(last.error).toBe('boom');
+    expect(last.loading).toBe(false);
+    sub.unsubscribe();
+  });
+
+  test('refetch error propagates to the global timelineResourcesErroring registry', async () => {
+    const { timelineResourcesErroring } = await import('./timelineResourceStatus');
+    getProfileSinceMock.mockRejectedValue(new Error('boom'));
+    setSimRunning(1);
+    const sub = makeSub(1, 'r', '2024-01-01T00:00:00', null);
+    let lastErrors: any[] = [];
+    const unsub = timelineResourcesErroring.subscribe(errs => {
+      lastErrors = errs;
+    });
+    await flushPromises();
+
+    expect(lastErrors).toHaveLength(1);
+    expect(lastErrors[0]).toMatchObject({ datasetId: 1, error: 'boom', name: 'r' });
+    unsub();
+    sub.unsubscribe();
+  });
+
+  test('dispose during in-flight refetch: no state mutations after unsubscribe', async () => {
+    let resolveFetch: (v: Profile | null) => void = () => {};
+    getProfileSinceMock.mockReturnValue(new Promise<Profile | null>(r => (resolveFetch = r)));
+    setSimRunning(1);
+    const sub = makeSub(1, 'r', '2024-01-01T00:00:00', null);
+
+    let updates = 0;
+    sub.store.subscribe(() => {
+      updates++;
+    });
+    const baseline = updates;
+
+    sub.unsubscribe();
+    resolveFetch(makeProfile({ duration: '00:10:00', segments: [{ start_offset: '00:00:00', value: 'A' }] }));
+    await flushPromises();
+
+    expect(updates).toBe(baseline);
   });
 });

--- a/src/stores/profile.test.ts
+++ b/src/stores/profile.test.ts
@@ -1,0 +1,239 @@
+import { writable, type Writable } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { Profile, ProfileSegment, Resource, SimulationDataset } from '../types/simulation';
+
+// Integration tests for createProfileSubscription's state machine. The pure
+// helpers (dedupNewSegments, pickEffectiveDuration) live in utilities/profile
+// and are tested there in isolation. These tests cover the COORDINATION bugs
+// — what happens when prefetch / waitForProfile / streaming-sub / sim-status
+// interleave in adversarial ways. The resimulate-fast scenario is the one
+// that bit us in production; the dispose test is the standard "no leaks"
+// guard; the sim-flip test pins the closing-value swap.
+
+type MockSub<T> = {
+  emit: (raw: any) => void;
+  error: { subscribe: (cb: (v: string) => void) => () => void };
+  loading: { subscribe: (cb: (v: boolean) => void) => () => void };
+  query: string;
+  setError: (e: string) => void;
+  setLoading: (l: boolean) => void;
+  subscribe: (cb: (v: T) => void) => () => void;
+};
+
+const subInstances: MockSub<any>[] = [];
+
+vi.mock('./subscribable', () => ({
+  gqlSubscribable: vi.fn((query: string, _vars: any, initial: any, transformer?: (raw: any) => any) => {
+    let value = initial;
+    let loading = true;
+    let error = '';
+    const subs = new Set<(v: any) => void>();
+    const loadingSubs = new Set<(v: boolean) => void>();
+    const errorSubs = new Set<(v: string) => void>();
+    const instance: MockSub<any> = {
+      emit: raw => {
+        value = transformer ? transformer(raw) : raw;
+        subs.forEach(s => s(value));
+      },
+      error: {
+        subscribe: cb => {
+          errorSubs.add(cb);
+          cb(error);
+          return () => errorSubs.delete(cb);
+        },
+      },
+      loading: {
+        subscribe: cb => {
+          loadingSubs.add(cb);
+          cb(loading);
+          return () => loadingSubs.delete(cb);
+        },
+      },
+      query,
+      setError: e => {
+        error = e;
+        errorSubs.forEach(s => s(e));
+      },
+      setLoading: l => {
+        loading = l;
+        loadingSubs.forEach(s => s(l));
+      },
+      subscribe: cb => {
+        subs.add(cb);
+        cb(value);
+        return () => subs.delete(cb);
+      },
+    };
+    subInstances.push(instance);
+    return instance;
+  }),
+}));
+
+const getProfileMock = vi.fn();
+vi.mock('../utilities/effects', () => ({
+  default: {
+    getProfile: (...args: any[]) => getProfileMock(...args),
+  },
+}));
+
+const simulationDatasetMock: Writable<SimulationDataset | null> = writable(null);
+vi.mock('./simulation', () => ({
+  simulationDataset: simulationDatasetMock,
+}));
+
+function setSimRunning(datasetId: number) {
+  simulationDatasetMock.set({ canceled: false, dataset_id: datasetId, status: 'incomplete' } as SimulationDataset);
+}
+function setSimComplete(datasetId: number) {
+  simulationDatasetMock.set({ canceled: false, dataset_id: datasetId, status: 'success' } as SimulationDataset);
+}
+
+function makeProfile(opts: { duration: string; segments: Array<{ start_offset: string; value: any }> }): Profile {
+  return {
+    dataset_id: 1,
+    duration: opts.duration,
+    id: 7,
+    name: 'r',
+    profile_segments: opts.segments.map(s => ({
+      dataset_id: 1,
+      dynamics: s.value,
+      is_gap: false,
+      profile_id: 7,
+      start_offset: s.start_offset,
+    })),
+    type: { schema: { type: 'string' } as any, type: 'discrete' },
+  };
+}
+
+function findSubByQuery(matcher: string): MockSub<any> | undefined {
+  return subInstances.find(s => s.query.includes(matcher));
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+describe('createProfileSubscription', () => {
+  let createProfileSubscription: typeof import('./profile').createProfileSubscription;
+
+  beforeEach(async () => {
+    subInstances.length = 0;
+    getProfileMock.mockReset();
+    simulationDatasetMock.set(null);
+    vi.resetModules();
+    const mod = await import('./profile');
+    createProfileSubscription = mod.createProfileSubscription;
+  });
+
+  afterEach(() => {
+    subInstances.length = 0;
+  });
+
+  // Regression test for the resimulate-on-fast-model bug: prefetch ran before
+  // the profile row existed, the live header sub delivered the row only after
+  // the sim had already terminated, and the streaming sub never opened — so
+  // accumulator stayed empty and the plot rendered nothing.
+  test('resimulate-fast: prefetch null + sim terminal at header-arrival opens stream for backfill', async () => {
+    getProfileMock.mockResolvedValue(null);
+    setSimRunning(1);
+    const sub = createProfileSubscription(1, 'r', '2024-01-01T00:00:00', null);
+    let last: any;
+    sub.store.subscribe(s => {
+      last = s;
+    });
+    await flushPromises();
+
+    // Prefetch returned null → live header sub is open, no streaming sub yet.
+    expect(findSubByQuery('SubProfileHeader')).toBeDefined();
+    expect(findSubByQuery('SubProfileSegmentsStream')).toBeUndefined();
+
+    // Sim races to completion before header sub fires.
+    setSimComplete(1);
+    await flushPromises();
+
+    // Header sub eventually fires with the profile row.
+    const headerSub = findSubByQuery('SubProfileHeader')!;
+    headerSub.emit([{ dataset_id: 1, duration: '00:10:00', id: 7, name: 'r', type: { schema: {}, type: 'discrete' } }]);
+    await flushPromises();
+
+    // Even though sim is now terminal, the streaming sub MUST open to backfill
+    // segments — header sub doesn't carry segment columns and prefetch already
+    // returned null.
+    const streamSub = findSubByQuery('SubProfileSegmentsStream');
+    expect(streamSub).toBeDefined();
+
+    // Stream delivers existing segments (server returns rows past initial cursor
+    // regardless of sim status).
+    streamSub!.emit([
+      { dataset_id: 1, dynamics: 'A', is_gap: false, profile_id: 7, start_offset: '00:00:00' },
+      { dataset_id: 1, dynamics: 'B', is_gap: false, profile_id: 7, start_offset: '00:01:00' },
+    ] as ProfileSegment[]);
+    streamSub!.setLoading(false);
+    await flushPromises();
+
+    expect(last.resource).not.toBeNull();
+    expect((last.resource as Resource).values.length).toBeGreaterThan(0);
+    expect(last.loading).toBe(false);
+
+    sub.unsubscribe();
+  });
+
+  test('sim flips terminal mid-stream: closing value swaps from lastOffset to header.duration', async () => {
+    const profile = makeProfile({
+      duration: '00:10:00',
+      segments: [{ start_offset: '00:00:00', value: 'A' }],
+    });
+    getProfileMock.mockResolvedValue(profile);
+    setSimRunning(1);
+    const sub = createProfileSubscription(1, 'r', '2024-01-01T00:00:00', null);
+    let last: any;
+    sub.store.subscribe(s => {
+      last = s;
+    });
+    await flushPromises();
+
+    const streamSub = findSubByQuery('SubProfileSegmentsStream')!;
+    streamSub.emit([
+      { dataset_id: 1, dynamics: 'B', is_gap: false, profile_id: 7, start_offset: '00:01:00' },
+    ] as ProfileSegment[]);
+    streamSub.setLoading(false);
+    await flushPromises();
+
+    const startMs = new Date('2024-01-01T00:00:00').getTime();
+    let values = (last.resource as Resource).values;
+    // Streaming → closing at last segment offset (1m).
+    expect(values[values.length - 1].x).toBe(startMs + 60000);
+
+    setSimComplete(1);
+    await flushPromises();
+
+    values = (last.resource as Resource).values;
+    // Terminal → closing at header.duration (10m).
+    expect(values[values.length - 1].x).toBe(startMs + 600000);
+
+    sub.unsubscribe();
+  });
+
+  test('dispose during pending prefetch: no state mutations after unsubscribe', async () => {
+    let resolvePrefetch: (v: Profile | null) => void = () => {};
+    getProfileMock.mockReturnValue(new Promise<Profile | null>(r => (resolvePrefetch = r)));
+    setSimRunning(1);
+    const sub = createProfileSubscription(1, 'r', '2024-01-01T00:00:00', null);
+
+    let updatesAfterUnsubscribe = 0;
+    sub.store.subscribe(() => {
+      updatesAfterUnsubscribe++;
+    });
+    const baseline = updatesAfterUnsubscribe;
+
+    sub.unsubscribe();
+    resolvePrefetch(makeProfile({ duration: '00:10:00', segments: [{ start_offset: '00:00:00', value: 'A' }] }));
+    await flushPromises();
+
+    // No store update fired post-unsubscribe.
+    expect(updatesAfterUnsubscribe).toBe(baseline);
+    // No streaming sub was opened either.
+    expect(findSubByQuery('SubProfileSegmentsStream')).toBeUndefined();
+  });
+});

--- a/src/stores/profile.test.ts
+++ b/src/stores/profile.test.ts
@@ -189,8 +189,9 @@ describe('createProfileSubscription', () => {
   });
 
   // Regression: terminal sim + null profile must clear loading (no ticks
-  // will fire to retry).
-  test('terminal sim with null profile resolves loading instead of getting stuck', async () => {
+  // will fire to retry) and surface a not-found error rather than silently
+  // rendering a blank row.
+  test('terminal sim with null profile surfaces a not-found error instead of getting stuck', async () => {
     getProfileSinceMock.mockResolvedValue(null);
     setSimComplete(1);
     const sub = makeSub(1, 'r', '2024-01-01T00:00:00', null);
@@ -201,7 +202,7 @@ describe('createProfileSubscription', () => {
     await flushPromises();
 
     expect(last.loading).toBe(false);
-    expect(last.error).toBe('');
+    expect(last.error).toBe('Resource not found in simulation dataset');
     expect(last.resource).toBeNull();
   });
 

--- a/src/stores/profile.ts
+++ b/src/stores/profile.ts
@@ -86,7 +86,7 @@ export function createProfileSubscription(
     logMessage(
       'log',
       `Retrieved profile "${name}" (${accumulator.length} segment${pluralize(accumulator.length)}) for dataset ID=${datasetId}.`,
-      {duration: performance.now() - createdAt}
+      { duration: performance.now() - createdAt },
     );
   }
 

--- a/src/stores/profile.ts
+++ b/src/stores/profile.ts
@@ -7,7 +7,7 @@ import { pickEffectiveDuration } from '../utilities/profile';
 import { INITIAL_SINCE, sampleProfiles } from '../utilities/resources';
 import { getSimulationExtent, getSimulationStatus } from '../utilities/simulation';
 import { pluralize } from '../utilities/text';
-import { catchError, logMessage } from './errors';
+import { catchError, logMessage } from './console';
 import { simulationDataset } from './simulation';
 import {
   acquireTimelineResource,
@@ -84,9 +84,9 @@ export function createProfileSubscription(
     }
     aggregateLogged = true;
     logMessage(
+      'log',
       `Retrieved profile "${name}" (${accumulator.length} segment${pluralize(accumulator.length)}) for dataset ID=${datasetId}.`,
-      '',
-      performance.now() - createdAt,
+      {duration: performance.now() - createdAt}
     );
   }
 
@@ -131,7 +131,7 @@ export function createProfileSubscription(
         // of silently settling into a blank row.
         resolved = true;
         lastError = 'Resource not found in simulation dataset';
-        catchError(`Unable to load resource "${name}"`, new Error(lastError));
+        catchError('log', `Unable to load resource "${name}"`, new Error(lastError));
       }
       if (!streamingActive) {
         logFinalAggregate();

--- a/src/stores/profile.ts
+++ b/src/stores/profile.ts
@@ -1,0 +1,318 @@
+import { derived, writable, type Readable } from 'svelte/store';
+import { Status } from '../enums/status';
+import type { User } from '../types/app';
+import type { Profile, ProfileSegment, Resource } from '../types/simulation';
+import effects from '../utilities/effects';
+import gql from '../utilities/gql';
+import { dedupNewSegments, pickEffectiveDuration } from '../utilities/profile';
+import { sampleProfiles } from '../utilities/resources';
+import { getSimulationStatus } from '../utilities/simulation';
+import { simulationDataset } from './simulation';
+import { gqlSubscribable } from './subscribable';
+
+export type ProfileSubscriptionError = {
+  datasetId: number;
+  error: string;
+  name: string;
+};
+
+export type ProfileSubscriptionState = {
+  error: string;
+  loading: boolean;
+  resource: Resource | null;
+};
+
+export type ProfileSubscription = {
+  store: Readable<ProfileSubscriptionState>;
+  unsubscribe: () => void;
+};
+
+type ProfileHeader = Pick<Profile, 'dataset_id' | 'duration' | 'id' | 'name' | 'type'>;
+
+/**
+ * Lifecycle phases for a profile subscription. Modeled as a discriminated
+ * union so transitions go through one chokepoint and impossible states
+ * (e.g. "ready without a header") are unrepresentable. Disposal is tracked
+ * separately because it can happen asynchronously from any phase.
+ *
+ *   prefetching  ── one-shot getProfile in flight ─────────────┐
+ *        │                                                     │
+ *        │ resolves with data                                  │
+ *        ▼                                                     │ resolves with null,
+ *      ready  ◄──────────────────── awaitingHeader ◄───────────┘ or rejects (non-abort)
+ *        ▲                              │
+ *        │ live SUB_PROFILE_HEADER fires │
+ *        └──────────────────────────────┘
+ *
+ * In the `ready` phase, `streamOpen` records whether we opened the segment
+ * stream. We open it whenever sim is actively streaming OR the accumulator
+ * is empty (prefetch missed; stream is needed to backfill, regardless of
+ * sim status — SUB_PROFILE_HEADER doesn't carry segment columns).
+ */
+type Phase =
+  | { kind: 'prefetching' }
+  | { kind: 'awaitingHeader' }
+  | { header: ProfileHeader; kind: 'ready'; streamOpen: boolean };
+
+// Hasura streaming cursor advances strictly past the last seen value, so the
+// initial offset must be < the smallest start_offset we want to receive.
+// Postgres interval syntax (HH:MM:SS) — Hasura's interval scalar rejects ISO 8601.
+const INITIAL_START_OFFSET = '-00:00:01';
+
+// Module-level registry of every live createProfileSubscription. Powers global
+// indicators (e.g. timeline-wide loading/error banner) without forcing each
+// caller to thread state up to a coordinator.
+const activeSubscriptions = writable<Map<string, ProfileSubscriptionState>>(new Map());
+
+export const profilesLoading: Readable<boolean> = derived(activeSubscriptions, $subs => {
+  for (const s of $subs.values()) {
+    if (s.loading) {
+      return true;
+    }
+  }
+  return false;
+});
+
+export const profilesErroring: Readable<ProfileSubscriptionError[]> = derived(activeSubscriptions, $subs => {
+  const errors: ProfileSubscriptionError[] = [];
+  for (const [key, s] of $subs.entries()) {
+    if (s.error) {
+      const colon = key.indexOf(':');
+      errors.push({ datasetId: Number(key.slice(0, colon)), error: s.error, name: key.slice(colon + 1) });
+    }
+  }
+  return errors;
+});
+
+function registryKey(datasetId: number, name: string): string {
+  return `${datasetId}:${name}`;
+}
+
+function lastSegmentOffset(segments: ProfileSegment[]): string {
+  if (segments.length === 0) {
+    return INITIAL_START_OFFSET;
+  }
+  return segments[segments.length - 1].start_offset;
+}
+
+/**
+ * Per-(datasetId, name) live subscription to a simulation resource (profile).
+ * See the `Phase` type comment for the lifecycle.
+ */
+export function createProfileSubscription(
+  datasetId: number,
+  name: string,
+  planStartTimeYmd: string,
+  user: User | null,
+): ProfileSubscription {
+  const key = registryKey(datasetId, name);
+  const initialState: ProfileSubscriptionState = { error: '', loading: true, resource: null };
+  activeSubscriptions.update(m => new Map(m).set(key, initialState));
+  const state = writable<ProfileSubscriptionState>(initialState);
+  function setState(next: ProfileSubscriptionState) {
+    state.set(next);
+    activeSubscriptions.update(m => new Map(m).set(key, next));
+  }
+
+  const accumulator: ProfileSegment[] = [];
+  let phase: Phase = { kind: 'prefetching' };
+  // True once the streaming sub has delivered its first response. Only
+  // meaningful when phase.kind === 'ready' && phase.streamOpen.
+  let streamFiredFirst = false;
+  // Errors from each source are tracked separately. emit() picks which to
+  // surface based on whether we already have data — pre-data, fetching errors
+  // (prefetch, header sub) matter; post-data, only stream errors do.
+  let prefetchError = '';
+  let headerError = '';
+  let segmentError = '';
+  let unsubscribers: Array<() => void> = [];
+  let disposed = false;
+  // Live "is the sim still streaming?" derived from simulationDataset.status
+  // for THIS sub's datasetId. Drives effectiveDuration's closing-value rule
+  // and the open-stream-or-not decision in adoptHeader. Captured synchronously
+  // on first subscribe so adoptHeader sees the right value when prefetch
+  // resolves.
+  let streamingActive = false;
+  const headerAbort = new AbortController();
+
+  function effectiveDuration(): string {
+    if (phase.kind !== 'ready') {
+      return '00:00:00';
+    }
+    const lastOffset = accumulator.length > 0 ? accumulator[accumulator.length - 1].start_offset : null;
+    return pickEffectiveDuration(phase.header.duration, lastOffset, streamingActive);
+  }
+
+  function emit() {
+    if (disposed) {
+      return;
+    }
+    // haveData is "ready to render": we're in `ready` AND either no stream
+    // was opened (prefetched data is the answer), the stream has fired its
+    // first response (telling us whether segments arrived), or we already
+    // have prefetched segments waiting for the stream.
+    const haveData =
+      phase.kind === 'ready' && (!phase.streamOpen || streamFiredFirst || accumulator.length > 0);
+    let resource: Resource | null = null;
+    if (haveData && phase.kind === 'ready') {
+      resource =
+        sampleProfiles(
+          [{ ...phase.header, duration: effectiveDuration(), profile_segments: accumulator }],
+          planStartTimeYmd,
+        )[0] ?? null;
+    }
+    const error = haveData ? segmentError : headerError || prefetchError;
+    setState({ error, loading: !haveData && !error, resource });
+  }
+
+  unsubscribers.push(
+    simulationDataset.subscribe($sd => {
+      // Only react when the live simulationDataset matches THIS sub's dataset.
+      // (The store can hold a different sim if the user navigated away.) Treat
+      // any unmatched / null state as "not streaming" so closing falls back to
+      // header.duration.
+      const matched = $sd !== null && $sd.dataset_id === datasetId;
+      const status = matched ? getSimulationStatus($sd) : null;
+      const next =
+        matched &&
+        status !== null &&
+        status !== Status.Complete &&
+        status !== Status.Failed &&
+        status !== Status.Canceled;
+      if (next === streamingActive) {
+        return;
+      }
+      streamingActive = next;
+      emit();
+    }),
+  );
+
+  function openSegmentStream(profileId: number, startOffset: string) {
+    if (disposed) {
+      return;
+    }
+    const segmentSub = gqlSubscribable<ProfileSegment[]>(
+      gql.SUB_PROFILE_SEGMENTS_STREAM,
+      { datasetId, profileId, startOffset },
+      [],
+      (delta: ProfileSegment[]) => {
+        accumulator.push(...dedupNewSegments(accumulator, delta));
+        return accumulator.slice();
+      },
+    );
+    unsubscribers.push(
+      segmentSub.subscribe(() => emit()),
+      segmentSub.loading.subscribe(loading => {
+        if (!loading && !streamFiredFirst) {
+          streamFiredFirst = true;
+          emit();
+        }
+      }),
+      segmentSub.error.subscribe(error => {
+        if (segmentError !== error) {
+          segmentError = error;
+          emit();
+        }
+      }),
+    );
+  }
+
+  function adoptHeader(newHeader: ProfileHeader) {
+    if (disposed) {
+      return;
+    }
+    if (phase.kind === 'ready') {
+      // Subsequent header delivery (e.g. live SUB_PROFILE_HEADER fires again
+      // because the backend updated `duration` post-completion). Refresh the
+      // header in place; don't reopen the stream.
+      phase = { ...phase, header: newHeader };
+      emit();
+      return;
+    }
+    // First adoption. Open the stream when (a) sim is actively streaming
+    // (need live deltas) or (b) accumulator is empty (prefetch missed; stream
+    // backfills). The stream returns rows past the initial cursor regardless
+    // of sim status, so it works as a backfill mechanism for already-completed
+    // sims discovered via waitForProfile too.
+    const streamOpen = streamingActive || accumulator.length === 0;
+    phase = { header: newHeader, kind: 'ready', streamOpen };
+    emit();
+    if (streamOpen) {
+      openSegmentStream(newHeader.id, lastSegmentOffset(accumulator));
+    }
+  }
+
+  function waitForProfile() {
+    if (phase.kind === 'ready' || disposed) {
+      return;
+    }
+    phase = { kind: 'awaitingHeader' };
+    const profileSub = gqlSubscribable<ProfileHeader | null>(
+      gql.SUB_PROFILE_HEADER,
+      { datasetId, name },
+      null,
+      (rows: ProfileHeader[]) => (rows && rows.length > 0 ? rows[0] : null),
+    );
+    unsubscribers.push(
+      profileSub.subscribe(profile => {
+        if (!profile || disposed) {
+          return;
+        }
+        adoptHeader(profile);
+      }),
+      profileSub.error.subscribe(error => {
+        if (headerError !== error) {
+          headerError = error;
+          emit();
+        }
+      }),
+    );
+  }
+
+  effects
+    .getProfile(datasetId, name, user, headerAbort.signal)
+    .then(initial => {
+      if (disposed || phase.kind !== 'prefetching') {
+        return;
+      }
+      if (initial) {
+        accumulator.push(...initial.profile_segments);
+        adoptHeader(initial);
+      } else {
+        waitForProfile();
+      }
+    })
+    .catch((e: unknown) => {
+      if (disposed || phase.kind !== 'prefetching') {
+        return;
+      }
+      const err = e as Error;
+      if (err.name === 'AbortError') {
+        return;
+      }
+      // Prefetch failed — surface the error and fall through to the live
+      // header sub. If the sub later succeeds we transition to `ready` and
+      // emit() drops prefetchError; if it also fails, headerError surfaces.
+      prefetchError = err.message || 'Profile prefetch failed';
+      emit();
+      waitForProfile();
+    });
+
+  return {
+    store: { subscribe: state.subscribe },
+    unsubscribe: () => {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      activeSubscriptions.update(m => {
+        const next = new Map(m);
+        next.delete(key);
+        return next;
+      });
+      headerAbort.abort();
+      unsubscribers.forEach(unsub => unsub());
+      unsubscribers = [];
+    },
+  };
+}

--- a/src/stores/profile.ts
+++ b/src/stores/profile.ts
@@ -1,26 +1,22 @@
-import { derived, writable, type Readable } from 'svelte/store';
+import { writable, type Readable } from 'svelte/store';
 import { Status } from '../enums/status';
 import type { User } from '../types/app';
 import type { Profile, ProfileSegment, Resource } from '../types/simulation';
 import effects from '../utilities/effects';
-import gql from '../utilities/gql';
-import { dedupNewSegments, pickEffectiveDuration } from '../utilities/profile';
+import { pickEffectiveDuration } from '../utilities/profile';
 import { sampleProfiles } from '../utilities/resources';
-import { getSimulationStatus } from '../utilities/simulation';
+import { getSimulationExtent, getSimulationStatus } from '../utilities/simulation';
+import { pluralize } from '../utilities/text';
+import { logMessage } from './errors';
 import { simulationDataset } from './simulation';
-import { gqlSubscribable } from './subscribable';
+import {
+  acquireTimelineResource,
+  releaseTimelineResource,
+  setTimelineResourceState,
+  type TimelineResourceState,
+} from './timelineResourceStatus';
 
-export type ProfileSubscriptionError = {
-  datasetId: number;
-  error: string;
-  name: string;
-};
-
-export type ProfileSubscriptionState = {
-  error: string;
-  loading: boolean;
-  resource: Resource | null;
-};
+export type ProfileSubscriptionState = TimelineResourceState;
 
 export type ProfileSubscription = {
   store: Readable<ProfileSubscriptionState>;
@@ -29,75 +25,19 @@ export type ProfileSubscription = {
 
 type ProfileHeader = Pick<Profile, 'dataset_id' | 'duration' | 'id' | 'name' | 'type'>;
 
-/**
- * Lifecycle phases for a profile subscription. Modeled as a discriminated
- * union so transitions go through one chokepoint and impossible states
- * (e.g. "ready without a header") are unrepresentable. Disposal is tracked
- * separately because it can happen asynchronously from any phase.
- *
- *   prefetching  ── one-shot getProfile in flight ─────────────┐
- *        │                                                     │
- *        │ resolves with data                                  │
- *        ▼                                                     │ resolves with null,
- *      ready  ◄──────────────────── awaitingHeader ◄───────────┘ or rejects (non-abort)
- *        ▲                              │
- *        │ live SUB_PROFILE_HEADER fires │
- *        └──────────────────────────────┘
- *
- * In the `ready` phase, `streamOpen` records whether we opened the segment
- * stream. We open it whenever sim is actively streaming OR the accumulator
- * is empty (prefetch missed; stream is needed to backfill, regardless of
- * sim status — SUB_PROFILE_HEADER doesn't carry segment columns).
- */
-type Phase =
-  | { kind: 'prefetching' }
-  | { kind: 'awaitingHeader' }
-  | { header: ProfileHeader; kind: 'ready'; streamOpen: boolean };
-
-// Hasura streaming cursor advances strictly past the last seen value, so the
-// initial offset must be < the smallest start_offset we want to receive.
-// Postgres interval syntax (HH:MM:SS) — Hasura's interval scalar rejects ISO 8601.
-const INITIAL_START_OFFSET = '-00:00:01';
-
-// Module-level registry of every live createProfileSubscription. Powers global
-// indicators (e.g. timeline-wide loading/error banner) without forcing each
-// caller to thread state up to a coordinator.
-const activeSubscriptions = writable<Map<string, ProfileSubscriptionState>>(new Map());
-
-export const profilesLoading: Readable<boolean> = derived(activeSubscriptions, $subs => {
-  for (const s of $subs.values()) {
-    if (s.loading) {
-      return true;
-    }
-  }
-  return false;
-});
-
-export const profilesErroring: Readable<ProfileSubscriptionError[]> = derived(activeSubscriptions, $subs => {
-  const errors: ProfileSubscriptionError[] = [];
-  for (const [key, s] of $subs.entries()) {
-    if (s.error) {
-      const colon = key.indexOf(':');
-      errors.push({ datasetId: Number(key.slice(0, colon)), error: s.error, name: key.slice(colon + 1) });
-    }
-  }
-  return errors;
-});
-
-function registryKey(datasetId: number, name: string): string {
-  return `${datasetId}:${name}`;
-}
-
-function lastSegmentOffset(segments: ProfileSegment[]): string {
-  if (segments.length === 0) {
-    return INITIAL_START_OFFSET;
-  }
-  return segments[segments.length - 1].start_offset;
-}
+// First-fetch sentinel: smaller than any real start_offset, so the windowed
+// query returns every existing segment. Postgres interval syntax (HH:MM:SS) —
+// Hasura's interval scalar rejects ISO 8601.
+const INITIAL_SINCE = '-00:00:01';
 
 /**
- * Per-(datasetId, name) live subscription to a simulation resource (profile).
- * See the `Phase` type comment for the lifecycle.
+ * Per-(datasetId, name) live view of a simulation resource. Driven by a
+ * windowed pull: each tick of `simulationDataset` (Hasura live query, ~1Hz)
+ * fires a refetch via GET_PROFILE_SINCE that returns only segments past the
+ * last seen `start_offset`. Same bandwidth profile as a streaming
+ * subscription, but without WS connection state, cursor reconnect handling,
+ * dedup, or a multi-phase state machine — every refetch is independent and
+ * returns the header alongside the segment delta.
  */
 export function createProfileSubscription(
   datasetId: number,
@@ -105,72 +45,125 @@ export function createProfileSubscription(
   planStartTimeYmd: string,
   user: User | null,
 ): ProfileSubscription {
-  const key = registryKey(datasetId, name);
   const initialState: ProfileSubscriptionState = { error: '', loading: true, resource: null };
-  activeSubscriptions.update(m => new Map(m).set(key, initialState));
+  acquireTimelineResource(datasetId, name);
+  setTimelineResourceState(datasetId, name, 'sim', initialState);
   const state = writable<ProfileSubscriptionState>(initialState);
   function setState(next: ProfileSubscriptionState) {
     state.set(next);
-    activeSubscriptions.update(m => new Map(m).set(key, next));
+    setTimelineResourceState(datasetId, name, 'sim', next);
   }
 
   const accumulator: ProfileSegment[] = [];
-  let phase: Phase = { kind: 'prefetching' };
-  // True once the streaming sub has delivered its first response. Only
-  // meaningful when phase.kind === 'ready' && phase.streamOpen.
-  let streamFiredFirst = false;
-  // Errors from each source are tracked separately. emit() picks which to
-  // surface based on whether we already have data — pre-data, fetching errors
-  // (prefetch, header sub) matter; post-data, only stream errors do.
-  let prefetchError = '';
-  let headerError = '';
-  let segmentError = '';
-  let unsubscribers: Array<() => void> = [];
-  let disposed = false;
-  // Live "is the sim still streaming?" derived from simulationDataset.status
-  // for THIS sub's datasetId. Drives effectiveDuration's closing-value rule
-  // and the open-stream-or-not decision in adoptHeader. Captured synchronously
-  // on first subscribe so adoptHeader sees the right value when prefetch
-  // resolves.
+  let header: ProfileHeader | null = null;
+  let sinceOffset = INITIAL_SINCE;
+  // Settled on a final state. Set when we receive a profile, OR when the sim
+  // goes terminal with no profile row — in that case there's no data but no
+  // more ticks will fire to retry, so we stop showing loading.
+  let resolved = false;
+  let lastError = '';
+  // Drives whether sampleProfiles closes the last segment at header.duration
+  // (terminal sim) or the last-seen offset (streaming, so header.duration
+  // would project past actual data).
   let streamingActive = false;
-  const headerAbort = new AbortController();
+  let inFlight = false;
+  // simulationDataset re-pushes on every column change; only extent
+  // advancement implies new segments worth refetching.
+  let lastExtent: string | null = null;
+  // Set when refetch() is called while an earlier one is in flight. The
+  // finally block re-fires once, so if the sim's terminal tick lands while
+  // a refetch is mid-flight we don't miss the tail.
+  let pendingRefetch = false;
+  let disposed = false;
+  const abortController = new AbortController();
+  const unsubscribers: Array<() => void> = [];
 
-  function effectiveDuration(): string {
-    if (phase.kind !== 'ready') {
-      return '00:00:00';
+  // One log per sub lifetime, on whichever comes first: sim flipping
+  // terminal, or sub disposal. Skipped if the sub never received data.
+  const createdAt = performance.now();
+  let aggregateLogged = false;
+
+  function logFinalAggregate() {
+    if (aggregateLogged || header === null) {
+      return;
     }
-    const lastOffset = accumulator.length > 0 ? accumulator[accumulator.length - 1].start_offset : null;
-    return pickEffectiveDuration(phase.header.duration, lastOffset, streamingActive);
+    aggregateLogged = true;
+    logMessage(
+      `Retrieved profile "${name}" (${accumulator.length} segment${pluralize(accumulator.length)}) for dataset ID=${datasetId}.`,
+      '',
+      performance.now() - createdAt,
+    );
   }
 
   function emit() {
     if (disposed) {
       return;
     }
-    // haveData is "ready to render": we're in `ready` AND either no stream
-    // was opened (prefetched data is the answer), the stream has fired its
-    // first response (telling us whether segments arrived), or we already
-    // have prefetched segments waiting for the stream.
-    const haveData =
-      phase.kind === 'ready' && (!phase.streamOpen || streamFiredFirst || accumulator.length > 0);
     let resource: Resource | null = null;
-    if (haveData && phase.kind === 'ready') {
-      resource =
-        sampleProfiles(
-          [{ ...phase.header, duration: effectiveDuration(), profile_segments: accumulator }],
-          planStartTimeYmd,
-        )[0] ?? null;
+    if (header && resolved) {
+      const lastOffset = accumulator.length > 0 ? accumulator[accumulator.length - 1].start_offset : null;
+      const duration = pickEffectiveDuration(header.duration, lastOffset, streamingActive);
+      resource = sampleProfiles([{ ...header, duration, profile_segments: accumulator }], planStartTimeYmd)[0] ?? null;
     }
-    const error = haveData ? segmentError : headerError || prefetchError;
-    setState({ error, loading: !haveData && !error, resource });
+    setState({ error: lastError, loading: !resolved && !lastError, resource });
+  }
+
+  async function refetch() {
+    if (disposed) {
+      return;
+    }
+    if (inFlight) {
+      pendingRefetch = true;
+      return;
+    }
+    inFlight = true;
+    try {
+      const profile = await effects.getProfileSince(datasetId, name, sinceOffset, user, abortController.signal);
+      if (disposed) {
+        return;
+      }
+      if (profile) {
+        if (profile.profile_segments.length > 0) {
+          accumulator.push(...profile.profile_segments);
+          sinceOffset = profile.profile_segments[profile.profile_segments.length - 1].start_offset;
+        }
+        header = profile;
+        resolved = true;
+        lastError = '';
+      } else if (!streamingActive) {
+        // No profile row + sim is terminal: settle so loading state clears.
+        // No more ticks will fire to retry.
+        resolved = true;
+        lastError = '';
+      }
+      if (!streamingActive) {
+        logFinalAggregate();
+      }
+      emit();
+    } catch (e) {
+      if (disposed) {
+        return;
+      }
+      const err = e as Error;
+      if (err.name === 'AbortError') {
+        return;
+      }
+      lastError = err.message || 'Profile fetch failed';
+      emit();
+    } finally {
+      inFlight = false;
+      if (pendingRefetch && !disposed) {
+        pendingRefetch = false;
+        refetch();
+      }
+    }
   }
 
   unsubscribers.push(
     simulationDataset.subscribe($sd => {
-      // Only react when the live simulationDataset matches THIS sub's dataset.
-      // (The store can hold a different sim if the user navigated away.) Treat
-      // any unmatched / null state as "not streaming" so closing falls back to
-      // header.duration.
+      if (disposed) {
+        return;
+      }
       const matched = $sd !== null && $sd.dataset_id === datasetId;
       const status = matched ? getSimulationStatus($sd) : null;
       const next =
@@ -179,124 +172,32 @@ export function createProfileSubscription(
         status !== Status.Complete &&
         status !== Status.Failed &&
         status !== Status.Canceled;
-      if (next === streamingActive) {
-        return;
-      }
+      const streamingChanged = next !== streamingActive;
       streamingActive = next;
-      emit();
+      if (matched) {
+        const extent = $sd ? getSimulationExtent($sd) : null;
+        const extentAdvanced = extent !== lastExtent;
+        lastExtent = extent;
+        // Extent moved → new segments available. streamingActive flipped →
+        // grab the tail (extent doesn't tick again on the terminal status).
+        if (extentAdvanced || streamingChanged) {
+          refetch();
+        }
+      } else if (streamingChanged && resolved) {
+        // Re-emit so the closing value picks up the new streamingActive.
+        emit();
+      }
     }),
   );
 
-  function openSegmentStream(profileId: number, startOffset: string) {
-    if (disposed) {
-      return;
-    }
-    const segmentSub = gqlSubscribable<ProfileSegment[]>(
-      gql.SUB_PROFILE_SEGMENTS_STREAM,
-      { datasetId, profileId, startOffset },
-      [],
-      (delta: ProfileSegment[]) => {
-        accumulator.push(...dedupNewSegments(accumulator, delta));
-        return accumulator.slice();
-      },
-    );
-    unsubscribers.push(
-      segmentSub.subscribe(() => emit()),
-      segmentSub.loading.subscribe(loading => {
-        if (!loading && !streamFiredFirst) {
-          streamFiredFirst = true;
-          emit();
-        }
-      }),
-      segmentSub.error.subscribe(error => {
-        if (segmentError !== error) {
-          segmentError = error;
-          emit();
-        }
-      }),
-    );
+  // Don't wait for the next simulationDataset tick — it may not come (the
+  // dataset may already be settled, null, or pointing at a different sim).
+  // Skip if `simulationDataset.subscribe` (above) already fired a refetch
+  // synchronously with its current value — otherwise we'd queue a redundant
+  // pendingRefetch and round-trip twice on first mount.
+  if (!inFlight) {
+    refetch();
   }
-
-  function adoptHeader(newHeader: ProfileHeader) {
-    if (disposed) {
-      return;
-    }
-    if (phase.kind === 'ready') {
-      // Subsequent header delivery (e.g. live SUB_PROFILE_HEADER fires again
-      // because the backend updated `duration` post-completion). Refresh the
-      // header in place; don't reopen the stream.
-      phase = { ...phase, header: newHeader };
-      emit();
-      return;
-    }
-    // First adoption. Open the stream when (a) sim is actively streaming
-    // (need live deltas) or (b) accumulator is empty (prefetch missed; stream
-    // backfills). The stream returns rows past the initial cursor regardless
-    // of sim status, so it works as a backfill mechanism for already-completed
-    // sims discovered via waitForProfile too.
-    const streamOpen = streamingActive || accumulator.length === 0;
-    phase = { header: newHeader, kind: 'ready', streamOpen };
-    emit();
-    if (streamOpen) {
-      openSegmentStream(newHeader.id, lastSegmentOffset(accumulator));
-    }
-  }
-
-  function waitForProfile() {
-    if (phase.kind === 'ready' || disposed) {
-      return;
-    }
-    phase = { kind: 'awaitingHeader' };
-    const profileSub = gqlSubscribable<ProfileHeader | null>(
-      gql.SUB_PROFILE_HEADER,
-      { datasetId, name },
-      null,
-      (rows: ProfileHeader[]) => (rows && rows.length > 0 ? rows[0] : null),
-    );
-    unsubscribers.push(
-      profileSub.subscribe(profile => {
-        if (!profile || disposed) {
-          return;
-        }
-        adoptHeader(profile);
-      }),
-      profileSub.error.subscribe(error => {
-        if (headerError !== error) {
-          headerError = error;
-          emit();
-        }
-      }),
-    );
-  }
-
-  effects
-    .getProfile(datasetId, name, user, headerAbort.signal)
-    .then(initial => {
-      if (disposed || phase.kind !== 'prefetching') {
-        return;
-      }
-      if (initial) {
-        accumulator.push(...initial.profile_segments);
-        adoptHeader(initial);
-      } else {
-        waitForProfile();
-      }
-    })
-    .catch((e: unknown) => {
-      if (disposed || phase.kind !== 'prefetching') {
-        return;
-      }
-      const err = e as Error;
-      if (err.name === 'AbortError') {
-        return;
-      }
-      // Prefetch failed — surface the error and fall through to the live
-      // header sub. If the sub later succeeds we transition to `ready` and
-      // emit() drops prefetchError; if it also fails, headerError surfaces.
-      prefetchError = err.message || 'Profile prefetch failed';
-      emit();
-      waitForProfile();
-    });
 
   return {
     store: { subscribe: state.subscribe },
@@ -305,14 +206,10 @@ export function createProfileSubscription(
         return;
       }
       disposed = true;
-      activeSubscriptions.update(m => {
-        const next = new Map(m);
-        next.delete(key);
-        return next;
-      });
-      headerAbort.abort();
+      logFinalAggregate();
+      releaseTimelineResource(datasetId, name);
+      abortController.abort();
       unsubscribers.forEach(unsub => unsub());
-      unsubscribers = [];
     },
   };
 }

--- a/src/stores/profile.ts
+++ b/src/stores/profile.ts
@@ -4,10 +4,10 @@ import type { User } from '../types/app';
 import type { Profile, ProfileSegment, Resource } from '../types/simulation';
 import effects from '../utilities/effects';
 import { pickEffectiveDuration } from '../utilities/profile';
-import { sampleProfiles } from '../utilities/resources';
+import { INITIAL_SINCE, sampleProfiles } from '../utilities/resources';
 import { getSimulationExtent, getSimulationStatus } from '../utilities/simulation';
 import { pluralize } from '../utilities/text';
-import { logMessage } from './errors';
+import { catchError, logMessage } from './errors';
 import { simulationDataset } from './simulation';
 import {
   acquireTimelineResource,
@@ -24,11 +24,6 @@ export type ProfileSubscription = {
 };
 
 type ProfileHeader = Pick<Profile, 'dataset_id' | 'duration' | 'id' | 'name' | 'type'>;
-
-// First-fetch sentinel: smaller than any real start_offset, so the windowed
-// query returns every existing segment. Postgres interval syntax (HH:MM:SS) —
-// Hasura's interval scalar rejects ISO 8601.
-const INITIAL_SINCE = '-00:00:01';
 
 /**
  * Per-(datasetId, name) live view of a simulation resource. Driven by a
@@ -131,10 +126,12 @@ export function createProfileSubscription(
         resolved = true;
         lastError = '';
       } else if (!streamingActive) {
-        // No profile row + sim is terminal: settle so loading state clears.
-        // No more ticks will fire to retry.
+        // No profile row + sim is terminal: no more ticks will fire to retry,
+        // so surface a not-found error (parallel to the external path) instead
+        // of silently settling into a blank row.
         resolved = true;
-        lastError = '';
+        lastError = 'Resource not found in simulation dataset';
+        catchError(`Unable to load resource "${name}"`, new Error(lastError));
       }
       if (!streamingActive) {
         logFinalAggregate();

--- a/src/stores/simulation.ts
+++ b/src/stores/simulation.ts
@@ -2,7 +2,6 @@ import { keyBy } from 'lodash-es';
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
 import { Status } from '../enums/status';
 import type {
-  Resource,
   ResourceType,
   Simulation,
   SimulationDataset,
@@ -18,19 +17,14 @@ import type { Axis } from '../types/timeline';
 import { createSpanUtilityMaps } from '../utilities/activities';
 import gql from '../utilities/gql';
 import { getSimulationProgress } from '../utilities/simulation';
-import { planId, planModelId, planModelRevision, planRevision } from './plan';
+import { planDatasets, planId, planModelId, planModelRevision, planRevision } from './plan';
 import { gqlSubscribable } from './subscribable';
 
 /* Writeable. */
 
 export const simulationDatasetId: Writable<number> = writable(-1);
 
-export const externalResources: Writable<Resource[]> = writable([]);
-
 export const externalResourceNames: Writable<string[]> = writable([]);
-
-// default to true since we cannot differentiate between "ext resources have been initially fetched" and "fetching ext resources"
-export const fetchingResourcesExternal: Writable<boolean> = writable(true);
 
 export const resourceTypes: Writable<ResourceType[]> = writable([]);
 
@@ -97,11 +91,32 @@ export const selectedSimulationEventId: Writable<number | null> = writable(null)
 /* Derived. */
 
 export const allResourceTypes: Readable<ResourceType[]> = derived(
-  [resourceTypes, externalResources],
-  ([$resourceTypes, $externalResources]) => {
-    return $resourceTypes
-      .map(({ name, schema }) => ({ name, schema }))
-      .concat($externalResources.map(({ name, schema }) => ({ name, schema })));
+  [resourceTypes, planDatasets, simulationDatasetId],
+  ([$resourceTypes, $planDatasets, $simulationDatasetId]) => {
+    const seen = new Set<string>();
+    const out: ResourceType[] = [];
+    // Add resource types from the model
+    for (const { name, schema } of $resourceTypes) {
+      if (!seen.has(name)) {
+        seen.add(name);
+        out.push({ name, schema });
+      }
+    }
+    // Add resource types from datasets tied to the current sim or untied to any sim (plan-level).
+    for (const planDataset of $planDatasets) {
+      const tiedToOtherSim =
+        planDataset.simulation_dataset_id !== null && planDataset.simulation_dataset_id !== $simulationDatasetId;
+      if (tiedToOtherSim) {
+        continue;
+      }
+      for (const profile of planDataset.dataset.profiles) {
+        if (!seen.has(profile.name)) {
+          seen.add(profile.name);
+          out.push({ name: profile.name, schema: profile.type.schema });
+        }
+      }
+    }
+    return out;
   },
 );
 
@@ -171,9 +186,7 @@ export const simulationDatasetLatestId = derived(
 /* Helper Functions. */
 
 export function resetSimulationStores() {
-  externalResources.set([]);
   externalResourceNames.set([]);
-  fetchingResourcesExternal.set(false);
   initialSpansLoading.set(true);
   selectedSpanId.update(() => null);
   simulation.updateValue(() => null);

--- a/src/stores/timelineResourceStatus.ts
+++ b/src/stores/timelineResourceStatus.ts
@@ -23,7 +23,11 @@ export type TimelineResourceError = {
   name: string;
 };
 
-type StoredState = TimelineResourceState & { kind: TimelineResourceKind };
+// datasetId/name are carried on the entry (not parsed back out of the key)
+// so the key format stays an internal detail and the id space we keyed on
+// (dataset_id for sim, simulation_dataset id for external) is preserved
+// verbatim for error reporting.
+type StoredState = TimelineResourceState & { datasetId: number; kind: TimelineResourceKind; name: string };
 
 const resourceStates = writable<Map<string, StoredState>>(new Map());
 
@@ -47,14 +51,13 @@ export const timelineResourcesLoading: Readable<boolean> = derived(resourceState
 
 export const timelineResourcesErroring: Readable<TimelineResourceError[]> = derived(resourceStates, $resourceStates => {
   const errors: TimelineResourceError[] = [];
-  for (const [key, s] of $resourceStates.entries()) {
+  for (const s of $resourceStates.values()) {
     if (s.error) {
-      const colon = key.indexOf(':');
       errors.push({
-        datasetId: Number(key.slice(0, colon)),
+        datasetId: s.datasetId,
         error: s.error,
         kind: s.kind,
-        name: key.slice(colon + 1),
+        name: s.name,
       });
     }
   }
@@ -77,7 +80,7 @@ export function setTimelineResourceState(
   state: TimelineResourceState,
 ): void {
   const key = registryKey(datasetId, name);
-  resourceStates.update(m => new Map(m).set(key, { ...state, kind }));
+  resourceStates.update(m => new Map(m).set(key, { ...state, datasetId, kind, name }));
 }
 
 export function releaseTimelineResource(datasetId: number, name: string): void {

--- a/src/stores/timelineResourceStatus.ts
+++ b/src/stores/timelineResourceStatus.ts
@@ -45,24 +45,21 @@ export const timelineResourcesLoading: Readable<boolean> = derived(resourceState
   return false;
 });
 
-export const timelineResourcesErroring: Readable<TimelineResourceError[]> = derived(
-  resourceStates,
-  $resourceStates => {
-    const errors: TimelineResourceError[] = [];
-    for (const [key, s] of $resourceStates.entries()) {
-      if (s.error) {
-        const colon = key.indexOf(':');
-        errors.push({
-          datasetId: Number(key.slice(0, colon)),
-          error: s.error,
-          kind: s.kind,
-          name: key.slice(colon + 1),
-        });
-      }
+export const timelineResourcesErroring: Readable<TimelineResourceError[]> = derived(resourceStates, $resourceStates => {
+  const errors: TimelineResourceError[] = [];
+  for (const [key, s] of $resourceStates.entries()) {
+    if (s.error) {
+      const colon = key.indexOf(':');
+      errors.push({
+        datasetId: Number(key.slice(0, colon)),
+        error: s.error,
+        kind: s.kind,
+        name: key.slice(colon + 1),
+      });
     }
-    return errors;
-  },
-);
+  }
+  return errors;
+});
 
 function registryKey(datasetId: number, name: string): string {
   return `${datasetId}:${name}`;

--- a/src/stores/timelineResourceStatus.ts
+++ b/src/stores/timelineResourceStatus.ts
@@ -1,0 +1,102 @@
+import { derived, writable, type Readable } from 'svelte/store';
+import type { Resource } from '../types/simulation';
+
+// Per-(datasetId, name) loading/error registry for any resource on the
+// timeline. Two writers — `createProfileSubscription` (sim profiles) and
+// `createExternalResourceSubscription` (external datasets) — share the same
+// keyspace; the global indicator reads the derived aggregates. `kind`
+// travels with each entry so the indicator can label errors with the right
+// source ("Profile" vs "External profile") instead of mixing them.
+
+export type TimelineResourceKind = 'sim' | 'external';
+
+export type TimelineResourceState = {
+  error: string;
+  loading: boolean;
+  resource: Resource | null;
+};
+
+export type TimelineResourceError = {
+  datasetId: number;
+  error: string;
+  kind: TimelineResourceKind;
+  name: string;
+};
+
+type StoredState = TimelineResourceState & { kind: TimelineResourceKind };
+
+const resourceStates = writable<Map<string, StoredState>>(new Map());
+
+// Refcount per key. Two Row.svelte instances showing the same
+// (datasetId, name) each create their own factory writing to this key.
+// Without refcounting, the first to dispose clears the entry while the
+// other factory is still live — and for a settled-error state (e.g.
+// external "Resource not found"), nothing would trigger a re-emit, so the
+// indicator would silently under-report. Acquire/release scopes the entry
+// to the union of writers' lifetimes.
+const refCounts = new Map<string, number>();
+
+export const timelineResourcesLoading: Readable<boolean> = derived(resourceStates, $resourceStates => {
+  for (const s of $resourceStates.values()) {
+    if (s.loading) {
+      return true;
+    }
+  }
+  return false;
+});
+
+export const timelineResourcesErroring: Readable<TimelineResourceError[]> = derived(
+  resourceStates,
+  $resourceStates => {
+    const errors: TimelineResourceError[] = [];
+    for (const [key, s] of $resourceStates.entries()) {
+      if (s.error) {
+        const colon = key.indexOf(':');
+        errors.push({
+          datasetId: Number(key.slice(0, colon)),
+          error: s.error,
+          kind: s.kind,
+          name: key.slice(colon + 1),
+        });
+      }
+    }
+    return errors;
+  },
+);
+
+function registryKey(datasetId: number, name: string): string {
+  return `${datasetId}:${name}`;
+}
+
+export function acquireTimelineResource(datasetId: number, name: string): void {
+  const key = registryKey(datasetId, name);
+  refCounts.set(key, (refCounts.get(key) ?? 0) + 1);
+}
+
+export function setTimelineResourceState(
+  datasetId: number,
+  name: string,
+  kind: TimelineResourceKind,
+  state: TimelineResourceState,
+): void {
+  const key = registryKey(datasetId, name);
+  resourceStates.update(m => new Map(m).set(key, { ...state, kind }));
+}
+
+export function releaseTimelineResource(datasetId: number, name: string): void {
+  const key = registryKey(datasetId, name);
+  const next = (refCounts.get(key) ?? 1) - 1;
+  if (next <= 0) {
+    refCounts.delete(key);
+    resourceStates.update(m => {
+      if (!m.has(key)) {
+        return m;
+      }
+      const after = new Map(m);
+      after.delete(key);
+      return after;
+    });
+  } else {
+    refCounts.set(key, next);
+  }
+}

--- a/src/types/simulation.ts
+++ b/src/types/simulation.ts
@@ -3,7 +3,6 @@ import type { UserId } from './app';
 import type { BaseError, SimulationDatasetError } from './errors';
 import type { ArgumentsMap } from './parameter';
 import type { ValueSchema } from './schema';
-import type { Subscription } from './subscribable';
 
 export type PlanDataset = {
   dataset: { profiles: Profile[] };
@@ -45,13 +44,12 @@ export type Resource = {
 };
 
 export type ResourceRequest = {
-  controller?: AbortController;
   error: string;
   loading: boolean;
   resource: Resource | null;
   simulationDatasetId: number;
-  subscription?: Subscription<Resource>;
   type: 'internal' | 'external';
+  unsubscribe?: () => void;
 };
 
 export type ResourceType = {

--- a/src/types/simulation.ts
+++ b/src/types/simulation.ts
@@ -8,6 +8,7 @@ export type PlanDataset = {
   dataset: { profiles: Profile[] };
   dataset_id: number;
   offset_from_plan_start: string;
+  simulation_dataset_id: number | null;
 };
 
 export type PlanDatasetNames = {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -216,7 +216,6 @@ import {
   type SequenceAdaptationMetadata,
 } from '../types/sequencing';
 import type {
-  PlanDataset,
   Profile,
   ProfileSegment,
   ResourceType,
@@ -261,8 +260,7 @@ import {
   bulkShiftActivityDirectivesInPlan,
   packActivityDirectivesInPlan,
 } from './activities';
-import { ErrorTypes } from './errors';
-import { compare, convertToQuery } from './generic';
+import { convertToQuery } from './generic';
 import gql, { convertToGQLArray } from './gql';
 import {
   showApplySequenceFilterModal,
@@ -300,14 +298,12 @@ import {
 } from './modal';
 import { featurePermissions, gatewayPermissions, queryPermissions } from './permissions';
 import {
-  CompoundError,
   reqActionServer,
   reqExtension,
   reqGateway,
   reqHasura,
   WorkspaceSaveConflictError,
 } from './requests';
-import { sampleProfiles } from './resources';
 import { convertResponseToMetadata } from './scheduling';
 import { buildSearchActivitiesWhereClauses, type ActivitySearchFilters } from './searchFilters';
 import { compareEvents } from './simulation';

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -5186,14 +5186,27 @@ const effects = {
     }
   },
 
-  getResource(
+  async getProfile(
     datasetId: number,
     name: string,
     user: User | null,
     signal: AbortSignal | undefined = undefined,
-  ): Promise<Record<string, Profile[] | null>> {
-    const data = reqHasura<Profile[]>(gql.GET_PROFILE, { datasetId, name }, user, signal);
-    return data;
+  ): Promise<Profile | null> {
+    try {
+      const data = await reqHasura<Profile[]>(gql.GET_PROFILE, { datasetId, name }, user, signal);
+      const { profile: profiles } = data;
+      if (profiles && profiles.length === 1) {
+        return profiles[0];
+      }
+      return null;
+    } catch (e) {
+      const error = e as Error;
+      if (error.name === 'AbortError') {
+        throw error;
+      }
+      catchError(`Unable to retrieve profile ${name}`, error);
+      return null;
+    }
   },
 
   async getResourceTypes(modelId: number, user: User | null, limit: number | null = null): Promise<ResourceType[]> {

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -297,13 +297,7 @@ import {
   showWorkspaceBulkOperationConflictModal,
 } from './modal';
 import { featurePermissions, gatewayPermissions, queryPermissions } from './permissions';
-import {
-  reqActionServer,
-  reqExtension,
-  reqGateway,
-  reqHasura,
-  WorkspaceSaveConflictError,
-} from './requests';
+import { reqActionServer, reqExtension, reqGateway, reqHasura, WorkspaceSaveConflictError } from './requests';
 import { convertResponseToMetadata } from './scheduling';
 import { buildSearchActivitiesWhereClauses, type ActivitySearchFilters } from './searchFilters';
 import { compareEvents } from './simulation';

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -217,9 +217,8 @@ import {
   type SequenceAdaptationMetadata,
 } from '../types/sequencing';
 import type {
-  PlanDataset,
   Profile,
-  Resource,
+  ProfileSegment,
   ResourceType,
   SimulateResponse,
   Simulation,
@@ -263,7 +262,7 @@ import {
   packActivityDirectivesInPlan,
 } from './activities';
 import { ErrorTypes } from './errors';
-import { compare, convertToQuery } from './generic';
+import { convertToQuery } from './generic';
 import gql, { convertToGQLArray } from './gql';
 import {
   showApplySequenceFilterModal,
@@ -308,7 +307,6 @@ import {
   reqHasura,
   WorkspaceSaveConflictError,
 } from './requests';
-import { sampleProfiles } from './resources';
 import { convertResponseToMetadata } from './scheduling';
 import { buildSearchActivitiesWhereClauses, type ActivitySearchFilters } from './searchFilters';
 import { compareEvents } from './simulation';
@@ -4809,6 +4807,38 @@ const effects = {
     }
   },
 
+  async getExternalProfileSegmentsSince(
+    datasetId: number,
+    profileId: number,
+    sinceOffset: string,
+    user: User | null,
+    signal: AbortSignal | undefined = undefined,
+  ): Promise<ProfileSegment[] | null> {
+    try {
+      const data = await reqHasura<{ profile_segments: ProfileSegment[] }[]>(
+        gql.GET_EXTERNAL_PROFILE_SEGMENTS_SINCE,
+        { datasetId, profileId, sinceOffset },
+        user,
+        signal,
+      );
+      const { profile: profiles } = data;
+      if (profiles && profiles.length === 1) {
+        return profiles[0].profile_segments;
+      }
+      return null;
+    } catch (e) {
+      const error = e as Error;
+      if (error.name === 'AbortError') {
+        throw error;
+      }
+      catchError(
+        `Failed to retrieve external profile segments (datasetId=${datasetId}, profileId=${profileId})`,
+        error,
+      );
+      throw error;
+    }
+  },
+
   async getFile(
     fileId: number,
     user: User | null,
@@ -5186,14 +5216,15 @@ const effects = {
     }
   },
 
-  async getProfile(
+  async getProfileSince(
     datasetId: number,
     name: string,
+    sinceOffset: string,
     user: User | null,
     signal: AbortSignal | undefined = undefined,
   ): Promise<Profile | null> {
     try {
-      const data = await reqHasura<Profile[]>(gql.GET_PROFILE, { datasetId, name }, user, signal);
+      const data = await reqHasura<Profile[]>(gql.GET_PROFILE_SINCE, { datasetId, name, sinceOffset }, user, signal);
       const { profile: profiles } = data;
       if (profiles && profiles.length === 1) {
         return profiles[0];
@@ -5204,8 +5235,10 @@ const effects = {
       if (error.name === 'AbortError') {
         throw error;
       }
+      // Re-throw so the caller can surface the error in the timeline status
+      // indicator; catchError still routes it to the global log pipeline.
       catchError(`Unable to retrieve profile ${name}`, error);
-      return null;
+      throw error;
     }
   },
 
@@ -5227,78 +5260,6 @@ const effects = {
     } catch (e) {
       catchError('Unable to retrieve resource types', e as Error);
       return [];
-    }
-  },
-
-  async getResourcesExternal(
-    planId: number,
-    simulationDatasetId: number | null,
-    startTimeYmd: string,
-    user: User | null,
-    signal: AbortSignal | undefined = undefined,
-  ): Promise<{ aborted: boolean; resources: Resource[] }> {
-    try {
-      // Always fetch external resources that aren't tied to a simulation, optionally get the resources tied to one if we have a dataset ID.
-      const clauses: { simulation_dataset_id: { _is_null: boolean } | { _eq: number } }[] = [
-        { simulation_dataset_id: { _is_null: true } },
-      ];
-      if (simulationDatasetId !== null) {
-        clauses.push({ simulation_dataset_id: { _eq: simulationDatasetId } });
-      }
-
-      const data = await reqHasura<PlanDataset[]>(
-        gql.GET_PROFILES_EXTERNAL,
-        {
-          planId,
-          simulationDatasetFilter: clauses,
-        },
-        user,
-        signal,
-      );
-      const { plan_dataset: planDatasets } = data;
-      if (planDatasets != null) {
-        let resources: Resource[] = [];
-
-        const profileMap: Set<string> = new Set();
-        planDatasets.sort(({ dataset_id: datasetIdA }, { dataset_id: datasetIdB }) => {
-          return compare(datasetIdA, datasetIdB, false);
-        });
-
-        for (const dataset of planDatasets) {
-          const {
-            dataset: { profiles },
-            offset_from_plan_start,
-          } = dataset;
-          const uniqueProfiles: Profile[] = profiles.filter(profile => {
-            if (!profileMap.has(profile.name)) {
-              profileMap.add(profile.name);
-              return true;
-            }
-            return false;
-          });
-
-          uniqueProfiles.forEach(profile => {
-            logMessage(
-              `Retrieved external profile ${profile.name} (${profile.profile_segments} segment${profile.profile_segments.length}) for simulation ID=${simulationDatasetId}.`,
-            );
-          });
-
-          const sampledResources: Resource[] = sampleProfiles(uniqueProfiles, startTimeYmd, offset_from_plan_start);
-          resources = [...resources, ...sampledResources];
-        }
-        return { aborted: false, resources };
-      } else {
-        throw Error('Unable to get external resources');
-      }
-    } catch (e) {
-      let aborted = false;
-      const error = e as Error;
-      if (error.name !== 'AbortError') {
-        catchError('Unable to retrieve external profiles ', error);
-        showFailureToast('Failed to retrieve external profiles');
-        aborted = true;
-      }
-      return { aborted, resources: [] };
     }
   },
 

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1415,6 +1415,28 @@ const gql = {
     }
   `,
 
+  // Windowed pull for an external profile's segments — counterpart to
+  // GET_PROFILE_SINCE for sim profiles. Keyed on (datasetId, profileId)
+  // because external names can collide across plan_dataset rows (e.g. one
+  // tied to a sim, one plan-level); planDatasets metadata is responsible
+  // for picking which row, then this query fetches that row's deltas.
+  GET_EXTERNAL_PROFILE_SEGMENTS_SINCE: `#graphql
+    query GetExternalProfileSegmentsSince($datasetId: Int!, $profileId: Int!, $sinceOffset: interval!) {
+      ${Queries.PROFILES}(where: { _and: { dataset_id: { _eq: $datasetId }, id: { _eq: $profileId } } }, limit: 1) {
+        profile_segments(
+          where: { _and: { dataset_id: { _eq: $datasetId }, start_offset: { _gt: $sinceOffset } } }
+          order_by: { start_offset: asc }
+        ) {
+          dataset_id
+          dynamics
+          is_gap
+          profile_id
+          start_offset
+        }
+      }
+    }
+  `,
+
   GET_MODELS: `#graphql
     query GetModels {
       models: ${Queries.MISSION_MODELS} {
@@ -1704,14 +1726,20 @@ const gql = {
     }
   `,
 
-  GET_PROFILE: `#graphql
-    query GetProfile($datasetId: Int!, $name: String!) {
+  // Windowed pull: returns the profile header + only the segments past
+  // sinceOffset. Pass "-00:00:01" on the first call to get everything; pass
+  // the last seen start_offset on subsequent calls to get only the delta.
+  GET_PROFILE_SINCE: `#graphql
+    query GetProfileSince($datasetId: Int!, $name: String!, $sinceOffset: interval!) {
       ${Queries.PROFILES}(where: { _and: { dataset_id: { _eq: $datasetId }, name: { _eq: $name } } }, limit: 1) {
         dataset_id
         duration
         id
         name
-        profile_segments(where: { dataset_id: { _eq: $datasetId } }, order_by: { start_offset: asc }) {
+        profile_segments(
+          where: { _and: { dataset_id: { _eq: $datasetId }, start_offset: { _gt: $sinceOffset } } }
+          order_by: { start_offset: asc }
+        ) {
           dataset_id
           dynamics
           is_gap
@@ -1719,31 +1747,6 @@ const gql = {
           start_offset
         }
         type
-      }
-    }
-  `,
-
-  GET_PROFILES_EXTERNAL: `#graphql
-    query GetProfilesExternal($planId: Int!, $simulationDatasetFilter: [plan_dataset_bool_exp!]) {
-      ${Queries.PLAN_DATASETS}(where: { plan_id: { _eq: $planId }, _or: $simulationDatasetFilter }) {
-        dataset {
-          profiles {
-            dataset_id
-            duration
-            id
-            name
-            profile_segments(order_by: { start_offset: asc }) {
-              dataset_id
-              dynamics
-              is_gap
-              profile_id
-              start_offset
-            }
-            type
-          }
-        }
-        dataset_id
-        offset_from_plan_start
       }
     }
   `,
@@ -2999,6 +3002,7 @@ const gql = {
     subscription SubPlanDatasets($planId: Int!) {
       ${Queries.PLAN_DATASETS}(where: {plan_id: {_eq: $planId}}) {
         dataset_id
+        offset_from_plan_start
         simulation_dataset_id
         dataset {
           profiles {
@@ -3300,38 +3304,6 @@ const gql = {
             name
           }
         }
-      }
-    }
-  `,
-
-  SUB_PROFILE_HEADER: `#graphql
-    subscription SubProfileHeader($datasetId: Int!, $name: String!) {
-      ${Queries.PROFILES}(where: { _and: { dataset_id: { _eq: $datasetId }, name: { _eq: $name } } }, limit: 1) {
-        dataset_id
-        duration
-        id
-        name
-        type
-      }
-    }
-  `,
-
-  // Hasura streaming subscription. The cursor advances strictly past the last seen
-  // start_offset, so $startOffset must be < the smallest start_offset we want to
-  // receive — pass a negative Postgres interval (e.g. "-00:00:01") to capture a
-  // segment at offset 0. ISO 8601 ("-PT1S") is rejected by Hasura's interval scalar.
-  SUB_PROFILE_SEGMENTS_STREAM: `#graphql
-    subscription SubProfileSegmentsStream($datasetId: Int!, $profileId: Int!, $startOffset: interval!) {
-      ${Queries.PROFILE_SEGMENT_STREAM}(
-        cursor: { initial_value: { start_offset: $startOffset }, ordering: ASC },
-        batch_size: 2000,
-        where: { _and: { dataset_id: { _eq: $datasetId }, profile_id: { _eq: $profileId } } }
-      ) {
-        dataset_id
-        dynamics
-        is_gap
-        profile_id
-        start_offset
       }
     }
   `,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -3304,6 +3304,38 @@ const gql = {
     }
   `,
 
+  SUB_PROFILE_HEADER: `#graphql
+    subscription SubProfileHeader($datasetId: Int!, $name: String!) {
+      ${Queries.PROFILES}(where: { _and: { dataset_id: { _eq: $datasetId }, name: { _eq: $name } } }, limit: 1) {
+        dataset_id
+        duration
+        id
+        name
+        type
+      }
+    }
+  `,
+
+  // Hasura streaming subscription. The cursor advances strictly past the last seen
+  // start_offset, so $startOffset must be < the smallest start_offset we want to
+  // receive — pass a negative Postgres interval (e.g. "-00:00:01") to capture a
+  // segment at offset 0. ISO 8601 ("-PT1S") is rejected by Hasura's interval scalar.
+  SUB_PROFILE_SEGMENTS_STREAM: `#graphql
+    subscription SubProfileSegmentsStream($datasetId: Int!, $profileId: Int!, $startOffset: interval!) {
+      ${Queries.PROFILE_SEGMENT_STREAM}(
+        cursor: { initial_value: { start_offset: $startOffset }, ordering: ASC },
+        batch_size: 2000,
+        where: { _and: { dataset_id: { _eq: $datasetId }, profile_id: { _eq: $profileId } } }
+      ) {
+        dataset_id
+        dynamics
+        is_gap
+        profile_id
+        start_offset
+      }
+    }
+  `,
+
   SUB_SCHEDULING_CONDITION: `#graphql
     subscription SubSchedulingCondition($id: Int!) {
       condition: ${Queries.SCHEDULING_CONDITION_METADATA}(id: $id) {

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -1044,6 +1044,8 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
     return isUserAdmin(user) || getPermission([Queries.PLAN_SNAPSHOTS], user);
   },
   SUB_PLAN_TAGS: () => true,
+  SUB_PROFILE_HEADER: () => true,
+  SUB_PROFILE_SEGMENTS_STREAM: () => true,
   SUB_SCHEDULING_CONDITION: () => true,
   SUB_SCHEDULING_CONDITIONS: (user: User | null): boolean => {
     return isUserAdmin(user) || getPermission([Queries.SCHEDULING_CONDITION_METADATAS], user);

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -818,6 +818,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
   GET_EXPANSION_SEQUENCE_SEQ_JSON: () => true,
   GET_EXTERNAL_EVENTS: () => true,
   GET_EXTERNAL_EVENT_TYPE_BY_SOURCE: () => true,
+  GET_EXTERNAL_PROFILE_SEGMENTS_SINCE: () => true,
   GET_MODELS: () => true,
   GET_PARCEL: () => true,
   GET_PARSED_CHANNEL_DICTIONARY: () => true,
@@ -835,8 +836,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
   GET_PLAN_SNAPSHOT_ACTIVITY_DIRECTIVES: (user: User | null): boolean => {
     return isUserAdmin(user) || getPermission([Queries.PLAN_SNAPSHOT_ACTIVITIES], user);
   },
-  GET_PROFILE: () => true,
-  GET_PROFILES_EXTERNAL: () => true,
+  GET_PROFILE_SINCE: () => true,
   GET_RESOURCE_TYPES: () => true,
   GET_ROLE_PERMISSIONS: () => true,
   GET_SCHEDULING_PROCEDURE_EFFECTIVE_ARGUMENTS_BULK: () => true,
@@ -1044,8 +1044,6 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
     return isUserAdmin(user) || getPermission([Queries.PLAN_SNAPSHOTS], user);
   },
   SUB_PLAN_TAGS: () => true,
-  SUB_PROFILE_HEADER: () => true,
-  SUB_PROFILE_SEGMENTS_STREAM: () => true,
   SUB_SCHEDULING_CONDITION: () => true,
   SUB_SCHEDULING_CONDITIONS: (user: User | null): boolean => {
     return isUserAdmin(user) || getPermission([Queries.SCHEDULING_CONDITION_METADATAS], user);

--- a/src/utilities/profile.test.ts
+++ b/src/utilities/profile.test.ts
@@ -1,35 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import type { ProfileSegment } from '../types/simulation';
-import { dedupNewSegments, pickEffectiveDuration } from './profile';
-
-function seg(start_offset: string): ProfileSegment {
-  return { dataset_id: 1, dynamics: null, is_gap: false, profile_id: 1, start_offset };
-}
-
-describe('dedupNewSegments', () => {
-  test('returns the full delta when accumulator is empty', () => {
-    const delta = [seg('00:00:00'), seg('00:01:00')];
-    expect(dedupNewSegments([], delta)).toEqual(delta);
-  });
-
-  test('skips segments at or before the accumulator max offset', () => {
-    // Reconnect-replay: server resends the prefetched 0s and the already-
-    // streamed 1m and 2m, then a genuinely-new 3m.
-    const accumulator = [seg('00:00:00'), seg('00:01:00'), seg('00:02:00')];
-    const replay = [seg('00:00:00'), seg('00:01:00'), seg('00:02:00'), seg('00:03:00')];
-    expect(dedupNewSegments(accumulator, replay)).toEqual([seg('00:03:00')]);
-  });
-
-  test('returns [] when the entire delta is a duplicate', () => {
-    const accumulator = [seg('00:00:00'), seg('00:01:00')];
-    expect(dedupNewSegments(accumulator, [seg('00:00:00'), seg('00:01:00')])).toEqual([]);
-  });
-
-  test('drops duplicates within a single delta after one passes through', () => {
-    // A delta containing the same offset twice should only produce one push.
-    expect(dedupNewSegments([], [seg('00:00:00'), seg('00:00:00')])).toEqual([seg('00:00:00')]);
-  });
-});
+import { pickEffectiveDuration } from './profile';
 
 describe('pickEffectiveDuration', () => {
   test('returns headerDuration when there are no segments yet', () => {

--- a/src/utilities/profile.test.ts
+++ b/src/utilities/profile.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest';
+import type { ProfileSegment } from '../types/simulation';
+import { dedupNewSegments, pickEffectiveDuration } from './profile';
+
+function seg(start_offset: string): ProfileSegment {
+  return { dataset_id: 1, dynamics: null, is_gap: false, profile_id: 1, start_offset };
+}
+
+describe('dedupNewSegments', () => {
+  test('returns the full delta when accumulator is empty', () => {
+    const delta = [seg('00:00:00'), seg('00:01:00')];
+    expect(dedupNewSegments([], delta)).toEqual(delta);
+  });
+
+  test('skips segments at or before the accumulator max offset', () => {
+    // Reconnect-replay: server resends the prefetched 0s and the already-
+    // streamed 1m and 2m, then a genuinely-new 3m.
+    const accumulator = [seg('00:00:00'), seg('00:01:00'), seg('00:02:00')];
+    const replay = [seg('00:00:00'), seg('00:01:00'), seg('00:02:00'), seg('00:03:00')];
+    expect(dedupNewSegments(accumulator, replay)).toEqual([seg('00:03:00')]);
+  });
+
+  test('returns [] when the entire delta is a duplicate', () => {
+    const accumulator = [seg('00:00:00'), seg('00:01:00')];
+    expect(dedupNewSegments(accumulator, [seg('00:00:00'), seg('00:01:00')])).toEqual([]);
+  });
+
+  test('drops duplicates within a single delta after one passes through', () => {
+    // A delta containing the same offset twice should only produce one push.
+    expect(dedupNewSegments([], [seg('00:00:00'), seg('00:00:00')])).toEqual([seg('00:00:00')]);
+  });
+});
+
+describe('pickEffectiveDuration', () => {
+  test('returns headerDuration when there are no segments yet', () => {
+    expect(pickEffectiveDuration('00:10:00', null, true)).toBe('00:10:00');
+    expect(pickEffectiveDuration('00:10:00', null, false)).toBe('00:10:00');
+  });
+
+  test('while streaming, returns the last segment offset (no extrapolation)', () => {
+    // header.duration may be plan duration upfront or running extent — both
+    // would extend past actually-received data. We terminate at last offset.
+    expect(pickEffectiveDuration('05:00:00', '00:01:00', true)).toBe('00:01:00');
+  });
+
+  test('once streaming stops, returns headerDuration when it is >= lastOffset', () => {
+    expect(pickEffectiveDuration('00:10:00', '00:01:00', false)).toBe('00:10:00');
+  });
+
+  test('once streaming stops, falls back to lastOffset when headerDuration is shorter', () => {
+    // Defensive: if backend somehow has a stale/short duration but we have
+    // a segment at a later offset, the segment offset wins so the values
+    // array stays sorted.
+    expect(pickEffectiveDuration('00:00:30', '00:01:00', false)).toBe('00:01:00');
+  });
+});

--- a/src/utilities/profile.ts
+++ b/src/utilities/profile.ts
@@ -1,34 +1,11 @@
-import type { ProfileSegment } from '../types/simulation';
-import { getIntervalInMs } from '../utilities/time';
+import { getIntervalInMs } from './time';
 
 /**
- * Returns only the segments in `delta` whose start_offset is strictly past the
- * last offset already in `accumulator`. graphql-ws reconnects re-run the
- * streaming subscription with the original cursor, so the server replays
- * everything past that cursor — including segments we already appended pre-
- * disconnect. Filtering here keeps the values array sorted.
- */
-export function dedupNewSegments(accumulator: ProfileSegment[], delta: ProfileSegment[]): ProfileSegment[] {
-  let lastMs = accumulator.length > 0 ? getIntervalInMs(accumulator[accumulator.length - 1].start_offset) : -Infinity;
-  const result: ProfileSegment[] = [];
-  for (const seg of delta) {
-    const segMs = getIntervalInMs(seg.start_offset);
-    if (segMs > lastMs) {
-      result.push(seg);
-      lastMs = segMs;
-    }
-  }
-  return result;
-}
-
-/**
- * Picks the duration sampleProfiles should use to place the closing value of
- * the final segment. While the sim is streaming the last received segment is
- * the data frontier (extending past it would draw a flat line of stale value
- * out to a fictional end). Once the sim is terminal, header.duration is
- * authoritative — but if the backend's value is stale and shorter than the
- * last segment we've actually received, the segment offset wins so the values
- * array stays sorted.
+ * Picks the duration sampleProfiles uses to place the closing value of the
+ * final segment. While streaming, the last received segment is the data
+ * frontier. Once terminal, header.duration wins — unless a stale/short
+ * header would land before the last received segment offset, in which case
+ * we fall back to the offset to keep values sorted.
  */
 export function pickEffectiveDuration(
   headerDuration: string,
@@ -41,7 +18,14 @@ export function pickEffectiveDuration(
   if (streamingActive) {
     return lastSegmentStartOffset;
   }
-  return getIntervalInMs(headerDuration) >= getIntervalInMs(lastSegmentStartOffset)
-    ? headerDuration
-    : lastSegmentStartOffset;
+  // Defend against malformed input: getIntervalInMs returns 0 for unparseable
+  // strings, which would silently pick a too-short header and produce an
+  // unsorted values array (pinned by sort-invariant regression test in
+  // resources.test.ts).
+  const headerMs = getIntervalInMs(headerDuration);
+  const offsetMs = getIntervalInMs(lastSegmentStartOffset);
+  if (!Number.isFinite(headerMs) || !Number.isFinite(offsetMs)) {
+    return lastSegmentStartOffset;
+  }
+  return headerMs >= offsetMs ? headerDuration : lastSegmentStartOffset;
 }

--- a/src/utilities/profile.ts
+++ b/src/utilities/profile.ts
@@ -1,0 +1,47 @@
+import type { ProfileSegment } from '../types/simulation';
+import { getIntervalInMs } from '../utilities/time';
+
+/**
+ * Returns only the segments in `delta` whose start_offset is strictly past the
+ * last offset already in `accumulator`. graphql-ws reconnects re-run the
+ * streaming subscription with the original cursor, so the server replays
+ * everything past that cursor — including segments we already appended pre-
+ * disconnect. Filtering here keeps the values array sorted.
+ */
+export function dedupNewSegments(accumulator: ProfileSegment[], delta: ProfileSegment[]): ProfileSegment[] {
+  let lastMs = accumulator.length > 0 ? getIntervalInMs(accumulator[accumulator.length - 1].start_offset) : -Infinity;
+  const result: ProfileSegment[] = [];
+  for (const seg of delta) {
+    const segMs = getIntervalInMs(seg.start_offset);
+    if (segMs > lastMs) {
+      result.push(seg);
+      lastMs = segMs;
+    }
+  }
+  return result;
+}
+
+/**
+ * Picks the duration sampleProfiles should use to place the closing value of
+ * the final segment. While the sim is streaming the last received segment is
+ * the data frontier (extending past it would draw a flat line of stale value
+ * out to a fictional end). Once the sim is terminal, header.duration is
+ * authoritative — but if the backend's value is stale and shorter than the
+ * last segment we've actually received, the segment offset wins so the values
+ * array stays sorted.
+ */
+export function pickEffectiveDuration(
+  headerDuration: string,
+  lastSegmentStartOffset: string | null,
+  streamingActive: boolean,
+): string {
+  if (lastSegmentStartOffset === null) {
+    return headerDuration;
+  }
+  if (streamingActive) {
+    return lastSegmentStartOffset;
+  }
+  return getIntervalInMs(headerDuration) >= getIntervalInMs(lastSegmentStartOffset)
+    ? headerDuration
+    : lastSegmentStartOffset;
+}

--- a/src/utilities/requests.test.ts
+++ b/src/utilities/requests.test.ts
@@ -3,6 +3,7 @@ import type { BaseUser } from '../types/app';
 import { ErrorTypes } from './errors';
 import { CompoundError, reqHasura, reqWorkspace, reqWorkspaceWithEtag, WorkspaceSaveConflictError } from './requests';
 
+// required for tests which transitively import `$env/dynamic/public` - unavailable in the vitest environment
 vi.mock('$env/dynamic/public', () => ({
   env: {
     PUBLIC_HASURA_CLIENT_URL: 'http://test/hasura',

--- a/src/utilities/resources.test.ts
+++ b/src/utilities/resources.test.ts
@@ -197,8 +197,6 @@ describe('sampleProfiles', () => {
     });
 
     test('connects consecutive segments at the same x with their respective y values', () => {
-      // values[1] (close of seg0 at 60s) and values[2] (open of seg1 at 60s)
-      // share the x but differ in y, producing the visual step jump.
       const profile = realProfile('00:02:00', [
         { initial: 0, rate: 0, start_offset: '00:00:00' },
         { initial: 10, rate: 0, start_offset: '00:01:00' },
@@ -223,13 +221,9 @@ describe('sampleProfiles', () => {
       expect(xs).toEqual([...xs].sort((a, b) => a - b));
     });
 
-    // sampleProfiles assumes profile.duration >= max(start_offset). If a caller
-    // passes a duration shorter than the last segment offset, the closing value
-    // of the last segment lands at start + durationMs — earlier than its own
-    // open x — and the values array is no longer sorted, which downstream
-    // decimation cannot handle. profile.ts synthesizes a safe duration via
-    // effectiveDuration. This test pins the contract so a future "be lenient"
-    // change to sampleProfiles doesn't regress silently.
+    // Pin: if duration < last segment offset, the closing value lands before
+    // its own open x and decimation breaks. profile.ts guards this via
+    // pickEffectiveDuration; this test catches a "be lenient" regression.
     test('garbage-in: values are NOT sorted when duration < last segment start_offset', () => {
       const profile = discreteProfile('00:00:00', [
         { start_offset: '00:00:00', value: 'A' },

--- a/src/utilities/resources.test.ts
+++ b/src/utilities/resources.test.ts
@@ -1,6 +1,38 @@
 import { describe, expect, test } from 'vitest';
-import type { Profile, Resource } from '../types/simulation';
+import type { Profile, ProfileSegment, Resource } from '../types/simulation';
 import { sampleProfiles } from './resources';
+
+const START = '2024-01-01T00:00:00';
+const startMs = new Date(START).getTime();
+
+type DiscreteSeg = { is_gap?: boolean; start_offset: string; value: any };
+type RealSeg = { initial: number; is_gap?: boolean; rate: number; start_offset: string };
+
+function makeSegment(start_offset: string, dynamics: any, is_gap = false): ProfileSegment {
+  return { dataset_id: 1, dynamics, is_gap, profile_id: 1, start_offset };
+}
+
+function discreteProfile(duration: string, segments: DiscreteSeg[]): Profile {
+  return {
+    dataset_id: 1,
+    duration,
+    id: 1,
+    name: 'r',
+    profile_segments: segments.map(s => makeSegment(s.start_offset, s.value, s.is_gap)),
+    type: { schema: { type: 'string' } as any, type: 'discrete' },
+  };
+}
+
+function realProfile(duration: string, segments: RealSeg[]): Profile {
+  return {
+    dataset_id: 1,
+    duration,
+    id: 1,
+    name: 'r',
+    profile_segments: segments.map(s => makeSegment(s.start_offset, { initial: s.initial, rate: s.rate }, s.is_gap)),
+    type: { schema: { type: 'real' } as any, type: 'real' },
+  };
+}
 
 describe('sampleProfiles', () => {
   test('Calculate the correct y-value for real profile segment rate of change', () => {
@@ -109,5 +141,136 @@ describe('sampleProfiles', () => {
     ];
 
     expect(resources).toEqual(expectedResources);
+  });
+
+  test('returns [] when profiles is null', () => {
+    expect(sampleProfiles(null, START)).toEqual([]);
+  });
+
+  test('returns [] when startTimeYmd is null', () => {
+    expect(sampleProfiles([discreteProfile('00:01:00', [])], null)).toEqual([]);
+  });
+
+  test('returns one resource with empty values for a profile with no segments', () => {
+    const result = sampleProfiles([discreteProfile('00:01:00', [])], START);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toEqual('r');
+    expect(result[0].values).toEqual([]);
+  });
+
+  describe('discrete profile', () => {
+    test('produces two values per segment using the next segment start as second x', () => {
+      const profile = discreteProfile('00:01:00', [
+        { start_offset: '00:00:00', value: 'A' },
+        { start_offset: '00:00:30', value: 'B' },
+      ]);
+      const [resource] = sampleProfiles([profile], START);
+      expect(resource.values).toEqual([
+        { is_gap: false, x: startMs + 0, y: 'A' },
+        { is_gap: false, x: startMs + 30000, y: 'A' },
+        { is_gap: false, x: startMs + 30000, y: 'B' },
+        { is_gap: false, x: startMs + 60000, y: 'B' },
+      ]);
+    });
+
+    test('uses durationMs for the closing x of the last segment', () => {
+      const profile = discreteProfile('00:02:00', [{ start_offset: '00:00:30', value: 'A' }]);
+      const [resource] = sampleProfiles([profile], START);
+      expect(resource.values).toEqual([
+        { is_gap: false, x: startMs + 30000, y: 'A' },
+        { is_gap: false, x: startMs + 120000, y: 'A' },
+      ]);
+    });
+
+    test('propagates is_gap to both values produced by a gap segment', () => {
+      const profile = discreteProfile('00:01:00', [{ is_gap: true, start_offset: '00:00:00', value: 'X' }]);
+      const [resource] = sampleProfiles([profile], START);
+      expect(resource.values.every(v => v.is_gap === true)).toBe(true);
+    });
+  });
+
+  describe('real profile', () => {
+    test('uses dynamics.initial as the segment-start y value', () => {
+      const profile = realProfile('00:01:00', [{ initial: 50, rate: 0, start_offset: '00:00:00' }]);
+      const [resource] = sampleProfiles([profile], START);
+      expect(resource.values[0]).toEqual({ is_gap: false, x: startMs, y: 50 });
+    });
+
+    test('connects consecutive segments at the same x with their respective y values', () => {
+      // values[1] (close of seg0 at 60s) and values[2] (open of seg1 at 60s)
+      // share the x but differ in y, producing the visual step jump.
+      const profile = realProfile('00:02:00', [
+        { initial: 0, rate: 0, start_offset: '00:00:00' },
+        { initial: 10, rate: 0, start_offset: '00:01:00' },
+      ]);
+      const [resource] = sampleProfiles([profile], START);
+      expect(resource.values[1].x).toEqual(resource.values[2].x);
+      expect(resource.values[1].y).toEqual(0);
+      expect(resource.values[2].y).toEqual(10);
+    });
+  });
+
+  describe('sort invariants', () => {
+    test('values are sorted ASC by x when duration >= max segment start_offset', () => {
+      const profile = discreteProfile('00:05:00', [
+        { start_offset: '00:00:00', value: 'A' },
+        { start_offset: '00:01:00', value: 'B' },
+        { start_offset: '00:02:00', value: 'C' },
+        { start_offset: '00:03:00', value: 'D' },
+      ]);
+      const [resource] = sampleProfiles([profile], START);
+      const xs = resource.values.map(v => v.x);
+      expect(xs).toEqual([...xs].sort((a, b) => a - b));
+    });
+
+    // sampleProfiles assumes profile.duration >= max(start_offset). If a caller
+    // passes a duration shorter than the last segment offset, the closing value
+    // of the last segment lands at start + durationMs — earlier than its own
+    // open x — and the values array is no longer sorted, which downstream
+    // decimation cannot handle. profile.ts synthesizes a safe duration via
+    // effectiveDuration. This test pins the contract so a future "be lenient"
+    // change to sampleProfiles doesn't regress silently.
+    test('garbage-in: values are NOT sorted when duration < last segment start_offset', () => {
+      const profile = discreteProfile('00:00:00', [
+        { start_offset: '00:00:00', value: 'A' },
+        { start_offset: '00:01:00', value: 'B' },
+      ]);
+      const [resource] = sampleProfiles([profile], START);
+      const xs = resource.values.map(v => v.x);
+      const sorted = [...xs].sort((a, b) => a - b);
+      expect(xs).not.toEqual(sorted);
+    });
+
+    test('produces only finite x and y for well-formed real-typed input', () => {
+      const profile = realProfile('00:10:00', [
+        { initial: 0, rate: 1, start_offset: '00:00:00' },
+        { initial: 5, rate: -1, start_offset: '00:05:00' },
+      ]);
+      const [resource] = sampleProfiles([profile], START);
+      for (const v of resource.values) {
+        expect(Number.isFinite(v.x)).toBe(true);
+        expect(typeof v.y === 'number' && Number.isFinite(v.y)).toBe(true);
+      }
+    });
+  });
+
+  test('offsetInterval shifts every x by the offset', () => {
+    const profile = discreteProfile('00:01:00', [{ start_offset: '00:00:00', value: 'A' }]);
+    const [resource] = sampleProfiles([profile], START, '00:00:10');
+    expect(resource.values).toEqual([
+      { is_gap: false, x: startMs + 10000, y: 'A' },
+      { is_gap: false, x: startMs + 70000, y: 'A' },
+    ]);
+  });
+
+  test('handles multiple profiles independently', () => {
+    const a = discreteProfile('00:01:00', [{ start_offset: '00:00:00', value: 'A' }]);
+    a.name = 'a';
+    const b = discreteProfile('00:01:00', [{ start_offset: '00:00:00', value: 'B' }]);
+    b.name = 'b';
+    const result = sampleProfiles([a, b], START);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toEqual('a');
+    expect(result[1].name).toEqual('b');
   });
 });

--- a/src/utilities/resources.ts
+++ b/src/utilities/resources.ts
@@ -1,6 +1,12 @@
 import type { Profile, Resource, ResourceValue } from '../types/simulation';
 import { getIntervalInMs } from './time';
 
+// First-fetch sentinel for windowed profile pulls: smaller than any real
+// start_offset, so the windowed query returns every existing segment.
+// Postgres interval syntax (HH:MM:SS) — Hasura's interval scalar rejects
+// ISO 8601.
+export const INITIAL_SINCE = '-00:00:01';
+
 /**
  * Samples a list of profiles at their change points. Converts the sampled profiles to Resources.
  */


### PR DESCRIPTION
## Summary

This PR implements streaming of simulation resources and external datasets (profiles) from the database as they are available, closes #1650 . External datasets are now fetched on an as-needed basis instead of fetching all external datasets that could possibly be associated with the plan every time `planDataset` subscription changed, closes #352.

- **Sim profiles** stream segments via a new `createProfileSubscription` factory keyed on `(datasetId, name)`. Each `simulationDataset` update triggers `GET_PROFILE_SINCE` for only the segments past the last seen `start_offset`.

- **External dataset profiles** stream the same way via a new `createExternalResourceSubscription` factory. Metadata source is `planDatasets` (live subscription, already in use). When a profile's `duration` advances, the factory pulls only the new segments via `GET_EXTERNAL_PROFILE_SEGMENTS_SINCE`.

- **Removes the batch external profiles fetch.** `GET_PROFILES_EXTERNAL`, `effects.getResourcesExternal`, the `externalResources`/`fetchingResourcesExternal` writable stores, and the +page.svelte reactive statement that re-fetched all external profiles on every `planDatasets` push are all gone.

- **Fixes external profile start time anchor**  modify external profile start time to use plan start time instead of sim start time so that external profiles draw correctly in time when plan is using subset sim.

- **New `TimelineStatusIndicator`** next to the Timeline header. Aggregates loading/error across profile subscriptions, span fetches, constraint runs, external-event raw subscriptions, and active simulation status. Tooltip shows what failed (sim "Profile X" vs external "External profile X").

- **`stores/timelineResourceStatus.ts`**  loading/error registry for any resource on the timeline.

- **`allResourceTypes`** now derives from `planDatasets` metadata directly (filtered to plan-level + current-sim rows) instead of the now removed batch fetch.

- **`External event row loading states`** loading/error states on rows containing external events. Note that this is derived from the global external sources store since there are no individual fetches or subscriptions for singular derivation groups so if one is loading/failed then all will share that state.


## Tests

- New: `stores/profile.test.ts`, `stores/externalResource.test.ts`, `utilities/profile.test.ts`. Cover settling→found, race-defer, settled-missing, sim-tied vs plan-level row preference, duration-advance refetch, profile-row switch reset, refetch error surface, dispose-during-in-flight.
- Expanded: `utilities/resources.test.ts` with sort-invariant regression pins on `sampleProfiles`.
- New e2e: `simulation.test.ts` **Streaming pipeline** smoke test — asserts the indicator settles and timeline canvases render non-transparent content across two re-sims. Shared canvas-pixel helper in `e2e-tests/utilities/canvas.ts` is now used by `plan-external-source.test.ts` too.

## Test plan
- [x] Configure backend to run orbiter model by mounting spice kernels as specified here https://github.com/NASA-AMMOS/plandev-examples/tree/main/examples/05-orbiter
- [x] Load a plan that produces thousands of profile segments such as the demo plan from the Orbiter model. Ensure that resources load in progressively during simulation and reach the end of the simulation once complete. Refresh the page and ensure that the simulation results look identical to the end-of-streaming state.
- [x] Load a basic model that simulates quickly like Banananation and verify that row data still loads quickly before and during simulation.
- [x] Upload a multi-thousand-segment external dataset: row plot fills in progressively, timeline indicator stays visible while sim is active.
- [x] Open a plan whose view references a resource that doesn't exist in the current model: row shows "Failed to load profiles for 1 layer", indicator shows error icon with "Resource not found in attached external datasets" tooltip.
- [x] Run a failed sim (e.g. invalid activity): indicator settles once status is Failed.