### PR TITLE
Clear derivationGroupVisibilityMap on external source store reset

### DIFF
--- a/src/stores/external-source.ts
+++ b/src/stores/external-source.ts
@@ -100,6 +100,7 @@ export function resetExternalSourceStores(): void {
   createDerivationGroupError.set(null);
   derivationGroupPlanLinkError.set(null);
   planDerivationGroupLinks.updateValue(() => []);
+  derivationGroupVisibilityMap.set({});
 }
 
 function transformDerivationGroups(


### PR DESCRIPTION
## Summary 
`resetExternalSourceStores()` runs when entering the external-sources route and when leaving a plan, but left derivationGroupVisibilityMap populated, so per-derivation-group visibility toggles leaked across plans/navigations. Reset it alongside the other external-source stores.

## Verification
- Add external events to plan 1
- Toggle derivation group visibility in the plan from the external sources plan panel
- Make plan 2 and link the same external events
- Verify that the external events are marked as visible