### PR TITLE
Fix workspace collaborator input overflow

### DIFF
--- a/src/components/ui/Tags/TagsInput.svelte
+++ b/src/components/ui/Tags/TagsInput.svelte
@@ -22,6 +22,7 @@
     closeSuggestions();
   };
   export let allowMultiple: boolean = true;
+  export let boxClassName: string = 'max-h-[40vh]';
   export let createTagObject: (name: string) => Tag = (name: string) => {
     return { color: generateRandomPastelColor(), created_at: '', id: -1, name, owner: '' };
   };
@@ -234,7 +235,7 @@
 
 <div
   class={classNames(
-    'flex max-h-[40vh] gap-2 overflow-hidden rounded-md border border-input bg-background p-[2px] focus-within:ring-2 focus-within:ring-ring',
+    `flex ${boxClassName} gap-2 overflow-hidden rounded-md border border-input bg-background p-[2px] focus-within:ring-2 focus-within:ring-ring`,
     {
       [className]: !!className,
       'cursor-not-allowed opacity-50': disabled,

--- a/src/components/ui/Tags/UserInput.svelte
+++ b/src/components/ui/Tags/UserInput.svelte
@@ -9,6 +9,7 @@
   import UserInputRow from './UserInputRow.svelte';
 
   export let allowMultiple: boolean = true;
+  export let boxClassName: string = 'max-h-[40vh]';
   export let className: string = '';
   export let disabled: boolean = false;
   export let name: string = '';
@@ -136,6 +137,7 @@
   bind:this={inputRef}
   {addTag}
   {allowMultiple}
+  {boxClassName}
   {disabled}
   {className}
   showPlaceholderIfDisabled

--- a/src/components/ui/Tags/WorkspaceCollaboratorInput.svelte
+++ b/src/components/ui/Tags/WorkspaceCollaboratorInput.svelte
@@ -73,6 +73,7 @@
 </script>
 
 <UserInput
+  boxClassName="max-h-none"
   className="w-full"
   placeholder="Search collaborators or workspaces"
   selectedUsers={collaborators.map(({ collaborator }) => collaborator)}

--- a/src/components/workspace/WorkspaceSidebar.svelte
+++ b/src/components/workspace/WorkspaceSidebar.svelte
@@ -136,7 +136,7 @@
 </script>
 
 <div class="flex h-full w-full flex-col">
-  <div class="h-full min-h-[300px]" role="tabpanel">
+  <div class="h-full min-h-0" role="tabpanel">
     {#if activeTab === 'files'}
       <div class="grid h-full grid-rows-[min-content_auto]">
         <Sidebar.Header className="p-0">
@@ -257,7 +257,7 @@
                     </select>
                   </Input>
                 </fieldset>
-                <fieldset>
+                <fieldset class="pb-4">
                   <Input layout="stacked">
                     <label use:tooltip={{ content: 'Collaborators', placement: 'top' }} for="collaborators">
                       Collaborators


### PR DESCRIPTION
## Summary
Resolve workspace collaborator cutoff by removing unneeded min-height 300px on workspace left sidebar content and passing in a min-h-0 class to the underlying tags input used by workspace collaborators component.

## Verification
1. Create a workspace 
2. Add dozens of collaborators
3. Verify that the collaborator input does not clip when there is still more room available (either from it's own height expanding OR from the window being sized smaller)