### PR TITLE
Manual GH workflow for analyzing flaky/failing/timed-out tests

### DIFF
--- a/.github/workflows/identify-flaky-tests.yml
+++ b/.github/workflows/identify-flaky-tests.yml
@@ -1,0 +1,12 @@
+name: Identify Flaky Tests
+
+on:
+  # todo remove pull_request after testing
+  pull_request:
+    branches:
+      - develop
+  workflow_dispatch:
+
+run: node .github/workflows/scripts/identify-flaky-tests.mjs
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/identify-flaky-tests.yml
+++ b/.github/workflows/identify-flaky-tests.yml
@@ -55,7 +55,7 @@ jobs:
           cache: npm
 
       - name: Install Dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Identify Flaky Tests
         run: node .github/workflows/scripts/identify-flaky-tests.mjs

--- a/.github/workflows/identify-flaky-tests.yml
+++ b/.github/workflows/identify-flaky-tests.yml
@@ -1,12 +1,77 @@
 name: Identify Flaky Tests
 
 on:
-  # todo remove pull_request after testing
-  pull_request:
-    branches:
-      - develop
   workflow_dispatch:
+    inputs:
+      workflows:
+        description: 'Comma-separated workflow files to analyze'
+        required: true
+        default: 'test.yml,canary.yml'
+      branch:
+        description: 'Branch to analyze'
+        required: true
+        default: 'develop'
+      max-runs:
+        description: 'Maximum completed runs to analyze per workflow'
+        required: true
+        default: '50'
+      artifact-name:
+        description: 'E2E results artifact name'
+        required: true
+        default: 'E2E Test Results'
+      output-limit:
+        description: 'Maximum leaderboard rows to show'
+        required: true
+        default: '25'
 
-run: node .github/workflows/scripts/identify-flaky-tests.mjs
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # temporary while developing; remove later if we only want manual runs
+  pull_request:
+    paths:
+      - '.github/workflows/identify-flaky-tests.yml'
+      - '.github/workflows/scripts/identify-flaky-tests.mjs'
+      - 'package.json'
+      - 'package-lock.json'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  identify-flaky-tests:
+    name: Identify Flaky Tests
+    runs-on: ubuntu-latest
+
+    # don't run on forks
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22.22.0'
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Identify Flaky Tests
+        run: node .github/workflows/scripts/identify-flaky-tests.mjs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          INPUT_WORKFLOWS: ${{ inputs.workflows || 'test.yml,canary.yml' }}
+          INPUT_BRANCH: ${{ inputs.branch || 'develop' }}
+          INPUT_MAX_RUNS: ${{ inputs.max-runs || '50' }}
+          INPUT_ARTIFACT_NAME: ${{ inputs.artifact-name || 'E2E Test Results' }}
+          INPUT_OUTPUT_LIMIT: ${{ inputs.output-limit || '25' }}
+
+      - name: Upload Flaky Test Report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: Flaky Test Report
+          path: |
+            tmp/flaky-test-report
+          if-no-files-found: warn

--- a/.github/workflows/identify-flaky-tests.yml
+++ b/.github/workflows/identify-flaky-tests.yml
@@ -14,7 +14,7 @@ on:
       max-runs:
         description: 'Maximum completed runs to analyze per workflow'
         required: true
-        default: '50'
+        default: '35'
       artifact-name:
         description: 'E2E results artifact name'
         required: true

--- a/.github/workflows/identify-flaky-tests.yml
+++ b/.github/workflows/identify-flaky-tests.yml
@@ -24,13 +24,10 @@ on:
         required: true
         default: '25'
 
-  # temporary while developing; remove later if we only want manual runs
   pull_request:
     paths:
       - '.github/workflows/identify-flaky-tests.yml'
       - '.github/workflows/scripts/identify-flaky-tests.mjs'
-      - 'package.json'
-      - 'package-lock.json'
 
 permissions:
   contents: read

--- a/.github/workflows/identify-flaky-tests.yml
+++ b/.github/workflows/identify-flaky-tests.yml
@@ -63,7 +63,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           INPUT_WORKFLOWS: ${{ inputs.workflows || 'test.yml,canary.yml' }}
           INPUT_BRANCH: ${{ inputs.branch || 'develop' }}
-          INPUT_MAX_RUNS: ${{ inputs.max-runs || '50' }}
+          INPUT_MAX_RUNS: ${{ inputs.max-runs || '35' }}
           INPUT_ARTIFACT_NAME: ${{ inputs.artifact-name || 'E2E Test Results' }}
           INPUT_OUTPUT_LIMIT: ${{ inputs.output-limit || '25' }}
 

