### PR TITLE
Flip timeline hover cursor left instead of overflowing right

### DIFF
--- a/src/components/timeline/TimelineCursor.svelte
+++ b/src/components/timeline/TimelineCursor.svelte
@@ -2,14 +2,39 @@
   import MarkerIcon from '@nasa-jpl/stellar/icons/marker.svg?component';
   import AddMarkerIcon from '@nasa-jpl/stellar/icons/marker_add.svg?component';
   import RemoveMarkerIcon from '@nasa-jpl/stellar/icons/marker_remove.svg?component';
+  import { afterUpdate } from 'svelte';
 
   export let x = 0;
   export let maxWidth = 0;
   export let label = '';
   export let activeCursor = false;
   export let color = '';
+  export let flippable = false;
+  export let maxWidthFlipped = 0;
 
   let hovered = false;
+  let flipped = false;
+  let labelElement: HTMLDivElement;
+
+  $: labelMaxWidth = flipped ? maxWidthFlipped : maxWidth;
+
+  afterUpdate(() => {
+    if (!flippable || !labelElement) {
+      if (flipped) {
+        flipped = false;
+      }
+      return;
+    }
+
+    // `scrollWidth` reports the label's natural (unclipped) content width even when it is
+    // ellipsized via `max-width` + `overflow: hidden`, so it is independent of the current
+    // flip state and the comparison below is stable.
+    const overflowsRight = labelElement.scrollWidth > maxWidth;
+    const nextFlipped = overflowsRight && maxWidthFlipped > maxWidth;
+    if (nextFlipped !== flipped) {
+      flipped = nextFlipped;
+    }
+  });
 </script>
 
 <div class="timeline-cursor" style="transform: translateX({x}px)">
@@ -30,7 +55,9 @@
       <MarkerIcon />
     {/if}
   </button>
-  <div class="timeline-cursor-label" style="max-width: {maxWidth}px;">{label}</div>
+  <div class="timeline-cursor-label" class:flipped style="max-width: {labelMaxWidth}px;" bind:this={labelElement}>
+    {label}
+  </div>
 </div>
 
 <style>
@@ -75,17 +102,23 @@
     border-radius: 16px;
     box-shadow: 0 0.5px 1px rgba(0, 0, 0, 0.25);
     font-size: 12px;
+    font-variant: tabular-nums;
     left: 10px;
-    letter-spacing: 0.04em;
     line-height: 16px;
     overflow: hidden;
     padding: 0 5px;
     pointer-events: all;
-    position: relative;
+    position: absolute;
     text-overflow: ellipsis;
     top: -11px;
     white-space: nowrap;
     z-index: 0;
+  }
+
+  .timeline-cursor-label.flipped {
+    left: auto;
+    right: 10px;
+    text-align: right;
   }
 
   .timeline-cursor:hover .timeline-cursor-label {

--- a/src/components/timeline/TimelineCursors.svelte
+++ b/src/components/timeline/TimelineCursors.svelte
@@ -36,6 +36,7 @@
   let offsetX: number = -1;
   let cursorX: number = 0;
   let cursorMaxWidth: number = 0;
+  let cursorMaxWidthFlipped: number = 0;
   let cursorTimeLabel: string = '';
   let computedVerticalGuides: ComputedVerticalGuide[] = [];
   let cursorWithinView = true;
@@ -158,7 +159,10 @@
         cursorTimeLabel = formatDate(date, $plugins.time.primary.format);
         cursorTimeLabel += ' ' + $plugins.time.primary.label;
       }
+      // Space available to the right (default) and to the left (when the label flips) of the
+      // cursor line, within the drawable area. `cursorX` is still in draw coordinates here.
       cursorMaxWidth = drawWidth - cursorX;
+      cursorMaxWidthFlipped = cursorX;
       cursorX = cursorX + marginLeft;
       cursorWithinView = true;
     } else {
@@ -184,6 +188,8 @@
       x={cursorX}
       label={cursorTimeLabel}
       maxWidth={cursorMaxWidth}
+      maxWidthFlipped={cursorMaxWidthFlipped}
+      flippable
       on:click={() => {
         if (xScaleView) {
           addVerticalGuide(getDoyTime(xScaleView.invert(offsetX)));


### PR DESCRIPTION
## Summary
Timeline date hover cursor near the right edge clipped its timestamp. This PR flips it to the left of the cursor line when it would overflow. Guides are unaffected by this change and still overflow to the right.

## Visible UX Changes
- Full timestamp stays readable at the right edge (flips left instead of clipping).
- Tighter labels with tabular figures; timestamp no longer shifts width as time ticks.

## Verification
- In a plan, hover left and right on the timeline. The label should flip near the right edge and stay readable with no flicker at the crossover threshold. Guides should remain unchanged and overflow on the right edge.
