### PR TITLE
Fix: Remove empty activity type from search filter and fix placeholder selection

### DIFF
--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -113,7 +113,7 @@
   ];
 
   $: {
-    const activityTypeNames: string[] = [''];
+    const activityTypeNames: string[] = [];
     if (selectedModel) {
       activityTypeNames.push(...selectedModel.activity_types.map(type => type.name));
     } else {

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -100,11 +100,52 @@
 
   $: orderedModels = [...$models].sort(({ id: idA }, { id: idB }) => idB - idA);
 
-  $: modelOptions = orderedModels.map(m => ({ display: getDisplayNameForModel(m), value: m.id }));
+  $: {
+    modelOptions = orderedModels.map(m => ({ display: getDisplayNameForModel(m), value: m.id }));
 
-  $: tagOptions = $tagsStore.map(tag => ({ display: tag.name, value: tag.name }));
+    // If the selected model is no longer available, reset the selection
+    if (selectedModelId !== undefined) {
+      const availableModels = new Set(modelOptions.map(opt => opt.value));
+      if (!availableModels.has(selectedModelId)) {
+        selectedModelId = undefined;
+      }
+    }
+  }
 
-  $: userOptions = $users.filter((u): u is string => u !== null).map(u => ({ display: u, value: u }));
+  $: {
+    tagOptions = $tagsStore.map(tag => ({ display: tag.name, value: tag.name }));
+
+    // If the selected tag is no longer available, reset the selection
+    if (filters.tagValue) {
+      const availableTags = new Set(tagOptions.map(opt => opt.value));
+      if (!availableTags.has(filters.tagValue)) {
+        filters = { ...filters, planTag: '', tagValue: '' };
+      }
+    }
+  }
+
+  $: {
+    userOptions = $users.filter((u): u is string => u !== null).map(u => ({ display: u, value: u }));
+
+    // If the user is no longer available, reset the selections
+    if (filters.createdBy || filters.lastModifiedBy || filters.planOwner) {
+      let filtersUpdate: Partial<typeof DEFAULT_FILTERS> = {};
+      const availableUsers = new Set(userOptions.map(opt => opt.value));
+      if (!availableUsers.has(filters.createdBy)) {
+        filtersUpdate = { ...filtersUpdate, createdBy: '' };
+      }
+      if (!availableUsers.has(filters.lastModifiedBy)) {
+        filtersUpdate = { ...filtersUpdate, lastModifiedBy: '' };
+      }
+      if (!availableUsers.has(filters.planOwner)) {
+        filtersUpdate = { ...filtersUpdate, planOwner: '' };
+      }
+
+      if (Object.keys(filtersUpdate).length > 0) {
+        filters = { ...filters, ...filtersUpdate };
+      }
+    }
+  }
 
   $: {
     const activityTypeNames: string[] = [];
@@ -118,6 +159,15 @@
     typeOptions = activityTypeNames
       .map(type => ({ display: type, value: type }))
       .sort((a, b) => a.display.localeCompare(b.display));
+
+    // If a selected activity type is no longer available, remove the selection
+    if (filters.actType.length > 0) {
+      const availableTypes = new Set(typeOptions.map(opt => opt.value));
+      const validTypes = filters.actType.filter(type => availableTypes.has(type));
+      if (validTypes.length !== filters.actType.length) {
+        filters = { ...filters, actType: validTypes };
+      }
+    }
   }
 
   $: {
@@ -129,6 +179,14 @@
       ),
     ];
     presetOptions = presetNames.map(name => ({ display: name, value: name }));
+
+    // If the selected preset is no longer available, reset the selection
+    if (filters.preset) {
+      const availablePresets = new Set(presetOptions.map(opt => opt.value));
+      if (!availablePresets.has(filters.preset)) {
+        filters = { ...filters, preset: '' };
+      }
+    }
   }
 
   $: {
@@ -145,11 +203,29 @@
       }
     }
     argNameOptions = [...paramNames].sort((a, b) => a.localeCompare(b)).map(name => ({ display: name, value: name }));
+
+    // If the selected argument is no longer available, reset the selection
+    if (filters.argName) {
+      const availableArgNames = new Set(argNameOptions.map(opt => opt.value));
+      if (!availableArgNames.has(filters.argName)) {
+        filters = { ...filters, argName: '' };
+      }
+    }
   }
 