--- a/.github/workflows/scripts/identify-flaky-tests.mjs
+++ b/.github/workflows/scripts/identify-flaky-tests.mjs
@@ -1,0 +1,86 @@
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+
+function getArg(name) {
+  const prefix = `--${name}=`;
+  const inline = process.argv.find(arg => arg.startsWith(prefix));
+  if (inline) return inline.slice(prefix.length);
+
+  const index = process.argv.indexOf(`--${name}`);
+  if (index !== -1) return process.argv[index + 1];
+
+  return '';
+}
+
+function getConfigValue(name, fallback = '') {
+  return getArg(name) || core.getInput(name) || fallback;
+}
+
+function getConfig() {
+  const repoInput = getConfigValue('repo');
+  const [owner, repo] = repoInput ? repoInput.split('/') : [github.context.repo.owner, github.context.repo.repo];
+
+  return {
+    owner,
+    repo,
+    workflows: getConfigValue('workflows', 'test.yml,canary.yml')
+      .split(',')
+      .map(workflow => workflow.trim())
+      .filter(Boolean),
+    branch: getConfigValue('branch', 'develop'),
+    artifactName: getConfigValue('artifact-name', 'E2E Test Results'),
+    maxRuns: Number(getConfigValue('max-runs', '10')),
+    outputLimit: Number(getConfigValue('output-limit', '25')),
+    token: process.env.GITHUB_TOKEN || '',
+  };
+}
+
+async function listRunsForWorkflow(octokit, config, workflow) {
+  const response = await octokit.rest.actions.listWorkflowRuns({
+    owner: config.owner,
+    repo: config.repo,
+    workflow_id: workflow,
+    branch: config.branch,
+    status: 'completed',
+    per_page: Math.min(config.maxRuns, 100),
+  });
+
+  return response.data.workflow_runs;
+}
+
+async function listArtifactsForRun(octokit, config, runId) {
+  const response = await octokit.rest.actions.listWorkflowRunArtifacts({
+    owner: config.owner,
+    repo: config.repo,
+    run_id: runId,
+    per_page: 100,
+  });
+
+  return response.data.artifacts;
+}
+
+try {
+  const config = getConfig();
+
+  console.log('identify flaky tests config:');
+  console.log(JSON.stringify({ ...config, token: config.token ? '<set>' : '<missing>' }, null, 2));
+
+  const octokit = github.getOctokit(config.token);
+
+  for (const workflow of config.workflows) {
+    const runs = await listRunsForWorkflow(octokit, config, workflow);
+
+    console.log(`\n${workflow}: found ${runs.length} completed runs`);
+    for (const run of runs.slice(0, 5)) {
+      console.log(`- ${run.id} ${run.conclusion} ${run.created_at} ${run.html_url}`);
+
+      const artifacts = await listArtifactsForRun(octokit, config, run.id);
+      const matchingArtifacts = artifacts.filter(artifact => artifact.name === config.artifactName);
+
+      console.log(`  artifacts: ${artifacts.map(artifact => artifact.name).join(', ') || '<none>'}`);
+      console.log(`  matching "${config.artifactName}": ${matchingArtifacts.length}`);
+    }
+  }
+} catch (error) {
+  core.setFailed(error instanceof Error ? error.message : String(error));
+}

--- a/.github/workflows/scripts/identify-flaky-tests.mjs
+++ b/.github/workflows/scripts/identify-flaky-tests.mjs
@@ -346,10 +346,10 @@ function renderMarkdownReport(leaderboard, config, stats) {
     '',
   ];
 
