### PR TITLE
Save before navigate in workspace

### DIFF
--- a/e2e-tests/fixtures/Workspace.ts
+++ b/e2e-tests/fixtures/Workspace.ts
@@ -156,8 +156,11 @@ export class Workspace {
   }
 
   async fillSequenceContent(content: string): Promise<void> {
-    await this.sequenceEditor.click();
-    await this.sequenceEditor.fill(content);
+    // Target the contenteditable host (.cm-content) rather than a line div (.cm-activeLine):
+    // CodeMirror remounts when navigating between files, and a line div can briefly resolve
+    // before its contenteditable ancestor is ready, making fill() throw "not editable".
+    await this.sequenceEditorContent.click();
+    await this.sequenceEditorContent.fill(content);
   }
 
   private async fillSequenceName(name: string, path?: string): Promise<void> {
@@ -223,7 +226,14 @@ export class Workspace {
     }
     const moreActionsButton = row.getByLabel('More actions');
     await hoverRowAndWaitForButton(this.page, row, moreActionsButton);
-    await moreActionsButton.click();
+    // Open the menu via a DOM click event instead of a synthesized pointer click. The button
+    // sits at the row's right edge under AG Grid's invisible vertical scrollbar overlay and
+    // is only revealed on hover, so a real click is fragile: its actionability scroll summons
+    // the overlay (which intercepts the click) and moves the row off the cursor (hiding the
+    // button, so the click retries forever). The handler positions the menu from the button's
+    // own getBoundingClientRect (event.currentTarget), so dispatching 'click' opens the menu
+    // correctly without depending on pointer coordinates, scroll position, or hover.
+    await moreActionsButton.dispatchEvent('click');
     await this.workspaceFileContextMenu.waitFor({ state: 'visible' });
   }
 

