### PR TITLE
Simplify action run logs viewer and add JSON download

### DIFF
--- a/src/components/sequencing/actions/ActionRunDetailView.svelte
+++ b/src/components/sequencing/actions/ActionRunDetailView.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
   import { Button, Tabs } from '@nasa-jpl/stellar-svelte';
   import { capitalize } from 'lodash-es';
-  import { ArrowLeft, Ban, RefreshCw } from 'lucide-svelte';
+  import { ArrowLeft, Ban, Download, RefreshCw } from 'lucide-svelte';
   import { createEventDispatcher } from 'svelte';
   import { writable } from 'svelte/store';
   import { Status } from '../../../enums/status';
@@ -12,25 +12,26 @@
   import { workspaceId } from '../../../stores/workspaces';
   import type { ActionDefinition, ActionDefinitionVersion, ActionRun } from '../../../types/actions';
   import type { User } from '../../../types/app';
-  import type { LogMessage } from '../../../types/errors';
   import type { ArgumentsMap, FormParameter } from '../../../types/parameter';
   import {
     getActionDefinitionForRun,
     getDefaultsFromSchema,
     getLatestRunnableVersion,
     getStatusForActionRun,
+    parseActionLogLines,
+    type ParsedActionLog,
     valueSchemaRecordToParametersMap,
   } from '../../../utilities/actions';
   import effects from '../../../utilities/effects';
-  import { ErrorTypes } from '../../../utilities/errors';
+  import { downloadJSON } from '../../../utilities/generic';
   import gql from '../../../utilities/gql';
   import { getFormParameters } from '../../../utilities/parameters';
   import { permissionHandler } from '../../../utilities/permissionHandler';
   import { formatMS } from '../../../utilities/time';
   import { tooltip } from '../../../utilities/tooltip';
-  import ConsoleLog from '../../console/views/ConsoleLog.svelte';
   import Parameters from '../../parameters/Parameters.svelte';
   import StatusBadge from '../../ui/StatusBadge.svelte';
+  import ActionRunLogs from './ActionRunLogs.svelte';
 
   const dispatch = createEventDispatcher<{
     back: void;
@@ -55,6 +56,7 @@
   let actionDefinition: ActionDefinition | null = null;
   let latestVersion: ActionDefinitionVersion | null = null;
   let isLatestVersion: boolean = false;
+  let parsedLogs: ParsedActionLog[] = [];
   let status: Status | null = null;
 
   $: actionRunIdStore.set(actionRunId);
@@ -71,6 +73,16 @@
   $: latestVersion = getLatestRunnableVersion(actionRun?.action_definition.versions ?? []);
   $: isLatestVersion = latestVersion != null && actionRun?.action_definition_revision === latestVersion.revision;
   $: status = actionRun ? getStatusForActionRun(actionRun) : null;
+  $: parsedLogs = actionRun?.logs ? parseActionLogLines(actionRun.logs) : ([] as ParsedActionLog[]);
+  $: errorEntry =
+    actionRun?.error?.message != null
+      ? ({
+          level: 'error',
+          message: actionRun.error.message,
+          timestamp: actionRun.requested_at,
+          trace: actionRun.error.stack,
+        } satisfies ParsedActionLog)
+      : null;
 
   function updateActionSettingsAndParameters(run: ActionRun) {
     const version =
@@ -102,64 +114,25 @@
     );
   }
 
