### PR TITLE
Add Warning Modal for Expansion on Constraint Violation

### DIFF
--- a/e2e-tests/fixtures/Constraints.ts
+++ b/e2e-tests/fixtures/Constraints.ts
@@ -44,9 +44,14 @@ export class Constraints {
     await this.page.waitForURL(`${baseURL}/constraints`);
   }
 
-  async deleteConstraint() {
+  async deleteConstraint(name: string) {
     await this.goto();
-    await this.filterTable(this.constraintName);
+    this.tableRow = await this.table.getByRole('row', { name });
+    this.tableRowDeleteButton = await this.tableRow
+      .getByRole('gridcell')
+      .getByRole('button', { name: 'Delete Constraint' });
+
+    await this.filterTable(name);
     await expect(this.tableRow).toBeVisible();
 
     await this.tableRow.hover();

--- a/e2e-tests/fixtures/Plan.ts
+++ b/e2e-tests/fixtures/Plan.ts
@@ -24,6 +24,7 @@ export class Plan {
   constraintManageButton: Locator;
   constraintModalFilter: Locator;
   constraintNewButton: Locator;
+  constraintStatusSelector: (status: string) => string;
   externalSourceManageButton: Locator;
   gridMenu: Locator;
   gridMenuButton: Locator;
@@ -96,6 +97,8 @@ export class Plan {
     public planName = plans.planName,
   ) {
     this.constraintListItemSelector = `.constraint-list-item:has-text("${constraints.constraintName}")`;
+    this.constraintStatusSelector = (status: string) =>
+      `.nav-button:has-text("Constraints") .status-badge[aria-label=${status}]`;
     this.schedulingConditionListItemSelector = (conditionName: string) =>
       `.scheduling-condition:has-text("${conditionName}")`;
     this.schedulingGoalListItemSelector = (goalName: string) => `.scheduling-goal:has-text("${goalName}")`;
@@ -485,10 +488,10 @@ export class Plan {
     await this.waitForSimulationStatus(expectedFinalState);
   }
 
-  async removeConstraint() {
+  async removeConstraint(name: string) {
     await this.constraintManageButton.click();
-    await this.constraintModalFilter.fill(this.constraints.constraintName);
-    const row = this.page.getByRole('row', { name: this.constraints.constraintName });
+    await this.constraintModalFilter.fill(name);
+    const row = this.page.getByRole('row', { name });
     await expect(row).toBeVisible();
     // Use click with force for AG Grid checkboxes - check/uncheck fails with Chrome for Testing
     const checkbox = row.getByRole('checkbox');
@@ -496,7 +499,7 @@ export class Plan {
     await checkbox.click({ force: true });
     await expect(checkbox).not.toBeChecked();
     await this.page.getByRole('button', { name: 'Update' }).click();
-    await this.page.locator(this.constraintListItemSelector).waitFor({ state: 'detached' });
+    await this.page.locator(this.constraintListItemSelector).first().waitFor({ state: 'detached' });
   }
 
   async removePlanCollaborator(name: string) {
@@ -738,7 +741,7 @@ export class Plan {
     this.changeMissionModelMigrateButton = this.changeMissionModelModal.getByRole('button', {
       name: 'Change Mission Model',
     });
-    this.constraintManageButton = page.locator(`button[name="manage-constraints"]`);
+    this.constraintManageButton = page.getByRole('button', { name: 'Manage Constraints' }).first();
     this.constraintModalFilter = page.locator('.modal').getByPlaceholder('Filter constraints');
     this.constraintNewButton = page.locator(`button[name="new-constraint"]`);
     this.consoleContainer = page.getByTestId('console');
@@ -830,6 +833,11 @@ export class Plan {
   async waitForActivityCheckingStatus(status: Status) {
     await expect(this.page.locator(this.activityCheckingStatusSelector(status))).toBeAttached({ timeout: 10000 });
     await expect(this.page.locator(this.activityCheckingStatusSelector(status))).toBeVisible();
+  }
+
+  async waitForConstraintStatus(status: string) {
+    await expect(this.page.locator(this.constraintStatusSelector(status))).toBeAttached({ timeout: 10000 });
+    await expect(this.page.locator(this.constraintStatusSelector(status))).toBeVisible();
   }
 
   async waitForPlanCollaboratorLoad() {

--- a/e2e-tests/tests/constraints.test.ts
+++ b/e2e-tests/tests/constraints.test.ts
@@ -1,7 +1,15 @@
-import test from '@playwright/test';
+import test, { expect } from '@playwright/test';
+import { adjectives, animals, colors, uniqueNamesGenerator } from 'unique-names-generator';
+import { Status } from '../../src/enums/status.js';
+import { PanelNames } from '../fixtures/Plan.js';
 import { setupTest, teardownTest, type FullSetupResult } from '../utilities/api.js';
 
 let setup: FullSetupResult;
+let originalConstraintName: string;
+const newConstraintName: string =
+  'FAILING_TEST_CONSTRAINT_' + uniqueNamesGenerator({ dictionaries: [adjectives, colors, animals] });
+const newConstraintDefinition: string =
+  "export default function peelFailing(): Constraint { return Real.Resource('/peel').lessThan(-1000); }";
 
 test.beforeAll(async ({ browser }) => {
   setup = await setupTest(browser);
@@ -21,8 +29,33 @@ test.describe.serial('Constraints', () => {
     await setup.plan.createConstraint(baseURL);
   });
 
+  test('Evaluate a failing and passing constraint', async ({ baseURL }) => {
+    originalConstraintName = setup.plan.constraints.constraintName;
+
+    // create a new constraint
+    setup.plan.constraints.constraintName = newConstraintName;
+    setup.plan.constraints.constraintDefinition = newConstraintDefinition;
+    await setup.plan.createConstraint(baseURL);
+
+    // simulate
+    await setup.plan.showPanel(PanelNames.SIMULATION, true);
+    await setup.plan.runSimulation(Status.Complete);
+
+    // evaluate constraints
+    await setup.page.getByRole('navigation').getByText('Constraints').click();
+    await setup.page.getByText('Check Constraints', { exact: true }).click();
+
+    // check results, should say "2 of 2 constraints, 1 of 1 violations"
+    await setup.plan.showPanel(PanelNames.CONSTRAINTS, true);
+    await expect(setup.page.getByText('2 of 2 constraints, 1 of 1').first()).toBeVisible({ timeout: 10000 });
+  });
+
   test('Delete constraint', async () => {
-    await setup.plan.removeConstraint();
-    await setup.constraints.deleteConstraint();
+    await setup.plan.removeConstraint(originalConstraintName);
+    await setup.plan.removeConstraint(newConstraintName);
+
+    await setup.page.pause();
+    await setup.constraints.deleteConstraint(originalConstraintName);
+    await setup.constraints.deleteConstraint(newConstraintName);
   });
 });

--- a/e2e-tests/tests/constraints.test.ts
+++ b/e2e-tests/tests/constraints.test.ts
@@ -29,6 +29,7 @@ test.describe.serial('Constraints', () => {
     await setup.plan.createConstraint(baseURL);
   });
 
+  // largely a test of backend functionality, but also tests that constraint results show correctly
   test('Evaluate a failing and passing constraint', async ({ baseURL }) => {
     originalConstraintName = setup.plan.constraints.constraintName;
 

--- a/e2e-tests/tests/plan-expansion.test.ts
+++ b/e2e-tests/tests/plan-expansion.test.ts
@@ -58,4 +58,33 @@ test.describe.serial('Plan Expansion', () => {
     await setup.plan.showPanel(PanelNames.EXPANSION);
     await setup.plan.applySequenceFilter(sequenceFilterName, setup.plans.planId);
   });
+
+  test('Planners warned if constraints have issues', async ({ baseURL }) => {
+    setup.plan.constraints.constraintDefinition =
+      "export default function peelFailing(): Constraint { return Real.Resource('/peel').lessThan(-1000); }";
+    await setup.plan.showConstraintsLayout();
+    await setup.plan.createConstraint(baseURL);
+
+    // evaluate constraints
+    await setup.page.getByRole('navigation').getByText('Constraints').click();
+    await setup.page.getByText('Check Constraints', { exact: true }).click();
+
+    // expand
+    await setup.plan.showPanel(PanelNames.EXPANSION);
+    await setup.page.locator('select[name="expansionSetId"]').selectOption('2');
+
+    const sequenceName = `${sequenceFilterName} Sequence (Plan ${setup.planId})`;
+    await setup.page.getByText(sequenceName, { exact: true }).hover();
+
+    const expansionButton = setup.page.getByRole('button', { name: `Expand '${sequenceName}'` });
+    await expansionButton.waitFor({ state: 'visible' });
+    await expansionButton.click();
+
+    // check warning
+    await expect(setup.page.getByText('Violating Constraints')).toBeVisible();
+    await expect(setup.page.getByText('This constraint is currently')).toBeVisible();
+    await expect(setup.page.getByText('(1 violation)')).toBeVisible();
+
+    await setup.page.getByRole('button', { name: 'Expand Anyways' }).click();
+  });
 });

--- a/e2e-tests/tests/plan-expansion.test.ts
+++ b/e2e-tests/tests/plan-expansion.test.ts
@@ -1,6 +1,8 @@
 import test, { expect } from '@playwright/test';
 import { adjectives, animals, colors, uniqueNamesGenerator } from 'unique-names-generator';
 import { Dictionaries } from '../fixtures/Dictionaries.js';
+import { ExpansionRules } from '../fixtures/ExpansionRules.js';
+import { ExpansionSets } from '../fixtures/ExpansionSets.js';
 import { Parcels } from '../fixtures/Parcels.js';
 import { PanelNames } from '../fixtures/Plan.js';
 import { setupTest, teardownTest, type FullSetupResult } from '../utilities/api.js';
@@ -12,11 +14,15 @@ let setup: FullSetupResult;
 let dictionaryName: string;
 let dictionaries: Dictionaries;
 let parcels: Parcels;
+let expansionRules: ExpansionRules;
+let expansionSets: ExpansionSets;
 
 test.beforeAll(async ({ baseURL, browser }) => {
   setup = await setupTest(browser);
   dictionaries = new Dictionaries(setup.page);
   parcels = new Parcels(setup.page);
+  expansionRules = new ExpansionRules(setup.page, parcels, setup.models);
+  expansionSets = new ExpansionSets(setup.page, parcels, setup.models, expansionRules);
 
   await dictionaries.goto();
   await dictionaries.createCommandDictionary();
@@ -26,7 +32,6 @@ test.beforeAll(async ({ baseURL, browser }) => {
 });
 
 test.afterAll(async () => {
-  await parcels.goto();
   await teardownTest(setup);
 });
 
@@ -60,18 +65,43 @@ test.describe.serial('Plan Expansion', () => {
   });
 
   test('Planners warned if constraints have issues', async ({ baseURL }) => {
+    await expansionRules.goto();
+    await expansionRules.createExpansionRule(baseURL);
+    await expansionSets.goto();
+    await expansionSets.createExpansionSet(baseURL);
+    const expansionSetId = await expansionSets.page
+      .getByRole('tabpanel')
+      .filter({ hasText: 'Expansion Sets' })
+      .getByRole('treegrid')
+      .getByRole('row', { name: expansionSets.expansionSetName })
+      .getByRole('gridcell')
+      .first()
+      .textContent();
+
+    await setup.plan.goto();
+
     setup.plan.constraints.constraintDefinition =
       "export default function peelFailing(): Constraint { return Real.Resource('/peel').lessThan(-1000); }";
     await setup.plan.showConstraintsLayout();
     await setup.plan.createConstraint(baseURL);
 
+    // running a simulation on the plan is required before being able to check constraints
+    await setup.plan.showPanel(PanelNames.SIMULATION, true);
+    // run the simulation if it already hasn't been
+    if (await setup.plan.simulateButton.isEnabled()) {
+      await setup.plan.runSimulation();
+    }
+
     // evaluate constraints
-    await setup.page.getByRole('navigation').getByText('Constraints').click();
-    await setup.page.getByText('Check Constraints', { exact: true }).click();
+    await setup.plan.navButtonConstraints.click();
+    await setup.plan.navButtonConstraintsMenu.getByText('Check Constraints', { exact: true }).click();
 
     // expand
     await setup.plan.showPanel(PanelNames.EXPANSION);
-    await setup.page.locator('select[name="expansionSetId"]').selectOption('2');
+
+    await setup.page
+      .locator('select[name="expansionSetId"]')
+      .selectOption({ label: `${expansionSets.expansionSetName} (${expansionSetId})` });
 
     const sequenceName = `${sequenceFilterName} Sequence (Plan ${setup.planId})`;
     await setup.page.getByText(sequenceName, { exact: true }).hover();

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -15,7 +15,12 @@
   import { plugins } from '../../stores/plugins';
   import { expandedTemplates } from '../../stores/sequence-template';
   import { sequenceFilters } from '../../stores/sequencing';
-  import { simulationDatasetLatest, simulationDatasetsPlan, simulationStatus } from '../../stores/simulation';
+  import {
+    simulationDatasetId,
+    simulationDatasetLatest,
+    simulationDatasetsPlan,
+    simulationStatus,
+  } from '../../stores/simulation';
   import type { User } from '../../types/app';
   import type { ConstraintInvocationMap, ConstraintResponse } from '../../types/constraint';
   import type { ExpansionSequence, SequenceFilter } from '../../types/expansion';
@@ -98,7 +103,7 @@
       }
     } else {
       // Question for PlanDev team: should we include this? Or only in the modal.
-      isExpansionDisabled = true;
+      isExpansionDisabled = false;
       expansionDisabledMessage = 'Simulation is out of date.';
     }
   }
@@ -241,7 +246,7 @@
   }
 
   async function onExpandSequence(sequence: ExpansionSequence) {
-    var result = { confirm: false };
+    var result = { confirm: true };
     if (
       !(
         $checkConstraintsStatus !== Status.Failed &&
@@ -257,6 +262,7 @@
         allConstraintsThatAreCheckedPass,
         constraintPlanSpecsInPlan,
         constraintToConstraintResponseMap,
+        $simulationDatasetId,
       );
     }
     if (result.confirm) {

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -243,8 +243,13 @@
   async function onExpandSequence(sequence: ExpansionSequence) {
     var result = { confirm: false };
     if (
-      !($checkConstraintsStatus !== Status.Failed,
-      !simulationOutOfDate && allConstraintsHaveBeenChecked && allConstraintsThatAreCheckedPass)
+      !(
+        $checkConstraintsStatus !== Status.Failed &&
+        $checkConstraintsStatus !== Status.Incomplete &&
+        !simulationOutOfDate &&
+        allConstraintsHaveBeenChecked &&
+        allConstraintsThatAreCheckedPass
+      )
     ) {
       result = await showConfirmExpansionModal(
         simulationOutOfDate,

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -8,20 +8,25 @@
   import { Download, FileCode2, SquareCode } from 'lucide-svelte';
   import { SEQUENCE_EXPANSION_MODE } from '../../constants/command-expansion';
   import { SequencingMode } from '../../enums/sequencing';
+  import { Status } from '../../enums/status';
+  import { allowedConstraintPlanSpecs, checkConstraintsStatus, constraintResponseMap } from '../../stores/constraints';
   import { expansionSequences, expansionSets, filteredExpansionSequences } from '../../stores/expansion';
   import { plan } from '../../stores/plan';
+  import { plugins } from '../../stores/plugins';
   import { expandedTemplates } from '../../stores/sequence-template';
   import { sequenceFilters } from '../../stores/sequencing';
-  import { simulationDatasetLatest, simulationDatasetsPlan } from '../../stores/simulation';
+  import { simulationDatasetLatest, simulationDatasetsPlan, simulationStatus } from '../../stores/simulation';
   import type { User } from '../../types/app';
+  import type { ConstraintInvocationMap, ConstraintResponse } from '../../types/constraint';
   import type { ExpansionSequence, SequenceFilter } from '../../types/expansion';
   import type { ActivityLayerFilter } from '../../types/timeline';
   import type { ViewGridSection } from '../../types/view';
   import effects from '../../utilities/effects';
   import { downloadBlob, downloadJSON } from '../../utilities/generic';
-  import { showExpansionSequenceModal, showNewSequenceModal } from '../../utilities/modal';
+  import { showConfirmExpansionModal, showExpansionSequenceModal, showNewSequenceModal } from '../../utilities/modal';
   import { permissionHandler } from '../../utilities/permissionHandler';
   import { featurePermissions } from '../../utilities/permissions';
+  import { convertDoyToYmd, formatDate } from '../../utilities/time';
   import { tooltip } from '../../utilities/tooltip';
   import GridMenu from '../menus/GridMenu.svelte';
   import ModalFooter from '../modals/ModalFooter.svelte';
@@ -73,22 +78,91 @@
   $: sequencesAndFilters = [...relevantExpansionSequences, ...$sequenceFilters];
 
   $: {
-    if ($simulationDatasetLatest) {
-      if (relevantExpansionSequences.length > 0) {
-        if (SEQUENCE_EXPANSION_MODE === SequencingMode.TEMPLATING) {
-          isExpansionDisabled = false;
-          expansionDisabledMessage = 'Expansion not available for sequence templates';
+    if (!simulationOutOfDate) {
+      if ($simulationDatasetLatest) {
+        if (relevantExpansionSequences.length > 0) {
+          if (SEQUENCE_EXPANSION_MODE === SequencingMode.TEMPLATING) {
+            isExpansionDisabled = false;
+            expansionDisabledMessage = 'Expansion not available for sequence templates';
+          } else {
+            isExpansionDisabled = selectedExpansionSetId === null;
+            expansionDisabledMessage = selectedExpansionSetId === null ? 'No expansion set selected' : '';
+          }
         } else {
-          isExpansionDisabled = selectedExpansionSetId === null;
-          expansionDisabledMessage = selectedExpansionSetId === null ? 'No expansion set selected' : '';
+          isExpansionDisabled = true;
+          expansionDisabledMessage = 'No relevant expansion sequences found';
         }
       } else {
         isExpansionDisabled = true;
-        expansionDisabledMessage = 'No relevant expansion sequences found';
+        expansionDisabledMessage = 'Completed simulation required';
       }
     } else {
+      // Question for PlanDev team: should we include this? Or only in the modal.
       isExpansionDisabled = true;
-      expansionDisabledMessage = 'Completed simulation required';
+      expansionDisabledMessage = 'Simulation is out of date.';
+    }
+  }
+
+  // copied from ConstraintsPanel. Unable to move this into a store, as ConstraintsPanel directly modifies startTime, though we do not need to here.
+  let startTime: string;
+  let endTime: string;
+  $: if ($plan) {
+    startTime = formatDate(new Date($plan.start_time), $plugins.time.primary.format);
+    const endTimeYmd = convertDoyToYmd($plan.end_time_doy);
+    if (endTimeYmd) {
+      endTime = formatDate(new Date(endTimeYmd), $plugins.time.primary.format);
+    } else {
+      endTime = '';
+    }
+  }
+  $: startTimeMs = typeof startTime === 'string' ? $plugins.time.primary.parse(startTime)?.getTime() : null;
+  $: endTimeMs = typeof endTime === 'string' ? $plugins.time.primary.parse(endTime)?.getTime() : null;
+  let constraintToConstraintResponseMap: ConstraintInvocationMap<ConstraintResponse> = {};
+  $: if ($allowedConstraintPlanSpecs && $constraintResponseMap && startTimeMs && endTimeMs) {
+    constraintToConstraintResponseMap = {};
+    $allowedConstraintPlanSpecs.forEach(constraintPlanSpec => {
+      const { constraint_id: constraintId, invocation_id: invocationId } = constraintPlanSpec;
+      const constraintResponse = $constraintResponseMap[constraintId]?.[invocationId];
+      if (constraintResponse) {
+        if (!constraintToConstraintResponseMap[constraintId]) {
+          constraintToConstraintResponseMap[constraintId] = {};
+        }
+
+        constraintToConstraintResponseMap[constraintId][invocationId] = {
+          constraintId,
+          constraintInvocationId: invocationId,
+          constraintName: constraintResponse.constraintName,
+          errors: constraintResponse.errors,
+          results: constraintResponse.results && {
+            ...constraintResponse.results,
+            violations:
+              constraintResponse.results.violations?.map(violation => ({
+                ...violation,
+                // Filter violations/windows by time bounds
+                windows: violation.windows.filter(
+                  window => window.end >= (startTimeMs ?? 0) && window.start <= (endTimeMs ?? 0),
+                ),
+              })) ?? null,
+          },
+          type: constraintResponse.type,
+        };
+      }
+    });
+  }
+
+  let allConstraintsHaveBeenChecked = true;
+  let allConstraintsThatAreCheckedPass = true;
+  let simulationOutOfDate = false;
+  $: constraintPlanSpecsInPlan = $allowedConstraintPlanSpecs.filter(spec => $plan && spec.plan_id === $plan.id);
+  $: {
+    simulationOutOfDate = $simulationStatus === Status.Modified;
+
+    for (let constraintSpec of constraintPlanSpecsInPlan) {
+      let checked = constraintToConstraintResponseMap[constraintSpec.constraint_id]?.[constraintSpec.invocation_id];
+      allConstraintsHaveBeenChecked &&= !!checked;
+      if (checked) {
+        allConstraintsThatAreCheckedPass &&= (checked.results.violations?.length ?? 0) <= 0;
+      }
     }
   }
 
@@ -166,12 +240,27 @@
     }
   }
 
-  function onExpandSequence(sequence: ExpansionSequence) {
-    if ($simulationDatasetLatest !== null && $plan !== null) {
-      if (SEQUENCE_EXPANSION_MODE === SequencingMode.TEMPLATING) {
-        effects.expandTemplates([sequence.seq_id], $simulationDatasetLatest.id, $plan, user);
-      } else if (selectedExpansionSetId !== null) {
-        effects.expand(selectedExpansionSetId, $simulationDatasetLatest.id, $plan, user);
+  async function onExpandSequence(sequence: ExpansionSequence) {
+    var result = { confirm: false };
+    if (
+      !($checkConstraintsStatus !== Status.Failed,
+      !simulationOutOfDate && allConstraintsHaveBeenChecked && allConstraintsThatAreCheckedPass)
+    ) {
+      result = await showConfirmExpansionModal(
+        simulationOutOfDate,
+        allConstraintsHaveBeenChecked,
+        allConstraintsThatAreCheckedPass,
+        constraintPlanSpecsInPlan,
+        constraintToConstraintResponseMap,
+      );
+    }
+    if (result.confirm) {
+      if ($simulationDatasetLatest !== null && $plan !== null) {
+        if (SEQUENCE_EXPANSION_MODE === SequencingMode.TEMPLATING) {
+          effects.expandTemplates([sequence.seq_id], $simulationDatasetLatest.id, $plan, user);
+        } else if (selectedExpansionSetId !== null) {
+          effects.expand(selectedExpansionSetId, $simulationDatasetLatest.id, $plan, user);
+        }
       }
     }
   }
@@ -411,9 +500,9 @@
                   aria-label={`Expand '${sequenceOrFilter.seq_id}'`}
                   class="st-button icon"
                   disabled={isExpansionDisabled}
-                  on:click|stopPropagation={() => {
+                  on:click|stopPropagation={async () => {
                     if (isExpansionSequence(sequenceOrFilter)) {
-                      onExpandSequence(sequenceOrFilter);
+                      await onExpandSequence(sequenceOrFilter);
                     }
                   }}
                 >
@@ -465,6 +554,21 @@
                   placement: 'top',
                 }}
               >
+                <!-- <button
+                  disabled={!(
+                    $simulationDatasetLatest &&
+                    $simulationStatus === Status.Complete &&
+                    $constraintsStatus === Status.Complete &&
+                    numConstraintsViolated === 0
+                  )}
+                  aria-label={`Apply '${sequenceOrFilter.name}'`}
+                  class="st-button icon"
+                  on:click|stopPropagation={() => {
+                    if (!isExpansionSequence(sequenceOrFilter)) {
+                      onApplyFilter(sequenceOrFilter);
+                    }
+                  }}
+                > -->
                 <button
                   disabled={!$simulationDatasetLatest}
                   aria-label={`Apply '${sequenceOrFilter.name}'`}

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -67,6 +67,14 @@
   let hasCreatePermissionSequence: boolean = false;
   let hasCreatePermissionSequenceFilter: boolean = false;
 
+  let allConstraintsHaveBeenChecked = true;
+  let allConstraintsThatAreCheckedPass = true;
+  let simulationOutOfDate = false;
+
+  // copied from ConstraintsPanel. Unable to move this into a store, as ConstraintsPanel directly modifies startTime, though we do not need to here.
+  let startTime: string;
+  let endTime: string;
+
   $: if (user !== null && $plan !== null && $plan.model) {
     hasDeletePermissionSequence = featurePermissions.expansionSequences.canDelete(user, $plan);
     hasDeletePermissionSequenceFilter = featurePermissions.sequenceFilter.canDelete(user, $plan.model);
@@ -108,9 +116,7 @@
     }
   }
 
-  // copied from ConstraintsPanel. Unable to move this into a store, as ConstraintsPanel directly modifies startTime, though we do not need to here.
-  let startTime: string;
-  let endTime: string;
+  // copied from ConstraintsPanel
   $: if ($plan) {
     startTime = formatDate(new Date($plan.start_time), $plugins.time.primary.format);
     const endTimeYmd = convertDoyToYmd($plan.end_time_doy);
@@ -155,9 +161,6 @@
     });
   }
 
-  let allConstraintsHaveBeenChecked = true;
-  let allConstraintsThatAreCheckedPass = true;
-  let simulationOutOfDate = false;
   $: constraintPlanSpecsInPlan = $allowedConstraintPlanSpecs.filter(spec => $plan && spec.plan_id === $plan.id);
   $: {
     simulationOutOfDate = $simulationStatus === Status.Modified;

--- a/src/components/expansion/ExpansionPanel.svelte
+++ b/src/components/expansion/ExpansionPanel.svelte
@@ -565,21 +565,6 @@
                   placement: 'top',
                 }}
               >
-                <!-- <button
-                  disabled={!(
-                    $simulationDatasetLatest &&
-                    $simulationStatus === Status.Complete &&
-                    $constraintsStatus === Status.Complete &&
-                    numConstraintsViolated === 0
-                  )}
-                  aria-label={`Apply '${sequenceOrFilter.name}'`}
-                  class="st-button icon"
-                  on:click|stopPropagation={() => {
-                    if (!isExpansionSequence(sequenceOrFilter)) {
-                      onApplyFilter(sequenceOrFilter);
-                    }
-                  }}
-                > -->
                 <button
                   disabled={!$simulationDatasetLatest}
                   aria-label={`Apply '${sequenceOrFilter.name}'`}

--- a/src/components/modals/ConfirmExpansionModal.svelte
+++ b/src/components/modals/ConfirmExpansionModal.svelte
@@ -25,10 +25,16 @@
     simulationOutOfDate && (!allConstraintsHaveBeenChecked || !allConstraintsThatAreCheckedPass) ? 300 : 200;
   export let width: number = 380;
 
-  let failingConstraints: string[] = constraintPlanSpecsInPlan
+  let failingConstraints: { name: string; viols: number }[] = constraintPlanSpecsInPlan
     .filter(spec => constraintToConstraintResponseMap[spec.constraint_id])
-    .map(spec => spec.constraint_metadata?.name ?? '')
-    .filter(name => name.length > 0); // in case metadata is undefined.
+    .map(spec => {
+      return {
+        name: spec.constraint_metadata?.name ?? '',
+        viols:
+          constraintToConstraintResponseMap[spec.constraint_id]?.[spec.invocation_id].results.violations?.length ?? -1,
+      };
+    })
+    .filter(obj => obj.name.length > 0 && obj.viols > 0); // in case metadata is undefined.
 
   // NOTE: this includes disabled constraints, as running constraints when some are disabled marks them as unchecked.
   //        As such, we consider this an accurate reflection of the constraint status.
@@ -98,7 +104,7 @@
       <p>The following constraints were violated:</p>
       <div class="constraints-list">
         {#each failingConstraints as failing}
-          <p>{failing}</p>
+          <p>{failing.name} <b>({failing.viols} violations)</b></p>
         {/each}
       </div>
     {/if}

--- a/src/components/modals/ConfirmExpansionModal.svelte
+++ b/src/components/modals/ConfirmExpansionModal.svelte
@@ -77,7 +77,7 @@
         : $checkConstraintsStatus === Status.Incomplete
           ? ' (incomplete evaluation)'
           : uncheckedConstraints.length > 0 || failingConstraints.length > 0
-            ? ` (${uncheckedConstraints.length > 0} unchecked, ${failingConstraints.length > 0} failed)`
+            ? ` (${uncheckedConstraints.length} unchecked, ${failingConstraints.length > 0} failed)`
             : ``;
     logMessage(`Constraint violations${brief} bypassed before expanding simulation ${simulationDatasetId}.`);
 

--- a/src/components/modals/ConfirmExpansionModal.svelte
+++ b/src/components/modals/ConfirmExpansionModal.svelte
@@ -23,9 +23,7 @@
   export let constraintToConstraintResponseMap: ConstraintInvocationMap<ConstraintResponse>;
   export let simulationDatasetId: number;
 
-  // TODO: adjust dynamically?
-  export let height: number =
-    simulationOutOfDate && (!allConstraintsHaveBeenChecked || !allConstraintsThatAreCheckedPass) ? 300 : 200;
+  export let height: number = 400;
   export let width: number = 380;
 
   let failingConstraints: { name: string; viols: number }[] = constraintPlanSpecsInPlan

--- a/src/components/modals/ConfirmExpansionModal.svelte
+++ b/src/components/modals/ConfirmExpansionModal.svelte
@@ -84,6 +84,20 @@
         The status of constraints is therefore undefined, and the plan have violations that the mission planner is not
         aware of.
       </p>
+      {#if uncheckedConstraints.length > 0 || failingConstraints.length > 0}
+        <br />
+        <p><i>For the most recent constraint run, the results were that:</i></p>
+      {/if}
+    {:else if $checkConstraintsStatus === Status.Incomplete}
+      <p>The most recent constraint evaluation is incomplete.</p>
+      <p>
+        The status of constraints is therefore ill-defined, and the plan have violations that the mission planner is not
+        aware of.
+      </p>
+      {#if uncheckedConstraints.length > 0 || failingConstraints.length > 0}
+        <br />
+        <p><i>For the most recent constraint run, the results were that:</i></p>
+      {/if}
     {:else if simulationOutOfDate}
       <!-- If expansion is disabled for an out of date simulation, this won't show. But if we remove that guard, this shows. -->
       <p>Simulation is out of date. This means the constraint results in the constraints tab are currently invalid.</p>

--- a/src/components/modals/ConfirmExpansionModal.svelte
+++ b/src/components/modals/ConfirmExpansionModal.svelte
@@ -4,6 +4,7 @@
   import { createEventDispatcher } from 'svelte';
   import { Status } from '../../enums/status';
   import { checkConstraintsStatus } from '../../stores/constraints';
+  import { logMessage } from '../../stores/errors';
   import type {
     ConstraintInvocationMap,
     ConstraintPlanSpecification,
@@ -17,8 +18,10 @@
   export let simulationOutOfDate: boolean;
   export let allConstraintsHaveBeenChecked: boolean;
   export let allConstraintsThatAreCheckedPass: boolean;
+
   export let constraintPlanSpecsInPlan: ConstraintPlanSpecification[];
   export let constraintToConstraintResponseMap: ConstraintInvocationMap<ConstraintResponse>;
+  export let simulationDatasetId: number;
 
   // TODO: adjust dynamically?
   export let height: number =
@@ -57,19 +60,29 @@
 
   const dispatch = createEventDispatcher<{
     close: void;
-    confirm: { addFilter: boolean };
+    confirm: void;
   }>();
 
   function onKeydown(event: KeyboardEvent) {
     const { key } = event;
     if (key === 'Enter') {
       event.preventDefault();
-      confirm(true);
+      confirm();
     }
   }
 
-  function confirm(addFilter: boolean = false) {
-    dispatch('confirm', { addFilter });
+  function confirm() {
+    const brief =
+      $checkConstraintsStatus === Status.Failed
+        ? ' (failed evaluation)'
+        : $checkConstraintsStatus === Status.Incomplete
+          ? ' (incomplete evaluation)'
+          : uncheckedConstraints.length > 0 || failingConstraints.length > 0
+            ? ` (${uncheckedConstraints.length > 0} unchecked, ${failingConstraints.length > 0} failed)`
+            : ``;
+    logMessage(`Constraint violations${brief} bypassed before expanding simulation ${simulationDatasetId}.`);
+
+    dispatch('confirm');
   }
 </script>
 
@@ -127,7 +140,7 @@
   </ModalContent>
   <ModalFooter>
     <button class="st-button secondary" on:click={() => dispatch('close')}> Cancel </button>
-    <button class="st-button" on:click={() => confirm(true)}> Expand</button>
+    <button class="st-button" on:click={() => confirm()}>Expand</button>
   </ModalFooter>
 </Modal>
 

--- a/src/components/modals/ConfirmExpansionModal.svelte
+++ b/src/components/modals/ConfirmExpansionModal.svelte
@@ -10,6 +10,7 @@
     ConstraintPlanSpecification,
     ConstraintResponse,
   } from '../../types/constraint';
+  import { pluralize } from '../../utilities/text';
   import Modal from './Modal.svelte';
   import ModalContent from './ModalContent.svelte';
   import ModalFooter from './ModalFooter.svelte';
@@ -129,7 +130,7 @@
       <p>The following constraints were violated:</p>
       <div class="constraints-list">
         {#each failingConstraints as failing}
-          <p>{failing.name} <b>({failing.viols} violations)</b></p>
+          <p>{failing.name} <b>({failing.viols} violation{pluralize(failing.viols)})</b></p>
         {/each}
       </div>
     {/if}

--- a/src/components/modals/ConfirmExpansionModal.svelte
+++ b/src/components/modals/ConfirmExpansionModal.svelte
@@ -48,9 +48,9 @@
   let warningMessage = '';
 
   $: if ($checkConstraintsStatus === Status.Failed) {
-    warningMessage = 'Constraint Evaluation Failure';
+    warningMessage = 'Constraints Could Not Be Evaluated';
   } else if (simulationOutOfDate) {
-    warningMessage = 'Simulation Outdated';
+    warningMessage = 'Simulation Is Out Of Date';
   } else if (!allConstraintsHaveBeenChecked && allConstraintsThatAreCheckedPass) {
     warningMessage = 'Unchecked Constraints';
   } else {
@@ -91,60 +91,99 @@
   <ModalHeader on:close>{warningMessage}</ModalHeader>
   <ModalContent>
     {#if $checkConstraintsStatus === Status.Failed}
-      <p>The most recent constraint evaluation failed.</p>
-      <p>
-        The status of constraints is therefore undefined, and the plan have violations that the mission planner is not
-        aware of.
-      </p>
+      <p>The most recent constraint evaluation failed, so the current constraint status is unknown.</p>
       {#if uncheckedConstraints.length > 0 || failingConstraints.length > 0}
         <br />
         <p><i>For the most recent constraint run, the results were that:</i></p>
+        <br />
       {/if}
     {:else if $checkConstraintsStatus === Status.Incomplete}
-      <p>The most recent constraint evaluation is incomplete.</p>
-      <p>
-        The status of constraints is therefore ill-defined, and the plan have violations that the mission planner is not
-        aware of.
-      </p>
+      <p>The most recent constraint evaluation didn't finish, so the current constraint status is incomplete.</p>
       {#if uncheckedConstraints.length > 0 || failingConstraints.length > 0}
         <br />
         <p><i>For the most recent constraint run, the results were that:</i></p>
+        <br />
       {/if}
     {:else if simulationOutOfDate}
       <!-- If expansion is disabled for an out of date simulation, this won't show. But if we remove that guard, this shows. -->
-      <p>Simulation is out of date. This means the constraint results in the constraints tab are currently invalid.</p>
+      <p>
+        The plan has changed since the last simulation, so the constraint results in the Constraints panel no longer
+        reflect the current plan.
+      </p>
       {#if uncheckedConstraints.length > 0 || failingConstraints.length > 0}
         <br />
         <p><i>For the most recent constraint run, the results were that:</i></p>
+        <br />
       {/if}
     {/if}
-    {#if uncheckedConstraints.length > 0}
-      <p>The following constraints were unchecked:</p>
-      <div class="constraints-list">
-        {#each uncheckedConstraints as unchecked}
-          <p>{unchecked}</p>
-        {/each}
-      </div>
-    {/if}
     {#if failingConstraints.length > 0}
-      <p>The following constraints were violated:</p>
-      <div class="constraints-list">
+      {#if simulationOutOfDate}
+        <p>
+          The last evaluation found violations in {failingConstraints.length === 1
+            ? 'this constraint'
+            : 'these constraints'}:
+        </p>
+      {:else}
+        <p>{failingConstraints.length === 1 ? 'This constraint is' : 'These constraints are'} currently violated:</p>
+      {/if}
+      <ul class="list-disc pl-5">
         {#each failingConstraints as failing}
-          <p>{failing.name} <b>({failing.viols} violation{pluralize(failing.viols)})</b></p>
+          <li>{failing.name} <b>({failing.viols} violation{pluralize(failing.viols)})</b></li>
         {/each}
-      </div>
+      </ul>
+      <br />
+    {/if}
+    {#if uncheckedConstraints.length > 0}
+      {#if simulationOutOfDate}
+        <p>
+          From the last evaluation, {uncheckedConstraints.length === 1
+            ? "this constraint hasn't"
+            : "these constraints haven't"} been checked and may be violated:
+        </p>
+      {:else}
+        <p>
+          {uncheckedConstraints.length === 1 ? "This constraint hasn't" : "These constraints haven't"} been checked and may
+          be violated:
+        </p>
+      {/if}
+      <ul class="list-disc pl-5">
+        {#each uncheckedConstraints as unchecked}
+          <li>{unchecked}</li>
+        {/each}
+      </ul>
     {/if}
     <br />
-    <p><i>Proceed with expansion?</i></p>
+    {#if simulationOutOfDate}
+      <p><b>Expansion will run against the previous simulation and may not match the current plan.</b></p>
+    {:else}
+      <p><b>Expanding now may produce sequences that violate mission constraints.</b></p>
+    {/if}
   </ModalContent>
+  <div class="final-warning">
+    <p><b><i>Do you want to expand anyway?</i></b></p>
+  </div>
   <ModalFooter>
     <button class="st-button secondary" on:click={() => dispatch('close')}> Cancel </button>
-    <button class="st-button" on:click={() => confirm()}>Expand</button>
+    <button
+      class="st-button bg-destructive text-destructive-foreground hover:!bg-destructive/90"
+      on:click={() => confirm()}>Expand Anyways</button
+    >
   </ModalFooter>
 </Modal>
 
 <style>
-  .constraints-list {
-    margin-left: 10px;
+  .final-warning {
+    position: relative;
+    bottom: 1rem;
+    left: 1rem;
+    right: 1rem;
+  }
+
+  p {
+    font-size: 0.75rem;
+  }
+
+  li {
+    font-size: 0.67rem;
   }
 </style>

--- a/src/components/modals/ConfirmExpansionModal.svelte
+++ b/src/components/modals/ConfirmExpansionModal.svelte
@@ -1,0 +1,118 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import { Status } from '../../enums/status';
+  import { checkConstraintsStatus } from '../../stores/constraints';
+  import type {
+    ConstraintInvocationMap,
+    ConstraintPlanSpecification,
+    ConstraintResponse,
+  } from '../../types/constraint';
+  import Modal from './Modal.svelte';
+  import ModalContent from './ModalContent.svelte';
+  import ModalFooter from './ModalFooter.svelte';
+  import ModalHeader from './ModalHeader.svelte';
+
+  export let simulationOutOfDate: boolean;
+  export let allConstraintsHaveBeenChecked: boolean;
+  export let allConstraintsThatAreCheckedPass: boolean;
+  export let constraintPlanSpecsInPlan: ConstraintPlanSpecification[];
+  export let constraintToConstraintResponseMap: ConstraintInvocationMap<ConstraintResponse>;
+
+  // TODO: adjust dynamically?
+  export let height: number =
+    simulationOutOfDate && (!allConstraintsHaveBeenChecked || !allConstraintsThatAreCheckedPass) ? 300 : 200;
+  export let width: number = 380;
+
+  let failingConstraints: string[] = constraintPlanSpecsInPlan
+    .filter(spec => constraintToConstraintResponseMap[spec.constraint_id])
+    .map(spec => spec.constraint_metadata?.name ?? '')
+    .filter(name => name.length > 0); // in case metadata is undefined.
+
+  // NOTE: this includes disabled constraints, as running constraints when some are disabled marks them as unchecked.
+  //        As such, we consider this an accurate reflection of the constraint status.
+  let uncheckedConstraints: string[] = constraintPlanSpecsInPlan
+    .filter(spec => !constraintToConstraintResponseMap[spec.constraint_id])
+    .map(spec => spec.constraint_metadata?.name ?? '')
+    .filter(name => name.length > 0); // in case metadata is undefined.
+
+  let warningMessage = '';
+
+  $: if ($checkConstraintsStatus === Status.Failed) {
+    warningMessage = 'Constraint Evaluation Failure';
+  } else if (simulationOutOfDate) {
+    warningMessage = 'Simulation Outdated';
+  } else if (!allConstraintsHaveBeenChecked && allConstraintsThatAreCheckedPass) {
+    warningMessage = 'Unchecked Constraints';
+  } else {
+    warningMessage = 'Violating Constraints';
+  }
+
+  const dispatch = createEventDispatcher<{
+    close: void;
+    confirm: { addFilter: boolean };
+  }>();
+
+  function onKeydown(event: KeyboardEvent) {
+    const { key } = event;
+    if (key === 'Enter') {
+      event.preventDefault();
+      confirm(true);
+    }
+  }
+
+  function confirm(addFilter: boolean = false) {
+    dispatch('confirm', { addFilter });
+  }
+</script>
+
+<svelte:window on:keydown={onKeydown} />
+
+<Modal {height} {width} on:close>
+  <ModalHeader on:close>{warningMessage}</ModalHeader>
+  <ModalContent>
+    {#if $checkConstraintsStatus === Status.Failed}
+      <p>The most recent constraint evaluation failed.</p>
+      <p>
+        The status of constraints is therefore undefined, and the plan have violations that the mission planner is not
+        aware of.
+      </p>
+    {:else if simulationOutOfDate}
+      <!-- If expansion is disabled for an out of date simulation, this won't show. But if we remove that guard, this shows. -->
+      <p>Simulation is out of date. This means the constraint results in the constraints tab are currently invalid.</p>
+      {#if uncheckedConstraints.length > 0 || failingConstraints.length > 0}
+        <br />
+        <p><i>For the most recent constraint run, the results were that:</i></p>
+      {/if}
+    {/if}
+    {#if uncheckedConstraints.length > 0}
+      <p>The following constraints were unchecked:</p>
+      <div class="constraints-list">
+        {#each uncheckedConstraints as unchecked}
+          <p>{unchecked}</p>
+        {/each}
+      </div>
+    {/if}
+    {#if failingConstraints.length > 0}
+      <p>The following constraints were violated:</p>
+      <div class="constraints-list">
+        {#each failingConstraints as failing}
+          <p>{failing}</p>
+        {/each}
+      </div>
+    {/if}
+    <br />
+    <p><i>Proceed with expansion?</i></p>
+  </ModalContent>
+  <ModalFooter>
+    <button class="st-button secondary" on:click={() => dispatch('close')}> Cancel </button>
+    <button class="st-button" on:click={() => confirm(true)}> Expand</button>
+  </ModalFooter>
+</Modal>
+
+<style>
+  .constraints-list {
+    margin-left: 10px;
+  }
+</style>

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -4246,7 +4246,13 @@ const effects = {
     }
   },
 
-  async expandTemplates(seqIds: string[], simulationDatasetId: number, plan: Plan, user: User | null): Promise<void> {
+  async expandTemplates(
+    seqIds: string[],
+    simulationDatasetId: number,
+    plan: Plan,
+    user: User | null,
+    bypassConstraints: boolean = true,
+  ): Promise<void> {
     try {
       if (!plan.model) {
         throw Error(`No model found for plan ${plan.id}, cannot expand templates`);
@@ -4261,6 +4267,7 @@ const effects = {
       const data = await reqHasura<{ success: boolean }>(
         gql.EXPAND_TEMPLATES,
         {
+          bypassConstraints,
           modelId: plan.model.id,
           seqIds,
           simulationDatasetId,

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -4283,6 +4283,8 @@ const effects = {
       }
     } catch (e) {
       catchError('Sequence Templating Failed', e as Error);
+
+      // TODO: show error more cleanly; e.extensions.internal.response.body
       sequenceTemplateExpansionStatus.set(Status.Failed);
       sequenceTemplateExpansionError.set(e as string);
       showFailureToast('Sequence Templating Failed');

--- a/src/utilities/effects.ts
+++ b/src/utilities/effects.ts
@@ -4227,7 +4227,15 @@ const effects = {
       }
 
       const startTime = performance.now();
-      const data = await reqHasura<{ id: number }>(gql.EXPAND, { expansionSetId, simulationDatasetId }, user);
+      const data = await reqHasura<{ id: number }>(
+        gql.EXPAND,
+        {
+          bypassConstraints: false,
+          expansionSetId,
+          simulationDatasetId,
+        },
+        user,
+      );
       if (data.expand != null) {
         planExpansionStatusStore.set(Status.Complete);
         showSuccessToast('Plan Expanded Successfully');

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1155,8 +1155,8 @@ const gql = {
   `,
 
   EXPAND: `#graphql
-    mutation Expand($expansionSetId: Int!, $simulationDatasetId: Int!) {
-      expand: ${Queries.EXPAND_ALL_ACTIVITIES}(expansionSetId: $expansionSetId, simulationDatasetId: $simulationDatasetId) {
+    mutation Expand($expansionSetId: Int!, $simulationDatasetId: Int!, $bypassConstraints: Boolean) {
+      expand: ${Queries.EXPAND_ALL_ACTIVITIES}(expansionSetId: $expansionSetId, simulationDatasetId: $simulationDatasetId, bypassConstraints: $bypassConstraints) {
         id
       }
     }

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1167,7 +1167,7 @@ const gql = {
       $seqIds: [String!]!,
       $modelId: Int!,
       $simulationDatasetId: Int!
-      $bypassConstraints: Bool
+      $bypassConstraints: Boolean
     ) {
       expandTemplates: ${Queries.EXPAND_ALL_TEMPLATES}(
         seqIds: $seqIds,

--- a/src/utilities/gql.ts
+++ b/src/utilities/gql.ts
@@ -1167,11 +1167,13 @@ const gql = {
       $seqIds: [String!]!,
       $modelId: Int!,
       $simulationDatasetId: Int!
+      $bypassConstraints: Bool
     ) {
       expandTemplates: ${Queries.EXPAND_ALL_TEMPLATES}(
         seqIds: $seqIds,
         simulationDatasetId: $simulationDatasetId,
         modelId: $modelId,
+        bypassConstraints: $bypassConstraints
       ) {
         success
       }

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -5,6 +5,7 @@ import ApplySequenceFilterModal from '../components/modals/ApplySequenceFilterMo
 import CancelActionRunModal from '../components/modals/CancelActionRunModal.svelte';
 import ChangePlanBoundsModal from '../components/modals/ChangePlanBoundsModal.svelte';
 import ConfirmActivityCreationModal from '../components/modals/ConfirmActivityCreationModal.svelte';
+import ConfirmExpansionModal from '../components/modals/ConfirmExpansionModal.svelte';
 import ConfirmModal from '../components/modals/ConfirmModal.svelte';
 import CreatePlanBranchModal from '../components/modals/CreatePlanBranchModal.svelte';
 import CreatePlanSnapshotModal from '../components/modals/CreatePlanSnapshotModal.svelte';
@@ -45,6 +46,7 @@ import NewSequenceTemplateModal from '../components/sequence-templates/NewSequen
 import { type ActionDefinition } from '../types/actions';
 import type { ActivityDirectiveDeletionMap, ActivityDirectiveId } from '../types/activity';
 import type { User } from '../types/app';
+import type { ConstraintInvocationMap, ConstraintPlanSpecification, ConstraintResponse } from '../types/constraint';
 import type { ExpansionSequence } from '../types/expansion';
 import type { DerivationGroup, ExternalSourcePkey, ExternalSourceSlim } from '../types/external-source';
 import type { ModalElement, ModalElementValue } from '../types/modal';
@@ -87,6 +89,50 @@ export async function showAboutModal(): Promise<ModalElementValue> {
           target.resolve = null;
           resolve({ confirm: true });
           aboutModal.$destroy(); // destroy the component since it was manually invoked
+        });
+      }
+    } else {
+      resolve({ confirm: false });
+    }
+  });
+}
+
+export async function showConfirmExpansionModal(
+  simulationOutOfDate: boolean,
+  allConstraintsHaveBeenChecked: boolean,
+  allConstraintsThatAreCheckedPass: boolean,
+  constraintPlanSpecsInPlan: ConstraintPlanSpecification[],
+  constraintToConstraintResponseMap: ConstraintInvocationMap<ConstraintResponse>,
+): Promise<ModalElementValue> {
+  return new Promise(resolve => {
+    if (browser) {
+      const target: ModalElement | null = document.querySelector('#svelte-modal');
+
+      if (target) {
+        const confirmModal = new ConfirmExpansionModal({
+          props: {
+            allConstraintsHaveBeenChecked,
+            allConstraintsThatAreCheckedPass,
+            constraintPlanSpecsInPlan,
+            constraintToConstraintResponseMap,
+            simulationOutOfDate,
+          },
+          target,
+        });
+        target.resolve = resolve;
+
+        confirmModal.$on('close', () => {
+          target.replaceChildren();
+          target.resolve = null;
+          resolve({ confirm: false });
+          confirmModal.$destroy();
+        });
+
+        confirmModal.$on('confirm', () => {
+          target.replaceChildren();
+          target.resolve = null;
+          resolve({ confirm: true });
+          confirmModal.$destroy();
         });
       }
     } else {

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -103,6 +103,7 @@ export async function showConfirmExpansionModal(
   allConstraintsThatAreCheckedPass: boolean,
   constraintPlanSpecsInPlan: ConstraintPlanSpecification[],
   constraintToConstraintResponseMap: ConstraintInvocationMap<ConstraintResponse>,
+  simulationDatasetId: number,
 ): Promise<ModalElementValue> {
   return new Promise(resolve => {
     if (browser) {
@@ -115,6 +116,7 @@ export async function showConfirmExpansionModal(
             allConstraintsThatAreCheckedPass,
             constraintPlanSpecsInPlan,
             constraintToConstraintResponseMap,
+            simulationDatasetId,
             simulationOutOfDate,
           },
           target,


### PR DESCRIPTION
Closes #1971

`___REQUIRES_AERIE_PR___="1837"`

This PR introduces a warning modal when a planner attempts to expand a sequence while there are still outstanding constraint violations. This feature was introduced based on a request by LRO mission operators. 

Generally, the idea is to only warn users, but not to block anything. As constraint status is slightly nuanced, the following conditions are considered.
- If simulation is out of date (i.e. the plan has been modified), the planner will be warned that their constraints may be outdated, and that expansion results could be misleading, as expansion will be done on the previous simulation, which may not match the current plan's status.
   - There is an additional modification made to the expansion disabling functionality, stating that if the simulation is out of date, expansion is disabled. This can be undone, but was proposed in `ExpansionPanel.svelte`.
- If constraint evaluation failed (not a violation, but failure to even evaluate), or incomplete, the planner is similarly warned.
- If there are unchecked (or disabled, as PlanDev treats them the same in the UI) constraints, the planner should be warned that the current constraint evaluation may not be exhaustive.
- If there are violated constraints, the planner should be warned that they are about to expand in spite of constraints that are failing. 

Other statuses of constraints, like their being out of date (considered unchecked), partially complete, or anything else are not considered here.

Furthermore, the boolean argument `bypassConstraints` was added to calls to `expandTemplates`, in conjunction with an [update to the backend](https://github.com/NASA-AMMOS/plandev/pull/1837) which would throw errors on expansion if there were a violation and the bypass was not set. The default in the UI (and in the backend) is to not throw errors and bypass, as a warning is sufficient.