-  $: goalOptions = [...$schedulingGoalResponses]
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .map(goal => ({ display: `${goal.name} (${goal.id})`, value: goal.id.toString() }));
+  $: {
+    goalOptions = [...$schedulingGoalResponses]
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map(goal => ({ display: `${goal.name} (${goal.id})`, value: goal.id.toString() }));
+
+    // If the selected goal is no longer available, reset the selection
+    if (filters.schedulingGoalId) {
+      const availableGoals = new Set(goalOptions.map(opt => opt.value));
+      if (!availableGoals.has(filters.schedulingGoalId)) {
+        filters = { ...filters, schedulingGoalId: '' };
+      }
+    }
+  }
 
   // Initialize from URL on first page load (browser only — SSR can't navigate)
   $: if (browser && $page.url) {

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -100,17 +100,11 @@
 
   $: orderedModels = [...$models].sort(({ id: idA }, { id: idB }) => idB - idA);
 
-  $: modelOptions = [
-    { display: '', value: '' },
-    ...orderedModels.map(m => ({ display: getDisplayNameForModel(m), value: m.id })),
-  ];
+  $: modelOptions = orderedModels.map(m => ({ display: getDisplayNameForModel(m), value: m.id }));
 
-  $: tagOptions = [{ display: '', value: '' }, ...$tagsStore.map(tag => ({ display: tag.name, value: tag.name }))];
+  $: tagOptions = $tagsStore.map(tag => ({ display: tag.name, value: tag.name }));
 
-  $: userOptions = [
-    { display: '', value: '' },
-    ...$users.filter((u): u is string => u !== null).map(u => ({ display: u, value: u })),
-  ];
+  $: userOptions = $users.filter((u): u is string => u !== null).map(u => ({ display: u, value: u }));
 
   $: {
     const activityTypeNames: string[] = [];
@@ -134,7 +128,7 @@
           .map(preset => preset.name),
       ),
     ];
-    presetOptions = [{ display: '', value: '' }, ...presetNames.map(name => ({ display: name, value: name }))];
+    presetOptions = presetNames.map(name => ({ display: name, value: name }));
   }
 
   $: {
@@ -150,18 +144,12 @@
         }
       }
     }
-    argNameOptions = [
-      { display: '', value: '' },
-      ...[...paramNames].sort((a, b) => a.localeCompare(b)).map(name => ({ display: name, value: name })),
-    ];
+    argNameOptions = [...paramNames].sort((a, b) => a.localeCompare(b)).map(name => ({ display: name, value: name }));
   }
 
