### PR TITLE
Update ui base docker image to node 22.22.3 to fix security issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.0-alpine3.22
+FROM node:22.22.3-alpine3.22
 COPY build /app
 COPY package.json /app
 COPY node_modules /app/node_modules


### PR DESCRIPTION
Per [recent security scans](https://github.com/NASA-AMMOS/plandev-ui/actions/runs/29515840821/job/87680526090) the Node 22.22.0 image we're using has these vulnerabilities:
```
Total: 2 (CRITICAL: 2)

┌────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬──────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                          Title                           │
├────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2026-31789 │ CRITICAL │ fixed  │ 3.5.5-r0          │ 3.5.6-r0      │ openssl: OpenSSL: Heap buffer overflow on 32-bit systems │
│            │                │          │        │                   │               │ from large X.509 certificate...                          │
│            │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-31789               │
├────────────┤                │          │        │                   │               │                                                          │
│ libssl3    │                │          │        │                   │               │                                                          │
│            │                │          │        │                   │               │                                                          │
│            │                │          │        │                   │               │                                                          │
└────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴──────────────────────────────────────────────────────────┘
```

The `node:22.22.3-alpine3.22` image is a minor upgrade and contains `3.5.6-r0` of these libraries, so should fix it.