### PR TITLE
Show live plan revision in the metadata panel

### DIFF
--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -309,9 +309,9 @@ export class Plan {
   }
 
   async fillPlanName(name: string) {
+    // Blur fires a single native `change` event, mirroring a real user editing the field and
+    // clicking away. Avoid also dispatching a synthetic `change`, which would double the update.
     await this.planNameInput.fill(name);
-    await this.planNameInput.evaluate(e => e.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' })));
-    await this.planNameInput.evaluate(e => e.dispatchEvent(new Event('change')));
     await this.planNameInput.blur();
   }
 

--- a/e2e-tests/tests/plan-metadata.test.ts
+++ b/e2e-tests/tests/plan-metadata.test.ts
@@ -154,6 +154,27 @@ test.describe.serial('Plan Metadata', () => {
     await planA.renamePlan(planA.planName);
   });
 
+  test('Plan revision increments by one when the plan changes', async () => {
+    await planA.showPanel(PanelNames.PLAN_METADATA, true);
+
+    const revisionInput = planA.panelPlanMetadata.getByRole('textbox', { exact: true, name: 'Revision' });
+
+    // Read the true current revision from the DB (the UI value can lag behind the metadata subscription).
+    const revisionBefore = await apiA.getPlanRevision(planAId);
+
+    await planA.renamePlan(planA.planName + '_rev');
+
+    // A single rename triggers exactly one plan update, bumping the revision by one...
+    expect(await apiA.getPlanRevision(planAId)).toBe(revisionBefore + 1);
+    // ...and the metadata panel must reflect the new revision via its live subscription (the
+    // regression guard: before the fix the panel showed a stale revision from initial load).
+    await expect(revisionInput).toHaveValue(String(revisionBefore + 1));
+
+    // Restore the original name, which bumps the revision once more.
+    await planA.renamePlan(planA.planName);
+    await expect(revisionInput).toHaveValue(String(revisionBefore + 2));
+  });
+
   test('Plan name uniqueness validation enforced', async () => {
     await planA.showPanel(PanelNames.PLAN_METADATA, true);
     await planA.fillPlanName(planB.planName);

--- a/e2e-tests/utilities/api.ts
+++ b/e2e-tests/utilities/api.ts
@@ -186,6 +186,11 @@ export class AerieApi {
     return data.plan;
   }
 
+  async getPlanRevision(planId: number): Promise<number> {
+    const data = await this.gqlQuery<{ plan: { revision: number } }>(gql.GET_PLAN_REVISION, { planId });
+    return data.plan.revision;
+  }
+
   async getSimulationDataset(id: number): Promise<{ reason: string | null; status: string }> {
     const data = await this.gqlQuery<{
       simulation_dataset_by_pk: { reason: string | null; status: string };

--- a/src/components/plan/PlanForm.svelte
+++ b/src/components/plan/PlanForm.svelte
@@ -31,9 +31,9 @@
   import { removeQueryParam, setQueryParam } from '../../utilities/url';
   import { required, unique } from '../../utilities/validators';
   import Collapse from '../Collapse.svelte';
-  import AsyncContentState from '../ui/AsyncContentState.svelte';
   import Field from '../form/Field.svelte';
   import Input from '../form/Input.svelte';
+  import AsyncContentState from '../ui/AsyncContentState.svelte';
   import CardList from '../ui/CardList.svelte';
   import FilterToggleButton from '../ui/FilterToggleButton.svelte';
   import ProgressRadial from '../ui/ProgressRadial.svelte';

--- a/src/stores/plan.ts
+++ b/src/stores/plan.ts
@@ -56,6 +56,8 @@ export const planModelId: Readable<number> = derived(plan, $plan => $plan?.model
 
 export const planModelRevision: Readable<number> = derived(plan, $plan => $plan?.model?.revision ?? -1);
 
+export const planRevision: Readable<number> = derived(plan, $plan => $plan?.revision ?? -1);
+
 /* Other Subscriptions. */
 
 export const planModelActivityTypes = gqlSubscribable<ActivityType[]>(
@@ -102,13 +104,6 @@ export const planMergeRequestsOutgoing = gqlSubscribable<PlanMergeRequest[]>(
   [],
   (planMergeRequests: PlanMergeRequestSchema[]): PlanMergeRequest[] =>
     planMergeRequests.map(planMergeRequest => ({ ...planMergeRequest, pending: false, type: 'outgoing' })),
-);
-
-export const planRevision = gqlSubscribable<number>(
-  gql.SUB_PLAN_REVISION,
-  { planId },
-  -1,
-  ({ revision }: Pick<Plan, 'revision'>) => revision,
 );
 
 /* Helper Functions. */

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -146,7 +146,7 @@ export type DeprecatedPlanTransfer = Omit<PlanTransfer, 'duration' | 'simulation
 
 export type PlanMetadata = Pick<
   PlanSchema,
-  'id' | 'updated_at' | 'updated_by' | 'name' | 'owner' | 'created_at' | 'collaborators' | 'model'
+  'id' | 'updated_at' | 'updated_by' | 'name' | 'owner' | 'created_at' | 'collaborators' | 'model' | 'revision'
 >;
 
 export type PlanSlim = Pick<

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -5083,8 +5083,7 @@ const effects = {
 
   async getPlanRevision(planId: number, user: User | null): Promise<number | null> {
     try {
-      const query = convertToQuery(gql.SUB_PLAN_REVISION);
-      const data = await reqHasura<Pick<Plan, 'revision'>>(query, { planId }, user);
+      const data = await reqHasura<Pick<Plan, 'revision'>>(gql.GET_PLAN_REVISION, { planId }, user);
       const { plan } = data;
       if (plan != null) {
         const { revision } = plan;

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1676,6 +1676,14 @@ const gql = {
     }
   `,
 
+  GET_PLAN_REVISION: `#graphql
+    query GetPlanRevision($planId: Int!) {
+      plan: ${Queries.PLAN}(id: $planId) {
+        revision
+      }
+    }
+  `,
+
   GET_PLAN_SNAPSHOT_ACTIVITY_DIRECTIVES: `#graphql
     query GetPlanSnapshotActivityDirectives($planSnapshotId: Int!) {
       plan_snapshot_activity_directives: ${Queries.PLAN_SNAPSHOT_ACTIVITIES}(where: { snapshot_id: { _eq: $planSnapshotId } }, order_by: { start_offset: asc }) {
@@ -3245,20 +3253,13 @@ const gql = {
         model_id
         name
         owner
+        revision
         updated_at
         updated_by
         created_at
         collaborators {
           collaborator
         }
-      }
-    }
-  `,
-
-  SUB_PLAN_REVISION: `#graphql
-    subscription SubPlanRevision($planId: Int!) {
-      plan: ${Queries.PLAN}(id: $planId) {
-        revision
       }
     }
   `,

--- a/src/utilities/permissions.ts
+++ b/src/utilities/permissions.ts
@@ -832,6 +832,7 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
   },
   GET_PLAN_EVENT_TYPES: () => true,
   GET_PLAN_MERGE_NON_CONFLICTING_ACTIVITIES: () => true,
+  GET_PLAN_REVISION: () => true,
   GET_PLAN_SNAPSHOT_ACTIVITY_DIRECTIVES: (user: User | null): boolean => {
     return isUserAdmin(user) || getPermission([Queries.PLAN_SNAPSHOT_ACTIVITIES], user);
   },
@@ -1039,7 +1040,6 @@ const queryPermissions: Record<GQLKeys, (user: User | null, ...args: any[]) => b
   SUB_PLAN_MERGE_REQUEST_IN_PROGRESS: () => true,
   SUB_PLAN_MERGE_REQUEST_STATUS: () => true,
   SUB_PLAN_METADATA: () => true,
-  SUB_PLAN_REVISION: () => true,
   SUB_PLAN_SNAPSHOTS: (user: User | null): boolean => {
     return isUserAdmin(user) || getPermission([Queries.PLAN_SNAPSHOTS], user);
   },


### PR DESCRIPTION
## Summary
Include plan revision in plan metadata subscription so that plan revision updates in plan metadata panel. Additionally refactors planRevision store to use the new live revision value instead of an independent subscription. Closes #1938. 

## Visible UX Changes
- plan revision should increase in the plan metadata panel input when the plan is changed

## Verification
- New plan-metadata.test.ts test added to ensure plan revision increases after plan name change