### PR TITLE
Use a full-page navigation on SSO logout so the login redirect is followed

### DIFF
--- a/src/utilities/login.test.ts
+++ b/src/utilities/login.test.ts
@@ -1,8 +1,15 @@
-import { afterEach, describe, expect, test, vi } from 'vitest';
-import { shouldRedirectToLogin } from './login';
+import { goto } from '$app/navigation';
+import { env } from '$env/dynamic/public';
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { logout, shouldRedirectToLogin } from './login';
 import { ADMIN_ROLE } from './permissions';
 
-vi.mock('$env/dynamic/public', () => import.meta.env); // https://github.com/sveltejs/kit/issues/8180
+// $app/* and $env/* are virtual modules provided by the SvelteKit Vite plugin. Mock them so
+// `logout()` runs in the browser branch with a controllable SSO flag and a spyable navigation.
+vi.mock('$app/environment', () => ({ browser: true }));
+vi.mock('$app/navigation', () => ({ goto: vi.fn() }));
+vi.mock('$app/paths', () => ({ base: '/aerie' }));
+vi.mock('$env/dynamic/public', () => ({ env: { PUBLIC_AUTH_SSO_ENABLED: 'false' } }));
 
 describe('login util functions', () => {
   afterEach(() => {
@@ -37,6 +44,58 @@ describe('login util functions', () => {
           token: 'foo',
         }),
       ).toEqual(false);
+    });
+  });
+
+  describe('logout', () => {
+    let assign: ReturnType<typeof vi.fn>;
+    let originalLocation: Location;
+
+    beforeEach(() => {
+      assign = vi.fn();
+      // jsdom's window.location can't be spied on directly; replace it for the duration of the test.
+      originalLocation = window.location;
+      Object.defineProperty(window, 'location', { configurable: true, value: { assign }, writable: true });
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({}));
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, 'location', { configurable: true, value: originalLocation, writable: true });
+      vi.unstubAllGlobals();
+    });
+
+    it('posts to the logout endpoint before navigating', async () => {
+      await logout();
+      expect(fetch).toHaveBeenCalledWith('/aerie/auth/logout', { method: 'POST' });
+    });
+
+    describe('when SSO is enabled', () => {
+      beforeEach(() => {
+        env.PUBLIC_AUTH_SSO_ENABLED = 'true';
+      });
+
+      it('does a full-page navigation so the external SSO redirect is followed, not swallowed by an SPA fetch', async () => {
+        await logout();
+        expect(assign).toHaveBeenCalledWith('/aerie/');
+        expect(goto).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when SSO is disabled', () => {
+      beforeEach(() => {
+        env.PUBLIC_AUTH_SSO_ENABLED = 'false';
+      });
+
+      it('does a client-side goto to the login route', async () => {
+        await logout();
+        expect(goto).toHaveBeenCalledWith('/aerie/login', { invalidateAll: true });
+        expect(assign).not.toHaveBeenCalled();
+      });
+
+      it('includes the reason in the login query string', async () => {
+        await logout('Session expired');
+        expect(goto).toHaveBeenCalledWith('/aerie/login?reason=Session expired', { invalidateAll: true });
+      });
     });
   });
 });

--- a/src/utilities/login.ts
+++ b/src/utilities/login.ts
@@ -13,8 +13,12 @@ export async function logout(reason?: string) {
   if (browser) {
     await fetch(`${base}/auth/logout`, { method: 'POST' });
     if (env.PUBLIC_AUTH_SSO_ENABLED === 'true') {
-      // hooks will handle SSO redirect
-      await goto(base, { invalidateAll: true });
+      // Full-page navigation (NOT goto): with SSO the post-logout request is redirected to
+      // the external login UI (by the CAM web agent and/or the server hook). A goto() makes
+      // that request as a background fetch, which silently follows a same-origin redirect and
+      // discards the login page instead of navigating (logging "expected json, got html"),
+      // stranding the user in a dead app. A top-level navigation follows it regardless of origin.
+      window.location.assign(`${base}/`);
     } else {
       await goto(`${base}/login${reason ? '?reason=' + reason : ''}`, { invalidateAll: true });
     }


### PR DESCRIPTION
## Summary

On SSO-enabled deployments (e.g. Clipper), clicking **Logout** correctly invalidated the session but, on some venues, never redirected to the login page. This left the user sitting on a non-functional app screen after logout. This PR switches the post-logout navigation from a client-side SvelteKit `goto` to a real `window` navigation so the login redirect is actually followed everywhere. Issue originally reported by @parkerabercrombie in [this thread](https://nasa-ammos.slack.com/archives/C0163E42UBF/p1781201976918239).

## Details

When SSO is on, `logout()` POSTs to `/auth/logout` (which kills the session) and then navigates. The old code used `goto(base, { invalidateAll: true })` – a client-side (SPA) navigation where SvelteKit fetches the destination's data and app JS in the background.

After logout, those background requests are intercepted by the CAM SSO layer and `302`-redirected to the external login UI. Whether that redirect turns into an actual page change depends on whether the login UI is served on the **same origin** as the app:

- **Same-origin:** the background `fetch` silently follows the `302`, gets the login page's HTML back, and SvelteKit discards it ("expected json, got html") without navigating and the user is stranded.
- **Cross-origin:** the same `fetch` fails CORS, and SvelteKit falls back to a full-page navigation that _happens_ to land on login.

So whether logout "worked" came down to an accident of how each venue hosted its login UI, not anything in our code.

The fix replaces the SSO branch with `window.location.assign(\`${base}/\`)`, a top-level browser navigation. The browser follows the redirect as a normal navigation regardless of origin, so there's no SPA `fetch` to swallow it.

**Why this is safe / no other side effects:**

- Only the SSO branch changed; the non-SSO (JWT) path is untouched.
- `logout()` is also triggered automatically on expired/invalid tokens and auth-related socket closes. Those now do a full reload instead of a soft navigation — which is fine (arguably better), because once the session is gone the SPA can't function anyway: every lazy chunk load just redirects to login.
- The `reason` argument was already ignored in the SSO branch, so nothing regresses there.
- Unit tests, e2e (runs in JWT mode), and SSR are unaffected.

## Visible UX Changes

- **SSO deployments:** Logout now reliably lands on the login page on all venues (previously some venues stayed on a dead app screen).
- The logout transition is now a brief full page load rather than an instant in-app transition.
- **Non-SSO deployments:** no change.

## Verification

- Added unit tests (`src/utilities/login.test.ts`)