-  function parseLogLines(logString: string): LogMessage[] {
-    // Action server formats logs as: TIMESTAMP [LEVEL] message
-    // Continuation lines (multi-line errors/stack traces) appear as: [LEVEL] text (indented, no timestamp)
-    const serverLogPattern = /^(\S+)\s+\[(INFO|WARN|ERROR|DEBUG)]\s(.*)$/;
-    const continuationLevelPattern = /^\s*\[(INFO|WARN|ERROR|DEBUG)]\s(.*)$/;
-    const results: LogMessage[] = [];
-
-    for (const line of logString.split('\n')) {
-      if (!line.trim()) {
-        continue;
-      }
-
-      const mainMatch = line.match(serverLogPattern);
-      if (mainMatch) {
-        const [, timestamp, rawLevel, message] = mainMatch;
-        results.push({
-          level: rawLevel.toLowerCase() as LogMessage['level'],
-          message,
-          timestamp,
-          type: ErrorTypes.LOG,
-        });
-        continue;
-      }
-
-      // Continuation line — strip [LEVEL] prefix and merge into previous entry's trace
-      const contMatch = line.match(continuationLevelPattern);
-      const cleanLine = contMatch ? contMatch[2] : line;
-
-      if (results.length > 0) {
-        const prev = results[results.length - 1];
-        prev.trace = prev.trace ? `${prev.trace}\n${cleanLine}` : cleanLine;
-      } else {
-        results.push({
-          level: 'info',
-          message: cleanLine,
-          timestamp: '',
-          type: ErrorTypes.LOG,
-        });
-      }
+  function onDownloadRun() {
+    if (!actionRun) {
+      return;
     }
-
-    // Post-process: when a message ends with '{' and trace contains the rest of
-    // a JSON object, reassemble and parse it into `data` for clean rendering.
-    for (const entry of results) {
-      if (entry.message.endsWith('{') && entry.trace) {
-        const jsonCandidate = '{\n' + entry.trace;
-        try {
-          const parsed = JSON.parse(jsonCandidate);
-          entry.message = entry.message.slice(0, -1).trimEnd();
-          entry.data = parsed;
-          entry.trace = undefined;
-        } catch {
-          // Not valid JSON, leave as-is
-        }
-      }
-    }
-
-    return results;
+    downloadJSON(
+      {
+        duration: actionRun.duration,
+        error: actionRun.error,
+        id: actionRun.id,
+        logs: parsedLogs,
+        parameters: actionRun.parameters,
+        requestedAt: actionRun.requested_at,
+        requestedBy: actionRun.requested_by,
+        results: actionRun.results,
+        settings: actionRun.settings,
+        status: actionRun.status,
+      },
+      `${actionRun.action_definition.name}-${actionRun.id}.json`,
+    );
   }
 
   async function onCancelRun() {
@@ -213,6 +186,10 @@
         </div>
       </div>
       <div class="flex items-center gap-2">
+        <Button variant="outline" on:click={onDownloadRun}>
+          <Download size={12} class="mr-1" />
+          Download
+        </Button>
         {#if actionDefinition && !actionDefinition.archived}
           <div
             use:permissionHandler={{
@@ -287,19 +264,13 @@
         <!-- Output tab (errors, results, logs) -->
         <Tabs.Content value="output" class="mt-0 flex-1 overflow-y-auto">
           <div class="mx-auto flex max-w-5xl flex-col gap-4 p-6">
-            {#if actionRun.error?.message}
-              {@const errorLog = {
-                level: 'error',
-                message: actionRun.error.message,
-                timestamp: actionRun.requested_at,
-                trace: actionRun.error.stack,
-                type: ErrorTypes.CAUGHT_ERROR,
-              }}
-              <div class="flex flex-col gap-3 rounded border border-destructive/30 bg-destructive/5 p-4">
+            {#if errorEntry}
+              <div
+                class="flex flex-col gap-3 rounded border border-destructive/30 bg-destructive/5 p-4"
+                data-testid="action-run-error-log"
+              >
                 <h3 class="text-sm font-medium text-destructive">Error</h3>
-                <div class="overflow-auto rounded bg-muted py-2 font-mono text-xs" data-testid="action-run-error-log">
-                  <ConsoleLog log={errorLog} showType={false} showLongTimestamp={false} />
-                </div>
+                <ActionRunLogs logs={[errorEntry]} />
               </div>
             {/if}
             <div class="flex flex-col gap-3 rounded border border-border p-4">
@@ -318,26 +289,8 @@
             </div>
             <div class="flex flex-col gap-3 rounded border border-border p-4">
               <h3 class="text-sm font-medium">Logs</h3>
-              {#if actionRun.logs}
-                {@const logMessages = parseLogLines(actionRun.logs)}
-                <div class="max-h-[600px] overflow-auto rounded bg-muted py-2 font-mono text-xs">
-                  {#each logMessages as log}
-                    <ConsoleLog {log} defaultExpanded={true} showType={false} showLongTimestamp={false}>
-                      <svelte:fragment slot="message" let:message let:expandable let:open>
-                        {#if expandable && !open}
-                          <!-- "preview" text for expandable logs, ellipsize to one line -->
-                          <span class="block w-full min-w-0 overflow-hidden text-ellipsis whitespace-pre">
-                            {message}
-                          </span>
-                        {:else}
-                          <span class="block w-full min-w-0 whitespace-pre-wrap break-words">
-                            {message}
-                          </span>
-                        {/if}
-                      </svelte:fragment>
-                    </ConsoleLog>
-                  {/each}
-                </div>
+              {#if parsedLogs.length}
+                <ActionRunLogs logs={parsedLogs} />
               {:else}
                 <p class="text-xs italic text-muted-foreground">No logs</p>
               {/if}

--- a/src/components/sequencing/actions/ActionRunDetailView.svelte
+++ b/src/components/sequencing/actions/ActionRunDetailView.svelte
@@ -120,6 +120,7 @@
     }
     downloadJSON(
       {
+        canceled: actionRun.canceled,
         duration: actionRun.duration,
         error: actionRun.error,
         id: actionRun.id,

--- a/src/components/sequencing/actions/ActionRunLogs.svelte
+++ b/src/components/sequencing/actions/ActionRunLogs.svelte
@@ -1,0 +1,37 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { cn } from '@nasa-jpl/stellar-svelte';
+  import type { ParsedActionLog, ParsedActionLogLevel } from '../../../utilities/actions';
+  import { safeStringify } from '../../../utilities/text';
+
+  export let logs: ParsedActionLog[];
+  export let maxHeightClass: string = 'max-h-[600px]';
+  export let className: string = '';
+
+  const levelTextClass: Record<ParsedActionLogLevel, string> = {
+    debug: 'text-muted-foreground',
+    error: 'text-destructive',
+    info: 'text-blue-500',
+    warn: 'text-yellow-600',
+  };
+</script>
+
+<div
+  data-testid="action-run-logs"
+  class={cn('overflow-auto rounded bg-muted py-2 font-mono text-xs leading-5', maxHeightClass, className)}
+>
+  {#each logs as log}
+    <div class="whitespace-pre-wrap break-words px-3">
+      {#if log.timestamp}<span class="text-muted-foreground">{log.timestamp}</span>{' '}{/if}<span
+        class={cn('uppercase', levelTextClass[log.level])}>{log.level.padEnd(5)}</span
+      >{' '}<span>{log.message}</span>
+      {#if log.data}
+        <div class="whitespace-pre-wrap break-words pl-4 text-muted-foreground">{safeStringify(log.data, 2)}</div>
+      {/if}
+      {#if log.trace}
+        <div class="whitespace-pre-wrap break-words pl-4 text-muted-foreground">{log.trace}</div>
+      {/if}
+    </div>
+  {/each}
+</div>

--- a/src/utilities/actions.test.ts
+++ b/src/utilities/actions.test.ts
@@ -9,6 +9,7 @@ import {
   getLatestRunnableVersion,
   getRunnableVersions,
   getStatusForActionRun,
+  parseActionLogLines,
   truncateRunParameters,
   valueSchemaRecordToParametersMap,
 } from './actions';
@@ -249,5 +250,72 @@ describe('truncateRunParameters', () => {
     };
     const result = truncateRunParameters(params, schema);
     expect(result).toMatch(/^primary:/);
+  });
+});
+
+describe('parseActionLogLines', () => {
+  test('parses a single well-formed line', () => {
+    const result = parseActionLogLines('2026-05-18T12:34:56Z [INFO] starting action');
+    expect(result).toEqual([
+      {
+        level: 'info',
+        message: 'starting action',
+        timestamp: '2026-05-18T12:34:56Z',
+      },
+    ]);
+  });
+
+  test('merges continuation lines into the previous entry trace', () => {
+    const input = [
+      '2026-05-18T12:34:58Z [ERROR] failed to validate',
+      '  [ERROR]   at validatePlan (validator.ts:12)',
+      '  [ERROR]   at run (action.ts:5)',
+    ].join('\n');
+    const result = parseActionLogLines(input);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      level: 'error',
+      message: 'failed to validate',
+      timestamp: '2026-05-18T12:34:58Z',
+      trace: '  at validatePlan (validator.ts:12)\n  at run (action.ts:5)',
+    });
+  });
+
+  test('reassembles {-suffixed JSON continuation into data', () => {
+    const input = [
+      '2026-05-18T12:34:57Z [INFO] fetching plan {',
+      '  [INFO]   "planId": 42,',
+      '  [INFO]   "name": "Mars Mission"',
+      '  [INFO] }',
+    ].join('\n');
+    const result = parseActionLogLines(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].message).toBe('fetching plan');
+    expect(result[0].data).toEqual({ name: 'Mars Mission', planId: 42 });
+    expect(result[0].trace).toBeUndefined();
+  });
+
+  test('keeps trace when {-suffix continuation is not valid JSON', () => {
+    const input = ['2026-05-18T12:34:57Z [INFO] open brace {', '  [INFO] not actually json'].join('\n');
+    const result = parseActionLogLines(input);
+    expect(result[0].message).toBe('open brace {');
+    expect(result[0].data).toBeUndefined();
+    expect(result[0].trace).toBe('not actually json');
+  });
+
+  test('returns [] for empty or whitespace-only input', () => {
+    expect(parseActionLogLines('')).toEqual([]);
+    expect(parseActionLogLines('   \n\n\t  \n')).toEqual([]);
+  });
+
+  test('handles orphan continuation line with no preceding main entry', () => {
+    const result = parseActionLogLines('  [ERROR] orphan trace line');
+    expect(result).toEqual([
+      {
+        level: 'info',
+        message: 'orphan trace line',
+        timestamp: '',
+      },
+    ]);
   });
 });

--- a/src/utilities/actions.ts
+++ b/src/utilities/actions.ts
@@ -145,6 +145,81 @@ export function openActionRun(workspaceId: number, runId: number, eventOrNewTab?
   }
 }
 
+export type ParsedActionLogLevel = 'debug' | 'error' | 'info' | 'warn';
+
+export interface ParsedActionLog {
+  data?: Record<string, unknown>;
+  level: ParsedActionLogLevel;
+  message: string;
+  timestamp: string;
+  trace?: string;
+}
+
+/**
+ * Parses an action server log string into structured entries.
+ *
+ * Action server log format:
+ *   TIMESTAMP [LEVEL] message
+ * Continuation lines (multi-line errors / stack traces) appear as:
+ *   [LEVEL] text  (indented, no timestamp)
+ *
+ * Continuation lines are merged into the previous entry's `trace`. As a
+ * post-process, when a message ends with `{` and `trace` contains the rest
+ * of a JSON object, the JSON is reassembled into `data`.
+ */
+export function parseActionLogLines(logString: string): ParsedActionLog[] {
+  const serverLogPattern = /^(\S+)\s+\[(INFO|WARN|ERROR|DEBUG)]\s(.*)$/;
+  const continuationLevelPattern = /^\s*\[(INFO|WARN|ERROR|DEBUG)]\s(.*)$/;
+  const results: ParsedActionLog[] = [];
+
+  for (const line of logString.split('\n')) {
+    if (!line.trim()) {
+      continue;
+    }
+
+    const mainMatch = line.match(serverLogPattern);
+    if (mainMatch) {
+      const [, timestamp, rawLevel, message] = mainMatch;
+      results.push({
+        level: rawLevel.toLowerCase() as ParsedActionLogLevel,
+        message,
+        timestamp,
+      });
+      continue;
+    }
+
+    const contMatch = line.match(continuationLevelPattern);
+    const cleanLine = contMatch ? contMatch[2] : line;
+
+    if (results.length > 0) {
+      const prev = results[results.length - 1];
+      prev.trace = prev.trace ? `${prev.trace}\n${cleanLine}` : cleanLine;
+    } else {
+      results.push({
+        level: 'info',
+        message: cleanLine,
+        timestamp: '',
+      });
+    }
+  }
+
+  for (const entry of results) {
+    if (entry.message.endsWith('{') && entry.trace) {
+      const jsonCandidate = '{\n' + entry.trace;
+      try {
+        const parsed = JSON.parse(jsonCandidate);
+        entry.message = entry.message.slice(0, -1).trimEnd();
+        entry.data = parsed;
+        entry.trace = undefined;
+      } catch {
+        // Not valid JSON, leave as-is
+      }
+    }
+  }
+
+  return results;
+}
+
 /**
  * Formats action run parameters as a truncated summary string.
  * Prioritizes parameters with `primary: true`, then by `order`.


### PR DESCRIPTION
## Summary
- Replace per-line `ConsoleLog` rendering in the action-run output with a new `ActionRunLogs` component — a tight monospace block (no chevrons, no expandable rows) so vertical text selection copies cleanly in source order, like GitHub Actions logs.
- Add a **Download** button in the run header that exports the full run (metadata + parameters + settings + error + results + parsed logs) as JSON via the existing `downloadJSON` utility.
- Move the log parser out of the Svelte file into `utilities/actions.ts` as `parseActionLogLines` with its own `ParsedActionLog` type, and migrate the Error block to render through `ActionRunLogs` too so both blocks share formatting (the red wrapper keeps the Error section visually distinct).

## Test plan
- [x] Open a run with multi-line logs (including ERROR with continuation lines). Drag-select across several rows and paste into a plain editor — output should be one line per entry with timestamps + levels, indented continuation preserved, no chevron/marker characters.
- [x] Levels render with their colors: INFO blue, WARN yellow, ERROR red, DEBUG muted (matching `ConsoleLog`'s palette).
- [x] Click **Download** in the header → `{action-name}-{runId}.json` downloads. Open it: object with `id`, `status`, `requestedAt`, `requestedBy`, `duration`, `parameters`, `settings`, `error`, `results`, and `logs: [{ timestamp, level, message, trace?, data? }, ...]`.
- [x] Trigger a failing run → Error block renders inside the red wrapper using the same formatting as the Logs block.
- [x] Trigger a successful run with `results.data` → Results block renders unchanged.
- [x] Run with `logs: null` shows the italic "No logs" placeholder; Download button still functions.
