### PR TITLE
Auto-refresh workspace file list when an action finishes

### DIFF
--- a/e2e-tests/tests/actions.test.ts
+++ b/e2e-tests/tests/actions.test.ts
@@ -104,10 +104,10 @@ test.describe.serial('Actions', () => {
       stringParameters: { required: 'test-required-value', requiredNoDefault: 'test-no-default-value' },
     });
 
-    // Switch to file browser and verify the written file appears
+    // Switch to the file browser and verify the written file appears WITHOUT a manual refresh:
+    // the workspace listing auto-refreshes when an action run completes.
     await workspace.workspaceFileBrowserButton.click();
     await workspace.workspaceFileGrid.waitFor({ state: 'visible' });
-    await workspace.workspaceRefreshButton.click();
     await workspace.searchForFileAndWait('action_output.txt');
 
     // Go back to the actions tab

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -34,8 +34,9 @@
   import WorkspaceRightPanel from '../../../components/workspace/WorkspaceRightPanel.svelte';
   import WorkspaceSidebar from '../../../components/workspace/WorkspaceSidebar.svelte';
   import { SearchParameters } from '../../../enums/searchParameters';
+  import { Status } from '../../../enums/status';
   import { WorkspaceContentMode, WorkspaceContentType } from '../../../enums/workspace';
-  import { actionDefinitionsByWorkspace } from '../../../stores/actions';
+  import { actionDefinitionsByWorkspace, actionRuns, actionRunsByWorkspace } from '../../../stores/actions';
   import {
     activeDocument,
     activeDocumentIsDirty,
@@ -78,7 +79,7 @@
     workspaceId,
     workspaces,
   } from '../../../stores/workspaces';
-  import type { ActionDefinition } from '../../../types/actions';
+  import type { ActionDefinition, ActionRunSlim } from '../../../types/actions';
   import type { UserStore } from '../../../types/app';
   import type { LintDiagnostic, LogLevel } from '../../../types/errors';
   import type { ArgumentsMap } from '../../../types/parameter';
@@ -102,6 +103,7 @@
     WorkspaceTreeNode,
     WorkspaceTreeNodeWithFullPath,
   } from '../../../types/workspace-tree-view';
+  import { getStatusForActionRun } from '../../../utilities/actions';
   import { setClipboardContent } from '../../../utilities/clipboard';
   import effects from '../../../utilities/effects';
   import { ErrorTypes } from '../../../utilities/errors';
@@ -137,6 +139,7 @@
   const initialSidebarTab = $page.url.searchParams.get(SearchParameters.SIDEBAR_TAB);
 
   const { initialWorkspace } = data;
+  const actionRunsLoading = actionRuns.loading;
   const user: UserStore = getContext('user');
   const defaultLogLevels: LogLevel[] = ['error', 'warn', 'info'];
   const PANEL_DEFAULT_SIZE = 25;
@@ -185,6 +188,7 @@
   let logLevelLabel: string = 'Default levels';
   let logLevels: LogLevel[] = defaultLogLevels;
   let preserveAdaptationLog: boolean = false;
+  let previousTerminalActionRunCount: number = -1;
   let workspaceSequences: UserSequence[] = [];
   let workspaceTree: WorkspaceTreeNode | null = null;
   let workspaceTreeMap: WorkspaceTreeMap = {};
@@ -264,6 +268,11 @@
     $workspaceId = initialWorkspace.id;
     allActionsForWorkspace = Object.values($actionDefinitionsByWorkspace[$workspaceId] || {});
   }
+
+  // Refresh the workspace file listing whenever any action run for this workspace finishes
+  // (regardless of which user started it), since actions can create or modify files. Gated on
+  // the subscription's first response so pre-existing completed runs don't trigger a refresh.
+  $: refreshWorkspaceOnActionCompletion($actionRunsLoading, $actionRunsByWorkspace[$workspaceId] ?? []);
 
   // Re-compute permissions when user, workspace, or active document changes
   $: if ($user && (initialWorkspace || $workspace)) {
@@ -505,6 +514,28 @@
 
   function refreshWorkspaceContents() {
     return getWorkspaceContents(initialWorkspace);
+  }
+
+  function isTerminalActionRunStatus(status: Status): boolean {
+    return status === Status.Complete || status === Status.Failed || status === Status.Canceled;
+  }
+
+  function refreshWorkspaceOnActionCompletion(loading: boolean, actionRuns: ActionRunSlim[]) {
+    if (loading) {
+      return;
+    }
+
+    const terminalActionRunCount = actionRuns.filter(actionRun =>
+      isTerminalActionRunStatus(getStatusForActionRun(actionRun)),
+    ).length;
+
+    // The count of finished runs only grows when a run completes, so an increase means at least
+    // one run finished since the last update. The first post-load value just sets the baseline.
+    if (previousTerminalActionRunCount >= 0 && terminalActionRunCount > previousTerminalActionRunCount) {
+      refreshWorkspaceContents();
+    }
+
+    previousTerminalActionRunCount = terminalActionRunCount;
   }
 
   /**


### PR DESCRIPTION
## Summary
When an action finishes running, the workspace file listing now updates automatically, so any files the action created or changed show up right away. Before this change you had to click the refresh button (or wait for the periodic 5-minute refresh) to see them. All completed action runs in the workspace trigger this behavior.

## Details
- The workspace page watches the action runs store for the workspace you're viewing. Whenever the number of finished runs goes up (meaning a run just completed) it re-fetches the file list.
- The reactive statement only reacts to runs that finish after you open the workspace. Runs that were already finished when the page loaded don't cause an unnecessary refresh.
- "Finished" covers success, failure, and cancellation, since even a failed or canceled run can leave partial files behind and re-fetching is cheap.

## Visible UX Changes
- After an action completes, newly written files appear in the workspace file browser automatically with no manual refresh needed.

## Verification
- Updated the existing e2e test "Action writes a file visible in workspace file browser" (e2e-tests/tests/actions.test.ts) to remove its manual refresh-button click, so the test now confirms the file appears on its own after the action finishes.