### PR TITLE
Exclude test files from duplication detection in SonarQube

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,3 +12,7 @@ sonar.projectVersion=4.2.1
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
+
+# Exclude test files from Copy/Paste (duplication) detection only.
+# Tests remain in scope for all other rules (bugs, code smells, etc.).
+sonar.cpd.exclusions=**/*.test.ts,**/*.spec.ts,e2e-tests/**


### PR DESCRIPTION
Exclude test files from SonarQube's Copy/Paste (duplication) detection via `sonar.cpd.exclusions`. Covers `*.test.ts`, `*.spec.ts`, and `e2e-tests/`. Duplication noise in test code (repeated setup, fixtures, assertions) is expected and not worth flagging. Tests remain fully in scope for all other rules – bugs, code smells, etc.