### PR TITLE
Close plan branches modal on branch select

### DIFF
--- a/src/components/modals/PlanBranchesModal.svelte
+++ b/src/components/modals/PlanBranchesModal.svelte
@@ -2,7 +2,9 @@
 
 <script lang="ts">
   import { base } from '$app/paths';
+  import { createEventDispatcher } from 'svelte';
   import type { Plan } from '../../types/plan';
+  import { isMetaOrCtrlPressed } from '../../utilities/keyboardEvents';
   import Modal from './Modal.svelte';
   import ModalContent from './ModalContent.svelte';
   import ModalHeader from './ModalHeader.svelte';
@@ -10,6 +12,10 @@
   export let height: number = 270;
   export let plan: Plan;
   export let width: number = 400;
+
+  const dispatch = createEventDispatcher<{
+    close: void;
+  }>();
 </script>
 
 <Modal {height} {width} on:close>
@@ -17,7 +23,17 @@
   <ModalContent style=" overflow: auto;padding: 0">
     <div class="plan-branched-plans">
       {#each plan.child_plans as childPlan}
-        <a class="branched-plan" href={`${base}/plans/${childPlan.id}`}>{childPlan.name}</a>
+        <a
+          class="branched-plan"
+          href={`${base}/plans/${childPlan.id}`}
+          on:click={e => {
+            if (!isMetaOrCtrlPressed(e)) {
+              dispatch('close');
+            }
+          }}
+        >
+          {childPlan.name}
+        </a>
       {/each}
     </div>
   </ModalContent>


### PR DESCRIPTION
Close plan branches modal when user clicks on a branch. Prevents closure when user has meta/ctrl key pressed to preserve open in new tab/window behavior. Closes #1937. 

<a id="verification"></a>
## Verification
1. Create plan
2. Add activity
3. Create plan branch
4. Go back to parent plan
5. Open plan branches modal
6. Click on child branch
7. Branch should load and modal should close
8. Reopen branches modal from parent plan
9. Control/command click (windows/mac) on child branch and ensure it opens in new tab and doesn't close modal