-  $: goalOptions = [
-    { display: '', value: '' },
-    ...[...$schedulingGoalResponses]
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map(goal => ({ display: `${goal.name} (${goal.id})`, value: goal.id.toString() })),
-  ];
+  $: goalOptions = [...$schedulingGoalResponses]
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map(goal => ({ display: `${goal.name} (${goal.id})`, value: goal.id.toString() }));
 
   // Initialize from URL on first page load (browser only — SSR can't navigate)
   $: if (browser && $page.url) {
@@ -362,9 +350,10 @@
           <SearchableDropdown
             options={modelOptions}
             loading={$modelsLoading}
+            placeholder=""
             on:change={e => {
               const v = e.detail[0];
-              selectedModelId = v === '' || v === undefined ? undefined : Number(v);
+              selectedModelId = v === '' || v == null ? undefined : Number(v);
             }}
             selectedOptionValues={[selectedModelId ?? '']}
           >
@@ -401,6 +390,7 @@
           <SearchableDropdown
             options={argNameOptions}
             loading={$modelsLoading}
+            placeholder=""
             on:change={e => (filters = { ...filters, argName: e.detail[0]?.toString() ?? '' })}
             selectedOptionValues={[filters.argName]}
           >
@@ -431,6 +421,7 @@
           <SearchableDropdown
             options={tagOptions}
             loading={$tagsLoading}
+            placeholder=""
             on:change={e => (filters = { ...filters, tagValue: e.detail[0]?.toString() ?? '' })}
             selectedOptionValues={[filters.tagValue]}
           >
@@ -443,6 +434,7 @@
           <SearchableDropdown
             options={presetOptions}
             loading={$presetsLoading}
+            placeholder=""
             on:change={e => (filters = { ...filters, preset: e.detail[0]?.toString() ?? '' })}
             selectedOptionValues={[filters.preset]}
           >
@@ -455,6 +447,7 @@
           <SearchableDropdown
             options={userOptions}
             loading={$usersLoading}
+            placeholder=""
             on:change={e => (filters = { ...filters, createdBy: e.detail[0]?.toString() ?? '' })}
             selectedOptionValues={[filters.createdBy]}
           >
@@ -467,6 +460,7 @@
           <SearchableDropdown
             options={userOptions}
             loading={$usersLoading}
+            placeholder=""
             on:change={e => (filters = { ...filters, lastModifiedBy: e.detail[0]?.toString() ?? '' })}
             selectedOptionValues={[filters.lastModifiedBy]}
           >
@@ -555,6 +549,7 @@
           <SearchableDropdown
             options={userOptions}
             loading={$usersLoading}
+            placeholder=""
             on:change={e => (filters = { ...filters, planOwner: e.detail[0]?.toString() ?? '' })}
             selectedOptionValues={[filters.planOwner]}
           >
@@ -567,6 +562,7 @@
           <SearchableDropdown
             options={tagOptions}
             loading={$tagsLoading}
+            placeholder=""
             on:change={e => (filters = { ...filters, planTag: e.detail[0]?.toString() ?? '' })}
             selectedOptionValues={[filters.planTag]}
           >
@@ -579,6 +575,7 @@
           <SearchableDropdown
             options={goalOptions}
             loading={$goalsLoading}
+            placeholder=""
             on:change={e => (filters = { ...filters, schedulingGoalId: e.detail[0]?.toString() ?? '' })}
             selectedOptionValues={[filters.schedulingGoalId]}
           >

--- a/src/components/search/SearchPanel.svelte
+++ b/src/components/search/SearchPanel.svelte
@@ -104,7 +104,7 @@
     modelOptions = orderedModels.map(m => ({ display: getDisplayNameForModel(m), value: m.id }));
 
     // If the selected model is no longer available, reset the selection
-    if (selectedModelId !== undefined) {
+    if (modelOptions.length > 0 && selectedModelId !== undefined) {
       const availableModels = new Set(modelOptions.map(opt => opt.value));
       if (!availableModels.has(selectedModelId)) {
         selectedModelId = undefined;
@@ -116,7 +116,7 @@
     tagOptions = $tagsStore.map(tag => ({ display: tag.name, value: tag.name }));
 
     // If the selected tag is no longer available, reset the selection
-    if (filters.tagValue) {
+    if (tagOptions.length > 0 && filters.tagValue) {
       const availableTags = new Set(tagOptions.map(opt => opt.value));
       if (!availableTags.has(filters.tagValue)) {
         filters = { ...filters, planTag: '', tagValue: '' };
@@ -128,7 +128,7 @@
     userOptions = $users.filter((u): u is string => u !== null).map(u => ({ display: u, value: u }));
 
     // If the user is no longer available, reset the selections
-    if (filters.createdBy || filters.lastModifiedBy || filters.planOwner) {
+    if (userOptions.length > 0 && (filters.createdBy || filters.lastModifiedBy || filters.planOwner)) {
       let filtersUpdate: Partial<typeof DEFAULT_FILTERS> = {};
       const availableUsers = new Set(userOptions.map(opt => opt.value));
       if (!availableUsers.has(filters.createdBy)) {
@@ -161,7 +161,7 @@
       .sort((a, b) => a.display.localeCompare(b.display));
 
     // If a selected activity type is no longer available, remove the selection
-    if (filters.actType.length > 0) {
+    if (typeOptions.length > 0 && filters.actType.length > 0) {
       const availableTypes = new Set(typeOptions.map(opt => opt.value));
       const validTypes = filters.actType.filter(type => availableTypes.has(type));
       if (validTypes.length !== filters.actType.length) {
@@ -181,7 +181,7 @@
     presetOptions = presetNames.map(name => ({ display: name, value: name }));
 
     // If the selected preset is no longer available, reset the selection
-    if (filters.preset) {
+    if (presetOptions.length > 0 && filters.preset) {
       const availablePresets = new Set(presetOptions.map(opt => opt.value));
       if (!availablePresets.has(filters.preset)) {
         filters = { ...filters, preset: '' };
@@ -205,7 +205,7 @@
     argNameOptions = [...paramNames].sort((a, b) => a.localeCompare(b)).map(name => ({ display: name, value: name }));
 
     // If the selected argument is no longer available, reset the selection
-    if (filters.argName) {
+    if (argNameOptions.length > 0 && filters.argName) {
       const availableArgNames = new Set(argNameOptions.map(opt => opt.value));
       if (!availableArgNames.has(filters.argName)) {
         filters = { ...filters, argName: '' };
@@ -219,7 +219,7 @@
       .map(goal => ({ display: `${goal.name} (${goal.id})`, value: goal.id.toString() }));
 
     // If the selected goal is no longer available, reset the selection
-    if (filters.schedulingGoalId) {
+    if (goalOptions.length > 0 && filters.schedulingGoalId) {
       const availableGoals = new Set(goalOptions.map(opt => opt.value));
       if (!availableGoals.has(filters.schedulingGoalId)) {
         filters = { ...filters, schedulingGoalId: '' };

--- a/src/components/ui/SearchableDropdown.svelte
+++ b/src/components/ui/SearchableDropdown.svelte
@@ -277,7 +277,7 @@
           {@const displayedOption = item}
           {@const selected =
             !!selectedOptions.find(o => o.value === displayedOption.value) ||
-            (!!showPlaceholderOption && selectedOptions.length === 0 && index === 0)}
+            (!!showPlaceholderOption && selectedOptions.length === 0 && index === 0 && !displayedOption.value)}
           <MenuItem
             className="min-h-9 py-2"
             {selected}

--- a/src/components/ui/SearchableDropdown.svelte
+++ b/src/components/ui/SearchableDropdown.svelte
@@ -39,7 +39,7 @@
   export let maxListHeight: string = '300px';
   export let name: string | undefined = undefined;
   export let updatePermissionError: string = 'You do not have permission to update this';
-  export let placeholder: string = '';
+  export let placeholder: string | null = null;
   export let planReadOnly: boolean = false;
   export let selectedOptionLabel: string = '';
   export let selectedOptionValues: SelectedDropdownOptionValue[] = [];
@@ -132,7 +132,7 @@
   $: {
     filteredOptions = !searchFilter
       ? [
-          ...(showPlaceholderOption && placeholder
+          ...(showPlaceholderOption && placeholder !== null
             ? [
                 {
                   display: placeholder,
@@ -156,7 +156,7 @@
 
   $: {
     if (selectedOptions.length < 1) {
-      label = placeholder;
+      label = placeholder ?? '';
     } else if (selectedOptionLabel) {
       label = selectedOptionLabel;
     } else if (selectedOptions.length === 1) {

--- a/src/components/ui/SearchableDropdown.svelte.test.ts
+++ b/src/components/ui/SearchableDropdown.svelte.test.ts
@@ -115,4 +115,38 @@ describe('Searchable Dropdown component', () => {
 
     expect(getAllByRole('menuitem')).toHaveLength(3);
   });
+
+  it('Should mark placeholder option (with null value) as selected when no option is selected', async () => {
+    const { getByText, getAllByRole } = render(SearchableDropdown, {
+      options,
+      placeholder: 'Select an option',
+      showPlaceholderOption: true,
+    });
+
+    await fireEvent.click(getByText('Select an option'));
+
+    const menuItems = getAllByRole('menuitem');
+    expect(menuItems).toHaveLength(options.length + 1);
+
+    const placeholderMenuItem = menuItems[0];
+    expect(placeholderMenuItem.classList.contains('selected')).toBe(true);
+  });
+
+  it('Should not mark option with empty string value as selected when no option is selected and it is at index 0', async () => {
+    const emptyValueOption = { display: 'All Options', value: '' };
+    const optionsWithEmpty = [emptyValueOption, ...options];
+    const { getByText, getAllByRole } = render(SearchableDropdown, {
+      options: optionsWithEmpty,
+      placeholder: 'None',
+      showPlaceholderOption: true,
+    });
+
+    await fireEvent.click(getByText('None'));
+
+    const menuItems = getAllByRole('menuitem');
+    expect(menuItems).toHaveLength(optionsWithEmpty.length + 1);
+
+    const emptyValueMenuItem = menuItems[1];
+    expect(emptyValueMenuItem.classList.contains('selected')).toBe(false);
+  });
 });


### PR DESCRIPTION
This PR removes the empty option in the `Activity Type` dropdown in the Activity Search Form.  This is to prevent misleading the user that they can click on the empty option in order to clear their current selection of types. The ideal fix would probably involve adding an "clear" button somewhere.

This also refactors the logic in Search that explicitly adds empty options in order to do display an empty option in favor of the already existing feature of the dropdown component being used.

To verify:
1. Navigate to the activity search page: http://localhost:3000/search
2. Verify that the `Activity Type` dropdown no longer has the empty option
3. Select some types
4. Verify that the types are correctly selected
5. Select the same types to deselect them
6. Verify that the types are now deselected and the URL search parameters correctly reflect the removal
7. Verify that other dropdowns do still have an empty option
8. Select some options
9. Verify that the options are correctly selected
10. Select the empty option in the same dropdowns as step 8
11. Verify that the options are now correctly cleared out
