### PR TITLE
Fix: Datepicker default time view

### DIFF
--- a/src/components/TimelineItemList.svelte
+++ b/src/components/TimelineItemList.svelte
@@ -160,7 +160,7 @@
     <input
       bind:value={filterText}
       on:keydown={onInputKeydown}
-      class="st-input"
+      class="st-input min-w-20"
       name="search"
       autocomplete="off"
       placeholder="Filter {typeName} types"

--- a/src/components/ui/DatePicker/DatePicker.svelte
+++ b/src/components/ui/DatePicker/DatePicker.svelte
@@ -130,7 +130,20 @@
     updateView(currentMonthDate);
   }
 
-  onMount(() => (isMounted = true));
+  onMount(() => {
+    isMounted = true;
+
+    const currentDateTimestamp = currentDate.getTime();
+    const minDateTimestamp = minDate.getTime();
+    const maxDateTimestamp = maxDate.getTime();
+
+    // Default the view to be within the specified min and max dates if the current date lies outside the range
+    if (currentDateTimestamp < minDateTimestamp || currentDateTimestamp > maxDateTimestamp) {
+      const middleTimestamp = (minDateTimestamp + maxDateTimestamp) / 2;
+      const middleDate = new Date(middleTimestamp);
+      updateView(middleDate);
+    }
+  });
 
   onDestroy(closeDatePicker);
 
@@ -255,8 +268,7 @@
   function setToday() {
     setDateString(getDoyTime(currentDate));
 
-    viewMonth = currentDate.getUTCMonth();
-    viewYear = currentYear;
+    updateView(currentDate);
   }
 </script>
 

--- a/src/components/ui/DatePicker/DatePicker.svelte.test.ts
+++ b/src/components/ui/DatePicker/DatePicker.svelte.test.ts
@@ -137,4 +137,27 @@ describe('DatePicker DatePicker Component', () => {
 
     expect(getByRole('textbox').ariaInvalid).toBe('true');
   });
+
+  it('Should default the view to the middle of min/max range when current date is outside the range', async () => {
+    // Set min and max dates that don't include the current date (Feb 1, 2020)
+    const minDate = new Date(Date.UTC(2025, 0, 1)); // Jan 1, 2025
+    const maxDate = new Date(Date.UTC(2030, 11, 31)); // Dec 31, 2030
+
+    // Calculate the middle date: (minTimestamp + maxTimestamp) / 2
+    const middleTimestamp = (minDate.getTime() + maxDate.getTime()) / 2;
+    const middleDate = new Date(middleTimestamp);
+    const expectedYear = middleDate.getUTCFullYear(); // Should be 2028
+    const expectedMonth = middleDate.toLocaleString('en-US', { month: 'long', timeZone: 'UTC' }); // Should be July
+
+    const { getByRole, getByText } = render(DatePicker, {
+      maxDate,
+      minDate,
+    });
+
+    await fireEvent.click(getByRole('textbox'));
+
+    // The view should default to the exact middle of the range
+    expect(getByText(expectedMonth, { selector: 'span' })).toBeTruthy();
+    expect(getByText(expectedYear.toString(), { selector: 'span' })).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
Center the default view of datepicker calendar if today's date is outside of the min/max time range.

## Details
When the datepicker's current date falls outside the specified min/max date range, the component would display a view that the user cannot interact with or select dates from, creating a confusing UX. The user would have to try to navigate to a month/year that was within bounds.

This change ensures that only selectable dates are presented to the user when the datepicker is first opened.

## To test
1. Open a plan with time bounds that don't include today's date
2. Open the activity directive builder
3. Open the "Start Time" datepicker
4. Verify that the calendar view should now present selectable dates within the calendar.

## Verification
Added unit test to src/components/ui/DatePicker/DatePicker.svelte.test.ts