-  if (stats.runsWithoutMatchingArtifact || stats.runsWithoutJsonResults) {
+  if (stats.runsWithoutMatchingArtifact || stats.runsWithoutJsonResults || stats.runsWithArtifactDownloadErrors) {
     lines.push(
       '',
-      `**Skipped ${stats.runsWithoutMatchingArtifact} runs without a matching artifact and ${stats.runsWithoutJsonResults} runs without \`json-results.json\`.**`,
+      `**Skipped ${stats.runsWithoutMatchingArtifact} runs without a matching artifact, ${stats.runsWithoutJsonResults} runs without \`json-results.json\`, and ${stats.runsWithArtifactDownloadErrors} runs with artifact download errors.**`,
     );
   }
 
@@ -443,6 +443,7 @@ try {
   let runsAnalyzed = 0;
   let runsWithoutMatchingArtifact = 0;
   let runsWithoutJsonResults = 0;
+  let runsWithArtifactDownloadErrors = 0;
 
   for (const workflow of config.workflows) {
     const runs = await listRunsForWorkflow(octokit, config, workflow);
@@ -460,9 +461,19 @@ try {
         continue;
       }
 
-      const zipData = await getArtifactZipData(octokit, config, run, matchingArtifacts[0]);
+      let zipData;
+      try {
+        zipData = await getArtifactZipData(octokit, config, run, matchingArtifacts[0]);
+      } catch (error) {
+        console.warn(
+          `Unable to download artifact for run ${run.id}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        runsWithArtifactDownloadErrors += 1;
+        continue;
+      }
       const jsonResults = await readJsonResultsFromArtifactZip(zipData);
-
 
       if (jsonResults) {
         console.log(
@@ -500,6 +511,7 @@ try {
     runsAnalyzed,
     runsWithoutMatchingArtifact,
     runsWithoutJsonResults,
+    runsWithArtifactDownloadErrors,
     problemTestRuns: allProblemTests.length,
     uniqueProblemTests: leaderboard.length,
   };

--- a/.github/workflows/scripts/identify-flaky-tests.mjs
+++ b/.github/workflows/scripts/identify-flaky-tests.mjs
@@ -1,5 +1,15 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import jszip from 'jszip';
 import * as core from '@actions/core';
 import * as github from '@actions/github';
+
+// GITHUB_TOKEN=whatever node .github/workflows/scripts/identify-flaky-tests.mjs \
+//   --repo NASA-AMMOS/plandev-ui \
+//   --workflows test,canary \
+//   --branch develop \
+//   --max-runs 25
+
 
 function getArg(name) {
   const prefix = `--${name}=`;
@@ -13,12 +23,17 @@ function getArg(name) {
 }
 
 function getConfigValue(name, fallback = '') {
-  return getArg(name) || core.getInput(name) || fallback;
+  // get config values as args or env variables
+  const normalizedInputEnvName = `INPUT_${name.replaceAll('-', '_').replaceAll(' ', '_').toUpperCase()}`;
+  return getArg(name) || process.env[normalizedInputEnvName] || core.getInput(name) || fallback;
 }
 
 function getConfig() {
   const repoInput = getConfigValue('repo');
   const [owner, repo] = repoInput ? repoInput.split('/') : [github.context.repo.owner, github.context.repo.repo];
+
+  const isGithubActions = process.env.github_actions === 'true' || process.env.GITHUB_ACTIONS === 'true';
+  const cacheDirInput = getConfigValue('cache-dir');
 
   return {
     owner,
@@ -32,9 +47,15 @@ function getConfig() {
     maxRuns: Number(getConfigValue('max-runs', '10')),
     outputLimit: Number(getConfigValue('output-limit', '25')),
     token: process.env.GITHUB_TOKEN || '',
+    cacheDir: cacheDirInput || (isGithubActions ? '' : 'tmp/flaky-test-artifacts'),
+    outputDir: getConfigValue('output-dir', 'tmp/flaky-test-report'),
   };
 }
 
+/**
+ * list recent completed runs for one GH workflow on the configured branch.
+ * accepts a workflow id or workflow filename, e.g. "test.yml".
+ */
 async function listRunsForWorkflow(octokit, config, workflow) {
   const response = await octokit.rest.actions.listWorkflowRuns({
     owner: config.owner,
@@ -48,6 +69,9 @@ async function listRunsForWorkflow(octokit, config, workflow) {
   return response.data.workflow_runs;
 }
 
+/**
+ * list artifacts uploaded by a single github actions workflow run
+ */
 async function listArtifactsForRun(octokit, config, runId) {
   const response = await octokit.rest.actions.listWorkflowRunArtifacts({
     owner: config.owner,
@@ -59,27 +83,439 @@ async function listArtifactsForRun(octokit, config, runId) {
   return response.data.artifacts;
 }
 
+/**
+ * return a (workflow run) artifact zip from the local cache when available.
+ * otherwise download it from github and optionally cache it.
+ */
+async function getArtifactZipData(octokit, config, run, artifact) {
+  const cachePath = config.cacheDir ? path.join(config.cacheDir, String(run.id), `${artifact.id}.zip`) : '';
+
+  if (cachePath) {
+    try {
+      const cached = await fs.readFile(cachePath);
+      console.log(`  cache hit: ${cachePath}`);
+      return cached;
+    } catch {
+      // cache miss, download below
+    }
+  }
+
+  console.log(`  downloading artifact: ${artifact.name} (${artifact.id})`);
+
+  const response = await octokit.rest.actions.downloadArtifact({
+    owner: config.owner,
+    repo: config.repo,
+    artifact_id: artifact.id,
+    archive_format: 'zip',
+  });
+
+  const zipData = Buffer.from(response.data);
+
+  if (cachePath) {
+    await fs.mkdir(path.dirname(cachePath), { recursive: true });
+    await fs.writeFile(cachePath, zipData);
+    console.log(`  cached: ${cachePath}`);
+  }
+
+  return zipData;
+}
+
+/**
+ * extract and parse playwright's json-results.json from an e2e test run artifact zip.
+ * return null when the artifact does not contain that file.
+ */
+async function readJsonResultsFromArtifactZip(zipData) {
+  const zip = await jszip.loadAsync(zipData);
+  const file = zip.file(/(^|\/)json-results\.json$/)[0];
+
+  if (!file) return null;
+
+  return JSON.parse(await file.async('string'));
+}
+
+
+/**
+ * collect flaky and unexpectedly failing tests from playwright json results.
+ * include run metadata so examples can link back to github actions.
+ */
+function collectProblemTests(jsonResults, run, workflow) {
+  const problemTests = [];
+
+  function collectFromSuite(suite, parentTitles = []) {
+    const suiteTitles = suite.title ? [...parentTitles, suite.title] : parentTitles;
+
+    for (const spec of suite.specs ?? []) {
+      for (const test of spec.tests ?? []) {
+        if (test.status !== 'flaky' && test.status !== 'unexpected') {
+          continue;
+        }
+
+        const resultStatuses = (test.results ?? []).map(result => result.status);
+        const durationMs = (test.results ?? []).reduce((total, result) => total + (result.duration ?? 0), 0);
+
+        problemTests.push({
+          workflow,
+          runId: run.id,
+          runUrl: run.html_url,
+          runConclusion: run.conclusion,
+          runCreatedAt: run.created_at,
+          project: test.projectName,
+          file: suite.file,
+          title: [...suiteTitles, spec.title, test.title].filter(Boolean).join(' › '),
+          status: test.status,
+          resultStatuses,
+          durationMs,
+        });
+      }
+    }
+
+    for (const childSuite of suite.suites ?? []) {
+      collectFromSuite(childSuite, suiteTitles);
+    }
+  }
+
+  for (const suite of jsonResults.suites ?? []) {
+    collectFromSuite(suite);
+  }
+  return problemTests;
+}
+
+const PROBLEM_ATTEMPT_STATUSES = new Set(['failed', 'timedOut', 'interrupted']);
+
+/**
+ * count failed/timed-out/interrupted playwright attempts.
+ * ignore passed and skipped attempts.
+ */
+function countProblemAttempts(resultStatuses) {
+  return resultStatuses.filter(status => PROBLEM_ATTEMPT_STATUSES.has(status)).length;
+}
+
+/**
+ * build leaderboard rows from collected flaky/unexpected test results.
+ * group rows by project, file, and full test title.
+ */
+function buildLeaderboard(problemTests) {
+  const rowsByKey = new Map();
+
+  for (const test of problemTests) {
+    const key = [test.project, test.file, test.title].join('\0');
+
+    if (!rowsByKey.has(key)) {
+      rowsByKey.set(key, {
+        key,
+        project: test.project,
+        file: test.file,
+        title: test.title,
+        workflows: new Set(),
+        runIds: new Set(),
+        problemTestRuns: 0,
+        unexpectedRuns: 0,
+        flakyRuns: 0,
+        failedAttempts: 0,
+        timedOutAttempts: 0,
+        interruptedAttempts: 0,
+        totalProblemAttempts: 0,
+        totalDurationMs: 0,
+        lastSeenAt: '',
+        exampleRunUrl: '',
+        problemRuns: [],
+      });
+    }
+
+    const row = rowsByKey.get(key);
+
+    row.problemRuns.push({
+      workflow: test.workflow,
+      runId: test.runId,
+      runUrl: test.runUrl,
+      runConclusion: test.runConclusion,
+      runCreatedAt: test.runCreatedAt,
+      status: test.status,
+      resultStatuses: test.resultStatuses,
+    });
+
+    row.workflows.add(test.workflow);
+    row.runIds.add(test.runId);
+    row.problemTestRuns += 1;
+    row.totalDurationMs += test.durationMs ?? 0;
+
+    if (test.status === 'unexpected') {
+      row.unexpectedRuns += 1;
+    }
+
+    if (test.status === 'flaky') {
+      row.flakyRuns += 1;
+    }
+
+    for (const status of test.resultStatuses) {
+      if (status === 'failed') {
+        row.failedAttempts += 1;
+      } else if (status === 'timedOut') {
+        row.timedOutAttempts += 1;
+      } else if (status === 'interrupted') {
+        row.interruptedAttempts += 1;
+      }
+    }
+
+    row.totalProblemAttempts += countProblemAttempts(test.resultStatuses);
+
+    if (!row.lastSeenAt || test.runCreatedAt > row.lastSeenAt) {
+      row.lastSeenAt = test.runCreatedAt;
+      row.exampleRunUrl = test.runUrl;
+    }
+  }
+
+  return [...rowsByKey.values()]
+    .map(row => ({
+      ...row,
+      workflows: [...row.workflows].sort(),
+      runsSeen: row.runIds.size,
+      runIds: [...row.runIds],
+      score: row.totalProblemAttempts,
+      problemRuns: row.problemRuns.sort((a, b) => b.runCreatedAt.localeCompare(a.runCreatedAt)),
+    }))
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        b.unexpectedRuns - a.unexpectedRuns ||
+        b.timedOutAttempts - a.timedOutAttempts ||
+        b.lastSeenAt.localeCompare(a.lastSeenAt),
+    );
+}
+
+/**
+ * escape markdown table cell content to keep cells readable
+ */
+function escapeMarkdown(value) {
+  return String(value ?? '')
+    .replaceAll('\\', '\\\\')
+    .replaceAll('|', '\\|')
+    .replaceAll('\n', '<br>');
+}
+
+/**
+ * remove the repeated file prefix from a playwright title path.
+ * keep the human-readable describe/test portion for leaderboard display.
+ */
+function getDisplayTitle(row) {
+  const prefix = `${row.file} › `;
+  return row.title.startsWith(prefix) ? row.title.slice(prefix.length) : row.title;
+}
+
+/**
+ * Format an ISO timestamp for compact report display.
+ */
+function formatDate(value) {
+  if (!value) { return ''; }
+  return new Date(value).toISOString().slice(0, 10);
+}
+
+/**
+ * Render expandable links to every problematic workflow run for one test.
+ * Keep the content inline so it renders safely inside a markdown table cell.
+ */
+function renderProblemRunsCell(row) {
+  const links = row.problemRuns.map(run => {
+    const badAttemptCount = countProblemAttempts(run.resultStatuses);
+    return `<a href="${run.runUrl}">${run.runId}&nbsp;(${badAttemptCount})</a>`;
+  });
+
+  return [
+    '<details>',
+    `<summary>${row.problemRuns.length} run${row.problemRuns.length === 1 ? '' : 's'}</summary>`,
+    links.join('<br>'),
+    '</details>',
+  ].join('');
+}
+
+/**
+ * Render the E2E reliability leaderboard as a GitHub-flavored markdown report.
+ * Explain the scoring model and include links to example workflow runs.
+ */
+function renderMarkdownReport(leaderboard, config, stats) {
+  const topRows = leaderboard.slice(0, config.outputLimit);
+
+  const lines = [
+    '# E2E Test Reliability Leaderboard',
+    '',
+    `Analyzed ${stats.runsAnalyzed} workflow runs from ${config.workflows.map(workflow => `\`${workflow}\``).join(', ')} on branch \`${config.branch}\`.`,
+    '',
+    'This report ranks flaky or unexpectedly failing Playwright tests by total failed, timed-out, or interrupted retry attempts.',
+    '',
+    `Found ${stats.problemTestRuns} flaky/failing test results across ${stats.uniqueProblemTests} unique tests.`,
+    '',
+  ];
+
+  if (stats.runsWithoutMatchingArtifact || stats.runsWithoutJsonResults) {
+    lines.push(
+      '',
+      `**Skipped ${stats.runsWithoutMatchingArtifact} runs without a matching artifact and ${stats.runsWithoutJsonResults} runs without \`json-results.json\`.**`,
+    );
+  }
+
+  if (topRows.length === 0) {
+    lines.push('No flaky or unexpectedly failing E2E tests were found.');
+    return lines.join('\n');
+  }
+
+  lines.push(
+    '| Rank | Score | Test | Runs | Problem Runs | Unexpected Runs | Flaky Runs | Timeout Attempts | Failed Attempts | Last Seen |',
+    '|---:|---:|---|---|---:|---:|---:|---:|---:|---|',
+  );
+
+  for (const [index, row] of topRows.entries()) {
+    const testCell = [
+      `\`${escapeMarkdown(row.file)}\``,
+      escapeMarkdown(getDisplayTitle(row)),
+    ].join('<br>');
+
+    const lastSeenCell = row.exampleRunUrl
+      ? `[${escapeMarkdown(formatDate(row.lastSeenAt))}](${row.exampleRunUrl})`
+      : escapeMarkdown(formatDate(row.lastSeenAt));
+
+    lines.push(
+      [
+        index + 1,
+        row.score,
+        testCell,
+        renderProblemRunsCell(row),
+        row.problemTestRuns,
+        row.unexpectedRuns,
+        row.flakyRuns,
+        row.timedOutAttempts,
+        row.failedAttempts,
+        lastSeenCell,
+      ]
+        .join(' | ')
+        .replace(/^/, '| ')
+        .replace(/$/, ' |'),
+    );
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * write markdown and json report files for github artifact upload.
+ * create the output directory when it does not already exist.
+ */
+async function writeReportFiles(config, markdownReport, leaderboard, stats) {
+  await fs.mkdir(config.outputDir, { recursive: true });
+
+  await fs.writeFile(
+    path.join(config.outputDir, 'flaky-test-leaderboard.md'),
+    markdownReport,
+  );
+
+  await fs.writeFile(
+    path.join(config.outputDir, 'flaky-test-leaderboard.json'),
+    JSON.stringify(
+      {
+        generatedAt: new Date().toISOString(),
+        config: {
+          owner: config.owner,
+          repo: config.repo,
+          workflows: config.workflows,
+          branch: config.branch,
+          maxRuns: config.maxRuns,
+          artifactName: config.artifactName,
+          outputLimit: config.outputLimit,
+        },
+        stats,
+        leaderboard,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
 try {
   const config = getConfig();
-
-  console.log('identify flaky tests config:');
+  console.log('running with config:');
   console.log(JSON.stringify({ ...config, token: config.token ? '<set>' : '<missing>' }, null, 2));
 
+  if (!config.token) { throw new Error('GITHUB_TOKEN is required.'); }
   const octokit = github.getOctokit(config.token);
+
+  // collection of all problematic test runs from past N workflow runs
+  const allProblemTests = [];
+  let runsAnalyzed = 0;
+  let runsWithoutMatchingArtifact = 0;
+  let runsWithoutJsonResults = 0;
 
   for (const workflow of config.workflows) {
     const runs = await listRunsForWorkflow(octokit, config, workflow);
-
     console.log(`\n${workflow}: found ${runs.length} completed runs`);
-    for (const run of runs.slice(0, 5)) {
+
+    for (const run of runs) {
       console.log(`- ${run.id} ${run.conclusion} ${run.created_at} ${run.html_url}`);
 
       const artifacts = await listArtifactsForRun(octokit, config, run.id);
       const matchingArtifacts = artifacts.filter(artifact => artifact.name === config.artifactName);
 
-      console.log(`  artifacts: ${artifacts.map(artifact => artifact.name).join(', ') || '<none>'}`);
-      console.log(`  matching "${config.artifactName}": ${matchingArtifacts.length}`);
+      if (matchingArtifacts.length === 0) {
+        console.warn(`No e2e test artifacts found for run ${run.id}`);
+        runsWithoutMatchingArtifact += 1;
+        continue;
+      }
+
+      const zipData = await getArtifactZipData(octokit, config, run, matchingArtifacts[0]);
+      const jsonResults = await readJsonResultsFromArtifactZip(zipData);
+
+
+      if (jsonResults) {
+        console.log(
+          `  results: ${jsonResults.stats?.unexpected ?? 0} unexpected, ${jsonResults.stats?.flaky ?? 0} flaky, ${jsonResults.stats?.expected ?? 0} expected`,
+        );
+        const problemTests = collectProblemTests(jsonResults, run, workflow);
+        console.log(`  problem tests: ${problemTests.length}`);
+
+        for (const test of problemTests) {
+          console.log(
+            `  - ${test.status} ${test.project} ${test.file} ${test.title} results=${test.resultStatuses.join(',')}`,
+          );
+        }
+        allProblemTests.push(...problemTests);
+        runsAnalyzed += 1;
+      } else {
+        console.warn(`No JSON results for run ${run.id}`);
+        runsWithoutJsonResults += 1;
+      }
     }
+  }
+  // build leaderboard of all flaky/problematic test runs
+  const leaderboard = buildLeaderboard(allProblemTests);
+
+  console.log('\nflaky/failing e2e leaderboard');
+  for (const row of leaderboard.slice(0, config.outputLimit)) {
+    console.log(
+      `${row.score}\t${row.unexpectedRuns} unexpected\t${row.flakyRuns} flaky\t` +
+        `${row.timedOutAttempts} timeouts\t${row.failedAttempts} failures\t` +
+        `${row.project}\t${row.file}\t${row.title}\t${row.exampleRunUrl}`,
+    );
+  }
+
+  const stats = {
+    runsAnalyzed,
+    runsWithoutMatchingArtifact,
+    runsWithoutJsonResults,
+    problemTestRuns: allProblemTests.length,
+    uniqueProblemTests: leaderboard.length,
+  };
+
+  const markdownReport = renderMarkdownReport(leaderboard, config, stats);
+
+  console.log(`\nAnalyzed ${runsAnalyzed} runs`);
+  console.log(`Found ${allProblemTests.length} flaky/failing test results across ${leaderboard.length} unique tests`);
+
+  await writeReportFiles(config, markdownReport, leaderboard, stats);
+  console.log(`Wrote report files to ${config.outputDir}`);
+
+  // If running in a GH actions context, write the markdown report to the action run summary
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    await core.summary.addRaw(markdownReport).write();
+    console.log("Wrote Github run report summary");
   }
 } catch (error) {
   core.setFailed(error instanceof Error ? error.message : String(error));

--- a/.github/workflows/scripts/identify-flaky-tests.mjs
+++ b/.github/workflows/scripts/identify-flaky-tests.mjs
@@ -322,7 +322,7 @@ function renderProblemRunsCell(row) {
 
   return [
     '<details>',
-    `<summary>${row.problemRuns.length} run${row.problemRuns.length === 1 ? '' : 's'}</summary>`,
+    `<summary>**${row.problemRuns.length}&nbsp;run${row.problemRuns.length === 1 ? '' : 's'}**</summary>`,
     links.join('<br>'),
     '</details>',
   ].join('');
@@ -359,8 +359,8 @@ function renderMarkdownReport(leaderboard, config, stats) {
   }
 
   lines.push(
-    '| Rank | Score | Test | Runs | Problem Runs | Unexpected Runs | Flaky Runs | Timeout Attempts | Failed Attempts | Last Seen |',
-    '|---:|---:|---|---|---:|---:|---:|---:|---:|---|',
+    '| Rank | Score | Test | Problem Runs | Unexpected Runs | Flaky Runs | Timeout Attempts | Failed Attempts | Last Seen |',
+    '|---:|---:|---|---:|---:|---:|---:|---:|---|',
   );
 
   for (const [index, row] of topRows.entries()) {
@@ -376,7 +376,6 @@ function renderMarkdownReport(leaderboard, config, stats) {
         row.score,
         testCell,
         renderProblemRunsCell(row),
-        row.problemTestRuns,
         row.unexpectedRuns,
         row.flakyRuns,
         row.timedOutAttempts,

--- a/.github/workflows/scripts/identify-flaky-tests.mjs
+++ b/.github/workflows/scripts/identify-flaky-tests.mjs
@@ -10,7 +10,6 @@ import * as github from '@actions/github';
 //   --branch develop \
 //   --max-runs 25
 
-
 function getArg(name) {
   const prefix = `--${name}=`;
   const inline = process.argv.find(arg => arg.startsWith(prefix));
@@ -132,7 +131,6 @@ async function readJsonResultsFromArtifactZip(zipData) {
 
   return JSON.parse(await file.async('string'));
 }
-
 
 /**
  * collect flaky and unexpectedly failing tests from playwright json results.
@@ -306,7 +304,9 @@ function getDisplayTitle(row) {
  * Format an ISO timestamp for compact report display.
  */
 function formatDate(value) {
-  if (!value) { return ''; }
+  if (!value) {
+    return '';
+  }
   return new Date(value).toISOString().slice(0, 10);
 }
 
@@ -364,10 +364,7 @@ function renderMarkdownReport(leaderboard, config, stats) {
   );
 
   for (const [index, row] of topRows.entries()) {
-    const testCell = [
-      `\`${escapeMarkdown(row.file)}\``,
-      escapeMarkdown(getDisplayTitle(row)),
-    ].join('<br>');
+    const testCell = [`\`${escapeMarkdown(row.file)}\``, escapeMarkdown(getDisplayTitle(row))].join('<br>');
 
     const lastSeenCell = row.exampleRunUrl
       ? `[${escapeMarkdown(formatDate(row.lastSeenAt))}](${row.exampleRunUrl})`
@@ -402,10 +399,7 @@ function renderMarkdownReport(leaderboard, config, stats) {
 async function writeReportFiles(config, markdownReport, leaderboard, stats) {
   await fs.mkdir(config.outputDir, { recursive: true });
 
-  await fs.writeFile(
-    path.join(config.outputDir, 'flaky-test-leaderboard.md'),
-    markdownReport,
-  );
+  await fs.writeFile(path.join(config.outputDir, 'flaky-test-leaderboard.md'), markdownReport);
 
   await fs.writeFile(
     path.join(config.outputDir, 'flaky-test-leaderboard.json'),
@@ -435,7 +429,9 @@ try {
   console.log('running with config:');
   console.log(JSON.stringify({ ...config, token: config.token ? '<set>' : '<missing>' }, null, 2));
 
-  if (!config.token) { throw new Error('GITHUB_TOKEN is required.'); }
+  if (!config.token) {
+    throw new Error('GITHUB_TOKEN is required.');
+  }
   const octokit = github.getOctokit(config.token);
 
   // collection of all problematic test runs from past N workflow runs
@@ -466,9 +462,7 @@ try {
         zipData = await getArtifactZipData(octokit, config, run, matchingArtifacts[0]);
       } catch (error) {
         console.warn(
-          `Unable to download artifact for run ${run.id}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
+          `Unable to download artifact for run ${run.id}: ${error instanceof Error ? error.message : String(error)}`,
         );
         runsWithArtifactDownloadErrors += 1;
         continue;
@@ -527,7 +521,7 @@ try {
   // If running in a GH actions context, write the markdown report to the action run summary
   if (process.env.GITHUB_ACTIONS === 'true') {
     await core.summary.addRaw(markdownReport).write();
-    console.log("Wrote Github run report summary");
+    console.log('Wrote Github run report summary');
   }
 } catch (error) {
   core.setFailed(error instanceof Error ? error.message : String(error));

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ unit-test-results
 /playwright/.cache/
 /.playwright/
 .codex
+/tmp/

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^3.0.1",
-        "@actions/github": "^9.1.1",
         "@codemirror/autocomplete": "^6.16.0",
         "@codemirror/lang-json": "^6.0.1",
         "@codemirror/language": "^6.10.1",
@@ -68,6 +66,8 @@
         "toastify-js": "^1.12.0"
       },
       "devDependencies": {
+        "@actions/core": "^3.0.1",
+        "@actions/github": "^9.1.1",
         "@playwright/test": "1.58.2",
         "@poppanator/sveltekit-svg": "^4.2.1",
         "@sveltejs/vite-plugin-svelte": "^3.0.0",
@@ -131,6 +131,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
       "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@actions/exec": "^3.0.0",
@@ -141,6 +142,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
       "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@actions/io": "^3.0.2"
@@ -150,6 +152,7 @@
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/@actions/github/-/github-9.1.1.tgz",
       "integrity": "sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@actions/http-client": "^3.0.2",
@@ -165,6 +168,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
       "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
@@ -175,6 +179,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
       "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
@@ -185,6 +190,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
       "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
@@ -1745,6 +1751,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
       "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
@@ -1754,6 +1761,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
@@ -1772,6 +1780,7 @@
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
       "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^16.0.0",
@@ -1785,6 +1794,7 @@
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
       "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/request": "^10.0.6",
@@ -1799,12 +1809,14 @@
       "version": "27.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
       "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
       "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^16.0.0"
@@ -1820,6 +1832,7 @@
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
       "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^16.0.0"
@@ -1832,9 +1845,10 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "10.0.10",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
-      "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.11.tgz",
+      "integrity": "sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/endpoint": "^11.0.3",
@@ -1852,6 +1866,7 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
       "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^16.0.0"
@@ -1864,6 +1879,7 @@
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
       "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
@@ -3478,6 +3494,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/binary-extensions": {
@@ -3947,6 +3964,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6497,6 +6515,7 @@
       "version": "3.5.8",
       "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
       "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jszip": {
@@ -9774,6 +9793,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -9843,6 +9863,7 @@
       "version": "6.27.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
       "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -9861,6 +9882,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/universalify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "4.2.1",
       "license": "MIT",
       "dependencies": {
+        "@actions/core": "^3.0.1",
+        "@actions/github": "^9.1.1",
         "@codemirror/autocomplete": "^6.16.0",
         "@codemirror/lang-json": "^6.0.1",
         "@codemirror/language": "^6.10.1",
@@ -124,6 +126,66 @@
         "node": ">=22.0.0",
         "npm": ">=10.0.0"
       }
+    },
+    "node_modules/@actions/core": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
+      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/exec": "^3.0.0",
+        "@actions/http-client": "^4.0.0"
+      }
+    },
+    "node_modules/@actions/exec": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
+      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/io": "^3.0.2"
+      }
+    },
+    "node_modules/@actions/github": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-9.1.1.tgz",
+      "integrity": "sha512-tL5JbYOBZHc0ngEnCsaDcryUizIUIlQyIMwy1Wkx93H5HzbBJ7TbiPx2PnFjBwZW0Vh05JmfFZhecE6gglYegA==",
+      "license": "MIT",
+      "dependencies": {
+        "@actions/http-client": "^3.0.2",
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
+        "@octokit/request": "^10.0.7",
+        "@octokit/request-error": "^7.1.0",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/github/node_modules/@actions/http-client": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
+      "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.1.tgz",
+      "integrity": "sha512-+Nvd1ImaOZBSoPbsUtEhv+1z99H12xzncCkz0a3RuehINE81FZSe2QTj3uvAPTcJX/SCzUQHQ0D1GrPMbrPitg==",
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "^0.0.6",
+        "undici": "^6.23.0"
+      }
+    },
+    "node_modules/@actions/io": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
+      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -1677,6 +1739,134 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
+      "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "content-type": "^2.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^27.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -3284,6 +3474,12 @@
         }
       ]
     },
+    "node_modules/before-after-hook": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3746,6 +3942,19 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true
+    },
+    "node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cookie": {
       "version": "0.6.0",
@@ -6283,6 +6492,12 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+      "license": "MIT"
     },
     "node_modules/jszip": {
       "version": "3.10.1",
@@ -9555,6 +9770,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -9615,6 +9839,15 @@
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "dev": true
     },
+    "node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/unique-names-generator": {
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/unique-names-generator/-/unique-names-generator-4.7.1.tgz",
@@ -9623,6 +9856,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "license": "ISC"
     },
     "node_modules/universalify": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "version": "node ./scripts/version.js"
   },
   "dependencies": {
+    "@actions/core": "^3.0.1",
+    "@actions/github": "^9.1.1",
     "@codemirror/autocomplete": "^6.16.0",
     "@codemirror/lang-json": "^6.0.1",
     "@codemirror/language": "^6.10.1",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
     "version": "node ./scripts/version.js"
   },
   "dependencies": {
-    "@actions/core": "^3.0.1",
-    "@actions/github": "^9.1.1",
     "@codemirror/autocomplete": "^6.16.0",
     "@codemirror/lang-json": "^6.0.1",
     "@codemirror/language": "^6.10.1",
@@ -98,6 +96,8 @@
     "toastify-js": "^1.12.0"
   },
   "devDependencies": {
+    "@actions/core": "^3.0.1",
+    "@actions/github": "^9.1.1",
     "@playwright/test": "1.58.2",
     "@poppanator/sveltekit-svg": "^4.2.1",
     "@sveltejs/vite-plugin-svelte": "^3.0.0",


### PR DESCRIPTION
Adds a new "Identify Flaky Tests" workflow and supporting script to generate an E2E test reliability leaderboard from recent GitHub Actions runs. When run, the workflow:

- Aggregates recent E2E test results from test.yml and canary.yml
- Analyzes Playwright `json-results.json` artifacts from the configured workflows
- Collects flaky and unexpectedly failing tests
- Scores tests by failed, timed-out, or interrupted retry attempts
- Generates a markdown leaderboard with expandable links to problematic runs
- Publishes a ranked report in the GitHub Actions run summary & uploads markdown and JSON report artifacts.


## Testing

Ran the script locally against recent test.yml and canary.yml workflow runs and verified that it does all of the above. Local test command looks like:
```
GITHUB_TOKEN=YOUR_TOKEN_GOES_HERE node .github/workflows/scripts/identify-flaky-tests.mjs \
  --repo NASA-AMMOS/plandev-ui \
 --max-runs 3
 ```