--- a/e2e-tests/fixtures/Workspace.ts
+++ b/e2e-tests/fixtures/Workspace.ts
@@ -6,6 +6,7 @@ import { getWorkspacesUrl } from '../../src/utilities/routes';
 import { generateRandomName, hoverRowAndWaitForButton, setFileInputByBuffer } from '../utilities/helpers';
 
 export class Workspace {
+  actionsTabButton!: Locator;
   editSequenceButton!: Locator;
   fileInput!: Locator;
   folderNameInput!: Locator;
@@ -24,6 +25,7 @@ export class Workspace {
   saveSequenceButton!: Locator;
   searchInput!: Locator;
   sequenceEditor!: Locator;
+  sequenceEditorContent!: Locator;
   sequenceNameInput!: Locator;
   textEditor!: Locator;
   userMetadataEditor!: Locator;
@@ -289,6 +291,7 @@ export class Workspace {
   }
 
   updatePage(page: Page): void {
+    this.actionsTabButton = page.getByRole('button', { exact: true, name: 'Actions' });
     this.editSequenceButton = page.getByRole('button', { name: 'Edit Sequence' });
     // File input is detected as a button in Chrome for Testing (Playwright 1.57+)
     // Use locator chain: find by aria-label within the modal
@@ -309,6 +312,7 @@ export class Workspace {
     this.saveSequenceButton = page.getByRole('button', { name: 'Save' });
     this.searchInput = page.getByPlaceholder('Search files and folders');
     this.sequenceEditor = page.locator('.cm-activeLine').first();
+    this.sequenceEditorContent = page.locator('.cm-content').first();
     this.sequenceNameInput = page.locator('#modal-container').getByRole('textbox', { name: 'File Name' });
     this.textEditor = page.locator('.cm-activeLine').nth(2);
     this.userMetadataEditor = page.locator('.user-metadata-editor .cm-content').first();

--- a/e2e-tests/tests/workspace.test.ts
+++ b/e2e-tests/tests/workspace.test.ts
@@ -47,7 +47,7 @@ async function expectSequenceActive(seq: { sequenceName: string; sequencePath: s
 
 test.beforeAll(async ({ baseURL, browser }) => {
   // Increase global timeout to prevent early test termination
-  test.setTimeout(60000); // 60 seconds
+  test.setTimeout(120000); // 120 seconds
 
   // TODO need to accept downloads in context, used to be await browser.newContext({ acceptDownloads: true });
   setup = await setupTest(browser, { model: false });
@@ -354,10 +354,13 @@ test.describe.serial('Workspace', () => {
     await workspace.searchForFileAndWait(file2);
     await workspace.clickFile(file2, { force: true });
 
-    // Should show confirmation modal
+    // Should show confirmation modal with all three outcomes
     const modal = setup.page.locator('#modal-container');
     await modal.waitFor({ state: 'attached' });
     await expect(modal).toContainText('unsaved changes');
+    await expect(modal.getByRole('button', { name: 'Save and Navigate' })).toBeVisible();
+    await expect(modal.getByRole('button', { name: 'Discard and Navigate' })).toBeVisible();
+    await expect(modal.getByRole('button', { name: 'Keep Editing' })).toBeVisible();
 
     // Cancel navigation
     await setup.page.getByRole('button', { name: 'Keep Editing' }).click();
@@ -371,6 +374,167 @@ test.describe.serial('Workspace', () => {
     await workspace.deleteFile(file1);
     await workspace.searchForFileAndWait(file2);
     await workspace.deleteFile(file2);
+  });
+
+  test('Save and Navigate persists edits and lands on the target file', async () => {
+    const marker = `MARKER_${generateRandomName()}`;
+    const { sequenceName: file1 } = await workspace.createSequence();
+    const { sequenceName: file2, sequencePath: path2 } = await workspace.createSequence();
+
+    // Edit file1 so it has unsaved changes
+    await workspace.searchForFileAndWait(file1);
+    await workspace.clickFile(file1);
+    await workspace.fillSequenceContent(marker);
+    await expect(workspace.saveSequenceButton).toBeEnabled();
+
+    // Navigate to file2 and choose "Save and Navigate"
+    await workspace.searchForFileAndWait(file2);
+    await workspace.clickFile(file2, { force: true });
+    await setup.page.locator('#modal-container').getByRole('button', { name: 'Save and Navigate' }).click();
+    await workspace.waitForToast('Workspace File Saved Successfully');
+
+    // Landed on the target file
+    await expect(setup.page).toHaveURL(
+      getWorkspacesUrl(workspace.baseURL, parseInt(workspace.workspaceId), `${path2}/${file2}`),
+    );
+
+    // Reopening file1 shows the persisted edit
+    await workspace.searchForFileAndWait(file1);
+    await workspace.clickFile(file1);
+    await expect(workspace.sequenceEditorContent).toContainText(marker);
+
+    // Cleanup
+    await workspace.searchForFileAndWait(file1);
+    await workspace.deleteFile(file1);
+    await workspace.searchForFileAndWait(file2);
+    await workspace.deleteFile(file2);
+  });
+
+  test('Discard and Navigate drops edits and lands on the target file', async () => {
+    const marker = `MARKER_${generateRandomName()}`;
+    const { sequenceName: file1 } = await workspace.createSequence();
+    const { sequenceName: file2, sequencePath: path2 } = await workspace.createSequence();
+
+    await workspace.searchForFileAndWait(file1);
+    await workspace.clickFile(file1);
+    await workspace.fillSequenceContent(marker);
+    await expect(workspace.saveSequenceButton).toBeEnabled();
+
+    // Navigate to file2 and choose "Discard and Navigate"
+    await workspace.searchForFileAndWait(file2);
+    await workspace.clickFile(file2, { force: true });
+    await setup.page.locator('#modal-container').getByRole('button', { name: 'Discard and Navigate' }).click();
+
+    await expect(setup.page).toHaveURL(
+      getWorkspacesUrl(workspace.baseURL, parseInt(workspace.workspaceId), `${path2}/${file2}`),
+    );
+
+    // Reopening file1 shows the original (edit was discarded, never saved)
+    await workspace.searchForFileAndWait(file1);
+    await workspace.clickFile(file1);
+    await expect(workspace.sequenceEditorContent).not.toContainText(marker);
+
+    // Cleanup
+    await workspace.searchForFileAndWait(file1);
+    await workspace.deleteFile(file1);
+    await workspace.searchForFileAndWait(file2);
+    await workspace.deleteFile(file2);
+  });
+
+  test('Save and Navigate to the actions view saves the file and keeps it in the URL', async () => {
+    const marker = `MARKER_${generateRandomName()}`;
+    const { sequenceName: file, sequencePath: path } = await workspace.createSequence();
+    const fileUrl = getWorkspacesUrl(workspace.baseURL, parseInt(workspace.workspaceId), `${path}/${file}`);
+
+    await workspace.searchForFileAndWait(file);
+    await workspace.clickFile(file);
+    await workspace.fillSequenceContent(marker);
+    await expect(workspace.saveSequenceButton).toBeEnabled();
+
+    // Switch to the Actions view -> dirty guard -> Save and Navigate
+    await workspace.actionsTabButton.click();
+    await setup.page.locator('#modal-container').getByRole('button', { name: 'Save and Navigate' }).click();
+    await workspace.waitForToast('Workspace File Saved Successfully');
+
+    // Back to the Files tab: the file is still open, saved, and present in the URL
+    await workspace.workspaceFileBrowserButton.click();
+    await expect(setup.page).toHaveURL(fileUrl);
+    await expect(workspace.saveSequenceButton).toBeDisabled();
+    await expect(workspace.sequenceEditorContent).toContainText(marker);
+
+    // Cleanup
+    await workspace.searchForFileAndWait(file);
+    await workspace.deleteFile(file);
+  });
+
+  test('Discard and Navigate to the actions view reverts unsaved edits', async () => {
+    const marker = `MARKER_${generateRandomName()}`;
+    const { sequenceName: file } = await workspace.createSequence();
+
+    await workspace.searchForFileAndWait(file);
+    await workspace.clickFile(file);
+    await workspace.fillSequenceContent(marker);
+    await expect(workspace.saveSequenceButton).toBeEnabled();
+
+    // Switch to the Actions view -> dirty guard -> Discard and Navigate
+    await workspace.actionsTabButton.click();
+    await setup.page.locator('#modal-container').getByRole('button', { name: 'Discard and Navigate' }).click();
+
+    // Back to the Files tab: edits reverted, file is clean
+    await workspace.workspaceFileBrowserButton.click();
+    await expect(workspace.saveSequenceButton).toBeDisabled();
+    await expect(workspace.sequenceEditorContent).not.toContainText(marker);
+
+    // Cleanup
+    await workspace.searchForFileAndWait(file);
+    await workspace.deleteFile(file);
+  });
+
+  test('Saving an unsaved draft via navigation creates the file and keeps it in the URL', async () => {
+    const marker = `MARKER_${generateRandomName()}`;
+    const draftName = `${generateRandomName()}.seq`;
+
+    // Reset to a no-file (draft) state, then make the draft dirty
+    await workspace.goto();
+    await workspace.fillSequenceContent(marker);
+    await expect(workspace.saveSequenceButton).toBeEnabled();
+
+    // Switch to the Actions view -> dirty guard -> Save and Navigate -> name prompt
+    await workspace.actionsTabButton.click();
+    await setup.page.locator('#modal-container').getByRole('button', { name: 'Save and Navigate' }).click();
+    await workspace.sequenceNameInput.fill(draftName);
+    await setup.page.locator('#modal-container').getByRole('button', { name: 'Confirm' }).click();
+    await workspace.waitForToast('Workspace File Created Successfully');
+
+    // Back to the Files tab: the draft is now a real file, selected, and in the URL
+    // (regression: previously it returned as a path-less blank document)
+    await workspace.workspaceFileBrowserButton.click();
+    await expect(setup.page).toHaveURL(getWorkspacesUrl(workspace.baseURL, parseInt(workspace.workspaceId), draftName));
+    await expect(workspace.sequenceEditorContent).toContainText(marker);
+
+    // Cleanup
+    await workspace.searchForFileAndWait(draftName);
+    await workspace.deleteFile(draftName);
+  });
+
+  test('Returning to the Files tab preserves the open file in the URL', async () => {
+    const { sequenceName: file, sequencePath: path } = await workspace.createSequence();
+    const fileUrl = getWorkspacesUrl(workspace.baseURL, parseInt(workspace.workspaceId), `${path}/${file}`);
+
+    await workspace.searchForFileAndWait(file);
+    await workspace.clickFile(file);
+    await expect(setup.page).toHaveURL(fileUrl);
+
+    // Switch to Actions and back to Files (no unsaved changes, so no modal)
+    await workspace.actionsTabButton.click();
+    await workspace.workspaceFileBrowserButton.click();
+
+    // The open file must still be reflected in the URL (regression for the dropped file param)
+    await expect(setup.page).toHaveURL(fileUrl);
+
+    // Cleanup
+    await workspace.searchForFileAndWait(file);
+    await workspace.deleteFile(file);
   });
 
   test('Move file to folder', async () => {

--- a/src/components/modals/UnsavedChangesModal.svelte
+++ b/src/components/modals/UnsavedChangesModal.svelte
@@ -1,0 +1,56 @@
+<svelte:options immutable={true} />
+
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import Modal from './Modal.svelte';
+  import ModalContent from './ModalContent.svelte';
+  import ModalFooter from './ModalFooter.svelte';
+  import ModalHeader from './ModalHeader.svelte';
+
+  export let cancelText: string = 'Keep Editing';
+  export let discardText: string = 'Discard and Navigate';
+  export let height: number | string = 'auto';
+  export let message: string = 'There are unsaved changes.';
+  export let saveText: string = 'Save and Navigate';
+  export let title: string = 'Unsaved Changes';
+  export let width: number = 480;
+
+  const dispatch = createEventDispatcher<{
+    close: void;
+    discard: void;
+    save: void;
+  }>();
+
+  function onKeydown(event: KeyboardEvent) {
+    const { key } = event;
+    if (key === 'Enter') {
+      event.preventDefault();
+      dispatch('save');
+    }
+  }
+</script>
+
+<svelte:window on:keydown={onKeydown} />
+
+<Modal {height} {width} on:close>
+  <ModalHeader on:close>
+    {title}
+  </ModalHeader>
+  <ModalContent>
+    <span>{message}</span>
+  </ModalContent>
+  <ModalFooter>
+    <button class="st-button secondary" on:click={() => dispatch('close')}>
+      {cancelText}
+    </button>
+    <button
+      class="st-button bg-destructive text-destructive-foreground hover:!bg-destructive/90"
+      on:click={() => dispatch('discard')}
+    >
+      {discardText}
+    </button>
+    <button class="st-button" on:click={() => dispatch('save')}>
+      {saveText}
+    </button>
+  </ModalFooter>
+</Modal>

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -382,18 +382,13 @@
     }
     // Cancel navigation first, then show async modal and navigate if confirmed
     cancel();
-    showUnsavedChangesModal(
+    resolveUnsavedChanges(
       'There are unsaved changes. What would you like to do before leaving this page?',
-      'Unsaved Changes',
       'Save and Leave',
       'Discard and Leave',
       'Stay on Page',
-    ).then(async ({ confirm, value }) => {
-      if (!confirm || !to?.url) {
-        return;
-      }
-      if (value?.shouldSave && !(await saveActiveDocument())) {
-        // Save failed or was cancelled — stay on the page so edits aren't lost.
+    ).then(decision => {
+      if (decision === 'stay' || !to?.url) {
         return;
       }
       // Reset content to allow navigation without re-triggering the modal
@@ -420,22 +415,19 @@
     if (!$activeDocumentIsDirty) {
       return true;
     }
-    const { confirm, value } = await showUnsavedChangesModal(
+    const decision = await resolveUnsavedChanges(
       'There are unsaved changes. What would you like to do before navigating away from the current file?',
-      'Unsaved Changes',
       'Save and Navigate',
       'Discard and Navigate',
       'Keep Editing',
     );
-    if (!confirm) {
+    if (decision === 'stay') {
       return false;
     }
-    if (value?.shouldSave) {
-      // Only proceed if the save actually persisted; otherwise stay so edits aren't lost.
-      return await saveActiveDocument();
+    if (decision === 'proceed-discarded') {
+      // Discard: mark clean so navigation proceeds without re-prompting.
+      activeDocument.markClean();
     }
-    // Discard: mark clean so navigation proceeds without re-prompting.
-    activeDocument.markClean();
     return true;
   }
 
@@ -803,6 +795,38 @@
       }
     }
     return false;
+  }
+
+  /**
+   * Prompts the user about unsaved changes and resolves the save/discard decision so callers
+   * don't have to reimplement the modal + save-attempt dance. Returns:
+   * - 'stay': user cancelled, or chose Save but the save failed/was cancelled — do not navigate.
+   * - 'proceed-saved': document was saved (and marked clean); safe to navigate.
+   * - 'proceed-discarded': user chose to discard; caller decides whether to revert content.
+   * Callers own the post-decision action (goto / replaceState / content-mode switch) and any
+   * discard-time content revert, since those differ per call site.
+   */
+  async function resolveUnsavedChanges(
+    message: string,
+    confirmSaveLabel: string,
+    confirmDiscardLabel: string,
+    cancelLabel: string,
+  ): Promise<'stay' | 'proceed-saved' | 'proceed-discarded'> {
+    const { confirm, value } = await showUnsavedChangesModal(
+      message,
+      'Unsaved Changes',
+      confirmSaveLabel,
+      confirmDiscardLabel,
+      cancelLabel,
+    );
+    if (!confirm) {
+      return 'stay';
+    }
+    if (value?.shouldSave) {
+      // Save failed or was cancelled — stay so edits aren't lost.
+      return (await saveActiveDocument()) ? 'proceed-saved' : 'stay';
+    }
+    return 'proceed-discarded';
   }
 
   async function confirmAndNavigate(filePath: string | null) {
@@ -1280,22 +1304,16 @@
   ) {
     // Guard against switching away from dirty file
     if ($workspaceContentMode === WorkspaceContentMode.File && $activeDocumentIsDirty) {
-      const { confirm, value } = await showUnsavedChangesModal(
+      const decision = await resolveUnsavedChanges(
         'There are unsaved changes. What would you like to do before navigating away from the current file?',
-        'Unsaved Changes',
         'Save and Navigate',
         'Discard and Navigate',
         'Keep Editing',
       );
-      if (!confirm) {
+      if (decision === 'stay') {
         return;
       }
-      if (value?.shouldSave) {
-        if (!(await saveActiveDocument())) {
-          // Save failed or was cancelled — stay on the current file so edits aren't lost.
-          return;
-        }
-      } else {
+      if (decision === 'proceed-discarded') {
         // Discard: revert content to last-saved state and mark clean
         activeDocument.updateContent($activeDocument.originalContent);
         activeDocument.markClean();

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -415,12 +415,7 @@
     if (!$activeDocumentIsDirty) {
       return true;
     }
-    const decision = await resolveUnsavedChanges(
-      'There are unsaved changes. What would you like to do before navigating away from the current file?',
-      'Save and Navigate',
-      'Discard and Navigate',
-      'Keep Editing',
-    );
+    const decision = await resolveUnsavedChangesBeforeFileSwitch();
     if (decision === 'stay') {
       return false;
     }
@@ -797,15 +792,7 @@
     return false;
   }
 
-  /**
-   * Prompts the user about unsaved changes and resolves the save/discard decision so callers
-   * don't have to reimplement the modal + save-attempt dance. Returns:
-   * - 'stay': user cancelled, or chose Save but the save failed/was cancelled — do not navigate.
-   * - 'proceed-saved': document was saved (and marked clean); safe to navigate.
-   * - 'proceed-discarded': user chose to discard; caller decides whether to revert content.
-   * Callers own the post-decision action (goto / replaceState / content-mode switch) and any
-   * discard-time content revert, since those differ per call site.
-   */
+  /** Shared core for the unsaved-changes prompt; prefer the context-specific wrappers below. */
   async function resolveUnsavedChanges(
     message: string,
     confirmSaveLabel: string,
@@ -827,6 +814,16 @@
       return (await saveActiveDocument()) ? 'proceed-saved' : 'stay';
     }
     return 'proceed-discarded';
+  }
+
+  /** Unsaved-changes prompt for navigating away from the current file (in-page file/mode switch). */
+  function resolveUnsavedChangesBeforeFileSwitch() {
+    return resolveUnsavedChanges(
+      'There are unsaved changes. What would you like to do before navigating away from the current file?',
+      'Save and Navigate',
+      'Discard and Navigate',
+      'Keep Editing',
+    );
   }
 
   async function confirmAndNavigate(filePath: string | null) {
@@ -1304,12 +1301,7 @@
   ) {
     // Guard against switching away from dirty file
     if ($workspaceContentMode === WorkspaceContentMode.File && $activeDocumentIsDirty) {
-      const decision = await resolveUnsavedChanges(
-        'There are unsaved changes. What would you like to do before navigating away from the current file?',
-        'Save and Navigate',
-        'Discard and Navigate',
-        'Keep Editing',
-      );
+      const decision = await resolveUnsavedChangesBeforeFileSwitch();
       if (decision === 'stay') {
         return;
       }

--- a/src/routes/workspaces/[workspaceId]/+page.svelte
+++ b/src/routes/workspaces/[workspaceId]/+page.svelte
@@ -113,6 +113,7 @@
   import {
     showConfirmModal,
     showRunActionResultsModal,
+    showUnsavedChangesModal,
     showWorkspaceSaveConflictModal,
   } from '../../../utilities/modal';
   import { featurePermissions } from '../../../utilities/permissions';
@@ -381,18 +382,23 @@
     }
     // Cancel navigation first, then show async modal and navigate if confirmed
     cancel();
-    showConfirmModal(
-      'Leave Page',
-      'There are unsaved changes. Are you sure you want to leave this page?',
-      'Leave Page',
-      true,
+    showUnsavedChangesModal(
+      'There are unsaved changes. What would you like to do before leaving this page?',
+      'Unsaved Changes',
+      'Save and Leave',
+      'Discard and Leave',
       'Stay on Page',
-    ).then(({ confirm }) => {
-      if (confirm && to?.url) {
-        // Reset content to allow navigation without re-triggering the modal
-        activeDocument.markClean();
-        goto(to.url);
+    ).then(async ({ confirm, value }) => {
+      if (!confirm || !to?.url) {
+        return;
       }
+      if (value?.shouldSave && !(await saveActiveDocument())) {
+        // Save failed or was cancelled — stay on the page so edits aren't lost.
+        return;
+      }
+      // Reset content to allow navigation without re-triggering the modal
+      activeDocument.markClean();
+      goto(to.url);
     });
   });
 
@@ -407,23 +413,30 @@
     lastKnownUrl = window.location.href;
   }
 
-  // Prompts the user about discarding unsaved file changes. Resolves true if the
-  // user confirmed (and the doc was marked clean); false if they kept editing.
+  // Prompts the user about unsaved file changes before navigating. Offers Save, Discard, or
+  // Keep Editing. Resolves true if navigation should proceed (the doc was saved or discarded
+  // and marked clean); false if the user kept editing or the save failed/was cancelled.
   async function confirmNavigateAway(): Promise<boolean> {
     if (!$activeDocumentIsDirty) {
       return true;
     }
-    const { confirm } = await showConfirmModal(
-      'Navigate Away',
-      'There are unsaved changes. Are you sure you want to navigate away?',
-      'Navigate Away',
-      true,
+    const { confirm, value } = await showUnsavedChangesModal(
+      'There are unsaved changes. What would you like to do before navigating away from the current file?',
+      'Unsaved Changes',
+      'Save and Navigate',
+      'Discard and Navigate',
       'Keep Editing',
     );
-    if (confirm) {
-      activeDocument.markClean();
+    if (!confirm) {
+      return false;
     }
-    return confirm;
+    if (value?.shouldSave) {
+      // Only proceed if the save actually persisted; otherwise stay so edits aren't lost.
+      return await saveActiveDocument();
+    }
+    // Discard: mark clean so navigation proceeds without re-prompting.
+    activeDocument.markClean();
+    return true;
   }
 
   function syncStateFromUrl(url: URL) {
@@ -750,6 +763,46 @@
 
   function resetSequenceAdaptation(): void {
     setSequenceLanguages(undefined);
+  }
+
+  /**
+   * Saves the active document, handling both existing files and brand-new drafts (which
+   * have no path yet and are routed through the new-sequence flow, prompting for a name).
+   * Returns true only if the save actually persisted; marks the document clean on success.
+   */
+  async function saveActiveDocument(): Promise<boolean> {
+    const content = $activeDocument.currentContent;
+    if ($activeDocumentPath) {
+      const path = $activeDocumentPath;
+      const ifMatch = $activeDocument.baseEtag ?? '*';
+      try {
+        const { etag } = await effects.saveWorkspaceFile($workspaceId, path, content, $user, ifMatch);
+        activeDocument.markClean(content, etag);
+        return true;
+      } catch (e) {
+        if (e instanceof WorkspaceSaveConflictError) {
+          // Proceed only if the conflict resolution actually saved.
+          return await resolveSaveConflict(e, path, content);
+        }
+        // Any other failure was already toasted by the effect — just don't proceed.
+        return false;
+      }
+    }
+    if ($workspace && workspaceTree && content) {
+      const newFilePath = await effects.newWorkspaceSequence($workspace, workspaceTree, '', content, $user);
+      if (newFilePath !== null) {
+        const { filename } = separateFilenameFromPath(newFilePath);
+        // Re-associate the buffer with the newly created file. Without this the document
+        // keeps its null path, so returning to the editor shows the content as a path-less
+        // "blank" draft instead of the saved file. (The URL is kept in sync separately by
+        // the caller — updateContentModeUrl on File mode, or confirmAndNavigate's replaceState.)
+        activeDocument.updatePath(newFilePath, filename ?? undefined, WorkspaceContentType.Sequence);
+        activeDocument.markClean(content);
+        refreshWorkspaceContents();
+        return true;
+      }
+    }
+    return false;
   }
 
   async function confirmAndNavigate(filePath: string | null) {
@@ -1227,19 +1280,26 @@
   ) {
     // Guard against switching away from dirty file
     if ($workspaceContentMode === WorkspaceContentMode.File && $activeDocumentIsDirty) {
-      const { confirm } = await showConfirmModal(
-        'Navigate Away',
-        'There are unsaved changes. Are you sure you want to navigate away from the current file?',
-        'Navigate Away',
-        true,
+      const { confirm, value } = await showUnsavedChangesModal(
+        'There are unsaved changes. What would you like to do before navigating away from the current file?',
+        'Unsaved Changes',
+        'Save and Navigate',
+        'Discard and Navigate',
         'Keep Editing',
       );
       if (!confirm) {
         return;
       }
-      // Revert content to last-saved state and mark clean
-      activeDocument.updateContent($activeDocument.originalContent);
-      activeDocument.markClean();
+      if (value?.shouldSave) {
+        if (!(await saveActiveDocument())) {
+          // Save failed or was cancelled — stay on the current file so edits aren't lost.
+          return;
+        }
+      } else {
+        // Discard: revert content to last-saved state and mark clean
+        activeDocument.updateContent($activeDocument.originalContent);
+        activeDocument.markClean();
+      }
     }
 
     $workspaceContentMode = mode;

--- a/src/utilities/modal.ts
+++ b/src/utilities/modal.ts
@@ -39,6 +39,7 @@ import RunActionModal from '../components/modals/RunActionModal.svelte';
 import RunActionResultsModal from '../components/modals/RunActionResultsModal.svelte';
 import SavedViewsModal from '../components/modals/SavedViewsModal.svelte';
 import TransformActivitiesModal from '../components/modals/TransformActivitiesModal.svelte';
+import UnsavedChangesModal from '../components/modals/UnsavedChangesModal.svelte';
 import UpdatePlanMissionModelModal from '../components/modals/UpdatePlanMissionModelModal.svelte';
 import UploadViewModal from '../components/modals/UploadViewModal.svelte';
 import WorkspaceBulkOperationConflictModal from '../components/modals/WorkspaceBulkOperationConflictModal.svelte';
@@ -159,6 +160,56 @@ export async function showConfirmModal(
           target.resolve = null;
           resolve({ confirm: true });
           confirmModal.$destroy();
+        });
+      }
+    } else {
+      resolve({ confirm: false });
+    }
+  });
+}
+
+/**
+ * Shows an UnsavedChangesModal offering three outcomes: save and proceed, discard and
+ * proceed, or stay. Resolves with `confirm` (false = stay) and, when confirming, a
+ * `shouldSave` flag distinguishing the save button from the discard button.
+ */
+export async function showUnsavedChangesModal(
+  message: string,
+  title: string,
+  saveText: string,
+  discardText: string,
+  cancelText: string,
+): Promise<ModalElementValue<{ shouldSave: boolean }>> {
+  return new Promise(resolve => {
+    if (browser) {
+      const target: ModalElement | null = document.querySelector('#svelte-modal');
+
+      if (target) {
+        const unsavedChangesModal = new UnsavedChangesModal({
+          props: { cancelText, discardText, message, saveText, title },
+          target,
+        });
+        target.resolve = resolve;
+
+        unsavedChangesModal.$on('close', () => {
+          target.replaceChildren();
+          target.resolve = null;
+          resolve({ confirm: false });
+          unsavedChangesModal.$destroy();
+        });
+
+        unsavedChangesModal.$on('discard', () => {
+          target.replaceChildren();
+          target.resolve = null;
+          resolve({ confirm: true, value: { shouldSave: false } });
+          unsavedChangesModal.$destroy();
+        });
+
+        unsavedChangesModal.$on('save', () => {
+          target.replaceChildren();
+          target.resolve = null;
+          resolve({ confirm: true, value: { shouldSave: true } });
+          unsavedChangesModal.$destroy();
         });
       }
     } else {


### PR DESCRIPTION
## Summary
Adds a **Save and Navigate** option to the workspace "unsaved changes" prompt. Previously, leaving a file with unsaved edits meant either discarding them or staying put. Now you can save and continue in one step. Also fixes a couple of related bugs found along the way. Closes https://github.com/NASA-AMMOS/plandev-ui/issues/1959

## Details
- The unsaved-changes prompt now offers three choices everywhere it appears: switching files, leaving the page, and opening the Actions view: **Save and Leave**, **Discard and Leave**, or **Keep Editing** (Save is the default).
- If a save fails, navigation is cancelled and your edits are kept.
- Saving a brand-new (never-named) file through this prompt opens the save file modal first.
- Fixed a pre-existing bug where switching to the Actions view and back dropped the open file from the URL (broke refresh / deep links).
- The "don't proceed if the save failed" guard now also covers move / rename / download / run-action on a file with unsaved changes.

## Visible UX Changes
- New **Save and Navigate** / **Save and Leave** button in the unsaved-changes dialog.
- Clearer wording: the dialog is now titled **Unsaved Changes**, and the discard button reads **Discard and Navigate** (was "Navigate Away") and is styled as a destructive action so it's obvious it drops your edits.
- Returning to the Files tab keeps the current file in the URL.

## Verification
- Added e2e tests to `e2e-tests/tests/workspace.test.ts`

**Manual steps** (open a workspace with a couple of sequence files):
1. **Save and Navigate** — Open file A, make an edit, click file B → **Save and Navigate**. You land on file B; reopen file A and confirm the edit was saved.
2. **Discard and Navigate** — Edit file A, click file B → **Discard and Navigate**. You land on file B; reopen file A and confirm the edit is gone.
3. **Keep Editing** — Edit file A, click file B → **Keep Editing**. You stay on file A with the edit intact.
4. **Save into the Actions view** — Edit a file, click the **Actions** tab → **Save and Navigate**, then click back to **Files**. The file is saved, still open, and present in the URL.
5. **Save a brand-new draft** — With no file open, type in the editor, click the **Actions** tab → **Save and Navigate** → enter a name → Confirm. Back on **Files**, the new file is open with your content and in the URL (not a blank editor). Refresh to confirm the URL reopens it.
6. **Leave the page** — Edit a file, then navigate to another section (e.g. Plans). Confirm **Save and Leave**, **Discard and Leave**, and **Stay on Page** each behave as labeled.
7. **URL preservation** — Open a file, click the **Actions** tab, then the **Files** tab. The file is still in the URL; refreshing reopens the same file.
8. **Failed save aborts navigation** (optional) — In devtools, set the network offline, then choose **Save and Navigate**. A failure toast appears, navigation is cancelled, and your edits remain.
9. **Save before move/rename** — Edit a file, then move or rename it and confirm "Save and …". With the network offline, the operation aborts and your edits are kept.
