### PR TITLE
Simultaneous-edit protection for workspace files

### DIFF
--- a/e2e-tests/fixtures/WorkspaceSaveConflict.ts
+++ b/e2e-tests/fixtures/WorkspaceSaveConflict.ts
@@ -51,7 +51,7 @@ export class WorkspaceSaveConflict {
   updatePage(page: Page): void {
     this.page = page;
     this.modal = page.locator('#modal-container');
-    this.conflictTitle = this.modal.getByText('This file was updated by someone else');
+    this.conflictTitle = this.modal.getByText('This file was changed by someone else');
     this.deletedTitle = this.modal.getByText('File deleted or moved');
     this.theirsHeader = this.modal.getByText('Theirs (server)');
     this.mineHeader = this.modal.getByText('Mine (your edits)');

--- a/e2e-tests/fixtures/WorkspaceSaveConflict.ts
+++ b/e2e-tests/fixtures/WorkspaceSaveConflict.ts
@@ -1,0 +1,76 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+/**
+ * Page Object Model for the workspace save-conflict modal (`WorkspaceSaveConflictModal`),
+ * shown when a save is rejected by the optimistic-concurrency check (`412`). Covers both
+ * the "conflict" variant (the file changed underneath) and the "deleted" variant (the file
+ * was deleted/moved underneath). Selectors are scoped to the modal root.
+ */
+export class WorkspaceSaveConflict {
+  cancelButton!: Locator;
+  conflictTitle!: Locator;
+  deletedTitle!: Locator;
+  discardButton!: Locator;
+  mineHeader!: Locator;
+  modal!: Locator;
+  recreateButton!: Locator;
+  takeMineButton!: Locator;
+  takeTheirsButton!: Locator;
+  theirsHeader!: Locator;
+
+  constructor(public page: Page) {
+    this.updatePage(page);
+  }
+
+  async cancel(): Promise<void> {
+    await this.cancelButton.click();
+    await expect(this.modal).toBeHidden();
+  }
+
+  async discardAndClose(): Promise<void> {
+    await this.discardButton.click();
+    await expect(this.modal).toBeHidden();
+  }
+
+  async recreate(): Promise<void> {
+    await this.recreateButton.click();
+    await expect(this.modal).toBeHidden();
+  }
+
+  async takeMine(): Promise<void> {
+    await this.takeMineButton.click();
+    await expect(this.modal).toBeHidden();
+  }
+
+  async takeTheirs(): Promise<void> {
+    await this.takeTheirsButton.click();
+    await expect(this.modal).toBeHidden();
+  }
+
+  updatePage(page: Page): void {
+    this.page = page;
+    this.modal = page.locator('#modal-container');
+    this.conflictTitle = this.modal.getByText('This file changed since you opened it');
+    this.deletedTitle = this.modal.getByText('File deleted or moved');
+    this.theirsHeader = this.modal.getByText('Theirs (server)');
+    this.mineHeader = this.modal.getByText('Mine (your edits)');
+    this.takeTheirsButton = this.modal.getByRole('button', { name: 'Take theirs (discard mine)' });
+    this.takeMineButton = this.modal.getByRole('button', { name: 'Take mine (overwrite)' });
+    this.cancelButton = this.modal.getByRole('button', { name: 'Cancel' });
+    this.recreateButton = this.modal.getByRole('button', { name: 'Recreate file' });
+    this.discardButton = this.modal.getByRole('button', { name: 'Discard & close' });
+  }
+
+  /** Wait for the "conflict" variant (read-only diff of theirs vs mine). */
+  async waitForConflict(): Promise<void> {
+    await expect(this.conflictTitle).toBeVisible({ timeout: 15000 });
+    await expect(this.theirsHeader).toBeVisible();
+    await expect(this.mineHeader).toBeVisible();
+  }
+
+  /** Wait for the "deleted/moved" variant (single read-only pane of mine). */
+  async waitForDeleted(): Promise<void> {
+    await expect(this.deletedTitle).toBeVisible({ timeout: 15000 });
+  }
+}

--- a/e2e-tests/fixtures/WorkspaceSaveConflict.ts
+++ b/e2e-tests/fixtures/WorkspaceSaveConflict.ts
@@ -51,13 +51,13 @@ export class WorkspaceSaveConflict {
   updatePage(page: Page): void {
     this.page = page;
     this.modal = page.locator('#modal-container');
-    this.conflictTitle = this.modal.getByText('This file changed since you opened it');
+    this.conflictTitle = this.modal.getByText('This file was updated by someone else');
     this.deletedTitle = this.modal.getByText('File deleted or moved');
     this.theirsHeader = this.modal.getByText('Theirs (server)');
     this.mineHeader = this.modal.getByText('Mine (your edits)');
-    this.takeTheirsButton = this.modal.getByRole('button', { name: 'Take theirs (discard mine)' });
-    this.takeMineButton = this.modal.getByRole('button', { name: 'Take mine (overwrite)' });
-    this.cancelButton = this.modal.getByRole('button', { name: 'Cancel' });
+    this.takeTheirsButton = this.modal.getByRole('button', { name: 'Keep theirs' });
+    this.takeMineButton = this.modal.getByRole('button', { name: 'Keep mine' });
+    this.cancelButton = this.modal.getByRole('button', { name: 'Keep editing' });
     this.recreateButton = this.modal.getByRole('button', { name: 'Recreate file' });
     this.discardButton = this.modal.getByRole('button', { name: 'Discard & close' });
   }

--- a/e2e-tests/tests/workspace-edit-protection.test.ts
+++ b/e2e-tests/tests/workspace-edit-protection.test.ts
@@ -1,0 +1,206 @@
+import test, { expect } from '@playwright/test';
+import { Dictionaries } from '../fixtures/Dictionaries.js';
+import { Parcels } from '../fixtures/Parcels.js';
+import { Workspace } from '../fixtures/Workspace.js';
+import { WorkspaceSaveConflict } from '../fixtures/WorkspaceSaveConflict.js';
+import { Workspaces } from '../fixtures/Workspaces.js';
+import { setupTest, teardownTest, type BrowserSetupResult } from '../utilities/api.js';
+import { generateRandomName } from '../utilities/helpers.js';
+
+// Simultaneous-edit protection: a save is rejected (412) when the file changed underneath the
+// editor since it was opened. We simulate the "other editor" with a second browser context for
+// the same 'test' user editing the same workspace file.
+
+let setup: BrowserSetupResult; // primary editor — the one under test
+let setupOther: BrowserSetupResult; // concurrent editor — changes the file first
+
+let dictionaries: Dictionaries;
+let parcels: Parcels;
+let workspaces: Workspaces;
+let workspace: Workspace; // primary page
+let otherWorkspace: Workspace; // concurrent page (same workspace)
+let conflict: WorkspaceSaveConflict;
+let workspaceId: string;
+let workspaceName: string;
+
+test.beforeAll(async ({ baseURL, browser }) => {
+  test.setTimeout(120000);
+
+  setup = await setupTest(browser, { model: false });
+  dictionaries = new Dictionaries(setup.page);
+  parcels = new Parcels(setup.page);
+  workspaces = new Workspaces(setup.page, parcels, baseURL);
+
+  await dictionaries.goto();
+  await dictionaries.createCommandDictionary();
+  await parcels.goto();
+  await parcels.createParcel(dictionaries.commandDictionaryName, baseURL);
+
+  await workspaces.goto();
+  workspaceId = await workspaces.createWorkspace();
+  workspaceName = workspaces.workspaceName;
+  workspace = new Workspace(setup.page, workspaceId, workspaceName, baseURL);
+  conflict = new WorkspaceSaveConflict(setup.page);
+
+  // Second context (same 'test' user) editing the same workspace concurrently.
+  setupOther = await setupTest(browser, { model: false });
+  otherWorkspace = new Workspace(setupOther.page, workspaceId, workspaceName, baseURL);
+
+  await workspace.goto();
+});
+
+test.afterAll(async () => {
+  await workspaces.goto();
+  await workspaces.deleteWorkspace(workspaceName);
+  await parcels.goto();
+  await parcels.deleteParcel();
+  await dictionaries.goto();
+  await dictionaries.deleteCommandDictionary();
+
+  await teardownTest(setup);
+  await teardownTest(setupOther);
+});
+
+/** Create a sequence file on the primary page and open it (capturing its base version). */
+async function createAndOpenSequence(): Promise<string> {
+  const { sequenceName } = await workspace.createSequence(undefined, `${generateRandomName()}.seq`);
+  await workspace.searchForFileAndWait(sequenceName);
+  await workspace.clickFile(sequenceName);
+  await expect(workspace.saveSequenceButton).toBeVisible({ timeout: 10000 });
+  return sequenceName;
+}
+
+/** The concurrent editor opens the same file and saves a change, advancing the server version. */
+async function otherEditorSaves(sequenceName: string, content: string): Promise<void> {
+  await otherWorkspace.goto();
+  await otherWorkspace.searchForFileAndWait(sequenceName);
+  await otherWorkspace.clickFile(sequenceName);
+  await expect(otherWorkspace.saveSequenceButton).toBeVisible({ timeout: 10000 });
+  await otherWorkspace.fillSequenceContent(content);
+  await otherWorkspace.saveSequence();
+}
+
+/** Edit on the primary page and click Save, expecting the concurrency check to reject it. */
+async function editAndSaveExpectingConflict(content: string): Promise<void> {
+  await workspace.fillSequenceContent(content);
+  await expect(workspace.saveSequenceButton).toBeEnabled();
+  await workspace.saveSequenceButton.click();
+}
+
+test.describe.serial('Workspace simultaneous-edit protection', () => {
+  test('consecutive saves of the same file succeed (token round-trips on PUT)', async () => {
+    // No concurrent editor here: this confirms a save advances the stored token so the next
+    // save against the same editor does not spuriously conflict.
+    await createAndOpenSequence();
+
+    await workspace.fillSequenceContent('// first change');
+    await workspace.saveSequence();
+    await expect(workspace.saveSequenceButton).toBeDisabled();
+
+    await workspace.fillSequenceContent('// second change');
+    await workspace.saveSequence();
+    await expect(workspace.saveSequenceButton).toBeDisabled();
+  });
+
+  test('a stale save shows the conflict modal with a diff', async () => {
+    const sequenceName = await createAndOpenSequence();
+    await otherEditorSaves(sequenceName, '// their change');
+
+    await editAndSaveExpectingConflict('// my change');
+
+    await conflict.waitForConflict();
+
+    // Cancel leaves the document dirty (Save still enabled) and keeps the stale token.
+    await conflict.cancel();
+    await expect(workspace.saveSequenceButton).toBeEnabled();
+
+    // Resolve the still-dirty document so the next test starts from a clean editor:
+    // saving again re-checks the (still stale) token, then take theirs to rebase clean.
+    await workspace.saveSequenceButton.click();
+    await conflict.waitForConflict();
+    await conflict.takeTheirs();
+    await expect(workspace.saveSequenceButton).toBeDisabled();
+  });
+
+  test('"Take theirs" rebases the editor and the next save succeeds', async () => {
+    const sequenceName = await createAndOpenSequence();
+    await otherEditorSaves(sequenceName, '// their change');
+
+    await editAndSaveExpectingConflict('// my change');
+    await conflict.waitForConflict();
+    await conflict.takeTheirs();
+
+    // Editor now reflects the server version; saving a fresh edit succeeds (token advanced,
+    // no immediate re-conflict).
+    await workspace.fillSequenceContent('// after taking theirs');
+    await workspace.saveSequence();
+    await expect(workspace.saveSequenceButton).toBeDisabled();
+  });
+
+  test('"Take mine (overwrite)" saves the local version and the next save succeeds', async () => {
+    const sequenceName = await createAndOpenSequence();
+    await otherEditorSaves(sequenceName, '// their change');
+
+    await editAndSaveExpectingConflict('// my change');
+    await conflict.waitForConflict();
+    await conflict.takeMine();
+
+    // Force-overwrite saved successfully and advanced the token.
+    await workspace.waitForToast('Workspace File Saved Successfully');
+    await expect(workspace.saveSequenceButton).toBeDisabled();
+
+    await workspace.fillSequenceContent('// after taking mine');
+    await workspace.saveSequence();
+    await expect(workspace.saveSequenceButton).toBeDisabled();
+  });
+
+  test('Ctrl/Cmd+S is ignored while the conflict modal is open (no stacked save)', async () => {
+    const sequenceName = await createAndOpenSequence();
+    await otherEditorSaves(sequenceName, '// their change');
+
+    await editAndSaveExpectingConflict('// my change');
+    await conflict.waitForConflict();
+
+    // The global save shortcut must not fire another save / stack a second modal.
+    await setup.page.keyboard.press('ControlOrMeta+s');
+    await expect(conflict.takeMineButton).toHaveCount(1);
+    await expect(conflict.conflictTitle).toBeVisible();
+
+    await conflict.takeTheirs();
+  });
+
+  test('a file deleted underneath shows the deleted/moved variant — Recreate restores it', async () => {
+    const sequenceName = await createAndOpenSequence();
+
+    // Concurrent editor deletes the file out from under the open editor.
+    await otherWorkspace.goto();
+    await otherWorkspace.searchForFileAndWait(sequenceName);
+    await otherWorkspace.deleteFile(sequenceName);
+
+    await editAndSaveExpectingConflict('// my change after delete');
+    await conflict.waitForDeleted();
+    await conflict.recreate();
+
+    await workspace.waitForToast('Workspace File Saved Successfully');
+    // The recreated file is back in the tree.
+    await workspace.searchForFileAndWait(sequenceName);
+    await expect(workspace.getFileRow(sequenceName)).toBeVisible();
+  });
+
+  test('the deleted/moved variant — "Discard & close" closes the document', async () => {
+    const sequenceName = await createAndOpenSequence();
+
+    await otherWorkspace.goto();
+    await otherWorkspace.searchForFileAndWait(sequenceName);
+    await otherWorkspace.deleteFile(sequenceName);
+
+    await editAndSaveExpectingConflict('// my change after delete');
+    await conflict.waitForDeleted();
+    await conflict.discardAndClose();
+
+    // The unsaved edits are discarded — the editor is no longer dirty (Save disabled) and
+    // the discarded content is gone.
+    await expect(workspace.saveSequenceButton).toBeDisabled();
+    await expect(setup.page.locator('.cm-content').first()).not.toContainText('my change after delete');
+  });
+});

--- a/e2e-tests/tests/workspace-edit-protection.test.ts
+++ b/e2e-tests/tests/workspace-edit-protection.test.ts
@@ -122,7 +122,7 @@ test.describe.serial('Workspace simultaneous-edit protection', () => {
     await expect(workspace.saveSequenceButton).toBeDisabled();
   });
 
-  test('"Take theirs" rebases the editor and the next save succeeds', async () => {
+  test('"Keep theirs" rebases the editor and the next save succeeds', async () => {
     const sequenceName = await createAndOpenSequence();
     await otherEditorSaves(sequenceName, '// their change');
 
@@ -137,7 +137,27 @@ test.describe.serial('Workspace simultaneous-edit protection', () => {
     await expect(workspace.saveSequenceButton).toBeDisabled();
   });
 
-  test('"Take mine (overwrite)" saves the local version and the next save succeeds', async () => {
+  test('"Keep theirs" is undoable — Ctrl/Cmd+Z restores the discarded edits', async () => {
+    const sequenceName = await createAndOpenSequence();
+    await otherEditorSaves(sequenceName, '// their change');
+
+    await editAndSaveExpectingConflict('// my change');
+    await conflict.waitForConflict();
+    await conflict.takeTheirs();
+
+    // Right after taking theirs the editor shows the server version.
+    const editor = setup.page.locator('.cm-content').first();
+    await expect(editor).toContainText('// their change');
+
+    // The rebase is recorded in the undo history, so a single undo restores the discarded edits
+    // and the document goes dirty again (restored content differs from the new server baseline).
+    await editor.click();
+    await setup.page.keyboard.press('ControlOrMeta+z');
+    await expect(editor).toContainText('// my change');
+    await expect(workspace.saveSequenceButton).toBeEnabled();
+  });
+
+  test('"Keep mine" saves the local version and the next save succeeds', async () => {
     const sequenceName = await createAndOpenSequence();
     await otherEditorSaves(sequenceName, '// their change');
 

--- a/e2e-tests/tests/workspace-edit-protection.test.ts
+++ b/e2e-tests/tests/workspace-edit-protection.test.ts
@@ -155,6 +155,13 @@ test.describe.serial('Workspace simultaneous-edit protection', () => {
     await setup.page.keyboard.press('ControlOrMeta+z');
     await expect(editor).toContainText('// my change');
     await expect(workspace.saveSequenceButton).toBeEnabled();
+
+    // Leave a clean editor for the next serial test. "Keep theirs" already advanced the stored
+    // token to the server version, so this save succeeds without re-conflicting. Without it the
+    // dirty doc leaks: the next test's createAndOpenSequence auto-selects its new file, which pops
+    // a "Navigate Away" modal whose backdrop blocks the file-row click.
+    await workspace.saveSequence();
+    await expect(workspace.saveSequenceButton).toBeDisabled();
   });
 
   test('"Keep mine" saves the local version and the next save succeeds', async () => {

--- a/e2e-tests/tests/workspace.test.ts
+++ b/e2e-tests/tests/workspace.test.ts
@@ -603,17 +603,31 @@ test.describe.serial('Workspace', () => {
   });
 
   test('Toggle file read-only and verify editor is locked', async () => {
-    // Create a sequence file to test with
-    const { sequenceName } = await workspace.createSequence(undefined, `${generateRandomName()}.seq`);
+    // Use the adaptation's input-sequence extension so the file opens as a sequence with the
+    // Selected Command panel (a plain `.seq` would open as generic text — no command panel).
+    const { sequenceName } = await workspace.createSequence(undefined, `${generateRandomName()}.seqN.txt`);
     await workspace.searchForFileAndWait(sequenceName);
     await workspace.clickFile(sequenceName);
 
     // Wait for the editor to load and the file metadata banner to appear
     await expect(workspace.readOnlyCheckbox).toBeVisible({ timeout: 10000 });
 
+    // Add a command so the Selected Command panel renders editable argument inputs.
+    await workspace.fillSequenceContent('C FSW_CMD_0 "ON" true 0.5');
+
+    // The Selected Command panel (right side) shows the command's argument editors;
+    // float_arg_0 renders as a numeric input (spinbutton) labeled by its arg name.
+    const commandArgInput = setup.page.getByRole('spinbutton', { name: 'float_arg_0' });
+    await expect(commandArgInput).toBeVisible({ timeout: 10000 });
+
     // Verify the file is initially editable — title should NOT contain "(Read only)"
     await expect(setup.page.getByText('(Read only)')).not.toBeVisible();
     await expect(workspace.saveSequenceButton).toBeVisible();
+    // ...and the command argument inputs are interactive.
+    await expect(commandArgInput).toBeEnabled();
+
+    // Persist so the document is clean before toggling read-only / deleting later.
+    await workspace.saveSequence();
 
     // Toggle read-only ON
     await workspace.readOnlyCheckbox.click();
@@ -624,6 +638,10 @@ test.describe.serial('Workspace', () => {
 
     // Verify the Save button is hidden (read-only files can't be saved)
     await expect(workspace.saveSequenceButton).not.toBeVisible();
+
+    // Verify the Selected Command panel argument inputs are disabled while read-only —
+    // `EditorState.readOnly` alone wouldn't stop the form-builder from editing the document.
+    await expect(commandArgInput).toBeDisabled();
 
     // Verify the editor rejects input — type something and confirm content didn't change
     await workspace.sequenceEditor.click();
@@ -639,6 +657,8 @@ test.describe.serial('Workspace', () => {
 
     // Verify the Save button reappears
     await expect(workspace.saveSequenceButton).toBeVisible();
+    // ...and the command argument inputs are interactive again.
+    await expect(commandArgInput).toBeEnabled();
 
     // Cleanup
     await workspace.searchForFileAndWait(sequenceName);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@codemirror/lang-json": "^6.0.1",
         "@codemirror/language": "^6.10.1",
         "@codemirror/lint": "^6.5.0",
+        "@codemirror/merge": "^6.12.2",
         "@codemirror/view": "^6.38.2",
         "@fontsource/jetbrains-mono": "^5.0.19",
         "@lezer/common": "^1.2.3",
@@ -311,6 +312,19 @@
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.35.0",
         "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/merge": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/merge/-/merge-6.12.2.tgz",
+      "integrity": "sha512-V8JvyAPjHbPupqP7BeMcsdsYCbyPij74jxIbaIJDORI+VZzW44zFmon8bF+oxGWvOKhcRmkiUMXd8MxHr3YA2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/highlight": "^1.0.0",
+        "style-mod": "^4.1.0"
       }
     },
     "node_modules/@codemirror/search": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@codemirror/lang-json": "^6.0.1",
     "@codemirror/language": "^6.10.1",
     "@codemirror/lint": "^6.5.0",
+    "@codemirror/merge": "^6.12.2",
     "@codemirror/view": "^6.38.2",
     "@fontsource/jetbrains-mono": "^5.0.19",
     "@lezer/common": "^1.2.3",

--- a/src/components/modals/WorkspaceSaveConflictModal.svelte
+++ b/src/components/modals/WorkspaceSaveConflictModal.svelte
@@ -124,8 +124,7 @@
         </span>
       {:else if variant === 'deleted'}
         <span>
-          <b>{fileName}</b> was deleted or moved by user @{editedByText}
-          {whenText ? ` ${whenText}` : ''}. Your unsaved changes are shown below.
+          <b>{fileName}</b> was deleted or moved{whenText ? ` ${whenText}` : ''}. Your unsaved changes are shown below.
         </span>
       {:else if allowMerge}
         <span>

--- a/src/components/modals/WorkspaceSaveConflictModal.svelte
+++ b/src/components/modals/WorkspaceSaveConflictModal.svelte
@@ -16,7 +16,6 @@
   import ModalFooter from './ModalFooter.svelte';
   import ModalHeader from './ModalHeader.svelte';
 
-  /** Opt into the hand-merge UX (editable pane). Off by default → read-only take mine/theirs. */
   export let allowMerge: boolean = false;
   export let fileName: string;
   export let languageExtension: Extension | null = null;
@@ -38,11 +37,12 @@
   }>();
 
   let diffViewer: WorkspaceDiffViewer | undefined;
+  let editedByText: string = '';
+  let whenText: string = '';
   let isLoading: boolean = true;
   let loadError: boolean = false;
   let theirsContent: string | null = null;
   let theirsToken: string | null = null;
-  // Seed the variant from the 412 reason; the re-GET below is authoritative.
   let variant: WorkspaceSaveConflictReason = reason === 'deleted' ? 'deleted' : 'conflict';
 
   $: editedByText = lastEditedBy ?? 'another user';
@@ -51,7 +51,7 @@
   async function loadTheirs() {
     // Re-fetch the server's version for the diff. A 404 means it was deleted. Any other
     // failure is transient — the 412 proved the file exists, so don't assume deletion
-    // (Recreate would overwrite their change); show a retry and keep the doc dirty.
+    // (Recreate would overwrite their change) and just show a retry and keep the doc dirty.
     isLoading = true;
     loadError = false;
     try {
@@ -102,24 +102,24 @@
       {#if loadError}
         <span
           ><b>{fileName}</b> was changed by user @{editedByText}
-          {whenText ? ` ${whenText}` : ''}, but the latest version couldn't be loaded to compare.</span
-        >
+          {whenText ? ` ${whenText}` : ''}, but the latest version couldn't be loaded to compare.
+        </span>
       {:else if variant === 'deleted'}
-        <span
-          ><b>{fileName}</b> was deleted or moved by user @{editedByText}
-          {whenText ? ` ${whenText}` : ''}. Your unsaved changes are shown below.</span
-        >
+        <span>
+          <b>{fileName}</b> was deleted or moved by user @{editedByText}
+          {whenText ? ` ${whenText}` : ''}. Your unsaved changes are shown below.
+        </span>
       {:else if allowMerge}
-        <span
-          ><b>{fileName}</b> was changed by user @{editedByText}
+        <span>
+          <b>{fileName}</b> was changed by user @{editedByText}
           {whenText ? ` ${whenText}` : ''}. Edit your version on the right — use the arrows to pull in theirs — then
-          Save, or take theirs to discard your changes.</span
-        >
+          Save, or take theirs to discard your changes.
+        </span>
       {:else}
         <span
           ><b>{fileName}</b> was changed by user @{editedByText}
-          {whenText ? ` ${whenText}` : ''}. Review the differences, then choose how to resolve.</span
-        >
+          {whenText ? ` ${whenText}` : ''}. Review the differences, then choose how to resolve.
+        </span>
       {/if}
     </div>
 

--- a/src/components/modals/WorkspaceSaveConflictModal.svelte
+++ b/src/components/modals/WorkspaceSaveConflictModal.svelte
@@ -1,0 +1,175 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import type { Extension } from '@codemirror/state';
+  import { Button } from '@nasa-jpl/stellar-svelte';
+  import { LoaderCircle, TriangleAlert } from 'lucide-svelte';
+  import { createEventDispatcher, onMount } from 'svelte';
+  import type { WorkspaceContentType } from '../../enums/workspace';
+  import type { User } from '../../types/app';
+  import { WorkspaceRequestError, type WorkspaceSaveConflictReason } from '../../utilities/requests';
+  import { getTimeAgo } from '../../utilities/time';
+  import { WorkspaceApi } from '../../utilities/workspaces';
+  import WorkspaceDiffViewer from '../workspace/WorkspaceDiffViewer.svelte';
+  import Modal from './Modal.svelte';
+  import ModalContent from './ModalContent.svelte';
+  import ModalFooter from './ModalFooter.svelte';
+  import ModalHeader from './ModalHeader.svelte';
+
+  /** Opt into the hand-merge UX (editable pane). Off by default → read-only take mine/theirs. */
+  export let allowMerge: boolean = false;
+  export let fileName: string;
+  export let languageExtension: Extension | null = null;
+  export let lastEditedAt: string | undefined = undefined;
+  export let lastEditedBy: string | undefined = undefined;
+  export let mineContent: string;
+  export let path: string;
+  export let reason: WorkspaceSaveConflictReason;
+  export let type: WorkspaceContentType | null = null;
+  export let user: User | null = null;
+  export let workspaceId: number;
+
+  const dispatch = createEventDispatcher<{
+    close: void;
+    discard: void;
+    recreate: void;
+    takeMine: { content: string; token: string | null };
+    takeTheirs: { content: string; token: string | null };
+  }>();
+
+  let diffViewer: WorkspaceDiffViewer | undefined;
+  let isLoading: boolean = true;
+  let loadError: boolean = false;
+  let theirsContent: string | null = null;
+  let theirsToken: string | null = null;
+  // Seed the variant from the 412 reason; the re-GET below is authoritative.
+  let variant: WorkspaceSaveConflictReason = reason === 'deleted' ? 'deleted' : 'conflict';
+
+  $: editedByText = lastEditedBy ?? 'another user';
+  $: whenText = lastEditedAt ? getTimeAgo(new Date(lastEditedAt)) : '';
+
+  async function loadTheirs() {
+    // Re-fetch the server's version for the diff. A 404 means it was deleted. Any other
+    // failure is transient — the 412 proved the file exists, so don't assume deletion
+    // (Recreate would overwrite their change); show a retry and keep the doc dirty.
+    isLoading = true;
+    loadError = false;
+    try {
+      const { content, etag } = await WorkspaceApi.getFileContent(workspaceId, path, user);
+      theirsContent = content;
+      theirsToken = etag;
+      variant = 'conflict';
+    } catch (e) {
+      if (e instanceof WorkspaceRequestError && e.status === 404) {
+        variant = 'deleted';
+      } else {
+        loadError = true;
+      }
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  onMount(() => {
+    loadTheirs();
+  });
+
+  function onTakeMine() {
+    // Save the "Mine" pane against the version shown (theirsToken). If the file moved again,
+    // the save 412s and the diff re-opens rather than overwriting unseen changes.
+    dispatch('takeMine', { content: diffViewer?.getMergedContent() ?? mineContent, token: theirsToken });
+  }
+
+  function onTakeTheirs() {
+    dispatch('takeTheirs', { content: theirsContent ?? '', token: theirsToken });
+  }
+
+  function onRecreate() {
+    dispatch('recreate');
+  }
+
+  function onDiscard() {
+    dispatch('discard');
+  }
+</script>
+
+<Modal height="min(680px, 85vh)" width="min(1100px, 92vw)" on:close>
+  <ModalHeader on:close>
+    {variant === 'deleted' && !loadError ? 'File deleted or moved' : 'This file changed since you opened it'}
+  </ModalHeader>
+  <ModalContent style="display: flex; flex-direction: column; gap: 8px; overflow: hidden;">
+    <div class="st-typography-body flex flex-none flex-col gap-1.5">
+      {#if loadError}
+        <span
+          ><b>{fileName}</b> was changed by user @{editedByText}
+          {whenText ? ` ${whenText}` : ''}, but the latest version couldn't be loaded to compare.</span
+        >
+      {:else if variant === 'deleted'}
+        <span
+          ><b>{fileName}</b> was deleted or moved by user @{editedByText}
+          {whenText ? ` ${whenText}` : ''}. Your unsaved changes are shown below.</span
+        >
+      {:else if allowMerge}
+        <span
+          ><b>{fileName}</b> was changed by user @{editedByText}
+          {whenText ? ` ${whenText}` : ''}. Edit your version on the right — use the arrows to pull in theirs — then
+          Save, or take theirs to discard your changes.</span
+        >
+      {:else}
+        <span
+          ><b>{fileName}</b> was changed by user @{editedByText}
+          {whenText ? ` ${whenText}` : ''}. Review the differences, then choose how to resolve.</span
+        >
+      {/if}
+    </div>
+
+    <div class="flex min-h-0 flex-auto overflow-hidden rounded border">
+      {#if isLoading}
+        <div class="st-typography-body flex w-full items-center justify-center gap-2 text-muted-foreground">
+          <LoaderCircle class="animate-spin" size={16} />
+          <span>Loading the latest version…</span>
+        </div>
+      {:else if loadError}
+        <div
+          class="st-typography-body flex w-full items-center justify-center gap-2 px-4 text-center text-muted-foreground"
+        >
+          <TriangleAlert size={16} />
+          <span
+            >Couldn't load the latest version of this file. Your unsaved changes are preserved — retry, or cancel and
+            try saving again.</span
+          >
+        </div>
+      {:else if variant === 'deleted'}
+        <WorkspaceDiffViewer mine={mineContent} theirs={null} {type} {languageExtension} />
+      {:else}
+        <WorkspaceDiffViewer
+          bind:this={diffViewer}
+          mine={mineContent}
+          theirs={theirsContent}
+          {type}
+          {languageExtension}
+          editable={allowMerge}
+        />
+      {/if}
+    </div>
+  </ModalContent>
+  <ModalFooter>
+    <div class="flex gap-2">
+      {#if loadError}
+        <Button variant="outline" on:click={() => dispatch('close')}>Cancel</Button>
+        <Button variant="default" on:click={loadTheirs}>Retry</Button>
+      {:else if variant === 'deleted'}
+        <Button variant="outline" on:click={onDiscard}>Discard &amp; close</Button>
+        <Button variant="default" on:click={onRecreate}>Recreate file</Button>
+      {:else}
+        <Button on:click={onTakeTheirs} disabled={isLoading}>Take theirs (discard mine)</Button>
+        <Button variant="outline" on:click={() => dispatch('close')}>Cancel</Button>
+        {#if allowMerge}
+          <Button on:click={onTakeMine} disabled={isLoading}>Save</Button>
+        {:else}
+          <Button variant="destructive" on:click={onTakeMine} disabled={isLoading}>Take mine (overwrite)</Button>
+        {/if}
+      {/if}
+    </div>
+  </ModalFooter>
+</Modal>

--- a/src/components/modals/WorkspaceSaveConflictModal.svelte
+++ b/src/components/modals/WorkspaceSaveConflictModal.svelte
@@ -13,7 +13,6 @@
   import WorkspaceDiffViewer from '../workspace/WorkspaceDiffViewer.svelte';
   import Modal from './Modal.svelte';
   import ModalContent from './ModalContent.svelte';
-  import ModalFooter from './ModalFooter.svelte';
   import ModalHeader from './ModalHeader.svelte';
 
   export let allowMerge: boolean = false;
@@ -32,21 +31,23 @@
     close: void;
     discard: void;
     recreate: void;
-    takeMine: { content: string; token: string | null };
-    takeTheirs: { content: string; token: string | null };
+    takeMine: { content: string; etag: string | null };
+    takeTheirs: { content: string; etag: string | null };
   }>();
 
+  let changedLines: number = 0;
   let diffViewer: WorkspaceDiffViewer | undefined;
   let editedByText: string = '';
   let whenText: string = '';
   let isLoading: boolean = true;
   let loadError: boolean = false;
   let theirsContent: string | null = null;
-  let theirsToken: string | null = null;
+  let theirsEtag: string | null = null;
   let variant: WorkspaceSaveConflictReason = reason === 'deleted' ? 'deleted' : 'conflict';
 
   $: editedByText = lastEditedBy ?? 'another user';
   $: whenText = lastEditedAt ? getTimeAgo(new Date(lastEditedAt)) : '';
+  $: changedLinesText = changedLines > 0 ? ` · ${changedLines} changed ${changedLines === 1 ? 'line' : 'lines'}` : '';
 
   async function loadTheirs() {
     // Re-fetch the server's version for the diff. A 404 means it was deleted. Any other
@@ -57,7 +58,7 @@
     try {
       const { content, etag } = await WorkspaceApi.getFileContent(workspaceId, path, user);
       theirsContent = content;
-      theirsToken = etag;
+      theirsEtag = etag;
       variant = 'conflict';
     } catch (e) {
       if (e instanceof WorkspaceRequestError && e.status === 404) {
@@ -75,13 +76,30 @@
   });
 
   function onTakeMine() {
-    // Save the "Mine" pane against the version shown (theirsToken). If the file moved again,
+    // Save the "Mine" pane against the version shown (theirsEtag). If the file moved again,
     // the save 412s and the diff re-opens rather than overwriting unseen changes.
-    dispatch('takeMine', { content: diffViewer?.getMergedContent() ?? mineContent, token: theirsToken });
+    dispatch('takeMine', { content: diffViewer?.getMergedContent() ?? mineContent, etag: theirsEtag });
   }
 
-  function onTakeTheirs() {
-    dispatch('takeTheirs', { content: theirsContent ?? '', token: theirsToken });
+  async function onTakeTheirs() {
+    // Re-fetch so "take theirs" applies the *latest* server version, not the snapshot from when
+    // the modal opened — someone may have saved again while it was open. A 404 means it was since
+    // deleted, so switch to the deleted flow instead of loading empty content; any other failure
+    // is transient, so show the retry prompt and keep the doc dirty.
+    isLoading = true;
+    loadError = false;
+    try {
+      const { content, etag } = await WorkspaceApi.getFileContent(workspaceId, path, user);
+      dispatch('takeTheirs', { content, etag });
+    } catch (e) {
+      if (e instanceof WorkspaceRequestError && e.status === 404) {
+        theirsContent = null;
+        variant = 'deleted';
+      } else {
+        loadError = true;
+      }
+      isLoading = false;
+    }
   }
 
   function onRecreate() {
@@ -93,9 +111,9 @@
   }
 </script>
 
-<Modal height="min(680px, 85vh)" width="min(1100px, 92vw)" on:close>
+<Modal height="min(680px, 85vh)" width="min(1200px, 92vw)" on:close>
   <ModalHeader on:close>
-    {variant === 'deleted' && !loadError ? 'File deleted or moved' : 'This file changed since you opened it'}
+    {variant === 'deleted' && !loadError ? 'File deleted or moved' : 'This file was updated by someone else'}
   </ModalHeader>
   <ModalContent style="display: flex; flex-direction: column; gap: 8px; overflow: hidden;">
     <div class="st-typography-body flex flex-none flex-col gap-1.5">
@@ -111,14 +129,13 @@
         </span>
       {:else if allowMerge}
         <span>
-          <b>{fileName}</b> was changed by user @{editedByText}
-          {whenText ? ` ${whenText}` : ''}. Edit your version on the right — use the arrows to pull in theirs — then
-          Save, or take theirs to discard your changes.
+          <b>{fileName}</b> · edited by @{editedByText}{whenText ? ` ${whenText}` : ''}{changedLinesText}. Edit your
+          version on the right — use the arrows to pull in theirs — then Save, or keep theirs to discard your changes.
         </span>
       {:else}
-        <span
-          ><b>{fileName}</b> was changed by user @{editedByText}
-          {whenText ? ` ${whenText}` : ''}. Review the differences, then choose how to resolve.
+        <span>
+          <b>{fileName}</b> · edited by @{editedByText}{whenText ? ` ${whenText}` : ''}{changedLinesText}. Choose which
+          version to keep.
         </span>
       {/if}
     </div>
@@ -149,27 +166,52 @@
           {type}
           {languageExtension}
           editable={allowMerge}
+          on:stats={e => (changedLines = e.detail.changedLines)}
         />
       {/if}
     </div>
   </ModalContent>
-  <ModalFooter>
-    <div class="flex gap-2">
-      {#if loadError}
-        <Button variant="outline" on:click={() => dispatch('close')}>Cancel</Button>
-        <Button variant="default" on:click={loadTheirs}>Retry</Button>
-      {:else if variant === 'deleted'}
-        <Button variant="outline" on:click={onDiscard}>Discard &amp; close</Button>
-        <Button variant="default" on:click={onRecreate}>Recreate file</Button>
-      {:else}
-        <Button on:click={onTakeTheirs} disabled={isLoading}>Take theirs (discard mine)</Button>
-        <Button variant="outline" on:click={() => dispatch('close')}>Cancel</Button>
+  <!-- All variants share one gray footer bar so the white buttons read strong by contrast, with no
+       filled treatment; each lossy path spells out its consequence in a subline. -->
+  <div class="flex flex-none flex-col gap-2 rounded-b border-t bg-muted px-4 py-3">
+    {#if loadError}
+      <div class="flex justify-center">
+        <Button size="lg" variant="outline" on:click={loadTheirs}>Retry</Button>
+      </div>
+    {:else if variant === 'deleted'}
+      <div class="flex gap-3">
+        <Button size="lg" variant="outline" class="h-auto flex-1 flex-col gap-0.5 py-2" on:click={onDiscard}>
+          <span class="font-semibold text-destructive">Discard &amp; close</span>
+          <span class="text-xs font-normal text-muted-foreground">Discards your unsaved edits</span>
+        </Button>
+        <Button size="lg" variant="outline" class="h-auto flex-1 flex-col gap-0.5 py-2" on:click={onRecreate}>
+          <span class="font-semibold">Recreate file</span>
+          <span class="text-xs font-normal text-muted-foreground">Saves your edits as a new file</span>
+        </Button>
+      </div>
+    {:else if !isLoading}
+      <div class="flex gap-3">
+        <Button size="lg" variant="outline" class="h-auto flex-1 flex-col gap-0.5 py-2" on:click={onTakeTheirs}>
+          <span class="font-semibold">Keep theirs</span>
+          <span class="text-xs font-normal text-muted-foreground">Discards your unsaved edits</span>
+        </Button>
         {#if allowMerge}
-          <Button on:click={onTakeMine} disabled={isLoading}>Save</Button>
+          <Button size="lg" class="h-auto flex-1 flex-col gap-0.5 py-2" on:click={onTakeMine}>
+            <span class="font-semibold">Save merged</span>
+            <span class="text-xs font-normal text-muted-foreground">Saves your version to the server</span>
+          </Button>
         {:else}
-          <Button variant="destructive" on:click={onTakeMine} disabled={isLoading}>Take mine (overwrite)</Button>
+          <Button size="lg" variant="outline" class="h-auto flex-1 flex-col gap-0.5 py-2" on:click={onTakeMine}>
+            <span class="font-semibold">Keep mine</span>
+            <span class="text-xs font-normal text-muted-foreground">Overwrites the server copy</span>
+          </Button>
         {/if}
-      {/if}
+      </div>
+    {/if}
+    <div class="flex justify-center">
+      <Button variant="ghost" class="hover:bg-muted-foreground/10" on:click={() => dispatch('close')}
+        >Keep editing</Button
+      >
     </div>
-  </ModalFooter>
+  </div>
 </Modal>

--- a/src/components/modals/WorkspaceSaveConflictModal.svelte
+++ b/src/components/modals/WorkspaceSaveConflictModal.svelte
@@ -113,7 +113,7 @@
 
 <Modal height="min(680px, 85vh)" width="min(1200px, 92vw)" on:close>
   <ModalHeader on:close>
-    {variant === 'deleted' && !loadError ? 'File deleted or moved' : 'This file was updated by someone else'}
+    {variant === 'deleted' && !loadError ? 'File deleted or moved' : 'This file was changed by someone else'}
   </ModalHeader>
   <ModalContent style="display: flex; flex-direction: column; gap: 8px; overflow: hidden;">
     <div class="st-typography-body flex flex-none flex-col gap-1.5">

--- a/src/components/sequencing/CommandPanel/CommandPanel.svelte
+++ b/src/components/sequencing/CommandPanel/CommandPanel.svelte
@@ -17,6 +17,7 @@
   export let phoenixContext: PhoenixContext;
   export let commandInfoMapper: CommandInfoMapper;
   export let editorSequenceView: EditorView;
+  export let readOnly: boolean = false;
 
   enum CommandPanelTabs {
     COMMAND = 'command',
@@ -126,6 +127,7 @@
         {commandDictionary}
         {commandInfoMapper}
         {editorSequenceView}
+        {readOnly}
         {timeTagNode}
         on:selectCommandDefinition={onSelectCommandDefinition}
       />

--- a/src/components/sequencing/CommandPanel/SelectedCommand.svelte
+++ b/src/components/sequencing/CommandPanel/SelectedCommand.svelte
@@ -28,6 +28,7 @@
   export let commandNameNode: SyntaxNode | null = null;
   export let commandNode: SyntaxNode | null = null;
   export let editorSequenceView: EditorView;
+  export let readOnly: boolean = false;
   export let timeTagNode: TimeTagInfo = null;
   export let variablesInScope: string[] = [];
 
@@ -117,65 +118,70 @@
     </fieldset>
   {/if}
   {#if !!commandNode}
-    {#if commandInfoMapper.nodeTypeHasArguments(commandNode)}
-      {#if !!commandDef}
-        {#each editorArgInfoArray as argInfo}
-          <ArgEditor
-            {argInfo}
-            {commandDictionary}
-            {commandInfoMapper}
-            {variablesInScope}
-            setInEditor={debounce((token, val) => setInEditor(editorSequenceView, token, val), 250)}
-            addDefaultArgs={(commandNodeToAddArgs, missingArgDefs) =>
-              addDefaultArgs(
-                commandDictionary,
-                editorSequenceView,
-                commandNodeToAddArgs,
-                missingArgDefs,
-                commandInfoMapper,
-              )}
-          />
-        {/each}
-
-        {#if missingArgDefArray.length}
-          <fieldset>
-            <AddMissingArgsButton
-              setInEditor={() => {
-                if (commandNode) {
-                  addDefaultArgs(
-                    commandDictionary,
-                    editorSequenceView,
-                    commandNode,
-                    missingArgDefArray,
-                    commandInfoMapper,
-                  );
-                }
-              }}
+    <!-- fieldset[disabled] greys/locks every nested control when read-only, leaving labels
+         and values readable. The editor's change guard is the functional backstop. -->
+    <fieldset class="m-0 min-w-0 border-0 p-0" disabled={readOnly}>
+      {#if commandInfoMapper.nodeTypeHasArguments(commandNode)}
+        {#if !!commandDef}
+          {#each editorArgInfoArray as argInfo}
+            <ArgEditor
+              {argInfo}
+              {commandDictionary}
+              {commandInfoMapper}
+              {variablesInScope}
+              disabled={readOnly}
+              setInEditor={debounce((token, val) => setInEditor(editorSequenceView, token, val), 250)}
+              addDefaultArgs={(commandNodeToAddArgs, missingArgDefs) =>
+                addDefaultArgs(
+                  commandDictionary,
+                  editorSequenceView,
+                  commandNodeToAddArgs,
+                  missingArgDefs,
+                  commandInfoMapper,
+                )}
             />
+          {/each}
+
+          {#if missingArgDefArray.length}
+            <fieldset>
+              <AddMissingArgsButton
+                setInEditor={() => {
+                  if (commandNode) {
+                    addDefaultArgs(
+                      commandDictionary,
+                      editorSequenceView,
+                      commandNode,
+                      missingArgDefArray,
+                      commandInfoMapper,
+                    );
+                  }
+                }}
+              />
+            </fieldset>
+          {/if}
+        {:else}
+          <fieldset>
+            <div class="label-row">{commandName ?? ''}</div>
           </fieldset>
+          <div class="empty-state st-typography-label">Command type is not present in dictionary</div>
         {/if}
       {:else}
         <fieldset>
-          <div class="label-row">{commandName ?? ''}</div>
+          <div class="label-row">{`${formatTypeName(commandNode.name)} Name`}</div>
+          <div>
+            <StringEditor
+              argDef={nameArgumentDef}
+              initVal={commandName ?? ''}
+              setInEditor={val => {
+                if (commandNameNode) {
+                  setInEditor(editorSequenceView, commandNameNode, val);
+                }
+              }}
+            />
+          </div>
         </fieldset>
-        <div class="empty-state st-typography-label">Command type is not present in dictionary</div>
       {/if}
-    {:else}
-      <fieldset>
-        <div class="label-row">{`${formatTypeName(commandNode.name)} Name`}</div>
-        <div>
-          <StringEditor
-            argDef={nameArgumentDef}
-            initVal={commandName ?? ''}
-            setInEditor={val => {
-              if (commandNameNode) {
-                setInEditor(editorSequenceView, commandNameNode, val);
-              }
-            }}
-          />
-        </div>
-      </fieldset>
-    {/if}
+    </fieldset>
   {:else}
     <div class="empty-state st-typography-label">
       Select a command or open the

--- a/src/components/sequencing/CommandPanel/SelectedCommand.svelte
+++ b/src/components/sequencing/CommandPanel/SelectedCommand.svelte
@@ -10,9 +10,9 @@
     HwCommand,
   } from '@nasa-jpl/aerie-ampcs';
   import type { ArgTextDef, CommandInfoMapper, TimeTagInfo } from '@nasa-jpl/aerie-sequence-languages';
-  import { ArrowUpRight } from 'lucide-svelte';
   import type { EditorView } from 'codemirror';
   import { debounce } from 'lodash-es';
+  import { ArrowUpRight } from 'lucide-svelte';
   import { createEventDispatcher } from 'svelte';
   import { addDefaultArgs, getMissingArgDefs } from '../../../utilities/sequence-editor/sequence-utils';
   import { tooltip } from '../../../utilities/tooltip';
@@ -118,8 +118,6 @@
     </fieldset>
   {/if}
   {#if !!commandNode}
-    <!-- fieldset[disabled] greys/locks every nested control when read-only, leaving labels
-         and values readable. The editor's change guard is the functional backstop. -->
     <fieldset class="m-0 min-w-0 border-0 p-0" disabled={readOnly}>
       {#if commandInfoMapper.nodeTypeHasArguments(commandNode)}
         {#if !!commandDef}

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -22,6 +22,7 @@
   import type { LintDiagnostic } from '../../types/errors';
   import type { WorkspaceFileMetadata } from '../../types/workspace-tree-view';
   import { getLintDiagnostics } from '../../utilities/codemirror/lint';
+  import { readOnlyChangeGuard } from '../../utilities/codemirror/readOnly';
   import { blockTheme } from '../../utilities/codemirror/themes/block';
   import { phoenixResources } from '../../utilities/sequence-editor/adaptation-resources';
   import { showFailureToast, showSuccessToast } from '../../utilities/toast';
@@ -160,6 +161,9 @@
       effects: compartmentReadonly.reconfigure([
         EditorState.readOnly.of(!isEditable),
         EditorView.editable.of(isEditable),
+        // Block programmatic edits (lint fixes, command panel, sanitizer) that readOnly
+        // misses, but allow the editor's own 'file.open' content sync.
+        ...(isEditable ? [] : [readOnlyChangeGuard(['file.open'])]),
       ]),
     });
   }
@@ -385,7 +389,11 @@
         EditorView.updateListener.of(viewUpdate => dispatchLintChange(viewUpdate.view)),
         blockTheme,
         compartmentAdaptation.of(inputEditorExtension),
-        compartmentReadonly.of([EditorState.readOnly.of(readOnly || previewOnly || isLoading)]),
+        compartmentReadonly.of(
+          readOnly || previewOnly || isLoading
+            ? [EditorState.readOnly.of(true), readOnlyChangeGuard(['file.open'])]
+            : [EditorState.readOnly.of(false)],
+        ),
         EditorView.updateListener.of(viewUpdate => {
           for (const tr of viewUpdate.transactions) {
             if (tr.annotation(Transaction.userEvent) === 'sanitize.smartQuotes') {
@@ -496,7 +504,12 @@
   {#if showCommandFormBuilder}
     <CssGridGutter track={1} type="column" />
     {#if phoenixContext && phoenixContext.commandDictionary !== null}
-      <CommandPanel {phoenixContext} {commandInfoMapper} {editorSequenceView} />
+      <CommandPanel
+        {phoenixContext}
+        {commandInfoMapper}
+        {editorSequenceView}
+        readOnly={readOnly || previewOnly || isLoading}
+      />
     {:else}
       <Panel overflowYBody="hidden" padBody>
         <svelte:fragment slot="header">

--- a/src/components/sequencing/SequenceEditor.svelte
+++ b/src/components/sequencing/SequenceEditor.svelte
@@ -351,6 +351,20 @@
     return true;
   }
 
+  /**
+   * Replace the editor content and DO record it in the undo history — unlike the file-open sync,
+   * which is excluded from history. Used by "take theirs" so the user can Cmd-Z back to the edits
+   * they discarded (the full-doc replace and its inverse are exact, so undo/redo stay clean).
+   */
+  export function rebaseContent(content: string): void {
+    if (editorSequenceView && editorSequenceView.state.doc.toString() !== content) {
+      editorSequenceView.dispatch({
+        changes: { from: 0, insert: content, to: editorSequenceView.state.doc.length },
+        userEvent: 'file.rebase',
+      });
+    }
+  }
+
   // Exported function to allow parent to navigate to a specific line/column
   export function gotoLine(line: number, column: number = 0): void {
     if (editorSequenceView) {

--- a/src/components/sequencing/form/ArgEditor.svelte
+++ b/src/components/sequencing/form/ArgEditor.svelte
@@ -28,6 +28,7 @@
   export let setInEditor: (token: SyntaxNode, val: string) => void;
   export let addDefaultArgs: (commandNode: SyntaxNode, argDefs: FswCommandArgument[]) => void;
   export let commandInfoMapper: CommandInfoMapper;
+  export let disabled: boolean = false;
   export let variablesInScope: string[];
 
   let argDef: FswCommandArgument | undefined = undefined;
@@ -98,6 +99,7 @@
       <div class="st-typography-small-caps">Reference</div>
       <EnumEditor
         {argDef}
+        {disabled}
         initVal={argInfo.text ?? ''}
         setInEditor={val => {
           if (argInfo.node) {
@@ -110,6 +112,7 @@
         <EnumEditor
           {commandDictionary}
           {argDef}
+          {disabled}
           initVal={unquoteUnescape(argInfo.text ?? '')}
           setInEditor={val => {
             if (argInfo.node) {

--- a/src/components/sequencing/form/BooleanEditor.svelte
+++ b/src/components/sequencing/form/BooleanEditor.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <div>
-  <select class="st-select w-full" required bind:value title={argDef.description}>
+  <select class="st-select w-full" required bind:value title={argDef.description} aria-label={argDef.name}>
     {#each ['false', 'true'] as ev}
       <option>{ev}</option>
     {/each}

--- a/src/components/sequencing/form/EnumEditor.svelte
+++ b/src/components/sequencing/form/EnumEditor.svelte
@@ -9,6 +9,7 @@
 
   export let argDef: FswCommandArgumentEnum;
   export let commandDictionary: CommandDictionary | null = null;
+  export let disabled: boolean = false;
   export let initVal: string;
   export let setInEditor: (val: string) => void;
 
@@ -37,14 +38,16 @@
 <div>
   {#if enumValues.length > SEARCH_THRESHOLD}
     <SearchableDropdown
+      {disabled}
       {options}
       on:change={onSelectReferenceModel}
       {selectedOptionValues}
+      name={argDef.name}
       placeholder={value}
       searchPlaceholder="Filter values"
     />
   {:else}
-    <select class="st-select w-full" required bind:value>
+    <select class="st-select w-full" required bind:value aria-label={argDef.name}>
       {#if !isValueInEnum}
         <option>{value}</option>
       {/if}

--- a/src/components/sequencing/form/NumEditor.svelte
+++ b/src/components/sequencing/form/NumEditor.svelte
@@ -31,7 +31,7 @@
 </script>
 
 <div>
-  <input class="st-input w-full" type="number" bind:value required {min} {max} step="any" />
+  <input class="st-input w-full" type="number" bind:value required {min} {max} step="any" aria-label={argDef.name} />
   {#if typeof min === 'number' && typeof max === 'number' && (valFloat < min || valFloat > max)}
     <button style="margin-top: 4px" class="st-button" on:click={() => setInEditor(max)} title="Set to allowed value">
       Set to maximum: {max}

--- a/src/components/sequencing/form/StringEditor.svelte
+++ b/src/components/sequencing/form/StringEditor.svelte
@@ -26,4 +26,10 @@
   }
 </script>
 
-<input class="st-input w-full" spellcheck="false" bind:value title={argDef.description} />
+<input
+  class="st-input w-full"
+  spellcheck="false"
+  bind:value
+  title={argDef.description}
+  aria-label={argDef.name || undefined}
+/>

--- a/src/components/ui/TextEditor.svelte
+++ b/src/components/ui/TextEditor.svelte
@@ -14,6 +14,7 @@
   import type { LintDiagnostic } from '../../types/errors';
   import type { WorkspaceFileMetadata } from '../../types/workspace-tree-view';
   import { getLintDiagnostics } from '../../utilities/codemirror/lint';
+  import { readOnlyChangeGuard } from '../../utilities/codemirror/readOnly';
   import { blockTheme } from '../../utilities/codemirror/themes/block';
   import { showFailureToast, showSuccessToast } from '../../utilities/toast';
   import EditorToolbar from '../sequencing/EditorToolbar.svelte';
@@ -62,6 +63,8 @@
       editorView.dispatch({
         annotations: [Transaction.addToHistory.of(false)], // Prevent this change from being added to the undo history
         changes: { from: 0, insert: textFileContent, to: editorView.state.doc.length },
+        // Tagged so the read-only change guard lets this content sync through.
+        userEvent: 'file.open',
       });
     }
   }
@@ -71,6 +74,8 @@
       effects: compartmentReadonly.reconfigure([
         EditorState.readOnly.of(!isEditable),
         EditorView.editable.of(isEditable),
+        // Block programmatic edits readOnly misses (e.g. lint fixes), but allow 'file.open' sync.
+        ...(isEditable ? [] : [readOnlyChangeGuard(['file.open'])]),
       ]),
     });
   }
@@ -109,7 +114,11 @@
               textContentUpdateListener(viewUpdate);
             }
           }),
-          compartmentReadonly.of([EditorState.readOnly.of(readOnly || previewOnly || isLoading)]),
+          compartmentReadonly.of(
+            readOnly || previewOnly || isLoading
+              ? [EditorState.readOnly.of(true), readOnlyChangeGuard(['file.open'])]
+              : [EditorState.readOnly.of(false)],
+          ),
         ],
         parent: editorDiv,
       });
@@ -130,7 +139,11 @@
               textContentUpdateListener(viewUpdate);
             }
           }),
-          compartmentReadonly.of([EditorState.readOnly.of(readOnly || previewOnly || isLoading)]),
+          compartmentReadonly.of(
+            readOnly || previewOnly || isLoading
+              ? [EditorState.readOnly.of(true), readOnlyChangeGuard(['file.open'])]
+              : [EditorState.readOnly.of(false)],
+          ),
         ],
         parent: editorDiv,
       });

--- a/src/components/ui/TextEditor.svelte
+++ b/src/components/ui/TextEditor.svelte
@@ -166,6 +166,20 @@
     dispatch('textContentUpdated', { filePath: textFilePath, input: updatedText });
   }
 
+  /**
+   * Replace the editor content and DO record it in the undo history — unlike the file-open sync,
+   * which is excluded from history. Used by "take theirs" so the user can Cmd-Z back to the edits
+   * they discarded (the full-doc replace and its inverse are exact, so undo/redo stay clean).
+   */
+  export function rebaseContent(content: string): void {
+    if (editorView && editorView.state.doc.toString() !== content) {
+      editorView.dispatch({
+        changes: { from: 0, insert: content, to: editorView.state.doc.length },
+        userEvent: 'file.rebase',
+      });
+    }
+  }
+
   function downloadInputFormat(): void {
     dispatch('download', { filePath: textFilePath });
   }

--- a/src/components/workspace/WorkspaceDiffViewer.svelte
+++ b/src/components/workspace/WorkspaceDiffViewer.svelte
@@ -26,12 +26,13 @@
   export let type: WorkspaceContentType | null = null;
 
   let container: HTMLDivElement;
+  let isSinglePane: boolean = true;
   let mergeView: MergeView | null = null;
   let singleView: EditorView | null = null;
 
   $: isSinglePane = theirs === null;
 
-  /** Current content of the editable "Mine" pane (for the merge flow). */
+  /** Get the current contents of the editable "Mine" pane (for the merge flow). */
   export function getMergedContent(): string {
     return mergeView?.b.state.doc.toString() ?? mine;
   }
@@ -46,9 +47,9 @@
     return [];
   }
 
-  // A truly read-only pane. The guard blocks programmatic edits that `readOnly` misses
-  // (lint quick-fixes, sanitizers), keeping the diff faithful to the bytes; the theme hides
-  // the now-dead lint quick-fix buttons.
+  // Blocks programmatic edits that `readOnly` codemirror flag misses
+  // (lint quick-fixes, sanitizers), keeping the diff faithful to the bytes.
+  // The theme hides the irrelevant lint quick-fix buttons.
   function readOnlyExtensions(): Extension[] {
     return [
       lineNumbers(),
@@ -89,7 +90,6 @@
       return;
     }
 
-    // Divider between the two panes (matches the header divider).
     const dividerTheme = EditorView.theme({ '&': { borderLeft: '1px solid hsl(var(--border))' } });
 
     // `a` = Theirs (read-only), `b` = Mine (editable in merge mode). revertControls are the

--- a/src/components/workspace/WorkspaceDiffViewer.svelte
+++ b/src/components/workspace/WorkspaceDiffViewer.svelte
@@ -1,0 +1,130 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { json } from '@codemirror/lang-json';
+  import { defaultHighlightStyle, syntaxHighlighting } from '@codemirror/language';
+  import { MergeView } from '@codemirror/merge';
+  import { EditorState, type Extension } from '@codemirror/state';
+  import { EditorView, lineNumbers } from '@codemirror/view';
+  import { basicSetup } from 'codemirror';
+  import { onDestroy, onMount } from 'svelte';
+  import { WorkspaceContentType } from '../../enums/workspace';
+  import { readOnlyChangeGuard } from '../../utilities/codemirror/readOnly';
+
+  /**
+   * When true, the "Mine" pane is editable with revert chevrons to pull in "Theirs" — a
+   * hand-merge. Read the result via {@link getMergedContent}. Ignored when `theirs` is null.
+   */
+  export let editable: boolean = false;
+  /** Language extension for syntax highlighting; falls back to a `type`-based one (JSON). */
+  export let languageExtension: Extension | null = null;
+  /** The editor buffer ("Mine"); always shown. */
+  export let mine: string;
+  /** Current server content ("Theirs"). When null the file was deleted — "Mine" shows alone. */
+  export let theirs: string | null;
+  /** File type, used to pick the fallback language extension. */
+  export let type: WorkspaceContentType | null = null;
+
+  let container: HTMLDivElement;
+  let mergeView: MergeView | null = null;
+  let singleView: EditorView | null = null;
+
+  $: isSinglePane = theirs === null;
+
+  /** Current content of the editable "Mine" pane (for the merge flow). */
+  export function getMergedContent(): string {
+    return mergeView?.b.state.doc.toString() ?? mine;
+  }
+
+  function languageExtensions(): Extension[] {
+    if (languageExtension) {
+      return [languageExtension];
+    }
+    if (type === WorkspaceContentType.Json) {
+      return [json()];
+    }
+    return [];
+  }
+
+  // A truly read-only pane. The guard blocks programmatic edits that `readOnly` misses
+  // (lint quick-fixes, sanitizers), keeping the diff faithful to the bytes; the theme hides
+  // the now-dead lint quick-fix buttons.
+  function readOnlyExtensions(): Extension[] {
+    return [
+      lineNumbers(),
+      EditorView.lineWrapping,
+      EditorView.editable.of(false),
+      EditorState.readOnly.of(true),
+      readOnlyChangeGuard(),
+      EditorView.theme({ '.cm-diagnosticAction': { display: 'none' } }),
+      syntaxHighlighting(defaultHighlightStyle, { fallback: true }),
+      ...languageExtensions(),
+    ];
+  }
+
+  // Full editing surface for the "Mine" pane in merge mode — no read-only guard.
+  function editableExtensions(): Extension[] {
+    return [basicSetup, EditorView.lineWrapping, ...languageExtensions()];
+  }
+
+  function destroyViews() {
+    mergeView?.destroy();
+    mergeView = null;
+    singleView?.destroy();
+    singleView = null;
+  }
+
+  function buildViews() {
+    destroyViews();
+    if (!container) {
+      return;
+    }
+
+    if (theirs === null) {
+      singleView = new EditorView({
+        doc: mine,
+        extensions: readOnlyExtensions(),
+        parent: container,
+      });
+      return;
+    }
+
+    // Divider between the two panes (matches the header divider).
+    const dividerTheme = EditorView.theme({ '&': { borderLeft: '1px solid hsl(var(--border))' } });
+
+    // `a` = Theirs (read-only), `b` = Mine (editable in merge mode). revertControls are the
+    // chevrons that copy Theirs chunks into Mine.
+    mergeView = new MergeView({
+      a: { doc: theirs, extensions: readOnlyExtensions() },
+      b: { doc: mine, extensions: [...(editable ? editableExtensions() : readOnlyExtensions()), dividerTheme] },
+      collapseUnchanged: { margin: 3, minSize: 4 },
+      gutter: true,
+      highlightChanges: true,
+      parent: container,
+      revertControls: editable ? 'a-to-b' : undefined,
+    });
+  }
+
+  onMount(() => {
+    buildViews();
+  });
+
+  onDestroy(() => {
+    destroyViews();
+  });
+</script>
+
+<div class="flex h-full min-h-0 w-full flex-col">
+  <div
+    class="st-typography-medium grid flex-none border-b"
+    class:grid-cols-1={isSinglePane}
+    class:grid-cols-2={!isSinglePane}
+  >
+    {#if !isSinglePane}
+      <div class="border-r px-3 py-1.5 text-muted-foreground">Theirs (server)</div>
+    {/if}
+    <div class="px-3 py-1.5 text-muted-foreground">{editable ? 'Mine (editable)' : 'Mine (your edits)'}</div>
+  </div>
+  <!-- Scroll the whole diff here so both panes stay aligned (MergeView's recommended setup). -->
+  <div class="min-h-0 flex-auto overflow-auto" bind:this={container} />
+</div>

--- a/src/components/workspace/WorkspaceDiffViewer.svelte
+++ b/src/components/workspace/WorkspaceDiffViewer.svelte
@@ -7,7 +7,7 @@
   import { EditorState, type Extension } from '@codemirror/state';
   import { EditorView, lineNumbers } from '@codemirror/view';
   import { basicSetup } from 'codemirror';
-  import { onDestroy, onMount } from 'svelte';
+  import { createEventDispatcher, onDestroy, onMount } from 'svelte';
   import { WorkspaceContentType } from '../../enums/workspace';
   import { readOnlyChangeGuard } from '../../utilities/codemirror/readOnly';
 
@@ -24,6 +24,8 @@
   export let theirs: string | null;
   /** File type, used to pick the fallback language extension. */
   export let type: WorkspaceContentType | null = null;
+
+  const dispatch = createEventDispatcher<{ stats: { changedLines: number } }>();
 
   let container: HTMLDivElement;
   let isSinglePane: boolean = true;
@@ -75,6 +77,19 @@
     singleView = null;
   }
 
+  /** Total lines involved in changes (larger side of each chunk), for the header summary. */
+  function countChangedLines(view: MergeView): number {
+    const aDoc = view.a.state.doc;
+    const bDoc = view.b.state.doc;
+    let total = 0;
+    for (const chunk of view.chunks) {
+      const aLines = chunk.toA > chunk.fromA ? aDoc.lineAt(chunk.endA).number - aDoc.lineAt(chunk.fromA).number + 1 : 0;
+      const bLines = chunk.toB > chunk.fromB ? bDoc.lineAt(chunk.endB).number - bDoc.lineAt(chunk.fromB).number + 1 : 0;
+      total += Math.max(aLines, bLines);
+    }
+    return total;
+  }
+
   function buildViews() {
     destroyViews();
     if (!container) {
@@ -103,6 +118,8 @@
       parent: container,
       revertControls: editable ? 'a-to-b' : undefined,
     });
+
+    dispatch('stats', { changedLines: countChangedLines(mergeView) });
   }
 
   onMount(() => {

--- a/src/components/workspace/WorkspaceRightPanel.svelte
+++ b/src/components/workspace/WorkspaceRightPanel.svelte
@@ -144,6 +144,7 @@
             {commandDictionary}
             {commandInfoMapper}
             {editorSequenceView}
+            readOnly={!hasEditPermission || !!fileMetadata?.readOnly}
             {timeTagNode}
             on:selectCommandDefinition={onSelectCommandDefinition}
           />

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -190,6 +190,7 @@
   let selectedConsoleTab: WorkspaceConsoleTab = 'actions';
   let activeEditorView: EditorView | null = null;
   let sequenceEditorRef: SequenceEditor;
+  let textEditorRef: TextEditor;
   let showLoadingSpinner: boolean = false;
   let librarySequences: LibrarySequenceSignature[] = [];
   let loadingSpinnerTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -665,7 +666,7 @@
       return;
     }
 
-    // open() does the stale check and stores the ETag as baseToken for the next save.
+    // open() does the stale check and stores the ETag as baseEtag for the next save.
     activeDocument.open(filePath, content, etag);
 
     // Fetch fresh metadata so readOnly/user fields are current when the user opens the file
@@ -803,7 +804,7 @@
     // Save the file before the operation
     const path = $activeDocumentPath!;
     const content = $activeDocument.currentContent;
-    const ifMatch = $activeDocument.baseToken ?? '*';
+    const ifMatch = $activeDocument.baseEtag ?? '*';
     try {
       const result = await effects.saveWorkspaceFile($workspaceId, path, content, $user, ifMatch);
       if (!result) {
@@ -1029,8 +1030,8 @@
   async function saveCurrentFile(content: string) {
     if ($activeDocumentPath) {
       const path = $activeDocumentPath;
-      // baseToken runs the concurrency check; '*' forces (when no token was captured).
-      const ifMatch = $activeDocument.baseToken ?? '*';
+      // baseEtag runs the concurrency check; '*' forces (when no etag was captured).
+      const ifMatch = $activeDocument.baseEtag ?? '*';
       try {
         const result = await effects.saveWorkspaceFile($workspaceId, path, content, $user, ifMatch);
         if (result) {
@@ -1081,14 +1082,19 @@
     }
 
     if (value.action === 'take-theirs') {
-      activeDocument.replaceWithServer(path, value.content, value.token);
+      // Push the rebase INTO the editor's undo history (before replaceWithServer updates
+      // originalContent, so the non-undoable prop-sync then no-ops) so the user can Cmd-Z back to
+      // the edits they discarded.
+      const editorRef = activeFileIsSequence ? sequenceEditorRef : textEditorRef;
+      editorRef?.rebaseContent(value.content);
+      activeDocument.replaceWithServer(path, value.content, value.etag);
       showSuccessToast('Loaded the latest version of the file');
       return true;
     }
 
     if (value.action === 'take-mine') {
       // Save against the version shown; '*' forces if no token. A re-conflict reopens the diff.
-      return persistMine(path, value.content, value.token ?? '*');
+      return persistMine(path, value.content, value.etag ?? '*');
     }
 
     if (value.action === 'recreate') {
@@ -1711,6 +1717,7 @@
               {:else if isTextOrEmpty}
                 <div class="flex h-full">
                   <TextEditor
+                    bind:this={textEditorRef}
                     availableActions={availableActionsForActiveFile}
                     fileMetadata={activeFileMetadata}
                     includeActions={true}

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -1100,6 +1100,9 @@
     if (value.action === 'discard') {
       if ($activeDocumentPath === path) {
         activeDocument.close();
+        selectedFilePath = null;
+        confirmAndNavigate(null);
+        refreshWorkspaceContents();
       }
       return false;
     }

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -6,6 +6,7 @@
   import { base } from '$app/paths';
   import { page } from '$app/stores';
   import { env } from '$env/dynamic/public';
+  import type { Extension } from '@codemirror/state';
   import type { ChannelDictionary, CommandDictionary, ParameterDictionary } from '@nasa-jpl/aerie-ampcs';
   import type {
     CommandInfoMapper,
@@ -109,9 +110,15 @@
   import { ErrorTypes } from '../../../utilities/errors';
   import { downloadBlob, filterEmpty } from '../../../utilities/generic';
   import { isSaveEvent } from '../../../utilities/keyboardEvents';
-  import { showConfirmModal, showRunActionResultsModal } from '../../../utilities/modal';
+  import {
+    showConfirmModal,
+    showRunActionResultsModal,
+    showWorkspaceSaveConflictModal,
+  } from '../../../utilities/modal';
   import { featurePermissions } from '../../../utilities/permissions';
+  import { WorkspaceSaveConflictError } from '../../../utilities/requests';
   import { getWorkspacesUrl } from '../../../utilities/routes';
+  import { phoenixResources } from '../../../utilities/sequence-editor/adaptation-resources';
   import * as adaptationUtils from '../../../utilities/sequence-editor/adaptation-utils';
   import { pluralize } from '../../../utilities/text';
   import { showFailureToast, showSuccessToast } from '../../../utilities/toast';
@@ -634,11 +641,14 @@
 
   async function getSelectedFileContent(filePath: string) {
     let content: string | null = '';
+    let etag: string | null = null;
 
     if ($user) {
       const node = workspaceTreeMap[filePath];
       if (node?.type !== WorkspaceContentType.Directory) {
-        content = await effects.getWorkspaceFileContent($workspaceId, filePath, $user);
+        const result = await effects.getWorkspaceFileContent($workspaceId, filePath, $user);
+        content = result.content;
+        etag = result.etag;
       }
     }
 
@@ -655,8 +665,8 @@
       return;
     }
 
-    // activeDocument.open handles the stale check internally (compares filePath with loadingPath)
-    activeDocument.open(filePath, content);
+    // open() does the stale check and stores the ETag as baseToken for the next save.
+    activeDocument.open(filePath, content, etag);
 
     // Fetch fresh metadata so readOnly/user fields are current when the user opens the file
     const fileNode = workspaceTreeMap[filePath];
@@ -791,9 +801,24 @@
     }
 
     // Save the file before the operation
-    await effects.saveWorkspaceFile($workspaceId, $activeDocumentPath!, $activeDocument.currentContent, $user);
-    activeDocument.markClean($activeDocument.currentContent);
-    return true;
+    const path = $activeDocumentPath!;
+    const content = $activeDocument.currentContent;
+    const ifMatch = $activeDocument.baseToken ?? '*';
+    try {
+      const result = await effects.saveWorkspaceFile($workspaceId, path, content, $user, ifMatch);
+      if (!result) {
+        // Save failed (a failure toast was already shown) — don't proceed.
+        return false;
+      }
+      activeDocument.markClean(content, result.etag);
+      return true;
+    } catch (e) {
+      if (e instanceof WorkspaceSaveConflictError) {
+        // Proceed with the operation only if the conflict resolution actually saved.
+        return await resolveSaveConflict(e, path, content);
+      }
+      return false;
+    }
   }
 
   async function onAddCollaborator(event: CustomEvent<WorkspaceCollaborator[]>) {
@@ -1003,9 +1028,20 @@
 
   async function saveCurrentFile(content: string) {
     if ($activeDocumentPath) {
-      await effects.saveWorkspaceFile($workspaceId, $activeDocumentPath, content, $user);
-      activeDocument.markClean(content);
-      refreshWorkspaceContents();
+      const path = $activeDocumentPath;
+      // baseToken runs the concurrency check; '*' forces (when no token was captured).
+      const ifMatch = $activeDocument.baseToken ?? '*';
+      try {
+        const result = await effects.saveWorkspaceFile($workspaceId, path, content, $user, ifMatch);
+        if (result) {
+          activeDocument.markClean(content, result.etag);
+          refreshWorkspaceContents();
+        }
+      } catch (e) {
+        if (e instanceof WorkspaceSaveConflictError) {
+          await resolveSaveConflict(e, path, content);
+        }
+      }
     } else if ($workspace && workspaceTree && content) {
       const newFilePath = await effects.newWorkspaceSequence($workspace, workspaceTree, '', content, $user);
       if (newFilePath !== null) {
@@ -1014,6 +1050,104 @@
         refreshWorkspaceContents();
       }
     }
+  }
+
+  /**
+   * Shows the conflict modal and applies the user's choice. Returns whether the file was
+   * saved (so save-before-an-operation callers know it's safe to proceed).
+   */
+  async function resolveSaveConflict(
+    error: WorkspaceSaveConflictError,
+    path: string,
+    content: string,
+  ): Promise<boolean> {
+    const node = workspaceTreeMap[path];
+    const { confirm, value } = await showWorkspaceSaveConflictModal({
+      fileName: separateFilenameFromPath(path).filename,
+      languageExtension: getActiveFileLanguageExtension(path),
+      lastEditedAt: error.lastEditedAt,
+      lastEditedBy: error.lastEditedBy,
+      mineContent: content,
+      path,
+      reason: error.reason,
+      type: $activeDocument.type ?? node?.type ?? null,
+      user: $user,
+      workspaceId: $workspaceId,
+    });
+
+    // Cancel: leave the doc dirty with its stale token so the next save re-checks.
+    if (!confirm || !value) {
+      return false;
+    }
+
+    if (value.action === 'take-theirs') {
+      activeDocument.replaceWithServer(path, value.content, value.token);
+      showSuccessToast('Loaded the latest version of the file');
+      return true;
+    }
+
+    if (value.action === 'take-mine') {
+      // Save against the version shown; '*' forces if no token. A re-conflict reopens the diff.
+      return persistMine(path, value.content, value.token ?? '*');
+    }
+
+    if (value.action === 'recreate') {
+      // File was deleted underneath — force-create it.
+      return persistMine(path, content, '*');
+    }
+
+    if (value.action === 'discard') {
+      if ($activeDocumentPath === path) {
+        activeDocument.close();
+      }
+      return false;
+    }
+
+    return false;
+  }
+
+  /**
+   * Saves with the given `If-Match` and rebases the editor on success. If it still conflicts
+   * (file moved again), reopens the modal instead of overwriting. Returns whether it saved.
+   */
+  async function persistMine(path: string, content: string, ifMatch: string): Promise<boolean> {
+    try {
+      const result = await effects.saveWorkspaceFile($workspaceId, path, content, $user, ifMatch);
+      if (result) {
+        // Rebase the editor on the saved content (no-ops if the user navigated away).
+        activeDocument.replaceWithServer(path, content, result.etag);
+        refreshWorkspaceContents();
+        return true;
+      }
+      return false;
+    } catch (e) {
+      if (e instanceof WorkspaceSaveConflictError) {
+        return resolveSaveConflict(e, path, content);
+      }
+      return false;
+    }
+  }
+
+  /**
+   * The active file's language extension (same one the sequence editor uses) so the diff
+   * highlights consistently. Null when there's no adaptation or it isn't a sequence.
+   */
+  function getActiveFileLanguageExtension(path: string): Extension | null {
+    const adaptation = $sequenceAdaptation;
+    if (!phoenixContext || !adaptation || path !== $activeDocumentPath) {
+      return null;
+    }
+    const sequenceName = $activeDocument.fileName ?? '';
+    if (activeFileIsInputSequence && adaptation.input.getEditorExtension) {
+      return adaptation.input.getEditorExtension(phoenixContext, phoenixResources);
+    }
+    if (adaptation.outputs.length > 0) {
+      const matchingOutput = adaptation.outputs.find(output =>
+        doesFilenameMatchExtension(output.fileExtension, sequenceName),
+      );
+      return matchingOutput?.getEditorExtension?.(phoenixContext, phoenixResources) ?? null;
+    }
+    return null;
   }
 
   async function onReadOnlyChange(readOnly: boolean) {
@@ -1351,6 +1485,10 @@
   function onGlobalKeydown(event: KeyboardEvent) {
     if (isSaveEvent(event)) {
       event.preventDefault();
+      // Don't save while a modal is open — Ctrl/Cmd+S would stack another save under it.
+      if (browser && document.querySelector('#svelte-modal')?.childElementCount) {
+        return;
+      }
       if (hasEditFilePermission && $activeDocumentIsDirty) {
         saveCurrentFile($activeDocument.currentContent);
       }

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -806,18 +806,15 @@
     const content = $activeDocument.currentContent;
     const ifMatch = $activeDocument.baseEtag ?? '*';
     try {
-      const result = await effects.saveWorkspaceFile($workspaceId, path, content, $user, ifMatch);
-      if (!result) {
-        // Save failed (a failure toast was already shown) — don't proceed.
-        return false;
-      }
-      activeDocument.markClean(content, result.etag);
+      const { etag } = await effects.saveWorkspaceFile($workspaceId, path, content, $user, ifMatch);
+      activeDocument.markClean(content, etag);
       return true;
     } catch (e) {
       if (e instanceof WorkspaceSaveConflictError) {
         // Proceed with the operation only if the conflict resolution actually saved.
         return await resolveSaveConflict(e, path, content);
       }
+      // Any other failure was already toasted by the effect — just don't proceed.
       return false;
     }
   }
@@ -1033,11 +1030,9 @@
       // baseEtag runs the concurrency check; '*' forces (when no etag was captured).
       const ifMatch = $activeDocument.baseEtag ?? '*';
       try {
-        const result = await effects.saveWorkspaceFile($workspaceId, path, content, $user, ifMatch);
-        if (result) {
-          activeDocument.markClean(content, result.etag);
-          refreshWorkspaceContents();
-        }
+        const { etag } = await effects.saveWorkspaceFile($workspaceId, path, content, $user, ifMatch);
+        activeDocument.markClean(content, etag);
+        refreshWorkspaceContents();
       } catch (e) {
         if (e instanceof WorkspaceSaveConflictError) {
           await resolveSaveConflict(e, path, content);
@@ -1118,14 +1113,11 @@
    */
   async function persistMine(path: string, content: string, ifMatch: string): Promise<boolean> {
     try {
-      const result = await effects.saveWorkspaceFile($workspaceId, path, content, $user, ifMatch);
-      if (result) {
-        // Rebase the editor on the saved content (no-ops if the user navigated away).
-        activeDocument.replaceWithServer(path, content, result.etag);
-        refreshWorkspaceContents();
-        return true;
-      }
-      return false;
+      const { etag } = await effects.saveWorkspaceFile($workspaceId, path, content, $user, ifMatch);
+      // Rebase the editor on the saved content (no-ops if the user navigated away).
+      activeDocument.replaceWithServer(path, content, etag);
+      refreshWorkspaceContents();
+      return true;
     } catch (e) {
       if (e instanceof WorkspaceSaveConflictError) {
         return resolveSaveConflict(e, path, content);

--- a/src/stores/activeDocument.test.ts
+++ b/src/stores/activeDocument.test.ts
@@ -1,0 +1,90 @@
+import { get } from 'svelte/store';
+import { afterEach, describe, expect, test } from 'vitest';
+import { WorkspaceContentType } from '../enums/workspace';
+import { activeDocument, activeDocumentIsDirty } from './activeDocument';
+
+describe('activeDocument store — baseToken (simultaneous-edit protection)', () => {
+  afterEach(() => {
+    activeDocument.reset();
+  });
+
+  test('open stores the server etag as baseToken when the path matches loadingPath', () => {
+    activeDocument.startLoad('foo/bar.seq', 'bar.seq', WorkspaceContentType.Sequence);
+    expect(get(activeDocument).baseToken).toBeNull();
+
+    const opened = activeDocument.open('foo/bar.seq', 'hello', '"tok-1"');
+
+    expect(opened).toBe(true);
+    const state = get(activeDocument);
+    expect(state.baseToken).toBe('"tok-1"');
+    expect(state.currentContent).toBe('hello');
+    expect(state.originalContent).toBe('hello');
+    expect(get(activeDocumentIsDirty)).toBe(false);
+  });
+
+  test('open ignores a stale path and leaves baseToken untouched', () => {
+    activeDocument.startLoad('foo/bar.seq', 'bar.seq', WorkspaceContentType.Sequence);
+
+    const opened = activeDocument.open('other/file.seq', 'nope', '"tok-x"');
+
+    expect(opened).toBe(false);
+    expect(get(activeDocument).baseToken).toBeNull();
+  });
+
+  test('startLoad clears a previously stored baseToken', () => {
+    activeDocument.startLoad('a.seq', 'a.seq', WorkspaceContentType.Sequence);
+    activeDocument.open('a.seq', 'x', '"tok-a"');
+    expect(get(activeDocument).baseToken).toBe('"tok-a"');
+
+    activeDocument.startLoad('b.seq', 'b.seq', WorkspaceContentType.Sequence);
+
+    expect(get(activeDocument).baseToken).toBeNull();
+  });
+
+  test('markClean advances baseToken when a new token is given, and preserves it otherwise', () => {
+    activeDocument.startLoad('a.seq', 'a.seq', WorkspaceContentType.Sequence);
+    activeDocument.open('a.seq', 'x', '"tok-a"');
+    activeDocument.updateContent('x edited');
+    expect(get(activeDocumentIsDirty)).toBe(true);
+
+    activeDocument.markClean('x edited', '"tok-b"');
+
+    let state = get(activeDocument);
+    expect(state.baseToken).toBe('"tok-b"');
+    expect(state.originalContent).toBe('x edited');
+    expect(get(activeDocumentIsDirty)).toBe(false);
+
+    // No token argument -> baseToken is left unchanged.
+    activeDocument.updateContent('x edited 2');
+    activeDocument.markClean('x edited 2');
+    state = get(activeDocument);
+    expect(state.baseToken).toBe('"tok-b"');
+  });
+
+  test('replaceWithServer rebases content + token when the path still matches', () => {
+    activeDocument.startLoad('a.seq', 'a.seq', WorkspaceContentType.Sequence);
+    activeDocument.open('a.seq', 'mine', '"tok-a"');
+    activeDocument.updateContent('mine edited');
+
+    const applied = activeDocument.replaceWithServer('a.seq', 'theirs', '"tok-server"');
+
+    expect(applied).toBe(true);
+    const state = get(activeDocument);
+    expect(state.currentContent).toBe('theirs');
+    expect(state.originalContent).toBe('theirs');
+    expect(state.baseToken).toBe('"tok-server"');
+    expect(get(activeDocumentIsDirty)).toBe(false);
+  });
+
+  test('replaceWithServer ignores a path that is no longer the active document', () => {
+    activeDocument.startLoad('a.seq', 'a.seq', WorkspaceContentType.Sequence);
+    activeDocument.open('a.seq', 'mine', '"tok-a"');
+
+    const applied = activeDocument.replaceWithServer('different.seq', 'theirs', '"tok-server"');
+
+    expect(applied).toBe(false);
+    const state = get(activeDocument);
+    expect(state.currentContent).toBe('mine');
+    expect(state.baseToken).toBe('"tok-a"');
+  });
+});

--- a/src/stores/activeDocument.test.ts
+++ b/src/stores/activeDocument.test.ts
@@ -3,45 +3,45 @@ import { afterEach, describe, expect, test } from 'vitest';
 import { WorkspaceContentType } from '../enums/workspace';
 import { activeDocument, activeDocumentIsDirty } from './activeDocument';
 
-describe('activeDocument store — baseToken (simultaneous-edit protection)', () => {
+describe('activeDocument store — baseEtag (simultaneous-edit protection)', () => {
   afterEach(() => {
     activeDocument.reset();
   });
 
-  test('open stores the server etag as baseToken when the path matches loadingPath', () => {
+  test('open stores the server etag as baseEtag when the path matches loadingPath', () => {
     activeDocument.startLoad('foo/bar.seq', 'bar.seq', WorkspaceContentType.Sequence);
-    expect(get(activeDocument).baseToken).toBeNull();
+    expect(get(activeDocument).baseEtag).toBeNull();
 
     const opened = activeDocument.open('foo/bar.seq', 'hello', '"tok-1"');
 
     expect(opened).toBe(true);
     const state = get(activeDocument);
-    expect(state.baseToken).toBe('"tok-1"');
+    expect(state.baseEtag).toBe('"tok-1"');
     expect(state.currentContent).toBe('hello');
     expect(state.originalContent).toBe('hello');
     expect(get(activeDocumentIsDirty)).toBe(false);
   });
 
-  test('open ignores a stale path and leaves baseToken untouched', () => {
+  test('open ignores a stale path and leaves baseEtag untouched', () => {
     activeDocument.startLoad('foo/bar.seq', 'bar.seq', WorkspaceContentType.Sequence);
 
     const opened = activeDocument.open('other/file.seq', 'nope', '"tok-x"');
 
     expect(opened).toBe(false);
-    expect(get(activeDocument).baseToken).toBeNull();
+    expect(get(activeDocument).baseEtag).toBeNull();
   });
 
-  test('startLoad clears a previously stored baseToken', () => {
+  test('startLoad clears a previously stored baseEtag', () => {
     activeDocument.startLoad('a.seq', 'a.seq', WorkspaceContentType.Sequence);
     activeDocument.open('a.seq', 'x', '"tok-a"');
-    expect(get(activeDocument).baseToken).toBe('"tok-a"');
+    expect(get(activeDocument).baseEtag).toBe('"tok-a"');
 
     activeDocument.startLoad('b.seq', 'b.seq', WorkspaceContentType.Sequence);
 
-    expect(get(activeDocument).baseToken).toBeNull();
+    expect(get(activeDocument).baseEtag).toBeNull();
   });
 
-  test('markClean advances baseToken when a new token is given, and preserves it otherwise', () => {
+  test('markClean advances baseEtag when a new etag is given, and preserves it otherwise', () => {
     activeDocument.startLoad('a.seq', 'a.seq', WorkspaceContentType.Sequence);
     activeDocument.open('a.seq', 'x', '"tok-a"');
     activeDocument.updateContent('x edited');
@@ -50,18 +50,18 @@ describe('activeDocument store — baseToken (simultaneous-edit protection)', ()
     activeDocument.markClean('x edited', '"tok-b"');
 
     let state = get(activeDocument);
-    expect(state.baseToken).toBe('"tok-b"');
+    expect(state.baseEtag).toBe('"tok-b"');
     expect(state.originalContent).toBe('x edited');
     expect(get(activeDocumentIsDirty)).toBe(false);
 
-    // No token argument -> baseToken is left unchanged.
+    // No etag argument -> baseEtag is left unchanged.
     activeDocument.updateContent('x edited 2');
     activeDocument.markClean('x edited 2');
     state = get(activeDocument);
-    expect(state.baseToken).toBe('"tok-b"');
+    expect(state.baseEtag).toBe('"tok-b"');
   });
 
-  test('replaceWithServer rebases content + token when the path still matches', () => {
+  test('replaceWithServer rebases content + etag when the path still matches', () => {
     activeDocument.startLoad('a.seq', 'a.seq', WorkspaceContentType.Sequence);
     activeDocument.open('a.seq', 'mine', '"tok-a"');
     activeDocument.updateContent('mine edited');
@@ -72,7 +72,7 @@ describe('activeDocument store — baseToken (simultaneous-edit protection)', ()
     const state = get(activeDocument);
     expect(state.currentContent).toBe('theirs');
     expect(state.originalContent).toBe('theirs');
-    expect(state.baseToken).toBe('"tok-server"');
+    expect(state.baseEtag).toBe('"tok-server"');
     expect(get(activeDocumentIsDirty)).toBe(false);
   });
 
@@ -85,6 +85,6 @@ describe('activeDocument store — baseToken (simultaneous-edit protection)', ()
     expect(applied).toBe(false);
     const state = get(activeDocument);
     expect(state.currentContent).toBe('mine');
-    expect(state.baseToken).toBe('"tok-a"');
+    expect(state.baseEtag).toBe('"tok-a"');
   });
 });

--- a/src/stores/activeDocument.ts
+++ b/src/stores/activeDocument.ts
@@ -4,6 +4,11 @@ import type { WorkspaceContentType } from '../enums/workspace';
 /* Types */
 
 export interface ActiveDocumentState {
+  /**
+   * The server's ETag for the version the editor is based on. Sent back on save so the
+   * server can reject it if the file changed underneath. Opaque — only stored and echoed.
+   */
+  baseToken: string | null;
   currentContent: string;
   fileName: string | null;
   isLoading: boolean;
@@ -20,15 +25,23 @@ export interface ActiveDocumentStore {
   /** Close the current document. */
   close: () => void;
 
-  /** Mark the document as clean (after save). Syncs originalContent with currentContent. */
-  markClean: (savedContent?: string) => void;
+  /**
+   * Mark the document clean after save (syncs originalContent). Pass `newToken` to also
+   * advance `baseToken`.
+   */
+  markClean: (savedContent?: string, newToken?: string | null) => void;
 
   /**
-   * Open a document after content has been loaded.
-   * Only updates if the path matches loadingPath (stale check).
-   * Returns true if the document was opened, false if stale.
+   * Open a loaded document and store its `etag` as `baseToken`. Skips stale loads (only
+   * applies when `path` matches `loadingPath`). Returns false if stale.
    */
-  open: (path: string, content: string) => boolean;
+  open: (path: string, content: string, etag: string | null) => boolean;
+
+  /**
+   * Rebase the document onto `content` + `token` and mark it clean (e.g. "take theirs", or
+   * after a merged save). Only applies if `path` is still active. Returns false otherwise.
+   */
+  replaceWithServer: (path: string, content: string, token: string | null) => boolean;
 
   /** Reset the store to initial state. */
   reset: () => void;
@@ -52,6 +65,7 @@ export interface ActiveDocumentStore {
 /* Constants */
 
 const initialState: ActiveDocumentState = {
+  baseToken: null,
   currentContent: '',
   fileName: null,
   isLoading: false,
@@ -83,14 +97,15 @@ function createActiveDocumentStore(): ActiveDocumentStore {
       set(initialState);
     },
 
-    markClean(savedContent?: string): void {
+    markClean(savedContent?: string, newToken?: string | null): void {
       update(state => ({
         ...state,
+        baseToken: newToken !== undefined ? newToken : state.baseToken,
         originalContent: savedContent ?? state.currentContent,
       }));
     },
 
-    open(path: string, content: string): boolean {
+    open(path: string, content: string, etag: string | null): boolean {
       const currentState = get(internalStore);
 
       // Stale response check: only proceed if this is the path we're expecting
@@ -100,6 +115,27 @@ function createActiveDocumentStore(): ActiveDocumentStore {
 
       update(state => ({
         ...state,
+        baseToken: etag,
+        currentContent: content,
+        isLoading: false,
+        loadingPath: null,
+        originalContent: content,
+      }));
+
+      return true;
+    },
+
+    replaceWithServer(path: string, content: string, token: string | null): boolean {
+      const currentState = get(internalStore);
+
+      // Only replace if this is still the active document (no in-flight load to guard on).
+      if (currentState.path !== path) {
+        return false;
+      }
+
+      update(state => ({
+        ...state,
+        baseToken: token,
         currentContent: content,
         isLoading: false,
         loadingPath: null,
@@ -115,6 +151,7 @@ function createActiveDocumentStore(): ActiveDocumentStore {
 
     startLoad(path: string, fileName: string | null, type: WorkspaceContentType | null): void {
       set({
+        baseToken: null,
         currentContent: '',
         fileName,
         isLoading: true,

--- a/src/stores/activeDocument.ts
+++ b/src/stores/activeDocument.ts
@@ -8,7 +8,7 @@ export interface ActiveDocumentState {
    * The server's ETag for the version the editor is based on. Sent back on save so the
    * server can reject it if the file changed underneath. Opaque — only stored and echoed.
    */
-  baseToken: string | null;
+  baseEtag: string | null;
   currentContent: string;
   fileName: string | null;
   isLoading: boolean;
@@ -26,22 +26,22 @@ export interface ActiveDocumentStore {
   close: () => void;
 
   /**
-   * Mark the document clean after save (syncs originalContent). Pass `newToken` to also
-   * advance `baseToken`.
+   * Mark the document clean after save (syncs originalContent). Pass `newEtag` to also
+   * advance `baseEtag`.
    */
-  markClean: (savedContent?: string, newToken?: string | null) => void;
+  markClean: (savedContent?: string, newEtag?: string | null) => void;
 
   /**
-   * Open a loaded document and store its `etag` as `baseToken`. Skips stale loads (only
+   * Open a loaded document and store its `etag` as `baseEtag`. Skips stale loads (only
    * applies when `path` matches `loadingPath`). Returns false if stale.
    */
   open: (path: string, content: string, etag: string | null) => boolean;
 
   /**
-   * Rebase the document onto `content` + `token` and mark it clean (e.g. "take theirs", or
+   * Rebase the document onto `content` + `etag` and mark it clean (e.g. "take theirs", or
    * after a merged save). Only applies if `path` is still active. Returns false otherwise.
    */
-  replaceWithServer: (path: string, content: string, token: string | null) => boolean;
+  replaceWithServer: (path: string, content: string, etag: string | null) => boolean;
 
   /** Reset the store to initial state. */
   reset: () => void;
@@ -65,7 +65,7 @@ export interface ActiveDocumentStore {
 /* Constants */
 
 const initialState: ActiveDocumentState = {
-  baseToken: null,
+  baseEtag: null,
   currentContent: '',
   fileName: null,
   isLoading: false,
@@ -97,10 +97,10 @@ function createActiveDocumentStore(): ActiveDocumentStore {
       set(initialState);
     },
 
-    markClean(savedContent?: string, newToken?: string | null): void {
+    markClean(savedContent?: string, newEtag?: string | null): void {
       update(state => ({
         ...state,
-        baseToken: newToken !== undefined ? newToken : state.baseToken,
+        baseEtag: newEtag !== undefined ? newEtag : state.baseEtag,
         originalContent: savedContent ?? state.currentContent,
       }));
     },
@@ -115,7 +115,7 @@ function createActiveDocumentStore(): ActiveDocumentStore {
 
       update(state => ({
         ...state,
-        baseToken: etag,
+        baseEtag: etag,
         currentContent: content,
         isLoading: false,
         loadingPath: null,
@@ -125,7 +125,7 @@ function createActiveDocumentStore(): ActiveDocumentStore {
       return true;
     },
 
-    replaceWithServer(path: string, content: string, token: string | null): boolean {
+    replaceWithServer(path: string, content: string, etag: string | null): boolean {
       const currentState = get(internalStore);
 
       // Only replace if this is still the active document (no in-flight load to guard on).
@@ -135,7 +135,7 @@ function createActiveDocumentStore(): ActiveDocumentStore {
 
       update(state => ({
         ...state,
-        baseToken: token,
+        baseEtag: etag,
         currentContent: content,
         isLoading: false,
         loadingPath: null,
@@ -151,7 +151,7 @@ function createActiveDocumentStore(): ActiveDocumentStore {
 
     startLoad(path: string, fileName: string | null, type: WorkspaceContentType | null): void {
       set({
-        baseToken: null,
+        baseEtag: null,
         currentContent: '',
         fileName,
         isLoading: true,

--- a/src/utilities/codemirror/readOnly.test.ts
+++ b/src/utilities/codemirror/readOnly.test.ts
@@ -1,0 +1,46 @@
+import { EditorState } from '@codemirror/state';
+import { describe, expect, test } from 'vitest';
+import { readOnlyChangeGuard } from './readOnly';
+
+function stateWith(allowedUserEvents?: string[]): EditorState {
+  return EditorState.create({ doc: 'hello', extensions: [readOnlyChangeGuard(allowedUserEvents)] });
+}
+
+describe('readOnlyChangeGuard', () => {
+  test('blocks every document change when no user events are allowed', () => {
+    const tr = stateWith().update({ changes: { from: 0, insert: 'world', to: 5 } });
+    expect(tr.newDoc.toString()).toBe('hello');
+  });
+
+  test('blocks a document change whose user event is not in the allow-list', () => {
+    // e.g. the command-panel form-builder dispatches `userEvent: 'formView'`.
+    const tr = stateWith(['file.open']).update({
+      changes: { from: 0, insert: 'world', to: 5 },
+      userEvent: 'formView',
+    });
+    expect(tr.newDoc.toString()).toBe('hello');
+  });
+
+  test('allows a document change whose user event is in the allow-list', () => {
+    // e.g. the editor's own content sync when switching files.
+    const tr = stateWith(['file.open']).update({
+      changes: { from: 0, insert: 'world', to: 5 },
+      userEvent: 'file.open',
+    });
+    expect(tr.newDoc.toString()).toBe('world');
+  });
+
+  test('matches user-event prefixes (file.open.subtype is allowed by file.open)', () => {
+    const tr = stateWith(['file.open']).update({
+      changes: { from: 0, insert: 'world', to: 5 },
+      userEvent: 'file.open.subtype',
+    });
+    expect(tr.newDoc.toString()).toBe('world');
+  });
+
+  test('does not interfere with non-document (selection-only) transactions', () => {
+    const tr = stateWith().update({ selection: { anchor: 2 } });
+    expect(tr.state.selection.main.anchor).toBe(2);
+    expect(tr.newDoc.toString()).toBe('hello');
+  });
+});

--- a/src/utilities/codemirror/readOnly.ts
+++ b/src/utilities/codemirror/readOnly.ts
@@ -1,0 +1,19 @@
+import { EditorState, type Extension, type Transaction } from '@codemirror/state';
+
+/**
+ * Blocks edits to a "read-only" editor. `EditorState.readOnly` only stops typing/paste —
+ * lint quick-fixes, the command-panel form, and sanitizers edit via `view.dispatch` and
+ * slip past it. This rejects document changes outright.
+ *
+ * `allowedUserEvents` whitelists edits the editor still needs (e.g. `'file.open'` content
+ * sync on file switch); pass none to block everything. Non-document changes are allowed.
+ * Put it in the read-only compartment so it drops when the editor becomes editable.
+ */
+export function readOnlyChangeGuard(allowedUserEvents: string[] = []): Extension {
+  return EditorState.changeFilter.of((transaction: Transaction) => {
+    if (!transaction.docChanged) {
+      return true;
+    }
+    return allowedUserEvents.some(userEvent => transaction.isUserEvent(userEvent));
+  });
+}

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -7197,8 +7197,8 @@ const effects = {
   },
 
   /**
-   * Saves a workspace file. Pass `ifMatch` (the `baseToken`) to run the concurrency check,
-   * or `'*'` to force. Returns `{ etag }` (the new token) on success. Re-throws a
+   * Saves a workspace file. Pass `ifMatch` (the `baseEtag`) to run the concurrency check,
+   * or `'*'` to force. Returns `{ etag }` (the new etag) on success. Re-throws a
    * {@link WorkspaceSaveConflictError} on `412` so the caller can show the conflict modal;
    * other errors become a failure toast and return `null`.
    */

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -300,7 +300,14 @@ import {
   showWorkspaceBulkOperationConflictModal,
 } from './modal';
 import { featurePermissions, gatewayPermissions, queryPermissions } from './permissions';
-import { CompoundError, reqActionServer, reqExtension, reqGateway, reqHasura } from './requests';
+import {
+  CompoundError,
+  reqActionServer,
+  reqExtension,
+  reqGateway,
+  reqHasura,
+  WorkspaceSaveConflictError,
+} from './requests';
 import { sampleProfiles } from './resources';
 import { convertResponseToMetadata } from './scheduling';
 import { buildSearchActivitiesWhereClauses, type ActivitySearchFilters } from './searchFilters';
@@ -5848,22 +5855,21 @@ const effects = {
     return null;
   },
 
-  async getWorkspaceFileContent(workspaceId: number, filePath: string, user: User | null): Promise<string | null> {
+  async getWorkspaceFileContent(
+    workspaceId: number,
+    filePath: string,
+    user: User | null,
+  ): Promise<{ content: string | null; etag: string | null }> {
     try {
-      const fileContents = await WorkspaceApi.getFileContent(workspaceId, filePath, user);
-
-      if (fileContents != null) {
-        logMessage(`Retrieved workspace file "${filePath}" for workspace ID=${workspaceId}.`);
-        return fileContents;
-      } else {
-        throw Error(`Workspace file contents not found`);
-      }
+      const { content, etag } = await WorkspaceApi.getFileContent(workspaceId, filePath, user);
+      logMessage(`Retrieved workspace file "${filePath}" for workspace ID=${workspaceId}.`);
+      return { content, etag };
     } catch (e) {
       catchError('Unable to retrieve workspace file', e as Error);
       showFailureToast('Workspace File Retrieval Failed');
     }
 
-    return null;
+    return { content: null, etag: null };
   },
 
   async getWorkspaceFileContentBlob(workspace: Workspace, filePath: string, user: User | null): Promise<Blob | null> {
@@ -5933,7 +5939,7 @@ const effects = {
         chunkedWorkspaceNodes[i].map(async ({ fullPath }) => {
           let sequenceDefinition = '';
           if (getFileContents) {
-            sequenceDefinition = (await effects.getWorkspaceFileContent(workspaceId, fullPath, user)) ?? '';
+            sequenceDefinition = (await effects.getWorkspaceFileContent(workspaceId, fullPath, user)).content ?? '';
           }
           return {
             definition: sequenceDefinition,
@@ -7190,15 +7196,33 @@ const effects = {
     }
   },
 
-  async saveWorkspaceFile(workspaceId: number, filePath: string, fileContent: string, user: User | null = null) {
+  /**
+   * Saves a workspace file. Pass `ifMatch` (the `baseToken`) to run the concurrency check,
+   * or `'*'` to force. Returns `{ etag }` (the new token) on success. Re-throws a
+   * {@link WorkspaceSaveConflictError} on `412` so the caller can show the conflict modal;
+   * other errors become a failure toast and return `null`.
+   */
+  async saveWorkspaceFile(
+    workspaceId: number,
+    filePath: string,
+    fileContent: string,
+    user: User | null = null,
+    ifMatch?: string | '*',
+  ): Promise<{ etag: string | null } | null> {
     try {
-      await WorkspaceApi.saveFile(workspaceId, filePath, fileContent, true, user);
+      const etag = await WorkspaceApi.saveFile(workspaceId, filePath, fileContent, true, user, ifMatch);
 
       showSuccessToast('Workspace File Saved Successfully');
       logMessage(`Saved workspace file "${filePath}".`);
+      return { etag };
     } catch (e) {
+      if (e instanceof WorkspaceSaveConflictError) {
+        // Let the caller resolve the conflict (modal); don't swallow it in a toast.
+        throw e;
+      }
       catchError('Workspace file was unable to be saved', e as Error);
       showFailureToast('Workspace File Save Failed');
+      return null;
     }
   },
 

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -7198,9 +7198,9 @@ const effects = {
 
   /**
    * Saves a workspace file. Pass `ifMatch` (the `baseEtag`) to run the concurrency check,
-   * or `'*'` to force. Returns `{ etag }` (the new etag) on success. Re-throws a
-   * {@link WorkspaceSaveConflictError} on `412` so the caller can show the conflict modal;
-   * other errors become a failure toast and return `null`.
+   * or `'*'` to force. Returns `{ etag }` (the new etag) on success. Always throws on failure so
+   * callers have a single failure path: a {@link WorkspaceSaveConflictError} on `412` (the caller
+   * shows the conflict modal), or any other error (already surfaced as a failure toast here).
    */
   async saveWorkspaceFile(
     workspaceId: number,
@@ -7208,7 +7208,7 @@ const effects = {
     fileContent: string,
     user: User | null = null,
     ifMatch?: string | '*',
-  ): Promise<{ etag: string | null } | null> {
+  ): Promise<{ etag: string | null }> {
     try {
       const etag = await WorkspaceApi.saveFile(workspaceId, filePath, fileContent, true, user, ifMatch);
 
@@ -7216,13 +7216,13 @@ const effects = {
       logMessage(`Saved workspace file "${filePath}".`);
       return { etag };
     } catch (e) {
-      if (e instanceof WorkspaceSaveConflictError) {
-        // Let the caller resolve the conflict (modal); don't swallow it in a toast.
-        throw e;
+      // Conflict is the caller's to resolve (modal), so don't toast it. Everything else is a real
+      // failure we surface here before rethrowing, so callers just bail in their catch.
+      if (!(e instanceof WorkspaceSaveConflictError)) {
+        catchError('Workspace file was unable to be saved', e as Error);
+        showFailureToast('Workspace File Save Failed');
       }
-      catchError('Workspace file was unable to be saved', e as Error);
-      showFailureToast('Workspace File Save Failed');
-      return null;
+      throw e;
     }
   },
 

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -1720,8 +1720,8 @@ export async function showExpansionPanelModal(user: User | null): Promise<ModalE
  * the modal with `confirm: false` and no value, so it is not represented here.
  */
 type WorkspaceSaveConflictResolution =
-  | { action: 'take-mine'; content: string; token: string | null }
-  | { action: 'take-theirs'; content: string; token: string | null }
+  | { action: 'take-mine'; content: string; etag: string | null }
+  | { action: 'take-theirs'; content: string; etag: string | null }
   | { action: 'recreate' }
   | { action: 'discard' };
 
@@ -1754,11 +1754,11 @@ export async function showWorkspaceSaveConflictModal(props: {
         };
 
         conflictModal.$on('close', () => finish());
-        conflictModal.$on('takeMine', (e: CustomEvent<{ content: string; token: string | null }>) =>
-          finish({ action: 'take-mine', content: e.detail.content, token: e.detail.token }),
+        conflictModal.$on('takeMine', (e: CustomEvent<{ content: string; etag: string | null }>) =>
+          finish({ action: 'take-mine', content: e.detail.content, etag: e.detail.etag }),
         );
-        conflictModal.$on('takeTheirs', (e: CustomEvent<{ content: string; token: string | null }>) =>
-          finish({ action: 'take-theirs', content: e.detail.content, token: e.detail.token }),
+        conflictModal.$on('takeTheirs', (e: CustomEvent<{ content: string; etag: string | null }>) =>
+          finish({ action: 'take-theirs', content: e.detail.content, etag: e.detail.etag }),
         );
         conflictModal.$on('recreate', () => finish({ action: 'recreate' }));
         conflictModal.$on('discard', () => finish({ action: 'discard' }));

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -1719,17 +1719,12 @@ export async function showExpansionPanelModal(user: User | null): Promise<ModalE
  * The action a user chose in the workspace save-conflict modal. "Cancel" resolves
  * the modal with `confirm: false` and no value, so it is not represented here.
  */
-export type WorkspaceSaveConflictResolution =
+type WorkspaceSaveConflictResolution =
   | { action: 'take-mine'; content: string; token: string | null }
   | { action: 'take-theirs'; content: string; token: string | null }
   | { action: 'recreate' }
   | { action: 'discard' };
 
-/**
- * Shows the WorkspaceSaveConflictModal, which presents a read-only diff of the
- * user's edits ("Mine") against the current server content ("Theirs") after a save
- * was rejected by the optimistic-concurrency check, and lets the user resolve it.
- */
 export async function showWorkspaceSaveConflictModal(props: {
   allowMerge?: boolean;
   fileName: string;
@@ -1758,7 +1753,6 @@ export async function showWorkspaceSaveConflictModal(props: {
           conflictModal.$destroy();
         };
 
-        // Cancel / Escape / outside click — no resolution, leave the document dirty.
         conflictModal.$on('close', () => finish());
         conflictModal.$on('takeMine', (e: CustomEvent<{ content: string; token: string | null }>) =>
           finish({ action: 'take-mine', content: e.detail.content, token: e.detail.token }),

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -1,4 +1,5 @@
 import { browser } from '$app/environment';
+import type { Extension } from '@codemirror/state';
 import AboutModal from '../components/modals/AboutModal.svelte';
 import ActionCreationModal from '../components/modals/ActionCreationModal.svelte';
 import ApplySequenceFilterModal from '../components/modals/ApplySequenceFilterModal.svelte';
@@ -41,7 +42,9 @@ import TransformActivitiesModal from '../components/modals/TransformActivitiesMo
 import UpdatePlanMissionModelModal from '../components/modals/UpdatePlanMissionModelModal.svelte';
 import UploadViewModal from '../components/modals/UploadViewModal.svelte';
 import WorkspaceBulkOperationConflictModal from '../components/modals/WorkspaceBulkOperationConflictModal.svelte';
+import WorkspaceSaveConflictModal from '../components/modals/WorkspaceSaveConflictModal.svelte';
 import NewSequenceTemplateModal from '../components/sequence-templates/NewSequenceTemplateModal.svelte';
+import type { WorkspaceContentType } from '../enums/workspace';
 import { type ActionDefinition } from '../types/actions';
 import type { ActivityDirectiveDeletionMap, ActivityDirectiveId } from '../types/activity';
 import type { User } from '../types/app';
@@ -56,6 +59,7 @@ import type { ActivityTransformDirection } from '../types/time';
 import type { ViewDefinition } from '../types/view';
 import type { Workspace } from '../types/workspace';
 import type { WorkspaceTreeNode, WorkspaceTreeNodeWithFullPath } from '../types/workspace-tree-view';
+import type { WorkspaceSaveConflictReason } from './requests';
 
 /**
  * Closes the active modal if found and resolve nothing
@@ -1704,6 +1708,66 @@ export async function showExpansionPanelModal(user: User | null): Promise<ModalE
           resolve({ confirm: true, value: e.detail });
           expansionPanelModal.$destroy();
         });
+      }
+    } else {
+      resolve({ confirm: false });
+    }
+  });
+}
+
+/**
+ * The action a user chose in the workspace save-conflict modal. "Cancel" resolves
+ * the modal with `confirm: false` and no value, so it is not represented here.
+ */
+export type WorkspaceSaveConflictResolution =
+  | { action: 'take-mine'; content: string; token: string | null }
+  | { action: 'take-theirs'; content: string; token: string | null }
+  | { action: 'recreate' }
+  | { action: 'discard' };
+
+/**
+ * Shows the WorkspaceSaveConflictModal, which presents a read-only diff of the
+ * user's edits ("Mine") against the current server content ("Theirs") after a save
+ * was rejected by the optimistic-concurrency check, and lets the user resolve it.
+ */
+export async function showWorkspaceSaveConflictModal(props: {
+  allowMerge?: boolean;
+  fileName: string;
+  languageExtension?: Extension | null;
+  lastEditedAt?: string;
+  lastEditedBy?: string;
+  mineContent: string;
+  path: string;
+  reason: WorkspaceSaveConflictReason;
+  type: WorkspaceContentType | null;
+  user: User | null;
+  workspaceId: number;
+}): Promise<ModalElementValue<WorkspaceSaveConflictResolution>> {
+  return new Promise(resolve => {
+    if (browser) {
+      const target: ModalElement | null = document.querySelector('#svelte-modal');
+
+      if (target) {
+        const conflictModal = new WorkspaceSaveConflictModal({ props, target });
+        target.resolve = resolve;
+
+        const finish = (value?: WorkspaceSaveConflictResolution) => {
+          target.replaceChildren();
+          target.resolve = null;
+          resolve({ confirm: value !== undefined, value });
+          conflictModal.$destroy();
+        };
+
+        // Cancel / Escape / outside click — no resolution, leave the document dirty.
+        conflictModal.$on('close', () => finish());
+        conflictModal.$on('takeMine', (e: CustomEvent<{ content: string; token: string | null }>) =>
+          finish({ action: 'take-mine', content: e.detail.content, token: e.detail.token }),
+        );
+        conflictModal.$on('takeTheirs', (e: CustomEvent<{ content: string; token: string | null }>) =>
+          finish({ action: 'take-theirs', content: e.detail.content, token: e.detail.token }),
+        );
+        conflictModal.$on('recreate', () => finish({ action: 'recreate' }));
+        conflictModal.$on('discard', () => finish({ action: 'discard' }));
       }
     } else {
       resolve({ confirm: false });

--- a/src/utilities/requests.test.ts
+++ b/src/utilities/requests.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { reqWorkspaceWithMeta, WorkspaceRequestError, WorkspaceSaveConflictError } from './requests';
+import { reqWorkspaceWithEtag, WorkspaceRequestError, WorkspaceSaveConflictError } from './requests';
 
 vi.mock('$env/dynamic/public', () => ({
   env: { PUBLIC_WORKSPACE_CLIENT_URL: 'http://workspace' },
@@ -22,7 +22,7 @@ function mockResponse(opts: {
   } as unknown as Response;
 }
 
-describe('reqWorkspaceWithMeta', () => {
+describe('reqWorkspaceWithEtag', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -33,7 +33,7 @@ describe('reqWorkspaceWithMeta', () => {
       vi.fn().mockResolvedValue(mockResponse({ headers: { ETag: '"tok-1"' }, status: 200, textBody: 'file contents' })),
     );
 
-    const result = await reqWorkspaceWithMeta<string>('1/foo.seq', 'GET', null, null);
+    const result = await reqWorkspaceWithEtag<string>('1/foo.seq', 'GET', null, null);
 
     expect(result).toEqual({ data: 'file contents', etag: '"tok-1"', status: 200 });
   });
@@ -41,7 +41,7 @@ describe('reqWorkspaceWithMeta', () => {
   test('returns a null etag when the ETag header is absent (CORS not exposed)', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({ status: 200, textBody: 'x' })));
 
-    const result = await reqWorkspaceWithMeta<string>('1/foo.seq', 'GET', null, null);
+    const result = await reqWorkspaceWithEtag<string>('1/foo.seq', 'GET', null, null);
 
     expect(result.etag).toBeNull();
   });
@@ -66,7 +66,7 @@ describe('reqWorkspaceWithMeta', () => {
       ),
     );
 
-    await expect(reqWorkspaceWithMeta('1/foo.seq', 'PUT', null, null)).rejects.toMatchObject({
+    await expect(reqWorkspaceWithEtag('1/foo.seq', 'PUT', null, null)).rejects.toMatchObject({
       currentETag: '"server-tok"',
       lastEditedAt: '2026-06-11T12:00:00Z',
       lastEditedBy: 'alice@example.com',
@@ -85,7 +85,7 @@ describe('reqWorkspaceWithMeta', () => {
 
     let error: unknown;
     try {
-      await reqWorkspaceWithMeta('1/foo.seq', 'PUT', null, null);
+      await reqWorkspaceWithEtag('1/foo.seq', 'PUT', null, null);
     } catch (e) {
       error = e;
     }
@@ -111,7 +111,7 @@ describe('reqWorkspaceWithMeta', () => {
 
     let error: unknown;
     try {
-      await reqWorkspaceWithMeta('1/foo.seq', 'PUT', null, null);
+      await reqWorkspaceWithEtag('1/foo.seq', 'PUT', null, null);
     } catch (e) {
       error = e;
     }
@@ -127,7 +127,7 @@ describe('reqWorkspaceWithMeta', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({ status: 404 })));
     let notFound: unknown;
     try {
-      await reqWorkspaceWithMeta('1/foo.seq', 'GET', null, null);
+      await reqWorkspaceWithEtag('1/foo.seq', 'GET', null, null);
     } catch (e) {
       notFound = e;
     }
@@ -138,7 +138,7 @@ describe('reqWorkspaceWithMeta', () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({ status: 500 })));
     let serverError: unknown;
     try {
-      await reqWorkspaceWithMeta('1/foo.seq', 'GET', null, null);
+      await reqWorkspaceWithEtag('1/foo.seq', 'GET', null, null);
     } catch (e) {
       serverError = e;
     }

--- a/src/utilities/requests.test.ts
+++ b/src/utilities/requests.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { reqWorkspaceWithMeta, WorkspaceRequestError, WorkspaceSaveConflictError } from './requests';
+
+vi.mock('$env/dynamic/public', () => ({
+  env: { PUBLIC_WORKSPACE_CLIENT_URL: 'http://workspace' },
+}));
+
+// Minimal Response stand-in: `headers.get` is the only header API the code uses,
+// so a plain object avoids depending on a global `Headers` implementation.
+function mockResponse(opts: {
+  headers?: Record<string, string>;
+  jsonBody?: unknown;
+  status: number;
+  textBody?: string;
+}): Response {
+  return {
+    headers: { get: (name: string) => opts.headers?.[name] ?? null },
+    json: async () => opts.jsonBody,
+    ok: opts.status >= 200 && opts.status < 300,
+    status: opts.status,
+    text: async () => opts.textBody ?? '',
+  } as unknown as Response;
+}
+
+describe('reqWorkspaceWithMeta', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('returns data, the ETag header, and the status on success', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(mockResponse({ headers: { ETag: '"tok-1"' }, status: 200, textBody: 'file contents' })),
+    );
+
+    const result = await reqWorkspaceWithMeta<string>('1/foo.seq', 'GET', null, null);
+
+    expect(result).toEqual({ data: 'file contents', etag: '"tok-1"', status: 200 });
+  });
+
+  test('returns a null etag when the ETag header is absent (CORS not exposed)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({ status: 200, textBody: 'x' })));
+
+    const result = await reqWorkspaceWithMeta<string>('1/foo.seq', 'GET', null, null);
+
+    expect(result.etag).toBeNull();
+  });
+
+  test('throws a typed WorkspaceSaveConflictError with parsed fields on a 412 conflict', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        mockResponse({
+          jsonBody: {
+            data: {
+              currentETag: '"server-tok"',
+              lastEditedAt: '2026-06-11T12:00:00Z',
+              lastEditedBy: 'alice@example.com',
+              reason: 'conflict',
+            },
+            message: 'conflict!',
+            type: 'SAVE_CONFLICT',
+          },
+          status: 412,
+        }),
+      ),
+    );
+
+    await expect(reqWorkspaceWithMeta('1/foo.seq', 'PUT', null, null)).rejects.toMatchObject({
+      currentETag: '"server-tok"',
+      lastEditedAt: '2026-06-11T12:00:00Z',
+      lastEditedBy: 'alice@example.com',
+      name: 'WorkspaceSaveConflictError',
+      reason: 'conflict',
+    });
+  });
+
+  test('maps a 412 with reason "deleted" to the deleted variant with a null currentETag', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValue(mockResponse({ jsonBody: { data: { currentETag: null, reason: 'deleted' } }, status: 412 })),
+    );
+
+    let error: unknown;
+    try {
+      await reqWorkspaceWithMeta('1/foo.seq', 'PUT', null, null);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(WorkspaceSaveConflictError);
+    expect((error as WorkspaceSaveConflictError).reason).toBe('deleted');
+    expect((error as WorkspaceSaveConflictError).currentETag).toBeNull();
+  });
+
+  test('defaults to a "conflict" reason when the 412 body is missing or unparseable', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        headers: { get: () => null },
+        json: async () => {
+          throw new Error('not json');
+        },
+        ok: false,
+        status: 412,
+        text: async () => '',
+      } as unknown as Response),
+    );
+
+    let error: unknown;
+    try {
+      await reqWorkspaceWithMeta('1/foo.seq', 'PUT', null, null);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toBeInstanceOf(WorkspaceSaveConflictError);
+    expect((error as WorkspaceSaveConflictError).reason).toBe('conflict');
+    expect((error as WorkspaceSaveConflictError).currentETag).toBeNull();
+  });
+
+  test('throws a typed WorkspaceRequestError carrying the HTTP status on other non-ok responses', async () => {
+    // The status lets callers (e.g. the conflict modal) distinguish a definite 404 — file
+    // genuinely deleted — from a transient 5xx/network failure they should not treat as deletion.
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({ status: 404 })));
+    let notFound: unknown;
+    try {
+      await reqWorkspaceWithMeta('1/foo.seq', 'GET', null, null);
+    } catch (e) {
+      notFound = e;
+    }
+    expect(notFound).toBeInstanceOf(WorkspaceRequestError);
+    expect(notFound).not.toBeInstanceOf(WorkspaceSaveConflictError);
+    expect((notFound as WorkspaceRequestError).status).toBe(404);
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse({ status: 500 })));
+    let serverError: unknown;
+    try {
+      await reqWorkspaceWithMeta('1/foo.seq', 'GET', null, null);
+    } catch (e) {
+      serverError = e;
+    }
+    expect((serverError as WorkspaceRequestError).status).toBe(500);
+  });
+});

--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -311,6 +311,125 @@ export async function reqWorkspace<T = any>(
   return (await response.text()) as T;
 }
 
+/** Why a workspace save was rejected: the file changed, or it was deleted/moved. */
+export type WorkspaceSaveConflictReason = 'conflict' | 'deleted';
+
+/**
+ * Thrown on a `412` save rejection (the file changed underneath since it was opened).
+ * Carries the who/when fields from the response body for the conflict modal.
+ */
+export class WorkspaceSaveConflictError extends Error {
+  currentETag: string | null;
+  lastEditedAt?: string;
+  lastEditedBy?: string;
+  name: string;
+  reason: WorkspaceSaveConflictReason;
+
+  constructor(
+    data: {
+      currentETag: string | null;
+      lastEditedAt?: string;
+      lastEditedBy?: string;
+      reason: WorkspaceSaveConflictReason;
+    },
+    message?: string,
+  ) {
+    super(message ?? 'The file was changed by someone else since you opened it.');
+    this.currentETag = data.currentETag;
+    this.lastEditedAt = data.lastEditedAt;
+    this.lastEditedBy = data.lastEditedBy;
+    this.name = 'WorkspaceSaveConflictError';
+    this.reason = data.reason;
+  }
+}
+
+/**
+ * Thrown for a failed (non-`2xx`, non-`412`) workspace request. Carries the HTTP `status`
+ * so callers can tell a real `404` (file gone) from a transient blip (network/`5xx`).
+ */
+export class WorkspaceRequestError extends Error {
+  name: string;
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'WorkspaceRequestError';
+    this.status = status;
+  }
+}
+
+/** A workspace response plus its `ETag` token and HTTP status. */
+export interface WorkspaceResponseWithMeta<T> {
+  data: T;
+  etag: string | null;
+  status: number;
+}
+
+/**
+ * Like {@link reqWorkspace}, but returns the response `ETag` + status and, on `412`,
+ * throws a typed {@link WorkspaceSaveConflictError}. Used for the editor's file GET/save
+ * so the save token can be threaded through; `reqWorkspace` is left unchanged.
+ */
+export async function reqWorkspaceWithMeta<T = any>(
+  url: string,
+  method: string,
+  body: any | null,
+  user: BaseUser | User | null,
+  signal?: AbortSignal,
+  asJson: boolean = false,
+  headerOverrides: HeadersInit = {},
+): Promise<WorkspaceResponseWithMeta<T>> {
+  const WORKSPACE_URL = env.PUBLIC_WORKSPACE_CLIENT_URL;
+
+  const headers: HeadersInit = {
+    Authorization: `Bearer ${user?.token ?? ''}`,
+    'x-hasura-role': (user as User)?.activeRole ?? '',
+    'x-hasura-user-id': user?.id ?? '',
+    ...headerOverrides,
+  };
+  const options: RequestInit = {
+    headers,
+    method,
+    signal,
+  };
+
+  if (body !== null) {
+    options.body = body;
+  }
+
+  const response = await fetch(`${WORKSPACE_URL}/ws/${url}`, options);
+  // Null unless the server exposes ETag via CORS; protection degrades gracefully if so.
+  const etag = response.headers.get('ETag');
+
+  if (response.status === 412) {
+    let parsed: { data?: Record<string, any>; message?: string } | null = null;
+    try {
+      parsed = await response.json();
+    } catch {
+      // Body wasn't valid JSON — fall back to the defaults below.
+    }
+    const conflictData = parsed?.data ?? {};
+    throw new WorkspaceSaveConflictError(
+      {
+        currentETag: conflictData.currentETag ?? null,
+        lastEditedAt: conflictData.lastEditedAt,
+        lastEditedBy: conflictData.lastEditedBy,
+        reason: conflictData.reason === 'deleted' ? 'deleted' : 'conflict',
+      },
+      parsed?.message,
+    );
+  }
+
+  if (!response.ok) {
+    // Surface the status so callers can tell a definite 404 from a transient failure.
+    throw new WorkspaceRequestError(response.status, response.statusText);
+  }
+
+  const data = (asJson ? await response.json() : await response.text()) as T;
+
+  return { data, etag, status: response.status };
+}
+
 export async function reqWorkspaceMetadata<T = any>(
   url: string,
   method: string,

--- a/src/utilities/requests.ts
+++ b/src/utilities/requests.ts
@@ -358,8 +358,8 @@ export class WorkspaceRequestError extends Error {
   }
 }
 
-/** A workspace response plus its `ETag` token and HTTP status. */
-export interface WorkspaceResponseWithMeta<T> {
+/** A workspace response plus its `ETag` and HTTP status. */
+export interface WorkspaceResponseWithEtag<T> {
   data: T;
   etag: string | null;
   status: number;
@@ -368,9 +368,9 @@ export interface WorkspaceResponseWithMeta<T> {
 /**
  * Like {@link reqWorkspace}, but returns the response `ETag` + status and, on `412`,
  * throws a typed {@link WorkspaceSaveConflictError}. Used for the editor's file GET/save
- * so the save token can be threaded through; `reqWorkspace` is left unchanged.
+ * so the save etag can be threaded through; `reqWorkspace` is left unchanged.
  */
-export async function reqWorkspaceWithMeta<T = any>(
+export async function reqWorkspaceWithEtag<T = any>(
   url: string,
   method: string,
   body: any | null,
@@ -378,7 +378,7 @@ export async function reqWorkspaceWithMeta<T = any>(
   signal?: AbortSignal,
   asJson: boolean = false,
   headerOverrides: HeadersInit = {},
-): Promise<WorkspaceResponseWithMeta<T>> {
+): Promise<WorkspaceResponseWithEtag<T>> {
   const WORKSPACE_URL = env.PUBLIC_WORKSPACE_CLIENT_URL;
 
   const headers: HeadersInit = {

--- a/src/utilities/workspaces.test.ts
+++ b/src/utilities/workspaces.test.ts
@@ -38,8 +38,8 @@ const mockNavigator = {
 
 const reqWorkspaceMock = vi.spyOn(requests, 'reqWorkspace').mockResolvedValue({});
 const reqWorkspaceMetadataMock = vi.spyOn(requests, 'reqWorkspaceMetadata').mockResolvedValue({});
-const reqWorkspaceWithMetaMock = vi
-  .spyOn(requests, 'reqWorkspaceWithMeta')
+const reqWorkspaceWithEtagMock = vi
+  .spyOn(requests, 'reqWorkspaceWithEtag')
   .mockResolvedValue({ data: '', etag: null, status: 200 });
 vi.stubGlobal('navigator', mockNavigator);
 vi.mock('$env/dynamic/public', () => {
@@ -270,7 +270,7 @@ describe('Workspace utility function tests', () => {
 
     test('getFileContent', async () => {
       await WorkspaceApi.getFileContent(1, 'foo/bar/bazz.seq', null);
-      expect(reqWorkspaceWithMetaMock).toHaveBeenLastCalledWith(
+      expect(reqWorkspaceWithEtagMock).toHaveBeenLastCalledWith(
         '1/foo/bar/bazz.seq',
         'GET',
         null,
@@ -587,7 +587,7 @@ describe('Workspace utility function tests', () => {
       body.append('file', file, file.name);
 
       await WorkspaceApi.saveFile(1, 'foo/bar/bazz.seq', 'sequence contents', true, null);
-      expect(reqWorkspaceWithMetaMock).toHaveBeenLastCalledWith(
+      expect(reqWorkspaceWithEtagMock).toHaveBeenLastCalledWith(
         '1/foo/bar/bazz.seq?type=file&overwrite=true',
         'PUT',
         body,

--- a/src/utilities/workspaces.test.ts
+++ b/src/utilities/workspaces.test.ts
@@ -38,6 +38,9 @@ const mockNavigator = {
 
 const reqWorkspaceMock = vi.spyOn(requests, 'reqWorkspace').mockResolvedValue({});
 const reqWorkspaceMetadataMock = vi.spyOn(requests, 'reqWorkspaceMetadata').mockResolvedValue({});
+const reqWorkspaceWithMetaMock = vi
+  .spyOn(requests, 'reqWorkspaceWithMeta')
+  .mockResolvedValue({ data: '', etag: null, status: 200 });
 vi.stubGlobal('navigator', mockNavigator);
 vi.mock('$env/dynamic/public', () => {
   return {
@@ -267,7 +270,14 @@ describe('Workspace utility function tests', () => {
 
     test('getFileContent', async () => {
       await WorkspaceApi.getFileContent(1, 'foo/bar/bazz.seq', null);
-      expect(reqWorkspaceMock).toHaveBeenLastCalledWith('1/foo/bar/bazz.seq', 'GET', null, null, undefined, false);
+      expect(reqWorkspaceWithMetaMock).toHaveBeenLastCalledWith(
+        '1/foo/bar/bazz.seq',
+        'GET',
+        null,
+        null,
+        undefined,
+        false,
+      );
     });
 
     test('deleteFileMetadata', async () => {
@@ -577,13 +587,14 @@ describe('Workspace utility function tests', () => {
       body.append('file', file, file.name);
 
       await WorkspaceApi.saveFile(1, 'foo/bar/bazz.seq', 'sequence contents', true, null);
-      expect(reqWorkspaceMock).toHaveBeenLastCalledWith(
+      expect(reqWorkspaceWithMetaMock).toHaveBeenLastCalledWith(
         '1/foo/bar/bazz.seq?type=file&overwrite=true',
         'PUT',
         body,
         null,
         undefined,
         false,
+        {},
       );
     });
 

--- a/src/utilities/workspaces.ts
+++ b/src/utilities/workspaces.ts
@@ -14,7 +14,7 @@ import type {
 } from '../types/workspace-tree-view';
 import { filterEmpty } from './generic';
 import { pathMatchesExtensionPattern } from './parameters';
-import { reqWorkspace, reqWorkspaceMetadata, reqWorkspaceWithMeta } from './requests';
+import { reqWorkspace, reqWorkspaceMetadata, reqWorkspaceWithEtag } from './requests';
 import { pluralize } from './text';
 
 export function mapWorkspaceTreePaths(nodes: WorkspaceTreeNode[], currentPath: string[] = []): WorkspaceTreeMap {
@@ -494,7 +494,7 @@ export const WorkspaceApi = {
     user: User | null,
   ): Promise<{ content: string; etag: string | null }> {
     // Throws a WorkspaceRequestError (with status) on any non-2xx — content is never null.
-    const { data, etag } = await reqWorkspaceWithMeta<string>(
+    const { data, etag } = await reqWorkspaceWithEtag<string>(
       joinPath([workspaceId, filePath]),
       'GET',
       null,
@@ -631,7 +631,7 @@ export const WorkspaceApi = {
     ifMatch?: string | '*',
   ): Promise<string | null> {
     const body = createFormDataWithFile(filePath, fileContent);
-    const { etag } = await reqWorkspaceWithMeta<Workspace>(
+    const { etag } = await reqWorkspaceWithEtag<Workspace>(
       `${workspaceId}/${filePath}?type=file${shouldOverwrite ? '&overwrite=true' : ''}`,
       'PUT',
       body,

--- a/src/utilities/workspaces.ts
+++ b/src/utilities/workspaces.ts
@@ -14,7 +14,7 @@ import type {
 } from '../types/workspace-tree-view';
 import { filterEmpty } from './generic';
 import { pathMatchesExtensionPattern } from './parameters';
-import { reqWorkspace, reqWorkspaceMetadata } from './requests';
+import { reqWorkspace, reqWorkspaceMetadata, reqWorkspaceWithMeta } from './requests';
 import { pluralize } from './text';
 
 export function mapWorkspaceTreePaths(nodes: WorkspaceTreeNode[], currentPath: string[] = []): WorkspaceTreeMap {
@@ -488,8 +488,21 @@ export const WorkspaceApi = {
   async deleteWorkspace(workspaceId: number, user: User | null): Promise<void> {
     return reqWorkspace(`${workspaceId}`, 'DELETE', null, user, undefined, false);
   },
-  async getFileContent(workspaceId: number, filePath: string, user: User | null): Promise<string | null> {
-    return reqWorkspace<string>(joinPath([workspaceId, filePath]), 'GET', null, user, undefined, false);
+  async getFileContent(
+    workspaceId: number,
+    filePath: string,
+    user: User | null,
+  ): Promise<{ content: string; etag: string | null }> {
+    // Throws a WorkspaceRequestError (with status) on any non-2xx — content is never null.
+    const { data, etag } = await reqWorkspaceWithMeta<string>(
+      joinPath([workspaceId, filePath]),
+      'GET',
+      null,
+      user,
+      undefined,
+      false,
+    );
+    return { content: data, etag };
   },
   async getFileContentBlob(workspaceId: number, filePath: string, user: User | null): Promise<Blob | null> {
     return reqWorkspace<Blob>(joinPath([workspaceId, filePath]), 'GET', null, user, undefined, false, true);
@@ -604,22 +617,30 @@ export const WorkspaceApi = {
       { 'Content-Type': 'application/json' },
     );
   },
+  /**
+   * Saves a workspace file and returns the new `ETag`. With `ifMatch` the server runs the
+   * concurrency check and `412`s (as a `WorkspaceSaveConflictError`) if it changed; `'*'`
+   * forces. Only `If-Match` is injected — the browser sets the multipart `Content-Type`.
+   */
   async saveFile(
     workspaceId: number,
     filePath: string,
     fileContent: string,
     shouldOverwrite: boolean,
     user: User | null,
-  ) {
+    ifMatch?: string | '*',
+  ): Promise<string | null> {
     const body = createFormDataWithFile(filePath, fileContent);
-    return reqWorkspace<Workspace>(
+    const { etag } = await reqWorkspaceWithMeta<Workspace>(
       `${workspaceId}/${filePath}?type=file${shouldOverwrite ? '&overwrite=true' : ''}`,
       'PUT',
       body,
       user,
       undefined,
       false,
+      ifMatch ? { 'If-Match': ifMatch } : {},
     );
+    return etag;
   },
   async setFileMetadata(
     workspaceId: number,


### PR DESCRIPTION
`___REQUIRES_AERIE_PR___="1836"`

## Summary

Implements simultaneous edit protection for workspace files. Closes #1789 and will make a followup issue for auto-save. Previously, two people editing the same workspace file could silently overwrite each other. Now, if a file changed since you opened it, saving shows you a diff in a modal and lets you choose which version to keep (yours, theirs, or cancel). This PR also fixes a related bug where "read-only" files could still be edited through the syntax highlighting diagnostic auto-fix buttons and the right tab command panel inputs. 

Backend PR here: https://github.com/NASA-AMMOS/plandev/pull/1836, details the approach for edit protections using HTTP `ETag` and `If-Match` headers.

## Details

- Each open file remembers the ETag it was loaded with and sends it on save back to the server so the server can reject the save if the file changed underneath.
- When the server rejects, a modal re-fetches the file and shows a read-only side-by-side diff (built on
  `@codemirror/merge`). The modal handles the file being changed, deleted/moved, or temporarily unreachable — the last one never offers a destructive option.
- Read-only fix: the editor's read-only flag only blocks typing, so things like lint "quick fixes" and the command-panel form could still change the file. A guard now blocks those too, and the command panel's inputs are disabled when read-only.
- Command-argument inputs received proper accessible labels in support of e2e testing and general accessibility.

## Visible UX Changes

- Saving a file someone else changed → a **Theirs / Mine** diff with **Keep theirs**, **Keep Mine**,
  or **Keep editing**. Keeping theirs is undoable (cmd/ctrl-z restores your discarded edits).
- File was deleted or moved → a modal with **Recreate** or **Discard**.
- Couldn't load the latest version → a **Retry** prompt (nothing destructive).
- Selected Command panel's inputs are now greyed out while a file is in read-only mode.

## Verification
- New unit tests: 
  - `src/stores/activeDocument.test.ts`
  - `src/utilities/codemirror/readOnly.test.ts`
  - `src/utilities/requests.test.ts`
- Updated unit test: `src/utilities/workspaces.test.ts`
- New e2e test: `e2e-tests/tests/workspace-edit-protection.ts`
- Updated e2e test: `e2e-tests/tests/workspace.test.ts`